### PR TITLE
fix: do not activate acpx-provider by default

### DIFF
--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -495,7 +495,7 @@ export default function (pi: ExtensionAPI) {
 	// acpx needs this to find session markers in the project directory tree.
 	projectCwd = process.cwd();
 
-	const agentList = (process.env.ACPX_AGENTS || "cursor")
+	const agentList = (process.env.ACPX_AGENTS || "")
 		.split(",")
 		.map((a) => a.trim())
 		.filter(Boolean);


### PR DESCRIPTION
ACPX_AGENTS defaulted to `cursor` when unset, causing acpx to activate even without the user opting in. Now defaults to empty — only activates when explicitly set via `ACPX_AGENTS=cursor`.