### PR TITLE
fix: override core.excludesFile in entrypoint for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ RUN npm install -g @mariozechner/pi-coding-agent acpx agent-browser pi-web-acces
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
 USER node
-RUN git config --global core.excludesFile /home/node/.gitignore-global
 RUN mkdir -p /home/node/.npm-global && npm config set prefix /home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:/home/node/.pi/agent/bin:/home/node/.local/bin:$PATH"
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,4 +29,7 @@ if [ ! -d "$SKILL_DIR" ]; then
     ln -sf /usr/local/lib/node_modules/agent-browser/skills/agent-browser "$SKILL_DIR"
 fi
 
+# Fix git excludesFile path for container (host .gitconfig may have host-specific paths)
+git config --global core.excludesFile /home/node/.gitignore-global
+
 exec pi "$@"


### PR DESCRIPTION
Host .gitconfig is mounted read-only and contains host-specific absolute paths (e.g. `/home/myakove/.gitignore-global`). Inside the container, the file is at `/home/node/.gitignore-global`. Fix by overriding `core.excludesFile` in entrypoint.sh at startup. Remove the now-useless `git config` from Dockerfile since the mounted .gitconfig overwrites it anyway.