### PR TITLE
fix: add 5-second git status polling for long-running operations

### DIFF
--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -1906,6 +1906,15 @@ export default function (pi: ExtensionAPI) {
   pi.on("tool_result", updateBranch);
   pi.on("tool_execution_end", updateBranch);
 
+  // Poll git status every 5s for updates during long-running operations
+  let gitPollCtx: any = null;
+  pi.on("session_start", (_event, ctx) => { gitPollCtx = ctx; });
+  const gitPoller = setInterval(() => {
+    if (gitPollCtx) updateBranch(null, gitPollCtx);
+  }, 5000);
+  if (gitPoller.unref) gitPoller.unref();
+  pi.on("session_shutdown", () => { clearInterval(gitPoller); });
+
   // ── Container indicator in status line ─────────────────────────────────
 
   if (IN_CONTAINER) {


### PR DESCRIPTION
Git status only updated on events (tool_result, turn_end, etc.). During long-running operations like subagents, nothing updated. Add 5-second interval polling alongside existing event hooks.