### PR TITLE
fix: use $ARGUMENTS instead of {{args}} in prompt templates

### DIFF
--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -86,7 +86,7 @@ The underlying coding agent must be installed separately. acpx auto-downloads AC
 
 ### Step 2: Parse Arguments
 
-Parse `{{args}}` to extract the agent name(s) and prompt:
+Parse `$ARGUMENTS` to extract the agent name(s) and prompt:
 
 1. The **first token** is the agent specification (required). Format:
    `agent[:model]` or comma-separated `agent1[:model1],agent2[:model2],...`

--- a/prompts/coderabbit-rate-limit.md
+++ b/prompts/coderabbit-rate-limit.md
@@ -40,15 +40,15 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 ### Phase 1: Detect PR
 
-If `{{args}}` contains a URL, extract owner/repo and PR number from it.
+If `$ARGUMENTS` contains a URL, extract owner/repo and PR number from it.
 
-If `{{args}}` contains a number, detect the repository:
+If `$ARGUMENTS` contains a number, detect the repository:
 
 ```bash
 gh repo view --json nameWithOwner -q .nameWithOwner
 ```
 
-If `{{args}}` is empty, detect PR from current branch:
+If `$ARGUMENTS` is empty, detect PR from current branch:
 
 ```bash
 gh pr view --json number,url -q '.number'

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -47,7 +47,7 @@ If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool ins
 
 ### Phase 0: PR Detection (when no arguments provided)
 
-If `{{args}}` is empty:
+If `$ARGUMENTS` is empty:
 
 1. Detect PR from current branch:
 
@@ -79,7 +79,7 @@ If `{{args}}` is empty:
 
 4. Use `{pr_number}` for subsequent CLI commands
 
-If `{{args}}` contains a PR number or URL, use it directly.
+If `$ARGUMENTS` contains a PR number or URL, use it directly.
 
 ### Phase 1a: Data Fetching
 
@@ -94,7 +94,7 @@ myk-pi-tools pr diff {pr_number}
 Otherwise:
 
 ```bash
-myk-pi-tools pr diff {{args}}
+myk-pi-tools pr diff $ARGUMENTS
 ```
 
 Store the JSON output containing metadata, diff, and files.
@@ -112,7 +112,7 @@ myk-pi-tools pr claude-md {pr_number}
 Otherwise:
 
 ```bash
-myk-pi-tools pr claude-md {{args}}
+myk-pi-tools pr claude-md $ARGUMENTS
 ```
 
 Store the output as `claude_md_content`.

--- a/prompts/query-db.md
+++ b/prompts/query-db.md
@@ -141,7 +141,7 @@ The reviews database is located at `<project-root>/.claude/data/reviews.db`.
 
 ## Workflow
 
-1. Parse {{args}} to determine which query to run
+1. Parse $ARGUMENTS to determine which query to run
 2. Execute the appropriate myk-pi-tools db command
 3. Present results in a clear, formatted way
 4. For natural language questions, compose the appropriate query

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -38,7 +38,7 @@ If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool ins
 
 ### Phase 1: Fetch Pending Review
 
-Parse `{{args}}` as the PR URL. If empty, abort with: "PR URL required. Usage: `/refine-review https://github.com/owner/repo/pull/123`"
+Parse `$ARGUMENTS` as the PR URL. If empty, abort with: "PR URL required. Usage: `/refine-review https://github.com/owner/repo/pull/123`"
 
 ```bash
 myk-pi-tools reviews pending-fetch "<PR_URL>"

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -42,24 +42,24 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 > **CRITICAL — BEFORE ANY CLI COMMAND:**
 > `--autorabbit` is a **command-level flag**, NOT a CLI argument.
 > **NEVER** pass `--autorabbit` to `myk-pi-tools`. The CLI will reject it.
-> You MUST strip it from `{{args}}` first. See Phase 0 below.
+> You MUST strip it from `$ARGUMENTS` first. See Phase 0 below.
 
 ### Phase 0: Parse Arguments (MANDATORY — DO NOT SKIP)
 
-**Before calling ANY `myk-pi-tools` command**, parse `{{args}}`:
+**Before calling ANY `myk-pi-tools` command**, parse `$ARGUMENTS`:
 
-1. Check if `--autorabbit` is present in `{{args}}`
-2. If YES: **Remove** `--autorabbit` from `{{args}}` and set autorabbit mode = ON
-3. Store the cleaned `{{args}}` (without `--autorabbit`) for all subsequent CLI calls
+1. Check if `--autorabbit` is present in `$ARGUMENTS`
+2. If YES: **Remove** `--autorabbit` from `$ARGUMENTS` and set autorabbit mode = ON
+3. Store the cleaned `$ARGUMENTS` (without `--autorabbit`) for all subsequent CLI calls
 4. If NO: proceed normally
 
-**Example:** If `{{args}}` = `--autorabbit`, then after parsing:
+**Example:** If `$ARGUMENTS` = `--autorabbit`, then after parsing:
 
 - autorabbit mode = ON
 - cleaned arguments = (empty)
 - CLI call = `myk-pi-tools reviews fetch` (NO `--autorabbit` flag)
 
-**Example:** If `{{args}}` = `--autorabbit https://github.com/org/repo/pull/123#pullrequestreview-456`, then after parsing:
+**Example:** If `$ARGUMENTS` = `--autorabbit https://github.com/org/repo/pull/123#pullrequestreview-456`, then after parsing:
 
 - autorabbit mode = ON
 - cleaned arguments = `https://github.com/org/repo/pull/123#pullrequestreview-456`

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -24,12 +24,12 @@ Review uncommitted changes or changes compared to a specified branch.
 
 ### Step 1: Get the diff
 
-**If argument is provided (`{{args}}` is not empty):**
+**If argument is provided (`$ARGUMENTS` is not empty):**
 
 Compare current branch against the specified branch:
 
 ```bash
-git diff "{{args}}"...HEAD
+git diff "$ARGUMENTS"...HEAD
 ```
 
 **If no argument provided:**


### PR DESCRIPTION
Pi prompt templates use `$ARGUMENTS` for argument substitution, not `{{args}}`. The incorrect syntax caused all arguments to be empty when invoking commands like `/acpx-prompt cursor --peer review`.

22 replacements across 7 prompt files.