### PR TITLE
fix: warn on long sleep, enforce async in orchestrator rules

### DIFF
--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -39,6 +39,17 @@ export function registerEnforcement(pi: ExtensionAPI): void {
         reason: "Direct pre-commit forbidden. Use: prek run --all-files",
       };
 
+    // Warn on long sleep commands — suggest async subagent instead
+    const sleepMatch = command.match(/\bsleep\s+(\d+)/);
+    if (sleepMatch && parseInt(sleepMatch[1], 10) > 5) {
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `⚠️ sleep ${sleepMatch[1]}s — consider using subagent with async: true for polling/monitoring instead of blocking the session.`,
+          "warning",
+        );
+      }
+    }
+
     // Git protection
     if (isGitRepo(ctx.cwd)) {
       // Block git add . / git add -A

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -14,6 +14,15 @@
 
 Always maximize parallelism. Only execute sequentially when there's a proven dependency between operations.
 
+### Async Agents (MANDATORY)
+
+**ALWAYS use `async: true`** for independent tasks that can run in parallel —
+code reviews, opening issues, research, analysis.
+Only use sync (default) when the **very next step** depends on this agent's output.
+
+❌ **WRONG:** Spawn 3 sync reviewers → wait for all → respond
+✅ **RIGHT:** Spawn 3 async reviewers → continue → results surface when complete
+
 ---
 
 ## User Interaction (MANDATORY)


### PR DESCRIPTION
- Warn when sleep > 5s detected — suggest async subagent
- Add async rule to rules/40-critical-rules.md

Closes #86