### PR TITLE
fix: swap pi-vertex-anthropic for pi-vertex-claude

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # Install/update packages (non-blocking)
 pi install git:github.com/myk-org/pi-config 2>/dev/null || true
-pi install git:github.com/skyfallsin/pi-vertex-anthropic 2>/dev/null || true
+pi install git:github.com/isaacraja/pi-vertex-claude 2>/dev/null || true
 pi update 2>/dev/null || true
 
 exec pi "$@"


### PR DESCRIPTION
Replace `skyfallsin/pi-vertex-anthropic` (broken package.json, no `pi` key) with `isaacraja/pi-vertex-claude` which:
- Has proper pi package config
- Uses native ADC via `@anthropic-ai/vertex-sdk` (no gcloud shell exec)
- Uses standard `GOOGLE_CLOUD_PROJECT`/`GOOGLE_CLOUD_LOCATION` env vars
- Gracefully skips when credentials are missing