### PR TITLE
feat: add Docker support for sandboxed pi execution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.venv
+__pycache__
+*.pyc
+uv.lock
+node_modules

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+select=M511
+
+exclude =
+    doc,
+    .tox,
+    .git,
+    .yml,
+    Pipfile.*,
+    docs/*,
+    .cache/*

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,12 @@
+# Default state for all rules
+default: true
+
+# MD013/line-length - Line length
+MD013:
+  line_length: 180
+  code_blocks: false
+  tables: false
+
+# MD041/first-line-heading - Disabled because agent and prompt files
+# use YAML frontmatter; the body is a system prompt, not a document.
+MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,65 @@
+---
+default_language_version:
+  python: python3
+
+ci:
+  autofix_prs: false
+  autoupdate_commit_msg: "ci: [pre-commit.ci] pre-commit autoupdate"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-docstring-first
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: detect-private-key
+      - id: mixed-line-ending
+      - id: debug-statements
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md] # Do not process Markdown files.
+      - id: end-of-file-fixer
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: check-toml
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8
+        args: [--config=.flake8]
+        additional_dependencies:
+          [flake8-mutable]
+
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.14
+    hooks:
+      - id: ruff
+      - id: ruff-format
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.19.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          - pytest
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.44.0
+    hooks:
+      - id: markdownlint
+        exclude: ^docs/
+        args: [--config, .markdownlint.yaml]
+        types: [markdown]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,12 +39,14 @@ Use the `subagent` tool to delegate. Route by **intent**, not tool:
 ## Parallel Execution
 
 Before every response: can operations run in parallel?
+
 - **YES** → use `tasks` array in subagent tool
 - **NO** → prove dependency before sequencing
 
 ## Code Review Loop
 
 After ANY code change:
+
 1. Run 3 reviewers **in parallel**: `code-reviewer-quality`, `code-reviewer-guidelines`, `code-reviewer-security`
 2. Merge and deduplicate findings
 3. Fix issues → re-review until all approve
@@ -86,20 +88,34 @@ All temp files go to `/tmp/pi-work/` — never in the project directory.
 ## Python Execution with uv
 
 When running arbitrary Python files:
+
 - Use `uv run --with <package> script.py` for dependencies
 - NEVER use `uv run pip install`
 
 ## External Git Repos
 
 When exploring external repos, clone locally first:
+
 ```bash
 git clone --depth 1 https://github.com/org/repo.git /tmp/pi-work/repo
 ```
+
 Never use full clones. Clean up when done.
+
+## Docker / Dockerfile
+
+This repo includes a `Dockerfile` for running pi in a sandboxed container.
+
+**When adding a new feature that requires a new CLI tool or system dependency:**
+
+- ✅ Update the `Dockerfile` to install the new tool
+- ✅ Update the README Docker section if new mounts or env vars are needed
+- ❌ Never assume a tool exists in the container — check the Dockerfile
 
 ## Agent Bug Reporting
 
 If you discover a logic flaw or bug in an agent's instructions:
+
 1. Ask user: "I found a bug in [agent]. Create a GitHub issue?"
 2. If yes → delegate to `github-expert` to create issue on `myk-org/pi-config`
 3. Continue with original task (fix or workaround)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+FROM ghcr.io/astral-sh/uv:latest AS uv
+
+FROM node:22-slim
+
+LABEL maintainer="myk-org" \
+      description="Sandboxed pi coding agent with all required tools" \
+      org.opencontainers.image.source="https://github.com/myk-org/pi-config"
+
+# Avoid interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    jq \
+    openssh-client \
+    ca-certificates \
+    gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    apt-get update && apt-get install -y --no-install-recommends gh && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install pi coding agent and acpx
+RUN npm install -g @mariozechner/pi-coding-agent acpx
+
+# Copy uv and uvx from official image
+COPY --from=uv /uv /usr/local/bin/uv
+COPY --from=uv /uvx /usr/local/bin/uvx
+
+# Install Go
+RUN curl -fsSL https://go.dev/dl/go1.24.4.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+ENV PATH="/usr/local/go/bin:$PATH"
+
+# Install kubectl and oc (OpenShift CLI)
+RUN curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+    chmod +x /usr/local/bin/kubectl && \
+    curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
+      | tar -C /usr/local/bin -xzf - oc
+
+# Switch to non-root user (node:22 ships with user 'node' at UID 1000)
+USER node
+ENV PATH="/home/node/.local/bin:$PATH"
+RUN uv tool install mcp-launchpad --from "mcp-launchpad @ git+https://github.com/kenneth-liao/mcp-launchpad.git" && \
+    uv tool install myk-pi-tools --from "myk-pi-tools @ git+https://github.com/myk-org/pi-config.git" && \
+    uv tool install prek
+
+WORKDIR /workspace
+
+ENTRYPOINT ["bash", "-c", "[ -f ~/.exports ] && source ~/.exports; pi install git:github.com/myk-org/pi-config || echo 'WARNING: pi install failed, starting pi without package' >&2; exec pi \"$@\"", "--"]

--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ After updating, run `/reload` in pi or restart pi to pick up changes.
 
 Just describe your task — the orchestrator routes to the right specialist:
 
-```
+```text
 Add retry logic to the HTTP client in src/api.py
 ```
 
 ### Workflow prompts
 
-```
+```text
 /implement add Redis caching to the session store
 /scout-and-plan refactor auth to support OAuth
 /implement-and-review add input validation to API endpoints
@@ -90,7 +90,7 @@ Add retry logic to the HTTP client in src/api.py
 
 ### Slash commands
 
-```
+```text
 /pr-review 42
 /release --dry-run
 /review-local main
@@ -99,7 +99,7 @@ Add retry logic to the HTTP client in src/api.py
 
 ### Direct subagent usage
 
-```
+```text
 Use python-expert to fix the type errors in src/models.py
 Run scout and planner in a chain to analyze the auth module
 ```
@@ -137,6 +137,114 @@ Agent system prompt here.
 ```
 
 Use `agentScope: "both"` in the subagent tool to include project agents.
+
+## Docker (Sandboxed Execution)
+
+Run pi inside a disposable container for **filesystem isolation** — the agent can only access your mounted project directory and pi settings. Everything else on the host is protected.
+
+### Why?
+
+- **Safety** — Prevents accidental `rm -rf`, modifications outside the project, or unintended system changes
+- **Filesystem isolation** — pi can only read/write the mounted project directory
+- **Consistent tooling** — All required tools pre-installed in a single image
+- **Disposable** — Container is destroyed after each session (`--rm`)
+
+### Build the image
+
+> **Note:** The image is built for **linux/amd64** only. Go, kubectl, and oc binaries are x86_64. On ARM hosts, build with `--platform linux/amd64`.
+
+```bash
+git clone https://github.com/myk-org/pi-config.git
+cd pi-config
+
+# On x86_64 hosts:
+docker build -t pi-agent .
+
+# On ARM hosts (Apple Silicon, etc.):
+docker build --platform linux/amd64 -t pi-agent .
+```
+
+### Run
+
+```bash
+docker run --rm -it \
+  --network host \
+  -v "$PWD":/workspace:rw \
+  -v "$HOME/.pi":/home/node/.pi:rw \
+  -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
+  -v "$HOME/.ssh":/home/node/.ssh:ro \
+  -v "$HOME/.config/gh":/home/node/.config/gh:ro \
+  -w /workspace \
+  pi-agent
+```
+
+### Optional mounts
+
+| Mount | Purpose |
+|---|---|
+| `-v "$HOME/.exports":/home/node/.exports:ro` | Shell env vars (API keys, tokens) — sourced on startup |
+| `-v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro` | MCP server config for `mcpl` |
+| `-v "$HOME/.agents":/home/node/.agents:ro` | User-level skills (if not in the project) |
+
+### What's in the image
+
+| Tool | Purpose |
+|---|---|
+| `pi` | Coding agent |
+| `git` | Version control |
+| `gh` | GitHub CLI (PRs, issues) |
+| `uv` / `uvx` | Python execution (enforced by orchestrator) |
+| `go` | Go development and code review |
+| `mcpl` | MCP server access (search, Jenkins, etc.) |
+| `myk-pi-tools` | PR review, release, and other CLI utilities |
+| `prek` | Pre-commit hook runner |
+| `acpx` | Agent proxy for remote models |
+| `kubectl` / `oc` | Kubernetes and OpenShift CLI |
+| `jq` | JSON processing |
+| `curl` | HTTP requests |
+
+### What's protected
+
+**Filesystem isolation** — the container cannot access anything outside the mounted volumes:
+
+- ✅ `$PWD` (your project) — read/write
+- ✅ `~/.pi` (pi settings/sessions) — read/write
+- ✅ Git, GitHub, SSH config — read-only
+- ❌ Other directories on your host — not accessible
+- ❌ Other git repos — not accessible
+- ❌ System files — not accessible
+
+**Network** — `--network host` shares the host network stack,
+so the container can reach any service your host can (LAN, localhost).
+This is required for local MCP servers, LiteLLM proxy, etc.
+If your LLM provider is cloud-based and you don't use local MCPs,
+you can omit `--network host` for full network isolation.
+
+### Shell alias
+
+Add to your `~/.bashrc` or `~/.zshrc`:
+
+```bash
+alias pi-docker='docker run --rm -it \
+  --network host \
+  -v "$PWD":/workspace:rw \
+  -v "$HOME/.pi":/home/node/.pi:rw \
+  -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
+  -v "$HOME/.ssh":/home/node/.ssh:ro \
+  -v "$HOME/.config/gh":/home/node/.config/gh:ro \
+  -v "$HOME/.exports":/home/node/.exports:ro \
+  -v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro \
+  -w /workspace \
+  pi-agent'
+```
+
+Then just run `pi-docker` from any project directory.
+
+> **Startup note:** The container runs as non-root user `node` (UID 1000).
+> `pi install` runs on each start.
+> A `WARNING` on stderr is normal when the package is already cached in `~/.pi`.
+> If pi misbehaves or the warning persists, verify network connectivity
+> and run `pi install git:github.com/myk-org/pi-config` manually.
 
 ## Prerequisites
 

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -33,7 +33,8 @@ You are a code review specialist focused on **project guidelines and style adher
 ## Output Format
 
 For each finding:
-```
+
+```text
 [SEVERITY] file:line — Description
   Rule: Which guideline is violated
   Suggestion: How to fix

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -26,7 +26,8 @@ You are a code review specialist focused on **general code quality and maintaina
 ## Output Format
 
 For each finding:
-```
+
+```text
 [SEVERITY] file:line — Description
   Suggestion: What to change and why
 ```

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -37,7 +37,8 @@ You are a code review specialist focused on **bugs, logic errors, and security v
 ## Output Format
 
 For each finding:
-```
+
+```text
 [SEVERITY] file:line — Description
   Risk: What could go wrong
   Suggestion: How to fix

--- a/agents/debugger.md
+++ b/agents/debugger.md
@@ -29,6 +29,7 @@ You are a debugging specialist focused on root cause analysis of errors, test fa
 5. Report findings with fix recommendation
 
 For each issue, provide:
+
 - Root cause explanation
 - Evidence supporting the diagnosis
 - Recommended fix (describe what needs to change)

--- a/agents/git-expert.md
+++ b/agents/git-expert.md
@@ -34,6 +34,7 @@ echo -e "Your commit title\n\nYour commit body" | git commit -F -
 ```
 
 Format rules:
+
 - First line: Clear, concise title (50 chars or less)
 - Blank line separator
 - Body: Detailed explanation if needed
@@ -42,12 +43,14 @@ Format rules:
 ## Standard Workflows
 
 **Commit changes:**
+
 1. `git status` to see changes
 2. `git add <specific files>` for each file (NEVER `git add .`)
 3. Commit with proper format
 4. Report the result
 
 **Create branch and push:**
+
 1. `git checkout -b branch-name`
 2. Verify changes committed
 3. Ask orchestrator: "Have all tests passed?"

--- a/agents/github-expert.md
+++ b/agents/github-expert.md
@@ -21,23 +21,28 @@ You are a GitHub Expert responsible for all GitHub platform operations using the
 ## Test Verification
 
 This agent does NOT run tests. When tests are required (e.g., before creating a PR):
+
 1. Ask orchestrator: "Have all tests passed?"
 2. If NO/UNKNOWN: "Please delegate to test-runner, then call me again"
 
 ## Core Operations
 
 ### Pull Requests
+
 - `gh pr create`, `gh pr view`, `gh pr list`, `gh pr merge`
 - `gh pr close`, `gh pr checkout`, `gh pr diff`, `gh pr checks`
 
 ### Issues
+
 - `gh issue create`, `gh issue view`, `gh issue list`
 - `gh issue close`, `gh issue comment`, `gh issue edit`
 
 ### Releases
+
 - `gh release create`, `gh release view`, `gh release list`
 
 ### Workflows
+
 - `gh workflow list`, `gh workflow run`, `gh run list`, `gh run view`
 
 ## Issue Creation Format
@@ -45,6 +50,7 @@ This agent does NOT run tests. When tests are required (e.g., before creating a 
 Title: `<type>: <brief description>`
 
 Body template:
+
 ```markdown
 ## Summary
 [1-2 sentence description]

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -17,7 +17,8 @@ You are a code reviewer. Review code changes thoroughly.
 ## Output Format
 
 For each finding:
-```
+
+```text
 [SEVERITY] file:line — Description
   Suggestion: How to fix
 ```

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -17,7 +17,8 @@ You are a fast codebase scout. Your job is to quickly explore a codebase and ret
 ## Output Format
 
 Return a compressed summary:
-```
+
+```text
 ## Relevant Files
 - path/to/file.py — Description of what it contains
 - path/to/other.py — Description

--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -55,6 +55,7 @@ Parse `{{args}}` to extract:
 3. **Everything after flags** = prompt text
 
 **Validation:**
+
 - `--fix` and `--peer` are mutually exclusive → abort if both present
 - Multiple agents + `--fix` are mutually exclusive → abort if both
 - Duplicate flags → abort
@@ -85,6 +86,7 @@ git status --short
 
 If not a git repo: ask "Continue without git? No easy rollback."
 If dirty worktree: ask user:
+
 - **Commit first (Recommended)** — `git add -A && git commit -m "chore: checkpoint before acpx changes"`
 - **Continue anyway** — proceed, remember worktree was dirty
 - **Abort** — stop
@@ -98,11 +100,13 @@ Build the acpx command:
 **Model handling:** If agent spec includes `:model`, pass `--model <model>`.
 
 **Fix mode:**
+
 ```bash
 acpx --approve-all <agent> '<prompt> You have full permission to modify, create, and delete files as needed.'
 ```
 
 **Read-only (default):**
+
 ```bash
 acpx --approve-reads --non-interactive-permissions fail <agent> '<prompt> IMPORTANT: This is a read-only request. Do NOT modify any files. Report findings only.'
 ```
@@ -164,6 +168,7 @@ Original prompt: <user's prompt>
 ```
 
 Execute:
+
 ```bash
 acpx --approve-reads --non-interactive-permissions fail <agent> '<peer_framing_prompt>'
 ```
@@ -175,6 +180,7 @@ If ALL agents report no findings, skip to Step 9e.
 ### 9b: Act on Findings
 
 For each finding:
+
 1. **If agree** — Fix by delegating to the appropriate specialist subagent
 2. **If disagree** — Prepare technical counter-argument with specific reasoning
 

--- a/prompts/coderabbit-rate-limit.md
+++ b/prompts/coderabbit-rate-limit.md
@@ -12,7 +12,7 @@ Execute this workflow step by step. Run bash commands directly.
 uv --version
 ```
 
-If not found, stop — install from https://docs.astral.sh/uv/getting-started/installation/
+If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -46,6 +46,7 @@ myk-pi-tools coderabbit check <owner/repo> <pr_number>
 ```
 
 Parse the JSON result:
+
 - If `rate_limited` is `false` — notify user "Not rate limited" and exit
 - If `rate_limited` is `true` — read `wait_seconds` and proceed to Phase 3
 
@@ -58,6 +59,7 @@ myk-pi-tools coderabbit trigger <owner/repo> <pr_number> --wait <wait_seconds + 
 ```
 
 This command will:
+
 1. Sleep for the specified wait duration
 2. Post `@coderabbitai review` to re-trigger the review
 3. Poll every 60s (max 10 min) until the review starts
@@ -65,5 +67,6 @@ This command will:
 ## Phase 4: Notify User
 
 Based on the exit code of the trigger command:
+
 - **Exit 0** — Report success: "CodeRabbit review started on PR #N"
 - **Exit 1** — Report the error message from stderr

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -12,7 +12,7 @@ Execute this workflow step by step. Run bash commands directly — do NOT delega
 uv --version
 ```
 
-If not found, stop and tell the user to install from https://docs.astral.sh/uv/getting-started/installation/
+If not found, stop and tell the user to install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -21,6 +21,7 @@ myk-pi-tools --version
 ```
 
 If not found, ask the user: "myk-pi-tools is required. Install with: `uv tool install myk-pi-tools`. Install now?"
+
 - Yes: Run `uv tool install myk-pi-tools`
 - No: Abort
 
@@ -77,6 +78,7 @@ Use the subagent tool to run ALL 3 review agents IN PARALLEL (using the `tasks` 
 Pass each agent the full diff content from Phase 1a and the guidelines from Phase 1b.
 
 After all 3 finish, merge and deduplicate findings:
+
 - Same file/line range + same issue type = duplicate → keep most actionable
 - Conflicting suggestions → priority: security > correctness > performance > style
 - Complementary findings (different issue types) → keep both
@@ -86,6 +88,7 @@ After all 3 finish, merge and deduplicate findings:
 Present findings grouped by severity (CRITICAL, WARNING, SUGGESTION), numbered.
 
 Ask the user which to post:
+
 - `all` = Post all findings
 - `none` = Skip posting
 - Specific numbers (e.g., `1,3,5`) = Post only those
@@ -99,6 +102,7 @@ mkdir -p /tmp/pi-work
 ```
 
 Write a JSON array to `/tmp/pi-work/pr-review-comments.json` with format:
+
 ```json
 [{"path": "file.py", "line": 42, "body": "Comment text"}]
 ```
@@ -112,6 +116,7 @@ myk-pi-tools pr post-comment <owner>/<repo> <pr_number> <head_sha> /tmp/pi-work/
 ## Phase 5: Summary
 
 Display final summary:
+
 - Number of findings by severity
 - Number of comments posted
 - PR URL for reference

--- a/prompts/query-db.md
+++ b/prompts/query-db.md
@@ -12,7 +12,7 @@ Execute this workflow step by step. Run bash commands directly.
 uv --version
 ```
 
-If not found, stop — install from https://docs.astral.sh/uv/getting-started/installation/
+If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -66,7 +66,8 @@ echo '[{"body": "Consider adding error handling", "path": "src/main.py"}]' | myk
 
 **reviews table:** id, pr_number, owner, repo, commit_sha, created_at
 
-**comments table:** id, review_id (FK), source (human/qodo/coderabbit), thread_id, node_id, comment_id, author, path, line, body, priority (HIGH/MEDIUM/LOW), status (pending/addressed/skipped/not_addressed), reply, skip_reason, posted_at, resolved_at
+**comments table:** id, review_id (FK), source (human/qodo/coderabbit), thread_id, node_id, comment_id, author, path, line, body,
+priority (HIGH/MEDIUM/LOW), status (pending/addressed/skipped/not_addressed), reply, skip_reason, posted_at, resolved_at
 
 **Constraints:** Only SELECT statements and CTEs are allowed. INSERT/UPDATE/DELETE/DROP are blocked.
 

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -12,7 +12,7 @@ Execute this workflow step by step. Run bash commands directly.
 uv --version
 ```
 
-If not found, stop — install from https://docs.astral.sh/uv/getting-started/installation/
+If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -33,6 +33,7 @@ myk-pi-tools reviews pending-fetch "{{args}}"
 The command saves the review data to a JSON file and outputs the file path to stdout.
 
 The JSON file contains:
+
 - `metadata`: owner, repo, pr_number, review_id, username, json_path
 - `comments`: array of pending review comments with id, path, line, body, diff_hunk
 - `diff`: PR diff text for context
@@ -46,6 +47,7 @@ Capture the output (json_path) for later phases.
 For each comment in the JSON, use the PR diff context, file path, line number, and diff hunk to generate a refined version.
 
 **Refinement goals:**
+
 - Improve clarity and conciseness
 - Make comments more actionable (suggest specific fixes when possible)
 - Fix grammar and formatting
@@ -72,6 +74,7 @@ Comment #2 (src/main.py):
 Ask the user which refinements to accept:
 
 Options:
+
 - **Accept all** — Use all refined versions
 - **Pick specific** — Enter comment numbers to accept (e.g., "1,3,5")
 - **Keep originals** — Skip refinement, go straight to submit step
@@ -80,11 +83,14 @@ Options:
 
 If "Pick specific": ask for comma-separated numbers. Validate range. Re-prompt on invalid input.
 
-If "Custom text": user provides comment number followed by their custom text. The custom text replaces the refined version. After applying, re-display affected comment(s) for confirmation before proceeding.
+If "Custom text": user provides comment number followed by their custom text.
+The custom text replaces the refined version. After applying,
+re-display affected comment(s) for confirmation before proceeding.
 
 ## Phase 5: Update JSON
 
 Update the JSON file at `json_path`:
+
 - For each accepted refinement: set `refined_body` to the refined text and `status` to `"accepted"`
 - For comments kept as original: leave `refined_body` as null and `status` as `"pending"`
 
@@ -95,6 +101,7 @@ Update the JSON file at `json_path`:
 Ask the user what review action to take:
 
 Options:
+
 - **Comment** — Submit as general feedback
 - **Approve** — Approve the PR
 - **Request changes** — Request changes
@@ -103,6 +110,7 @@ Options:
 If user chooses to submit, optionally ask for a review summary (can be empty).
 
 Update the JSON metadata:
+
 - Set `submit_action` to the chosen action (COMMENT/APPROVE/REQUEST_CHANGES), or omit if keeping pending
 - Set `submit_summary` to the summary text
 
@@ -123,17 +131,20 @@ myk-pi-tools reviews pending-update "<json_path>"
 This updates accepted comment bodies on GitHub and submits the review when `--submit` is provided.
 
 If the command fails:
+
 - If 404: inform the user their pending review may have been submitted or deleted externally
 - Other errors: display the error
 
 ## Phase 8: Summary
 
 Display:
+
 - Number of comments refined vs kept as original
 - Review action taken (submitted as COMMENT/APPROVE/REQUEST_CHANGES, or kept pending)
 - PR URL for reference
 
 **CRITICAL RULES:**
+
 - NEVER update comments or submit the review without explicit user confirmation
 - Always show what will change before changing it
 - The user controls which refinements are accepted

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -25,6 +25,7 @@ Build the release info command:
 - Otherwise: `myk-pi-tools release info`
 
 Run the command. Check validations:
+
 - Must be on default branch (or target/auto-detected version branch)
 - Working tree must be clean
 - Must be synced with remote
@@ -38,6 +39,7 @@ myk-pi-tools release detect-versions
 ```
 
 Parse the JSON output. Key fields:
+
 - `version_files[].path` — file path relative to repo root
 - `version_files[].current_version` — current version string
 - `count` — number of detected files (0 = skip version bumping)
@@ -47,6 +49,7 @@ Store for Phase 4.
 ## Phase 3: Changelog Analysis
 
 Parse commits from Phase 1 output. Categorize by conventional commit type:
+
 - Breaking Changes → MAJOR bump
 - Features (`feat:`) → MINOR bump
 - Bug Fixes (`fix:`), Docs (`docs:`), Maintenance (`chore:`) → PATCH bump
@@ -60,11 +63,13 @@ Present the proposed release info to the user.
 **If version files were detected:**
 
 Show:
+
 - Proposed version (e.g., v1.2.0, minor bump)
 - List of version files to update with current → new version
 - Changelog preview
 
 Ask the user (options):
+
 - `yes` — Proceed with proposed version and all listed files
 - `major`/`minor`/`patch` — Override the version bump type
 - `exclude N` — Exclude file by number from the version bump
@@ -106,6 +111,7 @@ gh pr merge --merge --admin --delete-branch
 ```
 
 If `--admin` merge fails:
+
 - **Permission denied** — Show PR_URL, tell user to merge manually, wait for confirmation, verify merge state
 - **Other errors** — Abort and display error
 
@@ -137,6 +143,7 @@ rm -f "$CHANGELOG_FILE"
 ## Phase 7: Summary
 
 Display:
+
 - Release URL
 - Version bumped (if applicable)
 - Files updated (if applicable)

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -15,7 +15,7 @@ If `--autorabbit` mode: [PUSH_APPROVED]
 uv --version
 ```
 
-If not found, stop — install from https://docs.astral.sh/uv/getting-started/installation/
+If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -35,6 +35,7 @@ Before calling ANY `myk-pi-tools` command, parse `{{args}}`:
 4. If NO: proceed normally
 
 **Example:** If `{{args}}` = `--autorabbit`, then:
+
 - autorabbit mode = ON
 - cleaned arguments = (empty)
 - CLI call = `myk-pi-tools reviews fetch` (NO `--autorabbit` flag)
@@ -58,6 +59,7 @@ myk-pi-tools reviews fetch
 ```
 
 Returns JSON with:
+
 - `metadata`: owner, repo, pr_number, json_path
 - `human`: Human review threads
 - `qodo`: Qodo AI review threads
@@ -65,22 +67,25 @@ Returns JSON with:
 
 ## Phase 2: User Decision Collection
 
-### AUTORABBIT MODE CHECK (do this FIRST):
+### AUTORABBIT MODE CHECK (do this FIRST)
 
 If autorabbit mode is ON:
+
 1. CodeRabbit comments → ALL auto-approved. Do NOT ask the user. Set every CodeRabbit item to "yes" automatically. Display the table for visibility only.
 2. Human/Qodo comments → follow the normal decision flow below.
 3. If there are ONLY CodeRabbit comments (no human, no Qodo) → skip this entire phase and go directly to Phase 3.
 
 **In autorabbit mode, the user is NEVER asked about CodeRabbit items.**
 
-### Normal mode:
+### Normal mode
 
 Present ALL fetched items to the user for decision. Never silently hide or omit items — including auto-skipped ones.
 
 **Presentation format (MANDATORY):**
 
-Present one table per source (human, qodo, coderabbit). Skip sources with zero items. Within each table, sort by priority (HIGH → MEDIUM → LOW). Use a global counter for the `#` column across all tables.
+Present one table per source (human, qodo, coderabbit). Skip sources with zero items.
+Within each table, sort by priority (HIGH → MEDIUM → LOW).
+Use a global counter for the `#` column across all tables.
 
 ```text
 ## Review Items: {source} ({total} total, {auto_skipped} auto-skipped)
@@ -106,7 +111,8 @@ Respond with:
 
 For each approved comment, delegate to the appropriate specialist subagent using the subagent tool.
 
-When delegating, pass the FULL original review thread — including the complete comment body, all replies, every code suggestion/diff, and all referenced locations. Do NOT summarize or compress the thread.
+When delegating, pass the FULL original review thread — including the complete comment body, all replies,
+every code suggestion/diff, and all referenced locations. Do NOT summarize or compress the thread.
 
 **When fixing review comments (MANDATORY):**
 
@@ -114,7 +120,9 @@ When delegating, pass the FULL original review thread — including the complete
 - Do NOT simplify, minimize, or "half-fix" the suggestion
 - After fixing, verify your code matches what the reviewer asked for
 - **NO SKIP WITHOUT USER APPROVAL:** If you disagree with a suggestion, ASK THE USER before skipping
-- **Read the ENTIRE review thread before acting.** Comments often contain multiple parts: a main issue description, code suggestions, AND additional references like "Also applies to: 663-668" or mentions of other files/lines. You MUST address ALL parts.
+- **Read the ENTIRE review thread before acting.** Comments often contain multiple parts: a main issue description,
+  code suggestions, AND additional references like "Also applies to: 663-668" or mentions of other files/lines.
+  You MUST address ALL parts.
 - **Multi-location fixes are MANDATORY.** When a comment says "Also applies to: X-Y" or references other lines/files, apply the same fix to each location.
 - **Post-fix verification checklist.** After fixing a comment, re-read the ORIGINAL review thread in full and verify:
   1. Every code suggestion or diff was implemented
@@ -146,7 +154,7 @@ Update each JSON entry with `status` and `reply` fields before posting.
 - User said **yes** but change was not implemented → `not_addressed`
 - User said **no** → `skipped` (include the user's skip reason in `reply`)
 - User said **all** → same as **yes** for each remaining comment
-- User said **skip <source>** → `skipped` for all remaining from that source
+- User said **skip `<source>`** → `skipped` for all remaining from that source
 - User said **skip ai** → `skipped` for all remaining AI sources
 
 ## Phase 6: Testing

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -52,6 +52,7 @@ Merge and deduplicate findings from all 3 reviewers:
 - Complementary findings → keep both
 
 Display grouped by:
+
 - **Critical issues** (must fix)
 - **Warnings** (should fix)
 - **Suggestions** (nice to have)


### PR DESCRIPTION
## Summary

Add Dockerfile and documentation for running pi in a disposable container with filesystem isolation.

## Changes

- **Dockerfile** — Pre-built image with all required tools:
  pi, git, gh, uv/uvx, go, mcpl, myk-pi-tools, prek, acpx, kubectl, oc, jq, curl
- Runs as **non-root** user (`node`, UID 1000)
- Multi-stage build: copies uv/uvx from official `ghcr.io/astral-sh/uv` image
- **AGENTS.md** — Added rule: new tool dependencies must update Dockerfile
- **README.md** — Docker section with build/run instructions, shell alias, security tradeoffs
- **.markdownlint.yaml** — Config for markdownlint
- **.pre-commit-config.yaml** + **.flake8** — Pre-commit hooks
- Fixed all markdownlint errors across agents/ and prompts/

## Motivation

- Protect host filesystem: agent can only access mounted project directory
- Prevent accidental destructive operations outside the project
- Consistent environment with all tools pre-installed
- Disposable container destroyed after each session

## Review

Peer-reviewed by Cursor (4 rounds).

Closes #1