### PR TITLE
feat: add async background agents — spawn, track, notify

### DIFF
--- a/extensions/orchestrator/async-runner.ts
+++ b/extensions/orchestrator/async-runner.ts
@@ -1,0 +1,168 @@
+/**
+ * Async subagent runner — spawned as a detached process.
+ * Reads config from a JSON file, runs pi in print mode,
+ * writes status + result files for the parent to poll.
+ */
+
+import { spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+interface RunConfig {
+  id: string;
+  agent: string;
+  task: string;
+  cwd: string;
+  model?: string;
+  tools?: string[];
+  systemPrompt?: string;
+  resultPath: string;
+  asyncDir: string;
+  sessionId?: string;
+  piCommand: string;
+  piArgs: string[];
+}
+
+interface StatusPayload {
+  runId: string;
+  state: "queued" | "running" | "complete" | "failed";
+  agent: string;
+  task: string;
+  startedAt: number;
+  endedAt?: number;
+  lastUpdate: number;
+  pid: number;
+  cwd: string;
+  exitCode?: number | null;
+  error?: string;
+  outputLines: number;
+}
+
+function writeJson(filePath: string, data: object): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2), "utf-8");
+    fs.renameSync(tmp, filePath);
+  } finally {
+    try { fs.unlinkSync(tmp); } catch {}
+  }
+}
+
+async function run(config: RunConfig): Promise<void> {
+  const statusPath = path.join(config.asyncDir, "status.json");
+  const outputPath = path.join(config.asyncDir, "output.log");
+  const startedAt = Date.now();
+
+  const status: StatusPayload = {
+    runId: config.id,
+    state: "running",
+    agent: config.agent,
+    task: config.task.slice(0, 200),
+    startedAt,
+    lastUpdate: startedAt,
+    pid: process.pid,
+    cwd: config.cwd,
+    outputLines: 0,
+  };
+  writeJson(statusPath, status);
+
+  const outputStream = fs.createWriteStream(outputPath, { flags: "w" });
+  let stdout = "";
+  let lineCount = 0;
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    const proc = spawn(config.piCommand, config.piArgs, {
+      cwd: config.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    proc.stdout.on("data", (chunk: Buffer) => {
+      const text = chunk.toString();
+      stdout += text;
+      outputStream.write(text);
+      lineCount += text.split("\n").length - 1;
+
+      // Update status periodically (every ~10 lines)
+      if (lineCount % 10 === 0) {
+        status.lastUpdate = Date.now();
+        status.outputLines = lineCount;
+        writeJson(statusPath, status);
+      }
+    });
+
+    proc.stderr.on("data", (chunk: Buffer) => {
+      outputStream.write(chunk.toString());
+    });
+
+    proc.on("close", (code) => {
+      outputStream.end();
+      resolve(code);
+    });
+
+    proc.on("error", (err) => {
+      outputStream.end();
+      status.error = err.message;
+      resolve(1);
+    });
+  });
+
+  const endedAt = Date.now();
+
+  // Extract final output from JSON mode messages
+  let finalOutput = "";
+  for (const line of stdout.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const ev = JSON.parse(line);
+      if (ev.type === "message_end" && ev.message?.role === "assistant") {
+        for (const p of ev.message.content || []) {
+          if (p.type === "text") finalOutput = p.text;
+        }
+      }
+    } catch {}
+  }
+
+  // Write final status
+  status.state = exitCode === 0 ? "complete" : "failed";
+  status.endedAt = endedAt;
+  status.lastUpdate = endedAt;
+  status.exitCode = exitCode;
+  status.outputLines = lineCount;
+  writeJson(statusPath, status);
+
+  // Write result for the watcher to pick up
+  writeJson(config.resultPath, {
+    id: config.id,
+    agent: config.agent,
+    task: config.task,
+    success: exitCode === 0,
+    output: finalOutput || stdout.slice(-2000),
+    exitCode,
+    startedAt,
+    endedAt,
+    durationMs: endedAt - startedAt,
+    cwd: config.cwd,
+    sessionId: config.sessionId,
+    asyncDir: config.asyncDir,
+  });
+}
+
+// Entry point
+const configPath = process.argv[2];
+if (!configPath) {
+  console.error("Usage: async-runner.ts <config.json>");
+  process.exit(1);
+}
+
+try {
+  const config = JSON.parse(fs.readFileSync(configPath, "utf-8")) as RunConfig;
+  try { fs.unlinkSync(configPath); } catch {}
+  run(config).catch((err) => {
+    console.error("Async runner error:", err);
+    process.exit(1);
+  });
+} catch (err) {
+  console.error("Failed to read config:", err);
+  process.exit(1);
+}

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -11,8 +11,11 @@
 
 import { spawn, execSync, execFileSync } from "node:child_process";
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
+
+const require = createRequire(import.meta.url);
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { complete, type UserMessage, type Message } from "@mariozechner/pi-ai";
 import { StringEnum } from "@mariozechner/pi-ai";
@@ -588,6 +591,9 @@ const SubagentParams = Type.Object({
   cwd: Type.Optional(
     Type.String({ description: "Working directory (single mode)" }),
   ),
+  async: Type.Optional(
+    Type.Boolean({ description: "Run in background (default: false). Agent runs detached, results surface when complete.", default: false }),
+  ),
 });
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -607,6 +613,49 @@ function isRunningInContainer(): boolean {
 }
 
 const IN_CONTAINER = isRunningInContainer();
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// Async agent support
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+const ASYNC_DIR = path.join(os.tmpdir(), "pi-async-agents");
+const ASYNC_RESULTS_DIR = path.join(ASYNC_DIR, "results");
+const ASYNC_POLL_INTERVAL_MS = 3000;
+
+interface AsyncJob {
+  id: string;
+  agent: string;
+  task: string;
+  status: "queued" | "running" | "complete" | "failed";
+  asyncDir: string;
+  startedAt: number;
+  updatedAt: number;
+  output?: string;
+  exitCode?: number | null;
+  durationMs?: number;
+}
+
+interface AsyncState {
+  jobs: Map<string, AsyncJob>;
+  poller: ReturnType<typeof setInterval> | null;
+  watcher: fs.FSWatcher | null;
+  lastCtx: any;
+}
+
+function readAsyncStatus(asyncDir: string): any | null {
+  try {
+    const statusPath = path.join(asyncDir, "status.json");
+    return JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+  } catch { return null; }
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60000);
+  const s = Math.floor((ms % 60000) / 1000);
+  return `${m}m${s}s`;
+}
 
 export default function (pi: ExtensionAPI) {
   // ── ask_user tool ─────────────────────────────────────────────────────
@@ -805,6 +854,234 @@ export default function (pi: ExtensionAPI) {
     },
   });
 
+  // ── Async agent infrastructure ────────────────────────────────────────
+
+  const asyncState: AsyncState = {
+    jobs: new Map(),
+    poller: null,
+    watcher: null,
+    lastCtx: null,
+  };
+
+  function updateAsyncWidget() {
+    if (!asyncState.lastCtx?.hasUI) return;
+    const ctx = asyncState.lastCtx;
+    const running = Array.from(asyncState.jobs.values()).filter(j => j.status === "running" || j.status === "queued");
+    if (running.length > 0) {
+      const names = running.map(j => j.agent).join(", ");
+      ctx.ui.setStatus("async-agents", ctx.ui.theme.fg("warning", `⏳ ${running.length} async: ${names}`));
+    } else {
+      ctx.ui.setStatus("async-agents", undefined);
+    }
+  }
+
+  function ensureAsyncPoller() {
+    if (asyncState.poller) return;
+    asyncState.poller = setInterval(() => {
+      if (!asyncState.lastCtx?.hasUI) return;
+      if (asyncState.jobs.size === 0) {
+        updateAsyncWidget();
+        if (asyncState.poller) { clearInterval(asyncState.poller); asyncState.poller = null; }
+        return;
+      }
+
+      for (const job of asyncState.jobs.values()) {
+        if (job.status === "complete" || job.status === "failed") continue;
+        const status = readAsyncStatus(job.asyncDir);
+        if (status) {
+          job.status = status.state;
+          job.updatedAt = status.lastUpdate ?? Date.now();
+          if (status.exitCode !== undefined) job.exitCode = status.exitCode;
+        }
+      }
+      updateAsyncWidget();
+    }, ASYNC_POLL_INTERVAL_MS);
+    if (asyncState.poller.unref) asyncState.poller.unref();
+  }
+
+  function startResultWatcher() {
+    if (asyncState.watcher) return;
+    try {
+      fs.mkdirSync(ASYNC_RESULTS_DIR, { recursive: true });
+      asyncState.watcher = fs.watch(ASYNC_RESULTS_DIR, (ev, file) => {
+        if (ev !== "rename" || !file) return;
+        const fileName = file.toString();
+        if (!fileName.endsWith(".json")) return;
+
+        const resultPath = path.join(ASYNC_RESULTS_DIR, fileName);
+        setTimeout(() => {
+          try {
+            if (!fs.existsSync(resultPath)) return;
+            const data = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
+            const job = asyncState.jobs.get(data.id);
+            if (job) {
+              job.status = data.success ? "complete" : "failed";
+              job.output = data.output;
+              job.exitCode = data.exitCode;
+              job.durationMs = data.durationMs;
+              job.updatedAt = Date.now();
+            }
+
+            // Notify user
+            terminalNotify("pi", `Async agent ${data.agent} ${data.success ? "completed" : "failed"} (${formatDuration(data.durationMs)})`);
+
+            // Surface result in conversation
+            if (asyncState.lastCtx) {
+              const status = data.success ? "✅ completed" : "❌ failed";
+              const output = (data.output || "").slice(0, 3000);
+              pi.sendMessage({
+                customType: "async-agent-result",
+                content: `## Async Agent Result: ${data.agent} ${status}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}`,
+                display: true,
+              }, { triggerTurn: true, deliverAs: "followUp" });
+            }
+
+            updateAsyncWidget();
+
+            // Clean up result file
+            try { fs.unlinkSync(resultPath); } catch {}
+
+            // Remove completed jobs after 30s
+            setTimeout(() => {
+              asyncState.jobs.delete(data.id);
+              updateAsyncWidget();
+            }, 30000);
+          } catch {}
+        }, 100); // Small delay to ensure file is fully written
+      });
+      if (asyncState.watcher.unref) asyncState.watcher.unref();
+    } catch {}
+  }
+
+  function spawnAsyncAgent(
+    agentName: string,
+    task: string,
+    cwd: string,
+    agents: AgentConfig[],
+  ): { id: string; error?: string } {
+    const agent = agents.find(a => a.name === agentName);
+    if (!agent) return { id: "", error: `Unknown agent: "${agentName}"` };
+
+    const id = `${agentName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const asyncDir = path.join(ASYNC_DIR, id);
+    const resultPath = path.join(ASYNC_RESULTS_DIR, `${id}.json`);
+
+    fs.mkdirSync(asyncDir, { recursive: true });
+    fs.mkdirSync(ASYNC_RESULTS_DIR, { recursive: true });
+
+    // Build pi args
+    const piArgs: string[] = ["--mode", "json", "-p", "--no-session"];
+    if (agent.model) piArgs.push("--model", agent.model);
+    if (agent.tools?.length) piArgs.push("--tools", agent.tools.join(","));
+
+    let systemPromptFile: string | undefined;
+    if (agent.systemPrompt?.trim()) {
+      const promptPath = path.join(asyncDir, "system-prompt.md");
+      fs.writeFileSync(promptPath, agent.systemPrompt, { mode: 0o600 });
+      piArgs.push("--append-system-prompt", promptPath);
+      systemPromptFile = promptPath;
+    }
+
+    piArgs.push(`Task: ${task}`);
+
+    const inv = getPiInvocation(piArgs);
+
+    // Write config for the runner
+    const configPath = path.join(os.tmpdir(), `pi-async-cfg-${id}.json`);
+    fs.writeFileSync(configPath, JSON.stringify({
+      id,
+      agent: agentName,
+      task,
+      cwd,
+      model: agent.model,
+      resultPath,
+      asyncDir,
+      piCommand: inv.command,
+      piArgs: inv.args,
+    }));
+
+    // Find the runner script
+    const runnerPath = path.join(path.dirname(new URL(import.meta.url).pathname), "async-runner.ts");
+
+    // Find jiti for TypeScript execution
+    let jitiCliPath: string | undefined;
+    try {
+      const piPkgDir = path.dirname(require.resolve("@mariozechner/pi-coding-agent/package.json"));
+      const candidate = path.join(piPkgDir, "node_modules/@mariozechner/jiti/lib/jiti-cli.mjs");
+      if (fs.existsSync(candidate)) jitiCliPath = candidate;
+    } catch {}
+
+    const spawnArgs = jitiCliPath
+      ? [jitiCliPath, runnerPath, configPath]
+      : [runnerPath, configPath];
+
+    // Spawn detached
+    const proc = spawn(process.execPath, spawnArgs, {
+      cwd,
+      detached: true,
+      stdio: "ignore",
+      windowsHide: true,
+    });
+    proc.unref();
+
+    // Track the job
+    const job: AsyncJob = {
+      id,
+      agent: agentName,
+      task: task.slice(0, 200),
+      status: "queued",
+      asyncDir,
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    asyncState.jobs.set(id, job);
+    updateAsyncWidget();
+    ensureAsyncPoller();
+    startResultWatcher();
+
+    return { id };
+  }
+
+  // Start result watcher on session start
+  pi.on("session_start", (_event, ctx) => {
+    asyncState.lastCtx = ctx;
+    startResultWatcher();
+  });
+
+  // Clean up on shutdown
+  pi.on("session_shutdown", () => {
+    if (asyncState.poller) { clearInterval(asyncState.poller); asyncState.poller = null; }
+    if (asyncState.watcher) { asyncState.watcher.close(); asyncState.watcher = null; }
+  });
+
+  // /async-status command
+  pi.registerCommand("async-status", {
+    description: "Show status of background async agents",
+    handler: async (_args, ctx) => {
+      const jobs = Array.from(asyncState.jobs.values());
+      if (jobs.length === 0) {
+        ctx.ui.notify("No async agents running or recently completed.", "info");
+        return;
+      }
+
+      const lines: string[] = ["## Async Agents\n"];
+      lines.push("| Agent | Status | Duration | Task |");
+      lines.push("|-------|--------|----------|------|");
+      for (const job of jobs) {
+        const duration = job.durationMs
+          ? formatDuration(job.durationMs)
+          : formatDuration(Date.now() - job.startedAt);
+        const statusIcon = job.status === "complete" ? "✅" : job.status === "failed" ? "❌" : job.status === "running" ? "⏳" : "⏸️";
+        const taskPreview = job.task.length > 50 ? job.task.slice(0, 50) + "..." : job.task;
+        lines.push(`| ${job.agent} | ${statusIcon} ${job.status} | ${duration} | ${taskPreview} |`);
+      }
+
+      if (ctx.hasUI) {
+        ctx.ui.notify(lines.join("\n"), "info");
+      }
+    },
+  });
+
   // ── Subagent tool ──────────────────────────────────────────────────────
 
   pi.registerTool({
@@ -822,6 +1099,7 @@ export default function (pi: ExtensionAPI) {
       "Route by intent: python code → python-expert, git commit → git-expert, PR → github-expert, etc.",
       "Run independent tasks in parallel using the tasks array.",
       "For multi-step workflows, use chain mode with {previous} placeholder.",
+      "Set async: true when you don't need the result immediately for your next step. The result will surface automatically when complete. Use sync (default) only when the next step depends on this agent's output.",
     ],
     parameters: SubagentParams,
 
@@ -886,6 +1164,36 @@ export default function (pi: ExtensionAPI) {
               )([]),
             };
         }
+      }
+
+      // Async mode — spawn in background and return immediately
+      if (params.async === true) {
+        if (params.chain || params.tasks) {
+          return {
+            content: [{ type: "text", text: "Async mode currently supports single agent only. Use agent + task without chain/tasks." }],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
+        if (!params.agent || !params.task) {
+          return {
+            content: [{ type: "text", text: "Async mode requires agent and task." }],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
+        const result = spawnAsyncAgent(params.agent, params.task, params.cwd ?? ctx.cwd, agents);
+        if (result.error) {
+          return {
+            content: [{ type: "text", text: result.error }],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text", text: `Async agent spawned: ${params.agent} [${result.id}]\nUse /async-status to check progress. Results will appear when complete.` }],
+          details: mkd("single")([]),
+        };
       }
 
       // Chain mode
@@ -1108,10 +1416,11 @@ export default function (pi: ExtensionAPI) {
           t += `\n  ${theme.fg("muted", `... +${args.tasks.length - 3} more`)}`;
         return new Text(t, 0, 0);
       }
+      const asyncLabel = args.async === true ? theme.fg("warning", " [async]") : "";
       let t =
         theme.fg("toolTitle", theme.bold("subagent ")) +
         theme.fg("accent", args.agent || "...") +
-        theme.fg("muted", ` [${scope}]`);
+        theme.fg("muted", ` [${scope}]`) + asyncLabel;
       t += `\n  ${theme.fg("dim", args.task ? (args.task.length > 60 ? args.task.slice(0, 60) + "..." : args.task) : "...")}`;
       return new Text(t, 0, 0);
     },


### PR DESCRIPTION
Adds the ability to run subagents in the background while the user continues working.

## What's new
- `async: true` flag on the subagent tool — spawns agent as a detached process
- `async-runner.ts` — standalone script spawned via jiti for background execution
- Job tracker polls status files every 3s, updates `⏳ N async: agent` in status line
- Result watcher (`fs.watch`) detects completion and:
  - Sends desktop notification
  - Surfaces result in conversation via `sendMessage` with `triggerTurn: true`
- `/async-status` command shows running/completed background agents
- AI decides when to use async via promptGuideline — no user intervention needed
- `[async]` badge rendered on async subagent tool calls

## How it works
1. Subagent tool receives `async: true`
2. Writes config JSON, spawns detached `async-runner.ts` via jiti
3. Runner executes `pi --mode json -p` and writes status to `/tmp/pi-async-agents/<id>/status.json`
4. Poller in main extension reads status, updates widget
5. On completion, runner writes result to `/tmp/pi-async-agents/results/<id>.json`
6. `fs.watch` picks it up, notifies user, surfaces output in conversation

Closes #48