### PR TITLE
fix: move config mounts out of ~/.config to avoid Chrome conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,11 @@ RUN uv tool install mcp-launchpad --from "mcp-launchpad @ git+https://github.com
 # Install Cursor Agent CLI
 RUN /bin/bash -o pipefail -c "curl -fsSL https://cursor.com/install | bash"
 
+# Cursor auth: symlink from default location to mount-safe path
+# (mounting dirs under ~/.config/ breaks Chrome, so cursor auth mounts to ~/.cursor/)
+RUN mkdir -p /home/node/.config/cursor /home/node/.cursor && \
+    ln -sf /home/node/.cursor/auth.json /home/node/.config/cursor/auth.json
+
 # agent-browser: use Playwright's Chromium with container-safe flags
 ENV AGENT_BROWSER_ARGS="--no-sandbox,--disable-dev-shm-usage"
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ docker run --rm -it \
   -v "$HOME/.pi":/home/node/.pi:rw \
   -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
   -v "$HOME/.ssh":/home/node/.ssh:ro \
-  -v "$HOME/.config/gh":/home/node/.config/gh:ro \
+  -v "$HOME/.config/gh":/home/node/.gh-config:ro \
+  -e GH_CONFIG_DIR=/home/node/.gh-config \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest
 ```
@@ -191,7 +192,7 @@ Create a `.env` file with container-specific variables:
 # Google Cloud / Vertex AI
 GOOGLE_CLOUD_PROJECT=your-project-id
 GOOGLE_CLOUD_LOCATION=us-east5
-GOOGLE_APPLICATION_CREDENTIALS=/home/node/.config/gcloud/application_default_credentials.json
+GOOGLE_APPLICATION_CREDENTIALS=/home/node/.gcloud-adc.json
 VERTEX_PROJECT_ID=your-project-id
 VERTEX_REGION=us-east5
 
@@ -212,10 +213,10 @@ Pass via `--env-file /path/to/.env` in the docker run command.
 
 | Mount | Purpose |
 |---|---|
-| `-v "$HOME/.exports":/home/node/.exports:ro` | Shell env vars (sourced on startup, `.env` takes priority for container paths) |
 | `-v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro` | MCP server config for `mcpl` |
 | `-v "$HOME/.agents":/home/node/.agents:ro` | User-level skills (if not in the project) |
-| `-v "$HOME/.config/gcloud":/home/node/.config/gcloud:ro` | Google Cloud credentials (for Claude via Vertex AI) |
+| `-v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro` | Google Cloud ADC (for Claude via Vertex AI) |
+| `-v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro` | Cursor CLI auth (for acpx cursor models) |
 
 ### What's in the image
 
@@ -268,9 +269,11 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.pi":/home/node/.pi:rw \
   -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
   -v "$HOME/.ssh":/home/node/.ssh:ro \
-  -v "$HOME/.config/gh":/home/node/.config/gh:ro \
+  -v "$HOME/.config/gh":/home/node/.gh-config:ro \
+  -e GH_CONFIG_DIR=/home/node/.gh-config \
   -v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro \
-  -v "$HOME/.config/gcloud":/home/node/.config/gcloud:ro \
+  -v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro \
+  -v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest'
 ```


### PR DESCRIPTION
Mounting directories under `/home/node/.config/` breaks Chrome/Playwright.

- **gh**: mount to `/home/node/.gh-config` + `GH_CONFIG_DIR` env var
- **gcloud**: mount single ADC file to `/home/node/.gcloud-adc.json`
- **cursor**: mount `auth.json` to `/home/node/.cursor/`, Dockerfile creates symlink from `~/.config/cursor/auth.json`