### PR TITLE
fix: add unique container name to docker run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ docker build -t ghcr.io/myk-org/pi-config:latest .
 
 ```bash
 docker run --rm -it \
+  --name "pi-config-$(date +%s)" \
   --network host \
   --env-file /path/to/.env \
   -v "$PWD":"$PWD":rw \
@@ -262,6 +263,7 @@ Add to your `~/.bashrc` or `~/.zshrc`:
 ```bash
 alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   docker run --rm -it \
+  --name "pi-config-$(date +%s)" \
   --network host \
   --env-file "$HOME/.pi/.env" \
   -v "$PWD":"$PWD":rw \


### PR DESCRIPTION
Add `--name "pi-config-$(date +%s)"` to both the Run example and shell alias for unique container names per session.