### PR TITLE
fix: ask_user free-text input crash — getText() → getValue()

### DIFF
--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -374,7 +374,7 @@ export default function (pi: ExtensionAPI) {
 							selectList.handleInput(data);
 						} else {
 							if (matchesKey(data, Key.enter)) {
-								const text = input.getText().trim();
+								const text = input.getValue().trim();
 								if (text) done(text);
 							} else if (matchesKey(data, Key.escape)) {
 								if (selectList) { mode = "select"; } else { done(null); }


### PR DESCRIPTION
Input component from @mariozechner/pi-tui uses `getValue()`, not `getText()`. Calling `getText()` threw `TypeError: input.getText is not a function` crashing pi completely when user selected the free-text input option and tried to type.

Closes #33