### PR TITLE
feat: add Vertex AI Claude support via pi-vertex-anthropic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GitHub CLI
+# Install GitHub CLI and Google Cloud SDK
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 2>/dev/null && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
       | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
-    apt-get update && apt-get install -y --no-install-recommends gh && \
+    echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+      | tee /etc/apt/sources.list.d/google-cloud-sdk.list > /dev/null && \
+    curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+      | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
+    apt-get update && apt-get install -y --no-install-recommends gh google-cloud-cli && \
     rm -rf /var/lib/apt/lists/*
 
 # Install pi coding agent and acpx

--- a/README.md
+++ b/README.md
@@ -187,12 +187,15 @@ docker run --rm -it \
 | `-v "$HOME/.exports":/home/node/.exports:ro` | Shell env vars (API keys, tokens) — sourced on startup |
 | `-v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro` | MCP server config for `mcpl` |
 | `-v "$HOME/.agents":/home/node/.agents:ro` | User-level skills (if not in the project) |
+| `-v "$HOME/.config/gcloud":/home/node/.config/gcloud:ro` | Google Cloud credentials (for Claude via Vertex AI) |
 
 ### Optional environment variables
 
 | Variable | Purpose |
 |---|---|
 | `ACPX_AGENTS` | Comma-separated list of acpx agents to register as model providers (e.g., `cursor,claude,gemini`) |
+| `GOOGLE_CLOUD_PROJECT` | GCP project ID for Vertex AI (Claude and Gemini models) |
+| `GOOGLE_CLOUD_LOCATION` | GCP region (e.g., `us-east5`, `global`) |
 
 ### What's in the image
 
@@ -208,6 +211,7 @@ docker run --rm -it \
 | `prek` | Pre-commit hook runner |
 | `acpx` | Agent proxy for remote models |
 | `kubectl` / `oc` | Kubernetes and OpenShift CLI |
+| `gcloud` | Google Cloud CLI (Vertex AI authentication) |
 | `jq` | JSON processing |
 | `curl` | HTTP requests |
 
@@ -243,6 +247,7 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.config/gh":/home/node/.config/gh:ro \
   -v "$HOME/.exports":/home/node/.exports:ro \
   -v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro \
+  -v "$HOME/.config/gcloud":/home/node/.config/gcloud:ro \
   -e ACPX_AGENTS \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,9 @@ if [ -f ~/.exports ]; then
     source ~/.exports
 fi
 
-# Install/update pi-config package (non-blocking)
+# Install/update packages (non-blocking)
 pi install git:github.com/myk-org/pi-config 2>/dev/null || true
+pi install git:github.com/skyfallsin/pi-vertex-anthropic 2>/dev/null || true
 pi update 2>/dev/null || true
 
 exec pi "$@"


### PR DESCRIPTION
Adds support for Claude models via Google Cloud Vertex AI, enabling use outside the home network without LiteLLM proxy.

- **Dockerfile**: install `gcloud` CLI for Vertex AI auth
- **entrypoint.sh**: install `pi-vertex-anthropic` extension on startup
- **README**: document gcloud mount, env vars, and shell alias updates

Requires: gcloud credentials mounted + `GOOGLE_CLOUD_PROJECT` set.