### PR TITLE
refactor: remove push approval gate

### DIFF
--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -266,17 +266,6 @@ const SubagentParams = Type.Object({
 
 export default function (pi: ExtensionAPI) {
 
-	// ── Push approval state ─────────────────────────────────────────────
-	// Prompt templates can allow auto-push by including the marker:
-	//   [PUSH_APPROVED]
-	// Currently used by: /release, /review-handler --autorabbit
-
-	let pushApproved = false;
-
-	pi.on("before_agent_start", async (event) => {
-		pushApproved = event.prompt.includes("[PUSH_APPROVED]");
-	});
-
 	// ── Subagent tool ──────────────────────────────────────────────────────
 
 	pi.registerTool({
@@ -543,15 +532,6 @@ export default function (pi: ExtensionAPI) {
 					const pr = getPrMergeStatus(branch, ctx.cwd);
 					if (pr.merged) return { block: true, reason: `⛔ PR #${pr.info} for '${branch}' already merged. Create a new branch.` };
 					if (mainBranch && isBranchMerged(branch, mainBranch, ctx.cwd)) return { block: true, reason: `⛔ Branch '${branch}' already merged into '${mainBranch}'. Create a new branch.` };
-				}
-				// Require user approval for pushes (unless auto-approved by prompt template)
-				if (!pushApproved) {
-					if (ctx.hasUI) {
-						const ok = await ctx.ui.select(`🔀 Push to '${branch || "remote"}'?\n\n  ${command}\n\nApprove?`, ["Yes", "No"]);
-						if (ok !== "Yes") return { block: true, reason: "Push cancelled by user" };
-					} else {
-						return { block: true, reason: "⛔ git push requires user approval (no UI available)" };
-					}
 				}
 			}
 		}

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -4,8 +4,6 @@ description: "Create a GitHub release with changelog — /release [--dry-run] [-
 
 Execute this workflow step by step. Run bash commands directly — do NOT delegate to subagents for CLI commands.
 
-[PUSH_APPROVED]
-
 ## Prerequisites Check (MANDATORY)
 
 ```bash

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -5,8 +5,6 @@ description: "Process ALL review sources (human, Qodo, CodeRabbit) from current 
 Execute this workflow step by step. Run bash commands directly for CLI operations.
 Delegate code fixes to the appropriate specialist subagent.
 
-If `--autorabbit` mode: [PUSH_APPROVED]
-
 ## Prerequisites Check (MANDATORY)
 
 ### Step 0: Check uv


### PR DESCRIPTION
Remove the interactive push approval dialog. The extension already blocks pushes to main/master and merged branches, which provides the real safety. The approval prompt just added friction.

Removes:
- `pushApproved` state and `before_agent_start` listener
- User approval dialog on `git push`
- `[PUSH_APPROVED]` markers from `/release` and `/review-handler` prompts