### PR TITLE
feat: add web access, browser automation, ask_user tool, and UX impro…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Thumbs.db
 
 # Pi local
 .pi/
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,14 @@ git clone --depth 1 https://github.com/org/repo.git /tmp/pi-work/repo
 
 Never use full clones. Clean up when done.
 
+## Web Access
+
+- **Web search and fetch**: Use the `web_search` and `fetch_content` tools (from pi-web-access)
+- **Browser automation**: Use `agent-browser` CLI via bash for interactive web pages
+  (navigate, click, fill forms, screenshots)
+- Do NOT use `curl` for reading web pages — use `fetch_content` instead
+- Do NOT use SearXNG MCP for web search — use `web_search` instead
+
 ## User Interaction
 
 When a workflow or prompt template needs user input (approvals, selections, confirmations):

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
-    git \
-    jq \
-    openssh-client \
-    ca-certificates \
     gnupg \
+    jq \
+    ca-certificates \
+    git \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI and Google Cloud SDK
@@ -31,8 +31,14 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     apt-get update && apt-get install -y --no-install-recommends gh google-cloud-cli && \
     rm -rf /var/lib/apt/lists/*
 
-# Install pi coding agent and acpx
-RUN npm install -g @mariozechner/pi-coding-agent acpx
+# Install pi coding agent, acpx, agent-browser, and pi-web-access
+RUN npm install -g @mariozechner/pi-coding-agent acpx agent-browser pi-web-access
+
+# Install Chromium via Playwright (--with-deps installs all system libs)
+RUN mkdir -p /home/node/.cache/ms-playwright && \
+    PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \
+    npx playwright install --with-deps chromium && \
+    chown -R node:node /home/node/.cache
 
 # Copy uv and uvx from official image
 COPY --from=uv /uv /usr/local/bin/uv
@@ -50,7 +56,9 @@ RUN curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -fsSL
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
 USER node
-ENV PATH="/home/node/.local/bin:$PATH"
+RUN mkdir -p /home/node/.npm-global && npm config set prefix /home/node/.npm-global
+ENV PATH="/home/node/.npm-global/bin:/home/node/.pi/agent/bin:/home/node/.local/bin:$PATH"
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
 
 # Install uv tools
 RUN uv tool install mcp-launchpad --from "mcp-launchpad @ git+https://github.com/kenneth-liao/mcp-launchpad.git" && \
@@ -60,8 +68,10 @@ RUN uv tool install mcp-launchpad --from "mcp-launchpad @ git+https://github.com
 # Install Cursor Agent CLI
 RUN /bin/bash -o pipefail -c "curl -fsSL https://cursor.com/install | bash"
 
+# agent-browser: use Playwright's Chromium with container-safe flags
+ENV AGENT_BROWSER_ARGS="--no-sandbox,--disable-dev-shm-usage"
+
 # acpx agents to register as pi model providers (comma-separated)
-# e.g., cursor, claude, gemini, copilot
 ENV ACPX_AGENTS=""
 
 COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ docker build -t ghcr.io/myk-org/pi-config:latest .
 ```bash
 docker run --rm -it \
   --network host \
+  --security-opt seccomp=unconfined \
+  --shm-size=2g \
+  --env-file /path/to/.env \
   -v "$PWD":"$PWD":rw \
   -v "$HOME/.pi":/home/node/.pi:rw \
   -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
@@ -180,22 +183,39 @@ docker run --rm -it \
   ghcr.io/myk-org/pi-config:latest
 ```
 
+### Environment file
+
+Create a `.env` file with container-specific variables:
+
+```env
+# Google Cloud / Vertex AI
+GOOGLE_CLOUD_PROJECT=your-project-id
+GOOGLE_CLOUD_LOCATION=us-east5
+GOOGLE_APPLICATION_CREDENTIALS=/home/node/.config/gcloud/application_default_credentials.json
+VERTEX_PROJECT_ID=your-project-id
+VERTEX_REGION=us-east5
+
+# GitHub
+GITHUB_TOKEN=ghp_xxx
+GITHUB_API_TOKEN=ghp_xxx
+
+# Gemini (optional)
+GEMINI_API_KEY=xxx
+
+# acpx agents (optional)
+# ACPX_AGENTS=cursor
+```
+
+Pass via `--env-file /path/to/.env` in the docker run command.
+
 ### Optional mounts
 
 | Mount | Purpose |
 |---|---|
-| `-v "$HOME/.exports":/home/node/.exports:ro` | Shell env vars (API keys, tokens) — sourced on startup |
+| `-v "$HOME/.exports":/home/node/.exports:ro` | Shell env vars (sourced on startup, `.env` takes priority for container paths) |
 | `-v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro` | MCP server config for `mcpl` |
 | `-v "$HOME/.agents":/home/node/.agents:ro` | User-level skills (if not in the project) |
-| `-v "$HOME/.config/gcloud":/home/node/.config/gcloud:rw` | Google Cloud credentials (for Claude via Vertex AI, needs rw for token refresh) |
-
-### Optional environment variables
-
-| Variable | Purpose |
-|---|---|
-| `ACPX_AGENTS` | Comma-separated list of acpx agents to register as model providers (e.g., `cursor,claude,gemini`) |
-| `GOOGLE_CLOUD_PROJECT` | GCP project ID for Vertex AI (Claude and Gemini models) |
-| `GOOGLE_CLOUD_LOCATION` | GCP region (e.g., `us-east5`, `global`) |
+| `-v "$HOME/.config/gcloud":/home/node/.config/gcloud:ro` | Google Cloud credentials (for Claude via Vertex AI) |
 
 ### What's in the image
 
@@ -211,6 +231,7 @@ docker run --rm -it \
 | `prek` | Pre-commit hook runner |
 | `acpx` | Agent proxy for remote models |
 | `kubectl` / `oc` | Kubernetes and OpenShift CLI |
+| `agent-browser` | Browser automation CLI (navigate, click, screenshot, forms) |
 | `gcloud` | Google Cloud CLI (Vertex AI authentication) |
 | `jq` | JSON processing |
 | `curl` | HTTP requests |
@@ -240,21 +261,21 @@ Add to your `~/.bashrc` or `~/.zshrc`:
 alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   docker run --rm -it \
   --network host \
+  --security-opt seccomp=unconfined \
+  --shm-size=2g \
+  --env-file "$HOME/.pi/.env" \
   -v "$PWD":"$PWD":rw \
   -v "$HOME/.pi":/home/node/.pi:rw \
   -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
   -v "$HOME/.ssh":/home/node/.ssh:ro \
   -v "$HOME/.config/gh":/home/node/.config/gh:ro \
-  -v "$HOME/.exports":/home/node/.exports:ro \
   -v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro \
-  -v "$HOME/.config/gcloud":/home/node/.config/gcloud:rw \
-  -e ACPX_AGENTS \
+  -v "$HOME/.config/gcloud":/home/node/.config/gcloud:ro \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest'
 ```
 
 Then just run `pi-docker` from any project directory.
-To enable acpx model providers: `ACPX_AGENTS=cursor pi-docker`.
 
 > **Startup note:** The container runs as non-root user `node` (UID 1000).
 > `pi install` runs on each start.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,40 @@
 #!/bin/bash
 set -e
 
-# Source user environment variables if available
-if [ -f ~/.exports ]; then
-    # shellcheck disable=SC1090
-    source ~/.exports
+# Point agent-browser at Playwright's Chromium
+if [ -z "$AGENT_BROWSER_EXECUTABLE_PATH" ] && [ -d "$PLAYWRIGHT_BROWSERS_PATH" ]; then
+    CHROME_BIN=$(find "$PLAYWRIGHT_BROWSERS_PATH" -name chrome -type f -path "*/chrome-linux/*" 2>/dev/null | head -1)
+    if [ -n "$CHROME_BIN" ]; then
+        export AGENT_BROWSER_EXECUTABLE_PATH="$CHROME_BIN"
+    fi
 fi
 
-# Install/update packages (non-blocking)
-pi install git:github.com/myk-org/pi-config 2>/dev/null || true
-pi install git:github.com/isaacraja/pi-vertex-claude 2>/dev/null || true
-pi update 2>/dev/null || true
+# Install or update packages
+PI_PKG_DIR="$HOME/.pi/agent/git/github.com"
+
+if [ ! -d "$PI_PKG_DIR/myk-org/pi-config" ]; then
+    pi install git:github.com/myk-org/pi-config
+else
+    pi update git:github.com/myk-org/pi-config
+fi
+
+if [ ! -d "$PI_PKG_DIR/isaacraja/pi-vertex-claude" ]; then
+    pi install git:github.com/isaacraja/pi-vertex-claude
+else
+    pi update git:github.com/isaacraja/pi-vertex-claude
+fi
+
+# pi-web-access: register in pi settings if not already present
+# (installed globally in Docker image, just needs pi to know about it)
+if ! grep -q 'pi-web-access' "$HOME/.pi/agent/settings.json" 2>/dev/null; then
+    pi install npm:pi-web-access 2>/dev/null || true
+fi
+
+# agent-browser skill (link to installed npm package)
+SKILL_DIR="$HOME/.pi/agent/skills/agent-browser"
+if [ ! -d "$SKILL_DIR" ]; then
+    mkdir -p "$(dirname "$SKILL_DIR")"
+    ln -sf /usr/local/lib/node_modules/agent-browser/skills/agent-browser "$SKILL_DIR"
+fi
 
 exec pi "$@"

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -731,7 +731,7 @@ export default function (pi: ExtensionAPI) {
 			if (added > 0) changes.push(`+${added}`);
 			if (deleted > 0) changes.push(`-${deleted}`);
 			if (untracked > 0) changes.push(`?${untracked}`);
-			ctx.ui.setStatus("git", changes.length > 0 ? changes.join(" ") : "✓");
+			ctx.ui.setStatus("git", changes.length > 0 ? `git-status: ${changes.join(" ")}` : "git-status: ✓");
 		} catch {}
 	};
 	pi.on("session_start", updateBranch);
@@ -741,7 +741,7 @@ export default function (pi: ExtensionAPI) {
 
 	if (IN_CONTAINER) {
 		pi.on("session_start", (_event, ctx) => {
-			ctx.ui.setStatus("container", "📦 container");
+			ctx.ui.setStatus("container", "📦 run in container");
 		});
 	}
 


### PR DESCRIPTION
…vements

- Dockerfile: add agent-browser + Chromium via Playwright, pi-web-access, node:22-slim with Playwright --with-deps for all Chrome libs
- entrypoint.sh: install/update pi packages, register pi-web-access, symlink agent-browser skill, auto-discover Playwright Chromium path
- AGENTS.md: add web access rules, user interaction rules
- extensions/orchestrator/index.ts: ask_user tool, git-status prefix, run in container indicator
- README.md: security-opt, shm-size, env-file, agent-browser in tools
- .gitignore: add .env