### PR TITLE
fix: stronger async guideline for independent tasks

### DIFF
--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -484,6 +484,7 @@ export function registerSubagentTool(
       "Run independent tasks in parallel using the tasks array.",
       "For multi-step workflows, use chain mode with {previous} placeholder.",
       "Set async: true when you don't need the result immediately for your next step. The result will surface automatically when complete. Use sync (default) only when the next step depends on this agent's output.",
+      "ALWAYS use async: true for independent tasks that can run in parallel — code reviews, opening issues, research, analysis. Only use sync when the very next step depends on this agent's output (e.g., chain where step 2 needs step 1's result).",
     ],
     parameters: SubagentParams,
 


### PR DESCRIPTION
Make async usage guideline stronger — ALWAYS async for independent tasks (reviews, issues, research). Only sync when next step depends on output.