### PR TITLE
fix: remove invalid --approve-all flag from entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,4 +11,4 @@ fi
 pi install git:github.com/myk-org/pi-config || \
     echo 'WARNING: pi install failed, starting pi without package' >&2
 
-exec pi --approve-all "$@"
+exec pi "$@"


### PR DESCRIPTION
Pi does not have a `--approve-all` flag (that's Claude Code). Removes it from `entrypoint.sh` so the container starts correctly.