### PR TITLE
fix: prevent recursive subagent spawning

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -230,6 +230,7 @@ export function registerAsyncAgents(
       detached: true,
       stdio: "ignore",
       windowsHide: true,
+      env: { ...process.env, PI_SUBAGENT_CHILD: "1" },
     });
     proc.unref();
 

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -7,6 +7,9 @@ import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 export function registerRules(pi: ExtensionAPI): void {
+  // Skip orchestrator rules in child processes — they are specialists, not managers
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
   pi.on("before_agent_start", async (event, _ctx) => {
     // Load rules from rules/ directory (sorted alphabetically)
     const rulesDir = path.resolve(__dirname, "..", "..", "rules");

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -377,6 +377,7 @@ export async function runSingleAgent(
         cwd: cwd ?? defaultCwd,
         shell: false,
         stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, PI_SUBAGENT_CHILD: "1" },
       });
       let buf = "";
 
@@ -463,6 +464,10 @@ export function registerSubagentTool(
   pi: ExtensionAPI,
   spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[]) => { id: string; error?: string },
 ): void {
+  // Only the orchestrator (top-level pi) can spawn subagents.
+  // Child processes set PI_SUBAGENT_CHILD=1 to prevent infinite recursion.
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
   pi.registerTool({
     name: "subagent",
     label: "Subagent",


### PR DESCRIPTION
Only the orchestrator (top-level pi) can spawn subagents. Child processes get `PI_SUBAGENT_CHILD=1` which:
- Skips subagent tool registration (agents do work directly)
- Skips orchestrator rules injection (agents are specialists, not managers)
- Keeps enforcement handlers active (git protection, python/pip)

Fixes infinite pi process recursion seen in production (42+ nested pi processes spawning every ~9 seconds).