### PR TITLE
feat: auto-start diffity diff viewer in container sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ pi-config/
 │   │   ├── async-agents.ts          # Async background agent infrastructure
 │   │   ├── async-runner.ts          # Standalone async runner (spawned detached)
 │   │   ├── btw.ts                   # /btw command
+│   │   ├── diffity.ts               # Auto-start diffity diff viewer (container)
 │   │   ├── enforcement.ts           # Python/git/dangerous command enforcement
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── rules.ts                 # Rule injection (before_agent_start)

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir -p /home/node/.cache/ms-playwright && \
     chown -R node:node /home/node/.cache
 
 # Install pi coding agent, acpx, agent-browser, and pi-web-access
-RUN npm install -g @mariozechner/pi-coding-agent acpx agent-browser pi-web-access
+RUN npm install -g @mariozechner/pi-coding-agent acpx agent-browser pi-web-access diffity
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
 USER node

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Pass via `--env-file /path/to/.env` in the docker run command.
 | `agent-browser` | Browser automation CLI (navigate, click, screenshot, forms) |
 | `gcloud` | Google Cloud CLI (Vertex AI authentication) |
 | `procps` | Process utilities (ps, top, pgrep, pkill) |
+| `diffity` | Git diff viewer in the browser (auto-starts in container) |
 | `jq` | JSON processing |
 | `curl` | HTTP requests |
 

--- a/extensions/orchestrator/diffity.ts
+++ b/extensions/orchestrator/diffity.ts
@@ -1,0 +1,84 @@
+/**
+ * Diffity auto-start — launches diffity diff viewer in container sessions.
+ * Shows a status line link so the user can check code changes in real-time.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { execSync } from "node:child_process";
+import * as net from "node:net";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+const DIFFITY_START_PORT = 8090;
+const DIFFITY_MAX_PORT_TRIES = 10;
+
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+async function findAvailablePort(): Promise<number | null> {
+  for (let i = 0; i < DIFFITY_MAX_PORT_TRIES; i++) {
+    const port = DIFFITY_START_PORT + i;
+    if (await isPortAvailable(port)) return port;
+  }
+  return null;
+}
+
+function hasDiffity(): boolean {
+  try {
+    execSync("which diffity", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function registerDiffity(pi: ExtensionAPI, inContainer: boolean): void {
+  if (!inContainer) return;
+  if (!hasDiffity()) return;
+
+  let diffityProc: ChildProcess | null = null;
+  let diffityPort: number | null = null;
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (!ctx.hasUI) return;
+    if (diffityProc) return; // Already running
+
+    const port = await findAvailablePort();
+    if (!port) return;
+
+    try {
+      diffityProc = spawn("diffity", [
+        "--dark",
+        "--no-open",
+        "--quiet",
+        "--port", String(port),
+      ], {
+        cwd: ctx.cwd,
+        detached: true,
+        stdio: "ignore",
+      });
+      diffityProc.unref();
+      diffityPort = port;
+
+      // Show link in status line
+      ctx.ui.setStatus("diffity", ctx.ui.theme.fg("accent", `📊 diff: http://localhost:${port}`));
+    } catch {
+      // diffity failed to start, ignore silently
+    }
+  });
+
+  pi.on("session_shutdown", () => {
+    if (diffityProc) {
+      try { diffityProc.kill(); } catch {}
+      diffityProc = null;
+      diffityPort = null;
+    }
+  });
+}

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -16,6 +16,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { registerAskUser } from "./ask-user.js";
 import { registerAsyncAgents } from "./async-agents.js";
 import { registerBtw } from "./btw.js";
+import { registerDiffity } from "./diffity.js";
 import { registerEnforcement } from "./enforcement.js";
 import { registerRules } from "./rules.js";
 import { registerSessionValidation } from "./session-validation.js";
@@ -34,5 +35,6 @@ export default function (pi: ExtensionAPI) {
   registerRules(pi);
   registerStatusLine(pi, IN_CONTAINER, terminalNotify);
   registerBtw(pi);
+  registerDiffity(pi, IN_CONTAINER);
   registerSessionValidation(pi);
 }


### PR DESCRIPTION
Automatically starts diffity on session_start in container sessions. Users can check code changes in real-time via browser.

- Install `diffity` in Dockerfile
- New `diffity.ts` module: spawns `diffity --dark --no-open --quiet` detached
- Auto-detects available port (8090+)
- Shows clickable `📊 diff: http://localhost:8090` in status line
- Kills process on session_shutdown
- Container only — skipped on native runs

Closes #67