### PR TITLE
fix: add SSH timeout to prevent hung git operations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,4 +36,10 @@ if [ -f /home/node/.gitconfig-local ]; then
     git config --global core.excludesFile /home/node/.gitignore-global
 fi
 
+# SSH timeout — detect dead connections during git fetch/push/pull
+# ServerAliveInterval: send keepalive every 15s
+# ServerAliveCountMax: give up after 3 missed responses (45s total)
+# ConnectTimeout: fail if can't connect within 10s
+export GIT_SSH_COMMAND="ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ConnectTimeout=10"
+
 exec pi "$@"

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -21,9 +21,10 @@ import { registerRules } from "./rules.js";
 import { registerSessionValidation } from "./session-validation.js";
 import { registerStatusLine } from "./status-line.js";
 import { registerSubagentTool } from "./subagent-tool.js";
-import { isRunningInContainer, terminalNotify } from "./utils.js";
+import { ensureGitSshTimeout, isRunningInContainer, terminalNotify } from "./utils.js";
 
 const IN_CONTAINER = isRunningInContainer();
+ensureGitSshTimeout();
 
 export default function (pi: ExtensionAPI) {
   registerAskUser(pi, terminalNotify);

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -17,6 +17,13 @@ export function terminalNotify(title: string, body: string): void {
   } catch {}
 }
 
+/** Set SSH timeout for git operations — prevents hung connections */
+export function ensureGitSshTimeout(): void {
+  if (!process.env.GIT_SSH_COMMAND) {
+    process.env.GIT_SSH_COMMAND = "ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ConnectTimeout=10";
+  }
+}
+
 export function isRunningInContainer(): boolean {
   try {
     // Check for /.dockerenv (Docker) or /run/.containerenv (Podman)


### PR DESCRIPTION
Git fetch/push/pull over SSH can hang indefinitely when the TCP connection stalls mid-transfer. Root cause found: a stuck `git fetch origin v2.11` had been hanging for 38+ minutes with SSH in TCP retransmission state.

Fix: Set `GIT_SSH_COMMAND` with:
- `ServerAliveInterval=15` — send keepalive every 15s
- `ServerAliveCountMax=3` — give up after 45s of dead connection
- `ConnectTimeout=10` — fail fast if can't connect

Applied in:
- `entrypoint.sh` — covers container runs
- `extensions/orchestrator/utils.ts` — covers native runs

Both container and native git SSH operations are now covered.