### PR TITLE
fix: copy .gitconfig to writable path before modifying

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,7 +29,11 @@ if [ ! -d "$SKILL_DIR" ]; then
     ln -sf /usr/local/lib/node_modules/agent-browser/skills/agent-browser "$SKILL_DIR"
 fi
 
-# Fix git excludesFile path for container (host .gitconfig may have host-specific paths)
-git config --global core.excludesFile /home/node/.gitignore-global
+# Fix host-specific paths in mounted .gitconfig (read-only mount, can't write in-place)
+cp /home/node/.gitconfig /home/node/.gitconfig-local 2>/dev/null || true
+if [ -f /home/node/.gitconfig-local ]; then
+    export GIT_CONFIG_GLOBAL=/home/node/.gitconfig-local
+    git config --global core.excludesFile /home/node/.gitignore-global
+fi
 
 exec pi "$@"


### PR DESCRIPTION
Mounted .gitconfig is read-only, causing "Device or resource busy" when `git config --global` tries to write. Copy to `.gitconfig-local` and use `GIT_CONFIG_GLOBAL` env var to point git at the writable copy.