### PR TITLE
fix: re-port all prompt templates from Claude originals

### DIFF
--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -1,15 +1,17 @@
 ---
-description: "Run a prompt via acpx to any coding agent — /acpx-prompt <agent[:model]> [--fix|--peer] <prompt>"
+description: Run a prompt via acpx to any supported coding agent
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# acpx Multi-Agent Prompt Command
 
-Execute this workflow step by step. Run bash commands directly for CLI operations.
-Delegate code review/fix work to subagents as needed.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec issues,
+> `openclaw/acpx` for acpx CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Run a prompt through [acpx](https://github.com/openclaw/acpx) to any ACP-compatible coding agent.
 
 ## Supported Agents
 
@@ -30,112 +32,278 @@ Delegate code review/fix work to subagents as needed.
 | `opencode` | OpenCode |
 | `qwen` | Qwen Code |
 
-## Step 1: Prerequisites Check
+## Usage
 
-### 1a: Check acpx
+- `/acpx-prompt codex fix the tests`
+- `/acpx-prompt cursor review this code`
+- `/acpx-prompt gemini explain this function`
+- `/acpx-prompt codex:o3-pro review the architecture`
+- `/acpx-prompt codex --fix fix the code quality issues`
+- `/acpx-prompt codex:gpt-4o --fix fix the code quality issues`
+- `/acpx-prompt gemini --peer review this code`
+- `/acpx-prompt cursor:gpt-4o,claude:sonnet --peer review the architecture`
+- `/acpx-prompt cursor,codex review this code`
+- `/acpx-prompt cursor,gemini,codex --peer review the architecture`
+
+## Workflow
+
+### Step 1: Prerequisites Check
+
+#### 1a: Check acpx
 
 ```bash
 acpx --version
 ```
 
-If not found, ask the user:
-"acpx is not installed. Install globally with `npm install -g acpx@latest`? (yes/no)"
+If not found, ask the user via AskUserQuestion:
 
-If yes: run `npm install -g acpx@latest`, verify with `acpx --version`
-If no: abort
+"acpx is not installed. It provides structured access to multiple coding agents (Codex, Cursor, Gemini, etc.) via the Agent Client Protocol.
 
-### 1b: Verify Agent Prerequisite
+Install it now?"
 
-The underlying coding agent must be installed separately. acpx auto-downloads ACP adapters, but the agent itself must be available.
+Options:
 
-## Step 2: Parse Arguments
+- **Yes (Recommended)** — Install globally with `npm install -g acpx@latest`
+- **No** — Abort
 
-Parse `{{args}}` to extract:
+If user selects Yes, run:
 
-1. **First token** = agent specification (required): `agent[:model]` or comma-separated `agent1[:model1],agent2[:model2],...`
-   - If contains `:`, split on FIRST `:` only — left = agent name, right = model name
-   - Each agent name must be in the supported list above
-2. **Optional flags** after agent spec:
+```bash
+npm install -g acpx@latest
+```
+
+Verify installation:
+
+```bash
+acpx --version
+```
+
+If installation fails, display the error and abort.
+
+#### 1b: Verify Agent Prerequisite
+
+The underlying coding agent must be installed separately. acpx auto-downloads ACP adapters, but the agent itself (e.g., Codex CLI, Cursor CLI) must be available.
+
+### Step 2: Parse Arguments
+
+Parse `{{args}}` to extract the agent name(s) and prompt:
+
+1. The **first token** is the agent specification (required). Format:
+   `agent[:model]` or comma-separated `agent1[:model1],agent2[:model2],...`
+   Each agent name must be one of the supported agents listed above.
+   The optional `:model` suffix selects a specific model for that agent.
+2. After the agent specification, consume optional flags:
    - `--fix` — enable fix mode (agent can modify files)
    - `--peer` — enable peer review loop (AI-to-AI debate)
-3. **Everything after flags** = prompt text
+3. Everything after flags is the prompt text.
 
-**Validation:**
+**Agent:model parsing:**
 
-- `--fix` and `--peer` are mutually exclusive → abort if both present
-- Multiple agents + `--fix` are mutually exclusive → abort if both
-- Duplicate flags → abort
-- No agent name → abort with usage message
-- Unknown agent name → abort with supported list
-- No prompt → abort with usage message
+Split the first token by commas to get individual agent specs. For each spec:
 
-## Step 3: Session Management
+- If it contains `:`, split on the FIRST `:` only — left side is agent name,
+  right side is model name (model names may contain colons, e.g., `openai:gpt-4o`)
+- If no `:`, the agent name is the full spec and no model override is used
 
-For each agent, ensure a session exists:
+**Flag validation:**
+
+- `--fix` and `--peer` are **mutually exclusive**. If both are passed,
+  abort with: "`--fix` and `--peer` cannot be used together."
+- Multiple agents and `--fix` are **mutually exclusive**. If more than one
+  agent is specified with `--fix`, abort with:
+  "`--fix` can only be used with a single agent."
+- If `--fix` appears more than once, abort with: "Duplicate --fix flag."
+- If `--peer` appears more than once, abort with: "Duplicate --peer flag."
+
+If no agent name is provided, abort with:
+"No agent specified. Usage: `/acpx-prompt <agent[:model]>[,agent2[:model2],...] [--fix | --peer] <prompt>`
+
+Supported agents: pi, openclaw, codex, claude, gemini, cursor, copilot, droid, iflow, kilocode, kimi, kiro, opencode, qwen"
+
+If an agent name is not recognized, abort with:
+"Unknown agent: `<name>`. Each agent in a comma-separated list
+must be recognized. Supported agents: pi, openclaw, codex, claude,
+gemini, cursor, copilot, droid, iflow, kilocode, kimi, kiro,
+opencode, qwen"
+
+If no prompt is provided after the agent name, abort with:
+"No prompt provided. Usage: `/acpx-prompt <agent[:model]>[,agent2[:model2],...] [--fix | --peer] <prompt>`"
+
+### Step 3: Session Management
+
+Ensure a session exists for the current directory:
+
+**Multi-agent:** Run `sessions ensure` for each agent in the list.
 
 ```bash
 acpx <agent> sessions ensure
 ```
 
-If fails, try: `acpx <agent> sessions new`
+If this fails, try creating a new session:
 
-If both fail with "Invalid params" or session errors, show known issue links and abort.
+```bash
+acpx <agent> sessions new
+```
 
-## Step 4: Workspace Safety Check (--fix and --peer modes only)
+If session creation also fails, check the error output:
 
-Skip if neither `--fix` nor `--peer`.
+- If the error contains "Invalid params" or "session" and "not found", display:
+
+  "acpx session management failed for `<agent>`. This is a known issue — see:
+  - <https://github.com/openclaw/acpx/issues/152>
+  - <https://github.com/openclaw/acpx/issues/161>"
+
+  Display the error and abort.
+
+- For any other error, display the error and abort.
+
+### Step 4: Workspace Safety Check (--fix and --peer modes)
+
+**Skip this step if neither --fix nor --peer was passed.**
+
+Before running in fix or peer mode, inspect the workspace state.
 
 ```bash
 git rev-parse --is-inside-work-tree
 git status --short
 ```
 
-If not a git repo: ask "Continue without git? No easy rollback."
-If dirty worktree: ask user:
+Follow this decision process:
 
-- **Commit first (Recommended)** — `git add -A && git commit -m "chore: checkpoint before acpx changes"`
-- **Continue anyway** — proceed, remember worktree was dirty
-- **Abort** — stop
+1. If the current directory is not a Git repository, ask the user via
+   AskUserQuestion:
+   "This directory is not a Git repository. Continue anyway?
+   I won't be able to show a git diff or provide an easy rollback point."
+2. If the current directory is a Git repository and `git status --short`
+   shows any output (modified, staged, or untracked files), ask the user via
+   AskUserQuestion with the following options (in this order):
+   - **Commit first (Recommended)** — Create a checkpoint commit of the
+     current changes before proceeding, so the agent's changes are
+     cleanly isolated
+   - **Continue anyway** — Proceed despite uncommitted changes; the final
+     diff summary may include pre-existing edits
+   - **Abort** — Stop here to handle changes manually
+3. Handle the response:
+   - **Commit first**: Stage all changes with `git add -A` and create a
+     checkpoint commit with the message `chore: checkpoint before acpx changes`.
+     After the commit, verify with `git status --porcelain -z` that the
+     output is empty (workspace is clean) before proceeding. If the commit
+     fails or the workspace is still dirty, display the raw output and abort.
+   - **Continue anyway**: Proceed and remember the workspace was dirty.
+   - **Abort**: Stop immediately.
+4. If the user declines the non-git prompt from step 1, abort.
+5. If proceeding despite a dirty worktree (via **Continue anyway**),
+   remember that state so Steps 7-8 (`--fix`) or Step 9e (`--peer`)
+   can warn that diffs may include pre-existing edits.
 
-## Step 5: Run Prompt
+### Step 5: Run Prompt
 
-**If `--peer` was passed, skip Steps 5-8 and jump to Step 9.**
+**If `--peer` was passed, skip Steps 5-8 and jump to Step 9 (Peer Review Loop).**
 
-Build the acpx command:
+Build and execute the acpx command.
 
-**Model handling:** If agent spec includes `:model`, pass `--model <model>`.
+**Model handling:** If the agent spec includes a `:model` suffix (e.g., `codex:gpt-4o`),
+pass it to acpx with `--model <model>`. Otherwise, omit the `--model` flag.
 
 **Fix mode:**
 
 ```bash
-acpx --approve-all <agent> '<prompt> You have full permission to modify, create, and delete files as needed.'
+acpx --approve-all <agent> '<prompt>'
+acpx --approve-all <agent> --model <model> '<prompt>'
 ```
 
-**Read-only (default):**
+**Read-only prompt guard (non-fix mode):**
+
+When `--fix` is NOT passed, append to the user's prompt:
+
+```text
+IMPORTANT: This is a read-only request. Do NOT modify, create, or
+delete any files. Report your findings only.
+```
+
+In fix mode, append to the user's prompt:
+
+```text
+You have full permission to modify, create, and delete files as needed.
+Make all necessary changes directly.
+```
+
+**Session mode (persistent, default):**
 
 ```bash
-acpx --approve-reads --non-interactive-permissions fail <agent> '<prompt> IMPORTANT: This is a read-only request. Do NOT modify any files. Report findings only.'
+acpx --approve-reads --non-interactive-permissions fail <agent> '<prompt>'
+acpx --approve-reads --non-interactive-permissions fail <agent> --model <model> '<prompt>'
 ```
 
-**Multi-agent (without --peer):** Run all agents in parallel. Display results grouped by agent.
+**Permissions summary:**
 
-**Shell safety:** Single-quote the prompt. Replace single quotes with `'\''`.
+| Mode | Flag | Description |
+|------|------|-------------|
+| Default | `--approve-reads --non-interactive-permissions fail` | Agent can read files only, writes blocked |
+| Fix (`--fix`) | `--approve-all` | Agent can read and write files |
 
-**Error handling:** If permission failure (write denied), retry once with stricter instruction. If retry also fails, display error and abort.
+**Multi-agent execution:**
 
-## Step 6: Display Result
+When multiple agents are specified (without `--peer`), run all agents **in parallel**:
 
-Show output from acpx. After successful execution:
+- Send the same prompt to each agent simultaneously
+- Each agent uses its own model override if specified via `:model`
+- Collect results from all agents
+- Display results grouped by agent:
+
+```text
+## Results from <agent1>:
+<agent1 output>
+
+## Results from <agent2>:
+<agent2 output>
+```
+
+**Shell safety:** Single-quote the prompt to prevent shell expansion. Replace any single quotes in the prompt with `'\''` before interpolation.
+
+**Error handling:**
+
+If the command exits with a non-zero code:
+
+- If the error indicates a **permission failure** (write denied, permission
+  rejected, or similar), this means the agent attempted to modify files
+  without `--fix` mode. Retry the prompt once with a stricter instruction
+  appended:
+
+  ```text
+  CRITICAL: You are NOT allowed to modify any files. Your previous
+  attempt was blocked because you tried to write files. This is a
+  read-only review. Report findings as text only. Do NOT use any
+  file modification tools.
+  ```
+
+  If the retry also fails with a permission error, display the error
+  and abort.
+
+- For any other error, display the raw output as an error.
+
+### Step 6: Display Result
+
+Display the output from acpx to the user. acpx formats output as a readable stream with tool updates by default.
+
+After successful execution, display:
 
 ```text
 Agent: <agent>
 Mode: [session | fix]
+```
+
+If in session mode, also show:
+
+```text
 Session active. Send follow-up prompts with: /acpx-prompt <agent[:model]> <follow-up>
 ```
 
-## Step 7: Read Diff (--fix mode only)
+### Step 7: Read Diff (--fix mode only)
 
-Skip if not `--fix` or if command failed.
+**Skip this step if --fix was NOT passed or if the command failed.**
+
+After the agent completes in fix mode, inspect what changed:
 
 ```bash
 git status --short
@@ -145,98 +313,278 @@ git diff --cached --stat
 git diff --cached
 ```
 
-Report which files were modified/created/deleted and a summary of changes.
-If workspace was dirty before, note that diff may include pre-existing edits.
+If the diff is too large (over ~200 lines), use `--stat` summary only.
 
-## Step 8: Summary (--fix mode only)
+If the workspace was already dirty before running, note that the diff
+may include pre-existing edits.
+
+Report to the user:
+
+- Which files were modified/created/deleted
+- A summary of the changes
+- Verify suggestion: what command to run to confirm changes work
+
+### Step 8: Summary (--fix mode only)
+
+**Skip this step if --fix was NOT passed or if the command failed.**
+
+Present a clear summary:
 
 1. **Files changed** — List each file with what was modified
-2. **What was done** — Brief description
+2. **What was done** — Brief description in plain language
 3. **Impact** — Behavioral changes, new dependencies, verification steps
 
-## Step 9: Peer Review Loop (--peer mode only)
+### Step 9: Peer Review Loop (--peer mode only)
 
-Skip if `--peer` was NOT passed.
+**Skip this step if --peer was NOT passed.**
 
-### 9a: Initial Agent Review
+Claude orchestrates an AI-to-AI debate loop with the target agent(s) until
+all participants agree on the code. When multiple agents are specified,
+each agent reviews independently in parallel, and Claude evaluates the
+merged findings.
 
-Check if `AGENTS.md` (or `CLAUDE.md`) exists in the project. Send peer framing prompt:
+**CRITICAL RULE: Only the peer agent(s) can end the loop.** Claude fixing
+code does NOT count as convergence. After EVERY fix round, Claude MUST
+send the fixes back to the peer agent(s) (Step 9c) for re-review. The loop
+ends ONLY when each peer agent confirms no remaining issues. With multiple
+peers, ALL peer agents must agree before the loop exits.
+
+#### 9a: Initial Agent Review
+
+Initialize a round counter at 1. Use the current counter value in the Step 9c
+response template (`Round {N}`), then increment the counter after sending.
+
+Before sending the peer framing prompt, check if `AGENTS.md` exists
+in the project. If it does, include the AGENTS.md convention block
+in the framing prompt. If `AGENTS.md` does not exist, omit that
+block from the prompt.
+
+Send the first prompt to the agent with peer review framing:
+
+**If `AGENTS.md` exists:**
 
 ```text
-IMPORTANT FRAMING: You are participating in a peer-to-peer AI code review. The other participant is another AI. This is NOT a human interaction. Do NOT be agreeable or sycophantic. Hold your position when you have valid technical reasoning. Push back when you disagree. Only concede when the other AI provides a genuinely better technical argument.
+IMPORTANT FRAMING: You are participating in a peer-to-peer AI code
+review. The other participant is another AI (Claude). This is NOT a
+human interaction. Do NOT be agreeable or sycophantic. Hold your
+position when you have valid technical reasoning. Push back when you
+disagree. Only concede a point when the other AI provides a genuinely
+better technical argument.
 
-[If AGENTS.md/CLAUDE.md exists:]
-IMPORTANT: This project has an AGENTS.md/CLAUDE.md file with coding conventions. Read it before reviewing. Flag any violations.
+IMPORTANT: This project has a AGENTS.md file with coding conventions
+and project guidelines. Read it before reviewing. Flag any violations
+of those conventions as findings.
 
-Your role: Review the code and report findings. Be direct, specific, and technically rigorous.
+Your role: Review the code and report findings. Be direct, specific,
+and technically rigorous. For each finding, explain WHY it matters and
+provide a concrete fix or suggestion.
 
 Original prompt: <user's prompt>
 ```
 
-Execute:
+**If `AGENTS.md` does NOT exist:**
+
+```text
+IMPORTANT FRAMING: You are participating in a peer-to-peer AI code
+review. The other participant is another AI (Claude). This is NOT a
+human interaction. Do NOT be agreeable or sycophantic. Hold your
+position when you have valid technical reasoning. Push back when you
+disagree. Only concede a point when the other AI provides a genuinely
+better technical argument.
+
+Your role: Review the code and report findings. Be direct, specific,
+and technically rigorous. For each finding, explain WHY it matters and
+provide a concrete fix or suggestion.
+
+Original prompt: <user's prompt>
+```
+
+Execute via acpx:
 
 ```bash
 acpx --approve-reads --non-interactive-permissions fail <agent> '<peer_framing_prompt>'
+acpx --approve-reads --non-interactive-permissions fail <agent> --model <model> '<peer_framing_prompt>'
 ```
 
-Multi-agent: Send to ALL agents in parallel. Merge findings, deduplicating same issues.
+Do NOT display intermediate results to the user.
+If the command fails, abort the peer loop and report the error.
+
+**Multi-agent:** Send the peer framing prompt to ALL agents in parallel.
+Collect and merge findings from all agents, deduplicating where the same
+issue is raised by multiple agents.
+
+**Multi-agent group context:** In the first round, each agent reviews
+independently (no group context yet). Their individual responses are
+collected for use in subsequent rounds.
 
 If ALL agents report no findings, skip to Step 9e.
+If only SOME agents report no findings, continue to Step 9b with the findings
+from agents that did report issues. Agents that reported no findings still
+participate in subsequent rounds via GROUP CONTEXT.
 
-### 9b: Act on Findings
+#### 9b: Claude Acts on Findings
 
-For each finding:
+For each finding from the agent(s):
 
-1. **If agree** — Fix by delegating to the appropriate specialist subagent
-2. **If disagree** — Prepare technical counter-argument with specific reasoning
+1. **Evaluate the finding** — Does Claude agree it's a valid issue?
+2. **If Claude agrees** — Fix the code by delegating to the
+   appropriate specialist agent (follow the normal agent routing rules).
+3. **If Claude disagrees** — Prepare a technical counter-argument
+   explaining WHY the finding is not valid, not applicable, or would
+   cause other issues.
 
-### 9c: Respond to Agent
+**Rules for disagreement:**
 
-Send response back:
+- Claude MUST provide specific technical reasoning, not just "I disagree"
+- Reference the actual code, explain trade-offs, cite patterns or conventions
+- If the project has established conventions (AGENTS.md, etc.) that
+  support Claude's position, cite them explicitly
+- Claude should be open to changing its mind if the agent makes a good
+  point in the next round
+
+**Multi-agent:** Merge and deduplicate findings from all agents. When the
+same issue is raised by multiple agents, keep the most actionable version
+and note which agents flagged it.
+
+**After completing all fixes and counter-arguments, proceed to Step 9c.
+This is MANDATORY — do NOT skip to the summary.**
+
+#### 9c: Claude Responds to Agent
+
+After acting on all findings, send a response back to the agent:
 
 ```text
 PEER REVIEW RESPONSE — Round {N}
 
+IMPORTANT FRAMING: You are in an ongoing peer-to-peer AI code review
+with another AI (Claude). This is NOT a human interaction. Do NOT back
+down from valid technical positions just to be agreeable.
+
+Here is what I (Claude) did with your findings:
+
 ADDRESSED:
-{For each: "- Finding: {summary} → Fixed: {what was done}"}
+{For each addressed finding:
+  "- Finding: {summary} → Fixed: {what was done}"}
 
 NOT ADDRESSED (with reasoning):
-{For each: "- Finding: {summary} → Disagreed: {technical reason}"}
+{For each disagreement:
+  "- Finding: {summary} → Disagreed: {technical reason}"}
 
-Re-review the code. Focus on:
-1. Verify addressed findings were fixed correctly
-2. Re-evaluate disagreements
-3. Report any NEW issues
+Please re-review the code. Focus on:
+1. Verify that addressed findings were fixed correctly
+2. Re-evaluate your positions on the disagreements
+3. Report any NEW issues you find in the updated code.
 ```
 
-Multi-agent: Each peer's response includes GROUP CONTEXT showing what all other peers said.
+**Multi-agent group context:** When multiple peers are involved, each
+peer's response MUST include what ALL other peers said. Append a
+"GROUP CONTEXT" section to the response for each peer:
 
-### 9d: Loop Until Convergence
+```text
+GROUP CONTEXT — What other peers said in Round {N}:
 
-- **No findings and no disagreements** from ALL agents → exit loop
-- **New findings or continued disagreements** → go to Step 9b
-- If disagreement persists 3+ rounds on same point, note as "unresolved"
+{For each OTHER peer (not the recipient):
+  "## {peer_name} (model: {model}) findings:
+  {summary of that peer's findings and positions}
+  "}
 
-What does NOT count as convergence: Claude fixing all findings (fixes must be verified by agent).
+Always include the model when the agent was invoked with a `:model` override.
+If no model was specified, omit the model parenthetical (e.g., `## cursor findings:`).
+```
 
-### 9e: Summary to User
+This enables a true group conversation where every peer has full
+visibility into the discussion. Each peer can agree, disagree, or
+build on other peers' findings.
+
+When sending to peer A, include findings from peers B, C, etc.
+When sending to peer B, include findings from peers A, C, etc.
+
+Execute via acpx (same command pattern). Do NOT display intermediate results.
+
+**Multi-agent:** Send the response to ALL agents in parallel. Each agent
+re-reviews independently.
+
+#### 9d: Loop Until Convergence
+
+Parse each agent's response:
+
+- **No findings and no remaining disagreements** — All AIs agree. Exit loop.
+- **New findings or continued disagreements** — Go to Step 9b.
+
+**Convergence criteria (checked ONLY from each peer agent's response in Step 9c):**
+
+- All agents explicitly state no remaining issues, OR
+- All agents' responses contain no actionable findings (only acknowledgments)
+
+**What does NOT count as convergence:**
+
+- Claude fixing all findings (fixes must be verified by the agent)
+- Claude agreeing with all findings (the agent must confirm the fixes are correct)
+- A single round completing (minimum: agent reviews → Claude fixes → agent re-reviews)
+
+**Multi-agent convergence:** When multiple peers are involved, convergence
+requires ALL peers to independently confirm no remaining issues. If peer A
+agrees but peer B still has findings, the loop continues. A single peer
+cannot end the loop for the group.
+
+**Claude's behavior across rounds:**
+
+- Claude SHOULD change its mind when a peer agent provides a better argument
+- Claude SHOULD NOT stubbornly hold a position just to "win"
+- If a disagreement persists for 3+ rounds on the same point, note it as
+  "unresolved disagreement" and move on
+
+#### 9e: Summary to User
+
+After the loop exits, present a comprehensive summary:
 
 ```text
 ## Peer Review Complete — {N} round(s)
 
+Agent(s): <agent>[, <agent2>, ...]
+
 ### Findings Addressed ({count})
+
 | # | File | Line | Finding | Fix Applied |
+|---|------|------|---------|-------------|
+| 1 | src/foo.py | 42 | Missing null check | Added guard clause |
 
 ### Agreements Reached After Debate ({count})
+
 | # | File | Finding | Rounds | Resolution |
+|---|------|---------|--------|------------|
+| 1 | src/baz.py | Error swallowing | 2 | Claude conceded, added logging |
 
 ### Unresolved Disagreements ({count})
-| # | File | Finding | My Position | Agent(s) Position |
+
+| # | File | Finding | Claude's Position | Agent(s) Position |
+|---|------|---------|-------------------|------------------|
+| 1 | src/qux.py | Naming convention | Follows project style | Prefers stdlib convention |
 
 ### No Changes Needed ({count})
+
+Items where the agent initially flagged but later agreed no change was needed.
 ```
 
-Multi-agent: Add Group Dynamics table.
+**Summary rules:**
 
-If code was changed: "Next steps: Run tests and the standard review workflow before committing."
-If workspace was dirty before: note that diffs may include pre-existing edits.
+- **Always use tables** — consistent format
+- **Show both sides** for unresolved disagreements
+- **Include round count** for debated items
+- **Next steps reminder** — If any code was changed, end with:
+  "Next steps: Run tests and the standard review workflow before committing."
+- **Dirty worktree warning** — If the workspace was already dirty before
+  the peer review, note: "Workspace had pre-existing changes; resulting
+  diffs may include edits not made during this peer review."
+
+**Multi-agent group summary:** When multiple peers participated, add a
+section showing the group dynamics:
+
+```text
+### Group Dynamics
+
+| Finding | Raised By | Agreed By | Resolution |
+|---------|-----------|-----------|------------|
+| Missing null check | cursor | claude, codex | All agreed, fixed |
+| Naming convention | codex | — | Only codex flagged, Claude disagreed, codex conceded |
+```

--- a/prompts/coderabbit-rate-limit.md
+++ b/prompts/coderabbit-rate-limit.md
@@ -1,14 +1,16 @@
 ---
-description: "Handle CodeRabbit rate limits — wait and re-trigger automatically — /coderabbit-rate-limit [PR_NUMBER|PR_URL]"
+description: Handle CodeRabbit rate limits - waits and re-triggers review automatically
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# CodeRabbit Rate Limit Handler
 
-Execute this workflow step by step. Run bash commands directly.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Automatically handles CodeRabbit rate limits by waiting for the cooldown period and re-triggering the review.
 
 ## Prerequisites Check (MANDATORY)
 
@@ -18,7 +20,7 @@ Execute this workflow step by step. Run bash commands directly.
 uv --version
 ```
 
-If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
+If not found, install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -26,9 +28,17 @@ If not found, stop — install from <https://docs.astral.sh/uv/getting-started/i
 myk-pi-tools --version
 ```
 
-If not found, ask user to install: `uv tool install myk-pi-tools`
+If not found, prompt to install: `uv tool install myk-pi-tools`
 
-## Phase 1: Detect PR
+## Usage
+
+- `/coderabbit-rate-limit` - Handle rate limit on current branch's PR
+- `/coderabbit-rate-limit 123` - Handle rate limit on PR #123
+- `/coderabbit-rate-limit https://github.com/owner/repo/pull/123` - Handle rate limit via URL
+
+## Workflow
+
+### Phase 1: Detect PR
 
 If `{{args}}` contains a URL, extract owner/repo and PR number from it.
 
@@ -45,20 +55,20 @@ gh pr view --json number,url -q '.number'
 gh repo view --json nameWithOwner -q .nameWithOwner
 ```
 
-## Phase 2: Check Rate Limit
+### Phase 2: Check Rate Limit
 
 ```bash
 myk-pi-tools coderabbit check <owner/repo> <pr_number>
 ```
 
-Parse the JSON result:
+This outputs JSON to stdout. Parse the result:
 
 - If `rate_limited` is `false` — notify user "Not rate limited" and exit
 - If `rate_limited` is `true` — read `wait_seconds` and proceed to Phase 3
 
-## Phase 3: Wait and Trigger Review
+### Phase 3: Wait and Trigger Review
 
-Add a 30-second buffer to the wait time and run the trigger command:
+Add a 30-second buffer to the wait time and run the trigger command in background:
 
 ```bash
 myk-pi-tools coderabbit trigger <owner/repo> <pr_number> --wait <wait_seconds + 30>
@@ -70,9 +80,9 @@ This command will:
 2. Post `@coderabbitai review` to re-trigger the review
 3. Poll every 60s (max 10 min) until the review starts
 
-## Phase 4: Notify User
+### Phase 4: Notify User
 
 Based on the exit code of the trigger command:
 
-- **Exit 0** — Report success: "CodeRabbit review started on PR #N"
-- **Exit 1** — Report the error message from stderr
+- **Exit 0** — Report success to user ("CodeRabbit review started on PR #N")
+- **Exit 1** — Report the error message from stderr to the user

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -1,16 +1,20 @@
 ---
-description: "Review a GitHub PR and post inline comments — /pr-review [PR_NUMBER|PR_URL]"
+description: Review a GitHub PR and post inline comments on selected findings
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# GitHub PR Review Command
 
-Execute this workflow step by step. Run bash commands directly — do NOT delegate to subagents for CLI commands.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Reviews a GitHub PR and posts inline review comments on selected findings.
 
 ## Prerequisites Check (MANDATORY)
+
+Before starting, verify the tools are available:
 
 ### Step 0: Check uv
 
@@ -18,7 +22,7 @@ Execute this workflow step by step. Run bash commands directly — do NOT delega
 uv --version
 ```
 
-If not found, stop and tell the user to install from <https://docs.astral.sh/uv/getting-started/installation/>
+If not found, install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -26,109 +30,131 @@ If not found, stop and tell the user to install from <https://docs.astral.sh/uv/
 myk-pi-tools --version
 ```
 
-If not found, ask the user: "myk-pi-tools is required. Install with: `uv tool install myk-pi-tools`. Install now?"
+If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool install myk-pi-tools`. Install now?"
 
 - Yes: Run `uv tool install myk-pi-tools`
-- No: Abort
+- No: Abort with instructions
 
-## Phase 0: PR Detection
+### Step 2: Continue with workflow
 
-If `{{args}}` is empty — auto-detect from current branch:
+## Usage
+
+- `/pr-review` - Review PR from current branch (auto-detect)
+- `/pr-review 123` - Review PR #123 in current repo
+- `/pr-review https://github.com/owner/repo/pull/123` - Review from URL
+
+## Workflow
+
+### Phase 0: PR Detection (when no arguments provided)
+
+If `{{args}}` is empty:
+
+1. Detect PR from current branch:
+
+   ```bash
+   gh pr view --json number,headRefOid
+   ```
+
+2. Get base repository context (where PR targets):
+
+   The base repository (where the PR is opened) is determined by the current working directory context.
+   When you run `gh pr view` from a cloned repository, it operates in that repository's context.
+
+   To get `owner` and `repo`:
+
+   ```bash
+   gh repo view --json owner,name
+   ```
+
+   This returns the base repository information regardless of whether the PR comes from a fork.
+
+   **Note:** `baseRepository` is NOT available in `gh pr view --json`. For fork PRs, `headRepository` would incorrectly point to the fork, not the target repository.
+
+3. Extract and store:
+
+   - `pr_number` from the PR JSON response
+   - `owner` from `gh repo view` → `owner.login`
+   - `repo` from `gh repo view` → `name`
+   - `head_sha` from `headRefOid`
+
+4. Use `{pr_number}` for subsequent CLI commands
+
+If `{{args}}` contains a PR number or URL, use it directly.
+
+### Phase 1a: Data Fetching
+
+Run the diff command to get PR data:
+
+If PR was auto-detected (no arguments):
 
 ```bash
-gh pr view --json number,headRefOid -q '.'
+myk-pi-tools pr diff {pr_number}
 ```
 
-Extract `pr_number` and `head_sha` (headRefOid).
-
-Then get the base repository:
+Otherwise:
 
 ```bash
-gh repo view --json owner,name -q '.'
-```
-
-Extract `owner` (owner.login) and `repo` (name).
-
-If `{{args}}` contains a URL — extract owner/repo/number from it. Get head SHA:
-
-```bash
-gh pr view <number> --repo <owner>/<repo> --json headRefOid -q '.headRefOid'
-```
-
-If `{{args}}` is a number — use it as pr_number, detect repo with `gh repo view`, get head SHA.
-
-## Phase 1a: Fetch Diff
-
-```bash
-myk-pi-tools pr diff <pr_number_or_url>
+myk-pi-tools pr diff {{args}}
 ```
 
 Store the JSON output containing metadata, diff, and files.
 
-## Phase 1b: Fetch CLAUDE.md / AGENTS.md
+### Phase 1b: Fetch AGENTS.md
+
+Run the claude-md command to get project rules:
+
+If PR was auto-detected (no arguments):
 
 ```bash
-myk-pi-tools pr claude-md <pr_number_or_url>
+myk-pi-tools pr claude-md {pr_number}
 ```
 
-Store the output as project guidelines context.
+Otherwise:
 
-## Phase 2: Code Analysis
+```bash
+myk-pi-tools pr claude-md {{args}}
+```
 
-Use the subagent tool to run ALL 3 review agents IN PARALLEL (using the `tasks` array):
+Store the output as `claude_md_content`.
 
-1. **code-reviewer-quality** — General code quality and maintainability
-2. **code-reviewer-guidelines** — Project guidelines and style adherence (pass the CLAUDE.md/AGENTS.md content)
-3. **code-reviewer-security** — Bugs, logic errors, and security vulnerabilities
+### Phase 2: Code Analysis
 
-Pass each agent the full diff content from Phase 1a and the guidelines from Phase 1b.
+Delegate to ALL 3 review agents IN PARALLEL (single message with 3 Task tool calls):
 
-After all 3 finish, merge and deduplicate findings:
+- `superpowers:code-reviewer` - General code quality and maintainability
+- `pr-review-toolkit:code-reviewer` - Project guidelines and style adherence
+- `feature-dev:code-reviewer` - Bugs, logic errors, and security vulnerabilities
 
-- Same file/line range + same issue type = duplicate → keep most actionable
-- Conflicting suggestions → priority: security > correctness > performance > style
-- Complementary findings (different issue types) → keep both
+Provide each agent with:
 
-**Deduplication Criteria:**
+- The diff content from Phase 1a
+- The AGENTS.md content from Phase 1b (or "No AGENTS.md found" if empty)
 
-- Same file/line range + same issue type or root cause = duplicate. Keep the most actionable version.
-- Conflicting suggestions = follow priority order: security > correctness > performance > style. If still ambiguous, escalate to the user.
-- Complementary findings on the same code (different issue types) = keep both.
+Each agent should analyze for security, bugs, error handling, and performance issues and return their findings as prose.
+Merge and deduplicate the findings from all 3 reviewers before proceeding.
 
-## Phase 3: User Selection
+### Phase 3: User Selection
 
-Present findings grouped by severity (CRITICAL, WARNING, SUGGESTION), numbered.
+Present findings to user grouped by severity (CRITICAL, WARNING, SUGGESTION). Ask which to post:
 
-Ask the user which to post:
+- 'all' = Post all
+- 'none' = Skip posting
+- Specific numbers = Post only those
 
-- `all` = Post all findings
-- `none` = Skip posting
-- Specific numbers (e.g., `1,3,5`) = Post only those
+### Phase 4: Post Comments
 
-## Phase 4: Post Comments
-
-If user selected findings, create the JSON comment file:
+If user selected findings, create temp directory and write JSON to temp file:
 
 ```bash
 mkdir -p /tmp/pi-work
 ```
 
-Write a JSON array to `/tmp/pi-work/pr-review-comments.json` with format:
-
-```json
-[{"path": "file.py", "line": 42, "body": "Comment text"}]
-```
-
-Post using the owner, repo, pr_number, and head_sha from Phase 0/1a:
+Use the `owner`, `repo`, `pr_number`, and `head_sha` from Phase 0 or Phase 1a metadata:
 
 ```bash
-myk-pi-tools pr post-comment <owner>/<repo> <pr_number> <head_sha> /tmp/pi-work/pr-review-comments.json
+myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} /tmp/pi-work/pr-review-comments.json
 ```
 
-## Phase 5: Summary
+### Phase 5: Summary
 
-Display final summary:
-
-- Number of findings by severity
-- Number of comments posted
-- PR URL for reference
+Display final summary with counts and links.

--- a/prompts/query-db.md
+++ b/prompts/query-db.md
@@ -1,14 +1,16 @@
 ---
-description: "Query the reviews database for analytics — /query-db [stats|patterns|dismissed|query|find-similar] [OPTIONS]"
+description: Query the reviews database for analytics and insights
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# Review Database Query Command
 
-Execute this workflow step by step. Run bash commands directly.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Query the reviews database for analytics and insights about PR review history.
 
 ## Prerequisites Check (MANDATORY)
 
@@ -18,7 +20,7 @@ Execute this workflow step by step. Run bash commands directly.
 uv --version
 ```
 
-If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
+If not found, install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -26,13 +28,24 @@ If not found, stop — install from <https://docs.astral.sh/uv/getting-started/i
 myk-pi-tools --version
 ```
 
-If not found, ask user to install: `uv tool install myk-pi-tools`
+If not found, prompt to install: `uv tool install myk-pi-tools`
+
+## Usage
+
+```bash
+/query-db stats --by-source        # Stats by source
+/query-db stats --by-reviewer      # Stats by reviewer
+/query-db patterns --min 2         # Find duplicate patterns
+/query-db dismissed --owner X --repo Y
+/query-db query "SELECT * FROM comments WHERE status='skipped' LIMIT 10"
+/query-db find-similar < comments.json   # Find similar dismissed comments
+```
 
 ## Available Queries
 
-Parse `{{args}}` and run the appropriate command:
-
 ### Stats by Source
+
+Show addressed rate by source (human vs AI reviewers):
 
 ```bash
 myk-pi-tools db stats --by-source
@@ -40,11 +53,15 @@ myk-pi-tools db stats --by-source
 
 ### Stats by Reviewer
 
+Show statistics by individual reviewer:
+
 ```bash
 myk-pi-tools db stats --by-reviewer
 ```
 
 ### Duplicate Patterns
+
+Find recurring dismissed suggestions:
 
 ```bash
 myk-pi-tools db patterns --min 2
@@ -52,11 +69,15 @@ myk-pi-tools db patterns --min 2
 
 ### Dismissed Comments
 
+Get all dismissed comments for a specific repo:
+
 ```bash
 myk-pi-tools db dismissed --owner <owner> --repo <repo>
 ```
 
 ### Custom Query
+
+Run a custom SELECT query:
 
 ```bash
 myk-pi-tools db query "SELECT * FROM comments WHERE status = 'skipped' ORDER BY id DESC LIMIT 10"
@@ -64,22 +85,63 @@ myk-pi-tools db query "SELECT * FROM comments WHERE status = 'skipped' ORDER BY 
 
 ### Find Similar Comments
 
+Find comments similar to previously dismissed ones. Accepts JSON input via stdin:
+
 ```bash
 echo '[{"body": "Consider adding error handling", "path": "src/main.py"}]' | myk-pi-tools db find-similar
 ```
 
-## Database Schema Reference
+Input format: JSON array of objects with `body` (required) and optionally `path` fields.
 
-**reviews table:** id, pr_number, owner, repo, commit_sha, created_at
+Returns matches with similarity scores to help identify recurring patterns that were previously dismissed.
 
-**comments table:** id, review_id (FK), source (human/qodo/coderabbit), thread_id, node_id, comment_id, author, path, line, body,
-priority (HIGH/MEDIUM/LOW), status (pending/addressed/skipped/not_addressed), reply, skip_reason, posted_at, resolved_at
+## Database Schema
 
-**Constraints:** Only SELECT statements and CTEs are allowed. INSERT/UPDATE/DELETE/DROP are blocked.
+**reviews table:**
+
+| Column | Type |
+|--------|------|
+| id | INTEGER PRIMARY KEY |
+| pr_number | INTEGER |
+| owner | TEXT |
+| repo | TEXT |
+| commit_sha | TEXT |
+| created_at | TEXT (ISO 8601) |
+
+**comments table:**
+
+| Column | Type |
+|--------|------|
+| id | INTEGER PRIMARY KEY |
+| review_id | INTEGER (FK -> reviews.id) |
+| source | TEXT (human/qodo/coderabbit) |
+| thread_id | TEXT |
+| node_id | TEXT |
+| comment_id | INTEGER |
+| author | TEXT |
+| path | TEXT |
+| line | INTEGER |
+| body | TEXT |
+| priority | TEXT (HIGH/MEDIUM/LOW) |
+| status | TEXT (pending/addressed/skipped/not_addressed) |
+| reply | TEXT |
+| skip_reason | TEXT |
+| posted_at | TEXT (ISO 8601) |
+| resolved_at | TEXT (ISO 8601) |
+
+## Database Location and Constraints
+
+The reviews database is located at `<project-root>/.claude/data/reviews.db`.
+
+**Query Constraints:**
+
+- Only SELECT statements and CTEs (Common Table Expressions) are allowed
+- INSERT, UPDATE, DELETE, DROP, and other modifying statements are blocked
+- This ensures the database remains read-only for analytics queries
 
 ## Workflow
 
-1. Parse `{{args}}` to determine which query to run
-2. Execute the appropriate `myk-pi-tools db` command
+1. Parse {{args}} to determine which query to run
+2. Execute the appropriate myk-pi-tools db command
 3. Present results in a clear, formatted way
-4. For natural language questions, compose the appropriate SQL query
+4. For natural language questions, compose the appropriate query

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -1,14 +1,16 @@
 ---
-description: "Refine pending PR review comments before submitting — /refine-review <PR_URL>"
+description: Refine pending PR review comments with AI before submitting
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# Refine Pending Review Command
 
-Execute this workflow step by step. Run bash commands directly.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Refines the user's pending GitHub PR review comments using AI before submitting. The user starts a review on GitHub, adds comments, then calls this command to polish and submit.
 
 ## Prerequisites Check (MANDATORY)
 
@@ -18,7 +20,7 @@ Execute this workflow step by step. Run bash commands directly.
 uv --version
 ```
 
-If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
+If not found, install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -26,14 +28,20 @@ If not found, stop — install from <https://docs.astral.sh/uv/getting-started/i
 myk-pi-tools --version
 ```
 
-If not found, ask user: "myk-pi-tools is required. Install with: `uv tool install myk-pi-tools`. Install now?"
+If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool install myk-pi-tools`. Install now?"
 
-## Phase 1: Fetch Pending Review
+## Usage
+
+- `/refine-review https://github.com/owner/repo/pull/123`
+
+## Workflow
+
+### Phase 1: Fetch Pending Review
 
 Parse `{{args}}` as the PR URL. If empty, abort with: "PR URL required. Usage: `/refine-review https://github.com/owner/repo/pull/123`"
 
 ```bash
-myk-pi-tools reviews pending-fetch "{{args}}"
+myk-pi-tools reviews pending-fetch "<PR_URL>"
 ```
 
 The command saves the review data to a JSON file and outputs the file path to stdout.
@@ -48,7 +56,7 @@ If the command fails (exit code 1), display the error and abort.
 
 Capture the output (json_path) for later phases.
 
-## Phase 2: Refine Comments
+### Phase 2: Refine Comments
 
 For each comment in the JSON, use the PR diff context, file path, line number, and diff hunk to generate a refined version.
 
@@ -61,7 +69,7 @@ For each comment in the JSON, use the PR diff context, file path, line number, a
 - Preserve the original intent and technical accuracy
 - Keep the tone professional and constructive
 
-## Phase 3: Present Side-by-Side
+### Phase 3: Present Side-by-Side
 
 Display each comment with its refinement, numbered for reference. If a comment has no line number (file-level comment), show only the path:
 
@@ -75,43 +83,43 @@ Comment #2 (src/main.py):
   Refined:  <AI-refined version>
 ```
 
-## Phase 4: User Approval
+### Phase 4: User Approval
 
-Ask the user which refinements to accept:
+Ask the user which refinements to accept using AskUserQuestion:
 
 Options:
 
-- **Accept all** — Use all refined versions
-- **Pick specific** — Enter comment numbers to accept (e.g., "1,3,5")
-- **Keep originals** — Skip refinement, go straight to submit step
-- **Cancel** — Abort without making any changes
-- **Custom text** — Type a custom replacement for specific comments (e.g., "2: my custom comment text")
+- **Accept all** - Use all refined versions
+- **Pick specific** - Enter comment numbers to accept (e.g., "1,3,5")
+- **Keep originals** - Skip refinement, go straight to submit step
+- **Cancel** - Abort without making any changes
+- **Custom text** - Type a custom replacement for specific comments (e.g., "2: my custom comment text")
 
-If "Pick specific": ask for comma-separated numbers. Validate range. Re-prompt on invalid input.
+If "Pick specific": ask user to enter comma-separated numbers. Validate that numbers are within range (1 to N). Ignore duplicates. Re-prompt on invalid input.
 
-If "Custom text": user provides comment number followed by their custom text.
-The custom text replaces the refined version. After applying,
-re-display affected comment(s) for confirmation before proceeding.
+If "Custom text": user provides comment number followed by their custom text. The custom text replaces the refined version for that comment.
 
-## Phase 5: Update JSON
+After applying custom text, re-display the affected comment(s) showing the custom text for user confirmation before proceeding to Phase 5.
+
+### Phase 5: Update JSON
 
 Update the JSON file at `json_path`:
 
 - For each accepted refinement: set `refined_body` to the refined text and `status` to `"accepted"`
 - For comments kept as original: leave `refined_body` as null and `status` as `"pending"`
 
-**Important:** Only modify `refined_body` and `status` fields on each comment. Do NOT modify `diff`, `metadata`, or other fields.
+**Important:** Only modify `refined_body` and `status` fields on each comment. Do NOT modify the `diff`, `metadata`, or other fields — metadata is updated separately in Phase 6.
 
-## Phase 6: Submit Decision
+### Phase 6: Submit Decision
 
-Ask the user what review action to take:
+Ask the user what review action to take using AskUserQuestion:
 
 Options:
 
-- **Comment** — Submit as general feedback
-- **Approve** — Approve the PR
-- **Request changes** — Request changes
-- **Don't submit yet** — Keep the review pending
+- **Comment** - Submit as general feedback
+- **Approve** - Approve the PR
+- **Request changes** - Request changes
+- **Don't submit yet** - Keep the review pending
 
 If user chooses to submit, optionally ask for a review summary (can be empty).
 
@@ -120,7 +128,7 @@ Update the JSON metadata:
 - Set `submit_action` to the chosen action (COMMENT/APPROVE/REQUEST_CHANGES), or omit if keeping pending
 - Set `submit_summary` to the summary text
 
-## Phase 7: Execute Updates
+### Phase 7: Execute Updates
 
 If user chose to submit (Phase 6), run with `--submit` flag:
 
@@ -136,12 +144,9 @@ myk-pi-tools reviews pending-update "<json_path>"
 
 This updates accepted comment bodies on GitHub and submits the review when `--submit` is provided.
 
-If the command fails:
+If the command fails, display the error. If it reports a 404, inform the user their pending review may have been submitted or deleted externally.
 
-- If 404: inform the user their pending review may have been submitted or deleted externally
-- Other errors: display the error
-
-## Phase 8: Summary
+### Phase 8: Summary
 
 Display:
 
@@ -149,8 +154,11 @@ Display:
 - Review action taken (submitted as COMMENT/APPROVE/REQUEST_CHANGES, or kept pending)
 - PR URL for reference
 
+---
+
 **CRITICAL RULES:**
 
 - NEVER update comments or submit the review without explicit user confirmation
 - Always show what will change before changing it
 - The user controls which refinements are accepted
+- If an API call fails with 404/422, the pending review may have been externally submitted or deleted - inform the user

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -1,101 +1,135 @@
 ---
-description: "Create a GitHub release with changelog — /release [--dry-run] [--prerelease] [--draft] [--target <branch>]"
+description: Create a GitHub release with automatic changelog generation
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# GitHub Release Command
 
-Execute this workflow step by step. Run bash commands directly — do NOT delegate to subagents for CLI commands.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Creates a GitHub release with automatic changelog generation based on conventional commits.
+Optionally detects and updates version files before creating the release.
 
 ## Prerequisites Check (MANDATORY)
+
+### Step 1: Check myk-pi-tools
 
 ```bash
 myk-pi-tools --version
 ```
 
-If not found, ask user to install: `uv tool install myk-pi-tools`
+If not found, prompt to install: `uv tool install myk-pi-tools`
 
-## Phase 1: Validation
+## Usage
 
-Parse `{{args}}` for flags: `--dry-run`, `--prerelease`, `--draft`, `--target <branch>`, `--tag-match <pattern>`.
+- `/release` - Normal release
+- `/release --dry-run` - Preview without creating
+- `/release --prerelease` - Create prerelease
+- `/release --draft` - Create draft release
 
-Build the release info command:
+## Workflow
 
-- If `--target <branch>` was passed: `myk-pi-tools release info --target <branch>`
-- If `--tag-match <pattern>` was also passed: add `--tag-match <pattern>`
-- Otherwise: `myk-pi-tools release info`
+### Phase 1: Validation
 
-Run the command. Check validations:
+If `--target <branch>` was passed to the release command:
 
-- Must be on default branch (or target/auto-detected version branch)
+```bash
+myk-pi-tools release info --target <branch>
+```
+
+If `--tag-match <pattern>` was also passed:
+
+```bash
+myk-pi-tools release info --target <branch> --tag-match <pattern>
+```
+
+Otherwise (auto-detect from current branch):
+
+```bash
+myk-pi-tools release info
+```
+
+Note: If on a version branch (e.g., `v2.10`), the command auto-detects the target
+and filters tags to that version range. No `--target` flag needed.
+
+Check validations:
+
+- Must be on default branch (or target branch if `--target` specified, or auto-detected version branch like `v2.10`)
 - Working tree must be clean
 - Must be synced with remote
 
-If validation fails, display the error and stop.
-
-## Phase 2: Version Detection
+### Phase 2: Version Detection
 
 ```bash
 myk-pi-tools release detect-versions
 ```
 
-Parse the JSON output. Key fields:
+Parse the JSON output. If version files are found, store them for Phase 4.
+If no version files are detected, skip version bumping phases and continue normally.
 
-- `version_files[].path` — file path relative to repo root
-- `version_files[].current_version` — current version string
-- `count` — number of detected files (0 = skip version bumping)
+Store the detect-versions JSON output for use in Phase 4. The key fields are:
 
-Store for Phase 4.
+- `version_files[].path` -- file path relative to repo root
+- `version_files[].current_version` -- current version string
+- `count` -- number of detected files (0 means skip version bumping)
 
-## Phase 3: Changelog Analysis
+### Phase 3: Changelog Analysis
 
-Parse commits from Phase 1 output. Categorize by conventional commit type:
+Parse commits from Phase 1 output and categorize by conventional commit type:
 
-- Breaking Changes → MAJOR bump
-- Features (`feat:`) → MINOR bump
-- Bug Fixes (`fix:`), Docs (`docs:`), Maintenance (`chore:`) → PATCH bump
+- Breaking Changes (MAJOR)
+- Features (MINOR)
+- Bug Fixes, Docs, Maintenance (PATCH)
 
-Determine the version bump type and generate a changelog in markdown format.
+Determine version bump and generate changelog.
 
-## Phase 4: User Approval
+### Phase 4: User Approval
 
-Present the proposed release info to the user.
+Display the proposed release information. If version files were detected in Phase 2,
+include them in the approval prompt.
 
-**If version files were detected:**
+**With version files:**
 
-Show:
+Present using AskUserQuestion. Show:
 
 - Proposed version (e.g., v1.2.0, minor bump)
-- List of version files to update with current → new version
+- List of version files to update with current to new version
 - Changelog preview
 
-Ask the user (options):
+User options:
 
-- `yes` — Proceed with proposed version and all listed files
-- `major`/`minor`/`patch` — Override the version bump type
-- `exclude N` — Exclude file by number from the version bump
-- `no` — Cancel the release
+- 'yes' -- Proceed with proposed version and all listed files
+- 'major/minor/patch' -- Override the version bump type
+- 'exclude N' -- Exclude file by number from the version bump (e.g., 'exclude 2')
+- 'no' -- Cancel the release
 
-**If --dry-run:** Show what would happen and stop here.
+To exclude files, remove them from the list. Pass remaining file paths as
+`--files <path>` arguments to `bump-version` in Phase 5.
 
-**Without version files:** Show proposed version and changelog, ask for confirmation.
+**Without version files:**
 
-## Phase 5: Bump Version (if version files detected)
+Same as before -- show proposed version and changelog, ask for confirmation.
 
-Skip if no version files detected in Phase 2 or all excluded.
+### Phase 5: Bump Version (if version files detected)
+
+Skip this phase if no version files were detected in Phase 2.
+
+Run the bump command with the confirmed version and files:
 
 ```bash
 myk-pi-tools release bump-version <VERSION> --files <file1> --files <file2>
 ```
 
-Where `<VERSION>` is without `v` prefix (e.g., `1.2.0`).
+Where `<VERSION>` is the version number without `v` prefix (e.g., `1.2.0`, not `v1.2.0`).
 
-Parse JSON output. Only stage files listed in `updated[]` array. If `skipped[]` is non-empty, inform the user.
+Parse the JSON output from bump-version. Only stage the files listed in the
+`updated[]` array. If `skipped[]` is non-empty, inform the user which files were
+skipped and why before proceeding.
 
-Then create branch, stage, sync lockfile, commit, push — ALL in one sequence:
+Then create a branch, stage files, sync lockfile, commit, and push — **all in one sequence**:
 
 ```bash
 BUMP_BRANCH="chore/bump-version-<VERSION>-$(date +%s)"
@@ -103,52 +137,72 @@ git checkout -b "$BUMP_BRANCH"
 git add <updated-files>
 # MANDATORY: sync uv.lock when pyproject.toml is bumped
 if [ -f uv.lock ]; then uv lock && git add uv.lock; fi
-echo -e "chore: bump version to <VERSION>" | git commit -F -
+git commit -m "chore: bump version to <VERSION>"
 git push -u origin "$BUMP_BRANCH"
 ```
 
-Create and merge PR:
+> **DO NOT split this block.** The `uv lock` step syncs the lockfile after
+> `pyproject.toml` version changes. Skipping it leaves a dirty `uv.lock`
+> after the release merge.
+
+Note: The timestamp suffix prevents conflicts with previous bump attempts.
+
+Create a PR and capture its URL:
 
 ```bash
-PR_URL=$(gh pr create --title "chore: bump version to <VERSION>" --body "Bump version to <VERSION>" --base <target_branch>)
+PR_URL=$(gh pr create --title "chore: bump version to <VERSION>" \
+  --body "Bump version to <VERSION>" --base <target_branch>)
+```
+
+Merge the PR using admin privileges:
+
+```bash
 gh pr merge --merge --admin --delete-branch
 ```
 
-If `--admin` merge fails:
+If the `--admin` merge fails, check the error:
 
-- **Permission denied** — Show PR_URL, tell user to merge manually, wait for confirmation, verify merge state
-- **Other errors** — Abort and display error
+- **Permission denied / not admin** -- Fall back to manual merge:
+  1. Display `PR_URL` to the user
+  2. Tell the user: "Admin merge failed. Please merge the PR manually
+     (or wait for CI checks to pass). Let me know when it's merged."
+  3. Use `AskUserQuestion` to wait for confirmation
+  4. After user confirms, verify the PR is merged:
 
-After merge, sync local:
+     ```bash
+     gh pr view "$PR_URL" --json state --jq '.state'
+     ```
+
+     If the state is not `MERGED`, ask the user again.
+- **Other errors** (network, auth, etc.) -- Abort the release and
+  display the error.
+
+After merge (either admin or manual), sync the local target branch:
 
 ```bash
 git checkout <target_branch>
 git pull origin <target_branch>
 ```
 
-## Phase 6: Create Release
+Where `<target_branch>` is the branch from Phase 1 validation
+(default branch or `--target` value).
+
+### Phase 6: Create Release
+
+Create a temp file with cleanup, write changelog to it, and create release:
 
 ```bash
 CHANGELOG_FILE=$(mktemp /tmp/pi-release-XXXXXX.md)
+trap "rm -f $CHANGELOG_FILE" EXIT
+
+cat > "$CHANGELOG_FILE" << 'EOF'
+<changelog content from Phase 3>
+EOF
+
+myk-pi-tools release create {owner}/{repo} {tag} "$CHANGELOG_FILE" [--prerelease] [--draft] [--target {target_branch}]
 ```
 
-Write changelog content to the file.
+### Phase 7: Summary
 
-```bash
-myk-pi-tools release create <owner>/<repo> <tag> "$CHANGELOG_FILE" [--prerelease] [--draft] [--target <target_branch>]
-```
-
-Clean up:
-
-```bash
-rm -f "$CHANGELOG_FILE"
-```
-
-## Phase 7: Summary
-
-Display:
-
-- Release URL
-- Version bumped (if applicable)
-- Files updated (if applicable)
-- Changelog summary
+Display release URL and summary.
+If version files were bumped, include the list of updated files in the summary.

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -1,15 +1,17 @@
 ---
-description: "Process ALL review sources (human, Qodo, CodeRabbit) from current PR — /review-handler [--autorabbit] [REVIEW_URL]"
+description: Process ALL review sources (human, Qodo, CodeRabbit) from current PR
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# GitHub Review Handler
 
-Execute this workflow step by step. Run bash commands directly for CLI operations.
-Delegate code fixes to the appropriate specialist subagent.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+> Documented retry loops (e.g., autorabbit polling) are not bugs — only report reproducible failures.
+
+Unified handler that processes ALL review sources from the current branch's GitHub PR.
 
 ## Prerequisites Check (MANDATORY)
 
@@ -19,7 +21,7 @@ Delegate code fixes to the appropriate specialist subagent.
 uv --version
 ```
 
-If not found, stop — install from <https://docs.astral.sh/uv/getting-started/installation/>
+If not found, install from <https://docs.astral.sh/uv/getting-started/installation/>
 
 ### Step 1: Check myk-pi-tools
 
@@ -27,28 +29,47 @@ If not found, stop — install from <https://docs.astral.sh/uv/getting-started/i
 myk-pi-tools --version
 ```
 
-If not found, ask user to install: `uv tool install myk-pi-tools`
+If not found, prompt to install: `uv tool install myk-pi-tools`
 
-## Phase 0: Parse Arguments (MANDATORY — DO NOT SKIP)
+## Usage
 
-Before calling ANY `myk-pi-tools` command, parse `{{args}}`:
+- `/review-handler` - Process reviews from current PR
+- `/review-handler https://github.com/owner/repo/pull/123#pullrequestreview-456` - With specific review URL
+- `/review-handler --autorabbit` - Auto-fix CodeRabbit comments in a loop
+
+## Workflow
+
+> **CRITICAL — BEFORE ANY CLI COMMAND:**
+> `--autorabbit` is a **command-level flag**, NOT a CLI argument.
+> **NEVER** pass `--autorabbit` to `myk-pi-tools`. The CLI will reject it.
+> You MUST strip it from `{{args}}` first. See Phase 0 below.
+
+### Phase 0: Parse Arguments (MANDATORY — DO NOT SKIP)
+
+**Before calling ANY `myk-pi-tools` command**, parse `{{args}}`:
 
 1. Check if `--autorabbit` is present in `{{args}}`
-2. If YES: **Remove** `--autorabbit` from the arguments and set autorabbit mode = ON
-3. Store the cleaned arguments (without `--autorabbit`) for all subsequent CLI calls
+2. If YES: **Remove** `--autorabbit` from `{{args}}` and set autorabbit mode = ON
+3. Store the cleaned `{{args}}` (without `--autorabbit`) for all subsequent CLI calls
 4. If NO: proceed normally
 
-**Example:** If `{{args}}` = `--autorabbit`, then:
+**Example:** If `{{args}}` = `--autorabbit`, then after parsing:
 
 - autorabbit mode = ON
 - cleaned arguments = (empty)
 - CLI call = `myk-pi-tools reviews fetch` (NO `--autorabbit` flag)
 
-**CRITICAL: `--autorabbit` is a command-level flag, NOT a CLI argument. NEVER pass it to `myk-pi-tools`.**
+**Example:** If `{{args}}` = `--autorabbit https://github.com/org/repo/pull/123#pullrequestreview-456`, then after parsing:
 
-## Phase 1: Fetch Reviews
+- autorabbit mode = ON
+- cleaned arguments = `https://github.com/org/repo/pull/123#pullrequestreview-456`
+- CLI call = `myk-pi-tools reviews fetch https://github.com/...`
 
-Use the cleaned arguments from Phase 0.
+### Phase 1: Fetch Reviews
+
+The `reviews fetch` command auto-detects the PR from the current branch.
+
+**Use the cleaned arguments from Phase 0 — NEVER pass `--autorabbit` to the CLI.**
 
 If a specific review URL is in the cleaned arguments:
 
@@ -69,27 +90,39 @@ Returns JSON with:
 - `qodo`: Qodo AI review threads
 - `coderabbit`: CodeRabbit AI review threads
 
-## Phase 2: User Decision Collection
+### Phase 2: User Decision Collection
 
-### AUTORABBIT MODE CHECK (do this FIRST)
+> **CRITICAL — AUTORABBIT MODE CHECK (do this FIRST, before anything else):**
+>
+> If autorabbit mode is ON (set in Phase 0):
+>
+> 1. **CodeRabbit comments → ALL auto-approved.** Do NOT use AskUserQuestion
+>    for CodeRabbit. Do NOT ask the user. Set every CodeRabbit item to "yes"
+>    automatically. Display the table for visibility only.
+> 2. **Human/Qodo comments** → follow the normal decision flow below.
+> 3. **If there are ONLY CodeRabbit comments** (no human, no Qodo) →
+>    skip this entire phase and go directly to Phase 3.
+>
+> **In autorabbit mode, the user is NEVER asked about CodeRabbit items.**
 
-If autorabbit mode is ON:
+**Normal mode (no `--autorabbit`):** Follow the full decision flow below.
 
-1. CodeRabbit comments → ALL auto-approved. Do NOT ask the user. Set every CodeRabbit item to "yes" automatically. Display the table for visibility only.
-2. Human/Qodo comments → follow the normal decision flow below.
-3. If there are ONLY CodeRabbit comments (no human, no Qodo) → skip this entire phase and go directly to Phase 3.
+**MANDATORY: Present ALL fetched items to the user for decision.
+Never silently hide or omit items — including auto-skipped ones.**
 
-**In autorabbit mode, the user is NEVER asked about CodeRabbit items.**
+Even if an item appears to be a repeat from a previous round, was already addressed,
+or seems trivial — present it to the user. The user decides what to address or skip,
+not the AI.
 
-### Normal mode
+**Presentation format (MANDATORY — always use this exact structure):**
 
-Present ALL fetched items to the user for decision. Never silently hide or omit items — including auto-skipped ones.
-
-**Presentation format (MANDATORY):**
+**HARD RULE: The table MUST include ALL items — pending AND auto-skipped.
+No exceptions. Never present a partial table. If you omit auto-skipped items,
+the output is INVALID and must be redone.**
 
 Present one table per source (human, qodo, coderabbit). Skip sources with zero items.
 Within each table, sort by priority (HIGH → MEDIUM → LOW).
-Use a global counter for the `#` column across all tables.
+Use a **global counter** for the `#` column across all tables (not per-table).
 
 ```text
 ## Review Items: {source} ({total} total, {auto_skipped} auto-skipped)
@@ -99,9 +132,22 @@ Use a global counter for the `#` column across all tables.
 | 1 | HIGH | src/storage.py | 231 | Backfill destroys historical chronology | Pending |
 | 2 | MEDIUM | src/html_report.py | 1141 | Add/delete leaves badges stale | Pending |
 | 3 | LOW | src/utils.py | 42 | Unused import | Auto-skipped (skipped): "style only" |
+| 4 | LOW | src/config.py | 15 | Missing validation | Auto-skipped (addressed): "added in prev PR" |
+
+(Numbering continues across tables — e.g., if this table ends at 4, the next table starts at 5.)
 ```
 
-**After presenting all tables, show response options:**
+**Table rules:**
+
+- **Always a table** — never use bullets, prose, or any other format
+- **Summary column:** 1-2 lines summarizing the comment.
+  Include "Also applies to" references if present
+- **Status column values:**
+  - `Pending` — awaiting user decision
+  - `Auto-skipped ({original_status}): "{reason}"` — showing the original status (addressed/skipped/not_addressed) and the stored reason
+- **Every item gets a row** — including auto-skipped items so the user can override
+
+**After presenting all tables, show the response options:**
 
 ```text
 Respond with:
@@ -111,34 +157,54 @@ Respond with:
 - 'skip ai' — skip all AI sources (qodo + coderabbit) (ask for a reason)
 ```
 
-## Phase 3: Execute Approved Tasks
+**User input method (MANDATORY):**
 
-For each approved comment, delegate to the appropriate specialist subagent using the subagent tool.
+Always use the `AskUserQuestion` tool to collect user decisions — never rely on
+free-text conversation. Present the tables first as regular output, then call
+`AskUserQuestion` with a concise prompt summarizing the available options.
 
-When delegating, pass the FULL original review thread — including the complete comment body, all replies,
-every code suggestion/diff, and all referenced locations. Do NOT summarize or compress the thread.
+Example `AskUserQuestion` prompt:
+
+```text
+Enter your decisions (e.g., '1 yes, 2 no: already addressed, 3 yes, skip coderabbit: duplicates human review'):
+```
+
+The handler collects ALL decisions in a single `AskUserQuestion` call.
+If the user says 'no' or 'skip' without a reason, follow up with another
+`AskUserQuestion` asking for the reason before proceeding.
+
+### Phase 3: Execute Approved Tasks
+
+For each approved comment, delegate to appropriate specialist agent.
+When delegating, pass the FULL original review thread to the agent — including the complete comment body,
+all replies, every code suggestion/diff, and all referenced locations. Do NOT summarize or compress the thread.
 
 **When fixing review comments (MANDATORY):**
 
-- If the reviewer provides a specific code suggestion or diff, implement it exactly — not your own interpretation
+- If the reviewer provides a specific code suggestion or diff, implement IT exactly — not your own interpretation
 - Do NOT simplify, minimize, or "half-fix" the suggestion
-- After fixing, verify your code matches what the reviewer asked for
-- **NO SKIP WITHOUT USER APPROVAL:** If you disagree with a suggestion, ASK THE USER before skipping
-- **Read the ENTIRE review thread before acting.** Comments often contain multiple parts: a main issue description,
-  code suggestions, AND additional references like "Also applies to: 663-668" or mentions of other files/lines.
-  You MUST address ALL parts.
-- **Multi-location fixes are MANDATORY.** When a comment says "Also applies to: X-Y" or references other lines/files, apply the same fix to each location.
+- After fixing, verify your code matches what the reviewer asked for, not just "addresses the concern"
+- **NO SKIP WITHOUT USER APPROVAL:** If you disagree with the suggestion, ASK THE USER before skipping, partially fixing, or applying a minimum-viable fix
+- **Read the ENTIRE review thread before acting.** Review threads contain a top-level comment plus replies.
+  Comments often contain multiple parts: a main issue description, code suggestions, AND additional references
+  like "Also applies to: 663-668" or mentions of other files/lines. Replies may contain clarifications,
+  additional locations, or refined suggestions. You MUST address ALL parts from the comment AND replies,
+  not just the first paragraph.
+- **Multi-location fixes are MANDATORY.** When a comment says "Also applies to: X-Y" or references other lines/files,
+  apply the same logical fix, adapted as needed to each location. These are not optional — they are part of the
+  comment's requirements.
 - **Post-fix verification checklist.** After fixing a comment, re-read the ORIGINAL review thread in full and verify:
   1. Every code suggestion or diff was implemented
   2. Every referenced file and line range was addressed
   3. Every "Also applies to" location was fixed
   4. No secondary instructions or reply clarifications were skipped
+  If any part was missed, fix it before moving to the next comment.
 
-## Phase 4: Review Unimplemented
+### Phase 4: Review Unimplemented
 
 If any approved tasks weren't implemented, review with user.
 
-## Phase 5: Persist Decisions
+### Phase 5: Persist Decisions
 
 Update each JSON entry with `status` and `reply` fields before posting.
 
@@ -158,24 +224,40 @@ Update each JSON entry with `status` and `reply` fields before posting.
 - User said **yes** but change was not implemented → `not_addressed`
 - User said **no** → `skipped` (include the user's skip reason in `reply`)
 - User said **all** → same as **yes** for each remaining comment
-- User said **skip `<source>`** → `skipped` for all remaining from that source
+- User said **skip \<source\>** → `skipped` for all remaining from that source
+  (include the user's skip reason in `reply`)
 - User said **skip ai** → `skipped` for all remaining AI sources
+  (include the user's skip reason in `reply`)
 
-## Phase 6: Testing
+### Phase 6: Testing
 
-Run tests with coverage. **ALL tests must pass before proceeding. No exceptions.**
+Run tests with coverage.
 
-- Do NOT skip or ignore failures, even if they appear "pre-existing" or "unrelated"
+**ALL tests must pass before proceeding. No exceptions.**
+
+- Do NOT skip or ignore failures, even if they appear "pre-existing" or "unrelated to our changes"
+- Do NOT rationalize failures as acceptable
 - If a test fails, fix it — regardless of whether this PR introduced the failure
-- Only proceed when the test suite is fully green (zero failures)
+- Only proceed to Phase 7 when the test suite is fully green (zero failures)
 
-## Phase 7: Commit & Push
+### Phase 7: Commit & Push
 
 Ask user if they want to commit and push changes.
 
-Code must be pushed before posting replies so that reviewers can see the fixes when threads are resolved.
+Code must be pushed before posting replies so that reviewers can see the fixes
+when threads are resolved.
 
-## Phase 8: Post Replies
+### Phase 8: Post Replies
+
+Post all replies to GitHub and store results in the database.
+
+**Body comments (outside-diff, nitpick, duplicate):**
+
+Comments that don't have GitHub review threads (e.g., CodeRabbit outside-diff,
+nitpick, and duplicate comments) are replied to via a single consolidated PR
+comment per reviewer. The comment mentions the reviewer (e.g., `@coderabbitai`)
+and includes sections for each comment with the decision made. This ensures
+automated reviewers know their comments were reviewed and won't re-raise them.
 
 Post replies to GitHub:
 
@@ -183,14 +265,20 @@ Post replies to GitHub:
 myk-pi-tools reviews post {json_path}
 ```
 
-If non-zero exit code, re-run — only unposted entries are retried. Repeat until all succeed.
+If the command exits with a non-zero code, some threads failed to post.
+The command prints an ACTION REQUIRED message with the exact retry command.
+Re-run it to retry — only unposted entries are retried. Repeat until all succeed.
 
 **Output verification (MANDATORY):**
 
-- `Processed N threads` — N should equal entries with status addressed/not_addressed/skipped/failed
-- `Resolved: N` — should be non-zero if any entries have status `addressed`
-- If `Processed 0 threads`, the status values are wrong — fix and re-run
-- If output shows `Warning: Unknown status`, fix those entries
+After `reviews post` completes successfully, check the output:
+
+- `Processed N threads` — N should equal the number of entries with status `addressed`, `not_addressed`, `skipped`, or `failed` (everything except `pending`)
+- `Resolved: N` — should be non-zero if any entries have status `addressed` or if AI-source entries have status `skipped`/`not_addressed`
+- If `Processed 0 threads`, the status values in the JSON are wrong — fix them to use valid values from the table above and re-run before proceeding
+- If output shows `Warning: Unknown status`, fix those entries — e.g., `"done"` or `"completed"` are not valid, use `"addressed"` instead
+
+Do NOT proceed to `reviews store` until `reviews post` shows the expected thread count.
 
 Store to database:
 
@@ -198,42 +286,89 @@ Store to database:
 myk-pi-tools reviews store {json_path}
 ```
 
-## Phase 9: Autorabbit Polling Loop (--autorabbit mode only)
+### Phase 9: Autorabbit Polling Loop (--autorabbit mode only)
 
 **Skip this phase if `--autorabbit` was NOT passed.**
 
-### 9a: Wait
+After the review flow completes (Phases 1-8), enter a polling loop
+to watch for new CodeRabbit comments.
 
-Wait 5 minutes before checking for new comments. After waiting, ALWAYS proceed to 9b. NEVER exit the loop.
+#### 9a: Wait
 
-### 9b: Fetch New Reviews
+Wait 5 minutes before checking for new comments.
+
+**After waiting, ALWAYS proceed to 9b. NEVER exit the loop.
+If the wait is interrupted or errors, retry the wait. An error during waiting is NOT a reason to exit.**
+
+#### 9b: Fetch New Reviews
+
+Use the `reviews poll` command which atomically handles rate limit
+checking, triggering, and fetching in a single command:
 
 ```bash
 myk-pi-tools reviews poll [same arguments as Phase 1]
 ```
 
-This command atomically handles rate limit checking, triggering, and fetching.
+This command:
 
-Check if there are new CodeRabbit comments (without `posted_at` timestamps, not auto-skipped).
+1. Checks if CodeRabbit is rate limited
+2. If rate limited: waits the required time + 30s buffer, triggers re-review, polls until review starts
+3. Fetches all reviews (same output format as `reviews fetch`)
 
-- If **new CodeRabbit comments found**: Run Phases 2-8 again with autorabbit behavior. After completing, MUST return to Step 9a.
-- If **no new CodeRabbit comments**: Display "No new CodeRabbit comments. Checking again in 5 minutes..." and MUST return to Step 9a.
+Check if there are new CodeRabbit comments (comments without
+`posted_at` timestamps, not auto-skipped).
 
-### 9c: NEVER EXIT (MANDATORY)
+- If **new CodeRabbit comments found**: Run Phases 2-8 again with
+  autorabbit behavior (auto-approve CodeRabbit, ask user for others).
+  After completing (or if any phase errors), **MUST** return to Step 9a (NEVER exit).
+- If **no new CodeRabbit comments**: Display "No new CodeRabbit
+  comments. Checking again in 5 minutes..." and **MUST** return to Step 9a (NEVER exit).
+
+**Both paths return to 9a. NEVER exit the loop. Only the user can stop it.**
+
+#### 9c: NEVER EXIT (MANDATORY)
 
 **THE LOOP MUST NEVER STOP UNLESS THE USER EXPLICITLY REQUESTS IT.**
 
-There is NO automatic exit condition. The loop runs forever until the user intervenes (Ctrl+C or explicit "stop"/"exit"/"done"/"quit").
+There is NO automatic exit condition. The AI does NOT decide when the loop ends.
+The loop runs forever until the user intervenes.
+
+```text
+VIOLATION — The following rationalizations are FORBIDDEN reasons to exit the loop:
+
+  - "All comments have been addressed"
+  - "No new comments found for N cycles"
+  - "The loop seems complete"
+  - "Nothing left to process"
+  - "The review is done"
+  - "CodeRabbit has not posted anything new"
+  - "It appears the review cycle is finished"
+  - "The fetch command failed"
+  - "An error occurred during polling"
+  - "The API returned an error"
+  - "An error prevents continuing"
+  - Any variation of the AI deciding there is no more work to do
+```
 
 Even after 100 consecutive cycles with zero new comments, the loop continues.
+The absence of new comments is expected behavior, not a reason to stop.
 
-If any command fails, log the error, wait 5 minutes, and retry from 9a.
+If any command in the loop fails, log the error, wait 5 minutes, and retry from 9a.
+Errors are recoverable — NEVER treat a command failure as a reason to exit.
 
-Each cycle displays status:
+**ONLY these actions end the loop:**
+
+- The user presses `Ctrl+C`
+- The user sends an explicit message such as "stop", "exit", "done", or "quit"
+
+**Breaking the loop without user action is a HARD VIOLATION of this spec.**
+
+Each cycle displays a status update so the user knows the loop is active:
 
 ```text
 [autorabbit] Cycle {N} complete. Next check in 5 minutes...
 [autorabbit] Checking for new CodeRabbit comments...
 [autorabbit] Found {N} new comments — processing...
 [autorabbit] No new comments. Next check in 5 minutes...
+[autorabbit] CodeRabbit rate-limited. Handling automatically via reviews poll...
 ```

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -1,18 +1,30 @@
 ---
-description: "Review uncommitted changes with 3 parallel reviewers — /review-local [BRANCH]"
+description: Review uncommitted changes or changes compared to a branch
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it silently.
-> Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
-> or to the relevant tool's repository for CLI issues.
+# Local Code Review Command
 
-Execute this workflow step by step.
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
 
-## Step 1: Get the diff
+Review uncommitted changes or changes compared to a specified branch.
 
-**If `{{args}}` is provided (not empty):**
+**MANDATORY: This command MUST use 3 review agents in parallel via Task tool.**
+
+## Usage
+
+- `/review-local` - Review uncommitted changes (staged + unstaged)
+- `/review-local main` - Review changes compared to main branch
+- `/review-local feature/branch` - Review changes compared to specified branch
+
+## Workflow
+
+### Step 1: Get the diff
+
+**If argument is provided (`{{args}}` is not empty):**
 
 Compare current branch against the specified branch:
 
@@ -28,17 +40,15 @@ Get all uncommitted changes (staged + unstaged):
 git diff HEAD
 ```
 
-If the diff is empty, report "No changes to review" and stop.
+### Step 2: Route to review agents (MANDATORY)
 
-## Step 2: Route to review agents (MANDATORY)
+**CRITICAL: You MUST use the Task tool to call ALL 3 review agents IN PARALLEL (single message):**
 
-Use the subagent tool to run ALL 3 review agents IN PARALLEL (using the `tasks` array):
+- `superpowers:code-reviewer` - General code quality and maintainability
+- `pr-review-toolkit:code-reviewer` - Project guidelines and style adherence
+- `feature-dev:code-reviewer` - Bugs, logic errors, and security vulnerabilities
 
-1. **code-reviewer-quality** — General code quality and maintainability
-2. **code-reviewer-guidelines** — Project guidelines and style adherence
-3. **code-reviewer-security** — Bugs, logic errors, and security vulnerabilities
-
-Pass each agent the full diff and ask them to analyze for:
+Delegate to all 3 with the diff and ask them to analyze for:
 
 1. Code quality and best practices
 2. Potential bugs or logic errors
@@ -49,16 +59,10 @@ Pass each agent the full diff and ask them to analyze for:
 7. Code duplication
 8. Suggestions for improvement
 
-## Step 3: Present the review
+### Step 3: Present the review
 
-Merge and deduplicate findings from all 3 reviewers:
+Merge and deduplicate findings from all 3 reviewers. Display grouped by:
 
-- Same file/line + same issue = duplicate → keep most actionable
-- Conflicting suggestions → priority: security > correctness > performance > style
-- Complementary findings → keep both
-
-Display grouped by:
-
-- **Critical issues** (must fix)
-- **Warnings** (should fix)
-- **Suggestions** (nice to have)
+- Critical issues (must fix)
+- Warnings (should fix)
+- Suggestions (nice to have)


### PR DESCRIPTION
Deleted and re-copied all 8 prompt templates from myk-org/claude-code-config with only mechanical replacements. No rewording, no compressing. Full feature parity.

Replacements applied:
- `myk-claude-tools` → `myk-pi-tools`
- `/tmp/claude` → `/tmp/pi-work`
- `$ARGUMENTS` → `{{args}}`
- `/myk-github:X`, `/myk-review:X`, `/myk-acpx:X` → `/X`
- `myk-org/claude-code-config` → `myk-org/pi-config`
- `CLAUDE.md` → `AGENTS.md`
- Removed `allowed-tools` and `argument-hint` frontmatter

Closes #38