### PR TITLE
feat: add file preview rule and update network host docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,10 +247,12 @@ Pass via `--env-file /path/to/.env` in the docker run command.
 - ❌ System files — not accessible
 
 **Network** — `--network host` shares the host network stack,
-so the container can reach any service your host can (LAN, localhost).
-This is required for local MCP servers, LiteLLM proxy, etc.
-If your LLM provider is cloud-based and you don't use local MCPs,
-you can omit `--network host` for full network isolation.
+so the container can reach any service your host can (LAN, localhost),
+and the host can reach services started inside the container.
+This is required for local MCP servers, LiteLLM proxy, and file preview
+(agents serve generated HTML/frontend files via HTTP for browser access).
+If your LLM provider is cloud-based, you don't use local MCPs,
+and you don't need file preview, you can omit `--network host`.
 
 ### Shell alias
 

--- a/rules/45-file-preview.md
+++ b/rules/45-file-preview.md
@@ -1,0 +1,20 @@
+# File Preview (Container)
+
+When generating or modifying HTML, frontend, or any browser-viewable files inside a container:
+
+1. Save the file under the project directory (`$PWD`) or `/tmp/pi-work/`
+2. Serve it using:
+
+   ```bash
+   uv run python -m http.server <port> --directory <dir>
+   ```
+
+   Use port `8080` by default. If the port is in use, try `8081`, `8082`, etc.
+
+3. Tell the user:
+
+   > File is being served at `http://localhost:<port>/<filename>` — open this URL in your browser.
+
+4. Keep the server running until the user confirms they're done previewing.
+
+This works because the container uses `--network host`, so the host can reach services on any port.


### PR DESCRIPTION
- Add rules/45-file-preview.md — agents serve generated HTML/frontend files via `uv run python -m http.server` for browser preview from the host
- Update README network section to mention file preview alongside MCP servers as a reason for `--network host`

Closes #31