### PR TITLE
fix: block explicit git push to main/master from any branch

### DIFF
--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -95,12 +95,19 @@ export function registerEnforcement(pi: ExtensionAPI): void {
           };
       }
 
-      // Block pushes to protected branches + require user approval for all pushes
+      // Block pushes to protected branches
       if (hasGitSub(command, "push")) {
+        // Block if currently on main/master
         if (branch === "main" || branch === "master")
           return {
             block: true,
             reason: `⛔ Cannot push to '${branch}'. Create a feature branch.`,
+          };
+        // Block explicit push to main/master (e.g., git push origin main)
+        if (/\bgit\b.*\bpush\b.*\b(main|master)\b/.test(command))
+          return {
+            block: true,
+            reason: "⛔ Cannot push to main/master. Create a feature branch.",
           };
         if (branch) {
           const pr = getPrMergeStatus(branch, ctx.cwd);


### PR DESCRIPTION
Enforcement handler only blocked pushes when currently on main. Missed explicit targets like `git push origin main` from another branch. Closes #84