### PR TITLE
fix: nerd font icons, colored counts, remove separators

### DIFF
--- a/extensions/orchestrator/diffity.ts
+++ b/extensions/orchestrator/diffity.ts
@@ -54,21 +54,23 @@ export function registerDiffity(pi: ExtensionAPI, inContainer: boolean): void {
     if (!port) return;
 
     try {
-      diffityProc = spawn("diffity", [
-        "--dark",
-        "--no-open",
-        "--quiet",
-        "--port", String(port),
-      ], {
-        cwd: ctx.cwd,
-        detached: true,
-        stdio: "ignore",
-      });
+      diffityProc = spawn(
+        "diffity",
+        ["--dark", "--no-open", "--quiet", "--port", String(port)],
+        {
+          cwd: ctx.cwd,
+          detached: true,
+          stdio: "ignore",
+        },
+      );
       diffityProc.unref();
       diffityPort = port;
 
       // Show link in status line
-      ctx.ui.setStatus("diffity", ctx.ui.theme.fg("accent", `📊 diff: http://localhost:${port}`));
+      ctx.ui.setStatus(
+        "diffity",
+        ctx.ui.theme.fg("accent", ` http://localhost:${port}`),
+      );
     } catch {
       // diffity failed to start, ignore silently
     }
@@ -76,7 +78,9 @@ export function registerDiffity(pi: ExtensionAPI, inContainer: boolean): void {
 
   pi.on("session_shutdown", () => {
     if (diffityProc) {
-      try { diffityProc.kill(); } catch {}
+      try {
+        diffityProc.kill();
+      } catch {}
       diffityProc = null;
       diffityPort = null;
     }

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -35,20 +35,17 @@ export function registerStatusLine(
       }
 
       const changes: string[] = [];
-      if (modified > 0) changes.push(`~${modified}`);
-      if (added > 0) changes.push(`+${added}`);
-      if (deleted > 0) changes.push(`-${deleted}`);
-      if (untracked > 0) changes.push(`?${untracked}`);
-      const sep = IN_CONTAINER ? "| " : "";
+      if (modified > 0) changes.push(ctx.ui.theme.fg("warning", `~${modified}`));
+      if (added > 0) changes.push(ctx.ui.theme.fg("success", `+${added}`));
+      if (deleted > 0) changes.push(ctx.ui.theme.fg("error", `-${deleted}`));
+      if (untracked > 0) changes.push(ctx.ui.theme.fg("dim", `?${untracked}`));
       const icon =
         changes.length > 0
-          ? ctx.ui.theme.fg("error", "")
-          : ctx.ui.theme.fg("success", "");
+          ? ctx.ui.theme.fg("error", " ")
+          : ctx.ui.theme.fg("success", " ");
       ctx.ui.setStatus(
         "git",
-        changes.length > 0
-          ? `${sep}${icon} (${changes.join(" ")})`
-          : `${sep}${icon}`,
+        changes.length > 0 ? `${icon} ${changes.join(" ")}` : icon,
       );
     } catch {}
   };
@@ -60,18 +57,22 @@ export function registerStatusLine(
 
   // Poll git status every 5s for updates during long-running operations
   let gitPollCtx: any = null;
-  pi.on("session_start", (_event, ctx) => { gitPollCtx = ctx; });
+  pi.on("session_start", (_event, ctx) => {
+    gitPollCtx = ctx;
+  });
   const gitPoller = setInterval(() => {
     if (gitPollCtx) updateBranch(null, gitPollCtx);
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
-  pi.on("session_shutdown", () => { clearInterval(gitPoller); });
+  pi.on("session_shutdown", () => {
+    clearInterval(gitPoller);
+  });
 
   // ── Container indicator in status line ─────────────────────────────────
 
   if (IN_CONTAINER) {
     pi.on("session_start", (_event, ctx) => {
-      ctx.ui.setStatus("container", "📦 container");
+      ctx.ui.setStatus("container", "󰡨 ");
     });
   }
 


### PR DESCRIPTION
- Replace emoji with nerd font icons (docker, git-branch, git-diff)
- Remove `|` separator between status items
- Color git status counts: warning `~modified`, success `+added`, error `-deleted`, dim `?untracked`
- Remove parentheses from counts