### PR TITLE
fix: remove --slurp from gh api calls — incompatible with gh v2.89.0

### DIFF
--- a/myk_pi_tools/pr/diff.py
+++ b/myk_pi_tools/pr/diff.py
@@ -143,16 +143,19 @@ def fetch_pr_files(pr_info: PRInfo) -> list[dict[str, Any]]:
                 "api",
                 f"/repos/{pr_info.owner}/{pr_info.repo}/pulls/{pr_info.pr_number}/files",
                 "--paginate",
-                "--slurp",
-                "--jq",
-                "flatten",
             ],
             capture_output=True,
             text=True,
             check=True,
             timeout=120,
         )
-        files_data = json.loads(result.stdout)
+        # --paginate returns concatenated JSON arrays, merge them
+        files_data = []
+        for item in json.loads(f"[{result.stdout.replace('][', ',')}]"):
+            if isinstance(item, list):
+                files_data.extend(item)
+            else:
+                files_data.append(item)
         # Extract relevant fields
         return [
             {

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -307,7 +307,7 @@ def run_gh_api(endpoint: str, *, paginate: bool = False) -> Any | None:
     """Run a REST API call via gh api. Returns parsed JSON or None on error."""
     cmd = ["gh", "api"]
     if paginate:
-        cmd.extend(["--paginate", "--slurp"])
+        cmd.append("--paginate")
     cmd.append(endpoint)
 
     try:
@@ -322,10 +322,9 @@ def run_gh_api(endpoint: str, *, paginate: bool = False) -> Any | None:
         return None
 
     try:
-        data = json.loads(result.stdout)
-        # With --slurp, paginated results are wrapped in an outer array
-        # Flatten nested arrays for consistency
-        if paginate and isinstance(data, list):
+        # --paginate returns concatenated JSON arrays, merge them
+        if paginate:
+            data = json.loads(f"[{result.stdout.replace('][', ',')}]")
             merged = []
             for item in data:
                 if isinstance(item, list):
@@ -333,7 +332,7 @@ def run_gh_api(endpoint: str, *, paginate: bool = False) -> Any | None:
                 else:
                     merged.append(item)
             return merged
-        return data
+        return json.loads(result.stdout)
     except json.JSONDecodeError as e:
         print_stderr(f"Error parsing JSON from gh api: {e}")
         return None


### PR DESCRIPTION
gh v2.89.0 rejects `--slurp` combined with `--jq`. Handle pagination flattening in Python instead.

Closes #80