### PR TITLE
fix: remove turn_end notification — only notify on agent_end

### DIFF
--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -99,19 +99,8 @@ export function registerStatusLine(
 
   // ── Desktop notifications — notify when user attention is needed ─────
 
-  let agentEnded = false;
-
   pi.on("agent_end", async () => {
-    agentEnded = true;
     terminalNotify("pi", "Task completed");
-  });
-
-  pi.on("turn_end", async () => {
-    if (agentEnded) {
-      agentEnded = false;
-      return; // agent_end already sent notification
-    }
-    terminalNotify("pi", "Waiting for input");
   });
 
   return { setDiffityStatus } as any;


### PR DESCRIPTION
turn_end fires during intermediate turns while subagents run, causing noisy notifications. Only agent_end should notify.