### PR TITLE
fix: centralize icons, fix status line order and separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ pi install git:github.com/myk-org/pi-config
 uv tool install git+https://github.com/myk-org/pi-config
 ```
 
+#### Optional: Browser automation
+
+For browser automation (screenshots, form filling, web testing), install [agent-browser](https://github.com/nicobailon/agent-browser):
+
+```bash
+npm install -g agent-browser
+npx playwright install --with-deps chromium
+```
+
 The pi package installs globally to `~/.pi/agent/git/`. Agents are bundled with the extension and discovered automatically.
 
 ## Updating

--- a/extensions/orchestrator/diffity.ts
+++ b/extensions/orchestrator/diffity.ts
@@ -1,12 +1,14 @@
 /**
- * Diffity auto-start — launches diffity diff viewer in container sessions.
+ * Diffity auto-start — launches diffity diff viewer.
  * Shows a status line link so the user can check code changes in real-time.
+ * Works both in container and native — requires diffity to be installed.
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
 import { execSync } from "node:child_process";
 import * as net from "node:net";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { ICON_DIFF } from "./icons.js";
 
 const DIFFITY_START_PORT = 8090;
 const DIFFITY_MAX_PORT_TRIES = 10;
@@ -39,12 +41,19 @@ function hasDiffity(): boolean {
   }
 }
 
-export function registerDiffity(pi: ExtensionAPI, inContainer: boolean): void {
-  if (!inContainer) return;
+function killProcessTree(proc: ChildProcess): void {
+  try {
+    // Kill the process group (negative PID kills the group)
+    if (proc.pid) process.kill(-proc.pid, "SIGTERM");
+  } catch {
+    try { proc.kill("SIGTERM"); } catch {}
+  }
+}
+
+export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: string) => void): void {
   if (!hasDiffity()) return;
 
   let diffityProc: ChildProcess | null = null;
-  let diffityPort: number | null = null;
 
   pi.on("session_start", async (_event, ctx) => {
     if (!ctx.hasUI) return;
@@ -54,23 +63,27 @@ export function registerDiffity(pi: ExtensionAPI, inContainer: boolean): void {
     if (!port) return;
 
     try {
-      diffityProc = spawn(
-        "diffity",
-        ["--dark", "--no-open", "--quiet", "--port", String(port)],
-        {
-          cwd: ctx.cwd,
-          detached: true,
-          stdio: "ignore",
-        },
-      );
+      diffityProc = spawn("diffity", [
+        "--dark",
+        "--no-open",
+        "--quiet",
+        "--port", String(port),
+      ], {
+        cwd: ctx.cwd,
+        detached: true,
+        stdio: "ignore",
+      });
       diffityProc.unref();
-      diffityPort = port;
 
       // Show link in status line
-      ctx.ui.setStatus(
-        "diffity",
-        ctx.ui.theme.fg("accent", ` http://localhost:${port}`),
-      );
+      const statusText = ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${port}?theme=dark`);
+      if (setDiffityStatus) {
+        setDiffityStatus(statusText);
+        // Trigger a git status refresh to rebuild combined status
+        pi.events?.emit("diffity:ready");
+      } else {
+        ctx.ui.setStatus("diffity", statusText);
+      }
     } catch {
       // diffity failed to start, ignore silently
     }
@@ -78,11 +91,8 @@ export function registerDiffity(pi: ExtensionAPI, inContainer: boolean): void {
 
   pi.on("session_shutdown", () => {
     if (diffityProc) {
-      try {
-        diffityProc.kill();
-      } catch {}
+      killProcessTree(diffityProc);
       diffityProc = null;
-      diffityPort = null;
     }
   });
 }

--- a/extensions/orchestrator/icons.ts
+++ b/extensions/orchestrator/icons.ts
@@ -1,0 +1,10 @@
+/**
+ * Nerd font icons — single place to change all icons used across the extension.
+ * Browse icons at: https://www.nerdfonts.com/cheat-sheet
+ */
+
+export const ICON_SEP = " ❱ ";
+export const ICON_CONTAINER = "󰡨 ";
+export const ICON_GIT_CLEAN = "";
+export const ICON_GIT_DIRTY = "";
+export const ICON_DIFF = "";

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -33,8 +33,8 @@ export default function (pi: ExtensionAPI) {
   registerSubagentTool(pi, spawnAsyncAgent);
   registerEnforcement(pi);
   registerRules(pi);
-  registerStatusLine(pi, IN_CONTAINER, terminalNotify);
+  const { setDiffityStatus } = registerStatusLine(pi, IN_CONTAINER, terminalNotify) as any;
   registerBtw(pi);
-  registerDiffity(pi, IN_CONTAINER);
+  registerDiffity(pi, setDiffityStatus);
   registerSessionValidation(pi);
 }

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -4,15 +4,43 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getCurrentBranch, runGit } from "./git-helpers.js";
+import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
 
 export function registerStatusLine(
   pi: ExtensionAPI,
   IN_CONTAINER: boolean,
   terminalNotify: (title: string, body: string) => void,
 ): void {
+  // Track diffity URL so we can include it in the combined status
+  let diffityStatus = "";
+
+  // Called by diffity module to set its status text
+  const setDiffityStatus = (text: string) => {
+    diffityStatus = text;
+  };
+
+  // ── Combined status line builder ───────────────────────────────────────
+
+  const buildStatus = (ctx: any, gitPart: string) => {
+    const parts: string[] = [];
+
+    if (IN_CONTAINER) parts.push(ICON_CONTAINER);
+    if (diffityStatus) parts.push(diffityStatus);
+    parts.push(gitPart);
+
+    ctx.ui.setStatus("combined", parts.join(ctx.ui.theme.fg("dim", ICON_SEP)));
+    // Clear individual statuses to avoid duplicates
+    ctx.ui.setStatus("container", undefined);
+    ctx.ui.setStatus("git", undefined);
+    ctx.ui.setStatus("diffity", undefined);
+  };
+
   // ── Git branch status line ─────────────────────────────────────────────
 
+  let lastCtx: any = null;
+
   const updateBranch = (_event: any, ctx: any) => {
+    lastCtx = ctx;
     try {
       const b = getCurrentBranch(ctx.cwd);
       if (!b) return;
@@ -35,20 +63,22 @@ export function registerStatusLine(
       }
 
       const changes: string[] = [];
-      if (modified > 0) changes.push(ctx.ui.theme.fg("warning", `~${modified}`));
+      if (modified > 0)
+        changes.push(ctx.ui.theme.fg("warning", `~${modified}`));
       if (added > 0) changes.push(ctx.ui.theme.fg("success", `+${added}`));
       if (deleted > 0) changes.push(ctx.ui.theme.fg("error", `-${deleted}`));
       if (untracked > 0) changes.push(ctx.ui.theme.fg("dim", `?${untracked}`));
       const icon =
         changes.length > 0
-          ? ctx.ui.theme.fg("error", " ")
-          : ctx.ui.theme.fg("success", " ");
-      ctx.ui.setStatus(
-        "git",
-        changes.length > 0 ? `${icon} ${changes.join(" ")}` : icon,
-      );
+          ? ctx.ui.theme.fg("error", ICON_GIT_DIRTY)
+          : ctx.ui.theme.fg("success", ICON_GIT_CLEAN);
+      const gitPart =
+        changes.length > 0 ? `${icon} ${changes.join(" ")}` : icon;
+
+      buildStatus(ctx, gitPart);
     } catch {}
   };
+
   pi.on("session_start", updateBranch);
   pi.on("agent_end", updateBranch);
   pi.on("turn_end", updateBranch);
@@ -56,25 +86,16 @@ export function registerStatusLine(
   pi.on("tool_execution_end", updateBranch);
 
   // Poll git status every 5s for updates during long-running operations
-  let gitPollCtx: any = null;
   pi.on("session_start", (_event, ctx) => {
-    gitPollCtx = ctx;
+    lastCtx = ctx;
   });
   const gitPoller = setInterval(() => {
-    if (gitPollCtx) updateBranch(null, gitPollCtx);
+    if (lastCtx) updateBranch(null, lastCtx);
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
   pi.on("session_shutdown", () => {
     clearInterval(gitPoller);
   });
-
-  // ── Container indicator in status line ─────────────────────────────────
-
-  if (IN_CONTAINER) {
-    pi.on("session_start", (_event, ctx) => {
-      ctx.ui.setStatus("container", "󰡨 ");
-    });
-  }
 
   // ── Desktop notifications — notify when user attention is needed ─────
 
@@ -92,4 +113,6 @@ export function registerStatusLine(
     }
     terminalNotify("pi", "Waiting for input");
   });
+
+  return { setDiffityStatus } as any;
 }


### PR DESCRIPTION
- New `icons.ts` — single file for all nerd font icons
- Fix status line order: container → diff → git
- Add gray separators between items (no orphans when items missing)
- Icon constants imported from `icons.ts` by both `status-line.ts` and `diffity.ts`
- Diffity works on native too (checks if installed, not container-only)
- Add agent-browser install instructions for native setup in README