### PR TITLE
fix: remove agent-browser symlink, check skill on session start

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,12 +22,6 @@ if ! grep -q 'pi-web-access' "$HOME/.pi/agent/settings.json" 2>/dev/null; then
     pi install npm:pi-web-access 2>/dev/null || true
 fi
 
-# agent-browser skill (link to installed npm package)
-SKILL_DIR="$HOME/.pi/agent/skills/agent-browser"
-if [ ! -d "$SKILL_DIR" ]; then
-    mkdir -p "$(dirname "$SKILL_DIR")"
-    ln -sf /usr/local/lib/node_modules/agent-browser/skills/agent-browser "$SKILL_DIR"
-fi
 
 # Fix host-specific paths in mounted .gitconfig (read-only mount, can't write in-place)
 cp /home/node/.gitconfig /home/node/.gitconfig-local 2>/dev/null || true

--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -44,6 +44,17 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
         "myk-pi-tools — PR/release/review CLI. Install: uv tool install git+https://github.com/myk-org/pi-config",
       );
 
+    // Check agent-browser skill
+    const agentBrowserPaths = [
+      path.join(process.env.HOME || "", ".agents", "skills", "agent-browser", "SKILL.md"),
+      path.join(process.env.HOME || "", ".pi", "agent", "skills", "agent-browser", "SKILL.md"),
+    ];
+    if (!agentBrowserPaths.some((p) => fs.existsSync(p))) {
+      optional.push(
+        "agent-browser skill — browser automation. Install: npx skills add vercel-labs/agent-browser@agent-browser -g -y",
+      );
+    }
+
     // Check prek only if .pre-commit-config.yaml exists
     try {
       if (


### PR DESCRIPTION
Remove entrypoint symlink. Check on session start, tell user to install from skills.sh if missing. Comes in via ~/.agents mount.