### PR TITLE
fix: add missing entrypoint.sh and --approve-all from Docker PR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,14 @@ RUN curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -fsSL
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
 USER node
 ENV PATH="/home/node/.local/bin:$PATH"
+
+# Install uv tools
 RUN uv tool install mcp-launchpad --from "mcp-launchpad @ git+https://github.com/kenneth-liao/mcp-launchpad.git" && \
     uv tool install myk-pi-tools --from "myk-pi-tools @ git+https://github.com/myk-org/pi-config.git" && \
     uv tool install prek
 
+COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
+
 WORKDIR /workspace
 
-ENTRYPOINT ["bash", "-c", "[ -f ~/.exports ] && source ~/.exports; pi install git:github.com/myk-org/pi-config || echo 'WARNING: pi install failed, starting pi without package' >&2; exec pi --approve-all \"$@\"", "--"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,4 @@ RUN uv tool install mcp-launchpad --from "mcp-launchpad @ git+https://github.com
 
 WORKDIR /workspace
 
-ENTRYPOINT ["bash", "-c", "[ -f ~/.exports ] && source ~/.exports; pi install git:github.com/myk-org/pi-config || echo 'WARNING: pi install failed, starting pi without package' >&2; exec pi \"$@\"", "--"]
+ENTRYPOINT ["bash", "-c", "[ -f ~/.exports ] && source ~/.exports; pi install git:github.com/myk-org/pi-config || echo 'WARNING: pi install failed, starting pi without package' >&2; exec pi --approve-all \"$@\"", "--"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Source user environment variables if available
+if [ -f ~/.exports ]; then
+    # shellcheck disable=SC1090
+    source ~/.exports
+fi
+
+# Install pi-config package (non-blocking)
+pi install git:github.com/myk-org/pi-config || \
+    echo 'WARNING: pi install failed, starting pi without package' >&2
+
+exec pi --approve-all "$@"


### PR DESCRIPTION
Two commits from #2 were not pushed before merge:

1. `--approve-all` flag in Dockerfile entrypoint — skips interactive prompts since the orchestrator extension enforces safety
2. Extract inline ENTRYPOINT into `entrypoint.sh` for readability

Follow-up to #1.