### PR TITLE
fix: improve acpx-prompt discoverability for natural language triggers

### DIFF
--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -1,5 +1,5 @@
 ---
-description: Run a prompt via acpx to any supported coding agent
+description: "Run a prompt via acpx to any coding agent (cursor, codex, gemini, claude, copilot, droid, kiro, opencode, qwen, etc.). Use for peer review, code review, or any task involving an external AI agent — /acpx-prompt <agent> <prompt>"
 ---
 
 # acpx Multi-Agent Prompt Command

--- a/rules/10-agent-routing.md
+++ b/rules/10-agent-routing.md
@@ -21,6 +21,7 @@
 | Tests                                                        | `test-automator`                 |
 | Debugging                                                    | `debugger`                       |
 | API docs                                                     | `api-documenter`                 |
+| External AI agents (cursor, codex, gemini, claude, copilot, etc.) | `/acpx-prompt`               |
 | External library/framework docs (React, FastAPI, Django, etc.) | `docs-fetcher`                 |
 
 ## Routing by Intent, Not Tool


### PR DESCRIPTION
- Update acpx-prompt description with agent names and use cases as trigger keywords (cursor, codex, gemini, peer review, etc.)
- Add routing rule for external AI agents to `/acpx-prompt` in the agent routing table

Closes #55