### PR TITLE
fix: add procps to container for process debugging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     git \
     openssh-client \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI and Google Cloud SDK


### PR DESCRIPTION
Adds `procps` package (provides `ps`, `top`, `pgrep`, `pkill`) to the container image for debugging stuck subagent processes.