### PR TITLE
fix: run pi update in entrypoint to suppress stale package warnings

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,8 @@ if [ -f ~/.exports ]; then
     source ~/.exports
 fi
 
-# Install pi-config package (non-blocking)
-pi install git:github.com/myk-org/pi-config || \
-    echo 'WARNING: pi install failed, starting pi without package' >&2
+# Install/update pi-config package (non-blocking)
+pi install git:github.com/myk-org/pi-config 2>/dev/null || true
+pi update 2>/dev/null || true
 
 exec pi "$@"


### PR DESCRIPTION
Adds `pi update` after `pi install` in the container entrypoint so the package is always at latest, suppressing the 'Package Updates Available' banner.