### PR TITLE
docs: add project name to container name and debug section

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,6 +23,26 @@ pre-commit run --all-files
 uv run pytest
 ```
 
+## Debugging a Running Container
+
+Container names include the project directory: `pi-config-<project>-<timestamp>`.
+
+Requires [`fzf`](https://github.com/junegunn/fzf) on the host. Add to your `~/.bashrc` or `~/.zshrc`:
+
+```bash
+alias pi-docker-exec='docker exec -it $(docker ps --filter name=pi-config --format "{{.Names}}" | fzf --height 40% --reverse --prompt "Select container: ") bash'
+```
+
+This lists all running pi-config containers via `fzf` — select one and it drops you into a bash shell.
+
+Useful debug commands inside the container:
+
+```bash
+ps aux | grep pi              # Find stuck pi/subagent processes
+pkill -f 'pi.*--mode.*json'   # Kill stuck subagent processes
+cat /tmp/pi-async-agents/*/status.json  # Check async agent status
+```
+
 ## Python Dependencies
 
 Never use `pip` directly — always use `uv`:

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ docker build -t ghcr.io/myk-org/pi-config:latest .
 
 ```bash
 docker run --rm -it \
-  --name "pi-config-$(date +%s)" \
+  --name "pi-config-$(basename $PWD)-$(date +%s)" \
   --network host \
   --env-file /path/to/.env \
   -v "$PWD":"$PWD":rw \
@@ -294,7 +294,7 @@ Add to your `~/.bashrc` or `~/.zshrc`:
 ```bash
 alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   docker run --rm -it \
-  --name "pi-config-$(date +%s)" \
+  --name "pi-config-$(basename $PWD)-$(date +%s)" \
   --network host \
   --env-file "$HOME/.pi/.env" \
   -v "$PWD":"$PWD":rw \


### PR DESCRIPTION
- Container name now includes project dir: `pi-config-<project>-<timestamp>`
- Add "Debugging a Running Container" section to DEVELOPMENT.md with fzf-based `pi-docker-exec` alias and debug commands (ps, pkill, async status)