### PR TITLE
feat: add docker-safe wrapper, skill, and enforcement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,16 @@ RUN curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -fsSL
     curl -fsSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz \
       | tar -C /usr/local/bin -xzf - oc
 
+# Install Docker and Podman CLIs (for docker-safe wrapper — read-only container inspection)
+RUN DOCKER_VERSION=$(curl -fsSL https://download.docker.com/linux/static/stable/x86_64/ | grep -oP 'docker-\K[0-9.]+(?=\.tgz)' | sort -V | tail -1) && \
+    curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+      | tar -xzf - --strip-components=1 -C /usr/local/bin docker/docker && \
+    apt-get update && apt-get install -y --no-install-recommends podman && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy docker-safe wrapper
+COPY --chmod=755 scripts/docker-safe /usr/local/bin/docker-safe
+
 # Install pi coding agent, acpx, agent-browser, pi-web-access, diffity
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     npm install -g @mariozechner/pi-coding-agent acpx agent-browser pi-web-access diffity

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -39,6 +39,14 @@ export function registerEnforcement(pi: ExtensionAPI): void {
         reason: "Direct pre-commit forbidden. Use: prek run --all-files",
       };
 
+    // Block direct docker/podman CLI — force docker-safe wrapper
+    if (/(?:^|[|;&]\s*)(?:docker|podman)\s/.test(cmdLower) && !cmdLower.includes("docker-safe")) {
+      return {
+        block: true,
+        reason: "Direct docker/podman forbidden. Use docker-safe for read-only container inspection (ps, logs, inspect, top, stats).",
+      };
+    }
+
     // Block sleep inside loops — force async subagent for polling
     const hasLoop = /\b(while|for|until)\b/.test(command);
     const sleepMatch = command.match(/\bsleep\s+(\d+)/);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "pi": {
     "extensions": ["./extensions"],
-    "prompts": ["./prompts"]
+    "prompts": ["./prompts"],
+    "skills": ["./skills"]
   }
 }

--- a/scripts/docker-safe
+++ b/scripts/docker-safe
@@ -1,0 +1,76 @@
+#!/bin/bash
+# docker-safe — restricted Docker/Podman CLI wrapper
+# Only allows read-only inspection commands. Blocks anything that modifies state.
+# Supports both Docker and Podman via --runtime flag or DOCKER_SAFE_RUNTIME env var.
+
+set -euo pipefail
+
+ALLOWED_COMMANDS="ps|logs|inspect|top|stats|port|diff|images|version|info"
+
+usage() {
+    cat <<EOF
+docker-safe — read-only Docker/Podman wrapper
+
+Usage: docker-safe [--runtime docker|podman] <command> [args]
+
+Allowed commands:
+  docker-safe ps [args]          List containers
+  docker-safe logs [args]        View container logs
+  docker-safe inspect [args]     Inspect container/image
+  docker-safe top [args]         Display running processes
+  docker-safe stats [args]       Display resource usage
+  docker-safe port [args]        List port mappings
+  docker-safe diff [args]        Show filesystem changes
+  docker-safe images [args]      List images
+  docker-safe version            Show Docker/Podman version
+  docker-safe info               Show system info
+
+Options:
+  --runtime docker|podman    Select runtime (default: docker)
+                             Can also set DOCKER_SAFE_RUNTIME env var
+
+All other commands (exec, run, rm, cp, build, etc.) are blocked.
+EOF
+    exit 1
+}
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+# Parse --runtime flag
+RUNTIME="${DOCKER_SAFE_RUNTIME:-docker}"
+if [ "$1" = "--runtime" ]; then
+    if [ $# -lt 2 ]; then
+        echo "⛔ --runtime requires a value: docker or podman" >&2
+        exit 1
+    fi
+    RUNTIME="$2"
+    shift 2
+fi
+
+if [ $# -eq 0 ]; then
+    usage
+fi
+
+# Validate runtime
+if [ "$RUNTIME" != "docker" ] && [ "$RUNTIME" != "podman" ]; then
+    echo "⛔ Invalid runtime '$RUNTIME'. Use 'docker' or 'podman'." >&2
+    exit 1
+fi
+
+if ! command -v "$RUNTIME" &>/dev/null; then
+    echo "⛔ $RUNTIME CLI not found." >&2
+    exit 1
+fi
+
+CMD="$1"
+
+# Check if command is allowed
+if ! echo "$CMD" | grep -qwE "^($ALLOWED_COMMANDS)$"; then
+    echo "⛔ docker-safe: '$CMD' is not allowed. Only read-only commands permitted." >&2
+    echo "Allowed: ${ALLOWED_COMMANDS//|/, }" >&2
+    exit 1
+fi
+
+exec "$RUNTIME" "$@"

--- a/skills/docker-safe/SKILL.md
+++ b/skills/docker-safe/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: docker-safe
+description: Inspect and debug Docker/Podman containers safely. Use when the user asks to check container logs, debug a running container, inspect container state, or troubleshoot container issues.
+---
+
+# Docker Safe — Read-Only Container Inspection
+
+Use `docker-safe` to inspect and debug containers. This is a restricted wrapper that only allows read-only commands — it cannot modify, create, or delete containers.
+
+## Runtime Selection
+
+Default runtime is `docker`. Use `--runtime podman` for Podman containers:
+
+```bash
+docker-safe --runtime podman ps          # List Podman containers
+docker-safe --runtime docker logs foo    # Docker container logs
+docker-safe ps                           # Uses docker by default
+```
+
+Or set `DOCKER_SAFE_RUNTIME=podman` env var to change the default.
+
+## Commands
+
+### List containers
+
+```bash
+docker-safe ps                    # Running containers
+docker-safe ps -a                 # All containers (including stopped)
+docker-safe ps --filter name=foo  # Filter by name
+docker-safe ps --format '{{.Names}} {{.Status}}'  # Custom format
+```
+
+### View logs
+
+```bash
+docker-safe logs <container>              # All logs
+docker-safe logs <container> --tail 100   # Last 100 lines
+docker-safe logs <container> -f           # Follow (stream) — use with caution, blocks
+docker-safe logs <container> --since 5m   # Last 5 minutes
+docker-safe logs <container> 2>&1 | grep ERROR  # Search for errors
+```
+
+### Inspect container
+
+```bash
+docker-safe inspect <container>                        # Full JSON
+docker-safe inspect <container> --format '{{.State.Status}}'  # Status only
+docker-safe inspect <container> --format '{{json .Config.Env}}'  # Environment
+docker-safe inspect <container> --format '{{json .NetworkSettings.Ports}}'  # Ports
+docker-safe inspect <container> --format '{{.Config.Image}}'  # Image used
+```
+
+### Process and resource info
+
+```bash
+docker-safe top <container>        # Running processes
+docker-safe stats --no-stream      # Resource usage snapshot
+docker-safe stats <container> --no-stream  # Single container
+docker-safe port <container>       # Port mappings
+```
+
+### Filesystem changes
+
+```bash
+docker-safe diff <container>       # Changed files since start
+```
+
+### Images and system
+
+```bash
+docker-safe images                 # List images
+docker-safe version                # Docker/Podman version
+docker-safe info                   # System-wide info
+```
+
+## Common Debug Patterns
+
+### Find a container by name pattern
+
+```bash
+docker-safe ps --filter name=pi-config --format '{{.Names}} {{.Status}} {{.RunningFor}}'
+```
+
+### Check why a container exited
+
+```bash
+docker-safe inspect <container> --format '{{.State.ExitCode}} {{.State.Error}}'
+docker-safe logs <container> --tail 50
+```
+
+### Check resource usage
+
+```bash
+docker-safe stats --no-stream --format 'table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}'
+```
+
+### Find stuck processes in a container
+
+```bash
+docker-safe top <container> -eo pid,ppid,stat,etime,args
+```
+
+## Blocked Commands
+
+The following are **not available** through docker-safe:
+
+- `exec` — cannot run commands inside containers
+- `run` — cannot create new containers
+- `rm` / `stop` / `kill` — cannot modify container state
+- `cp` — cannot copy files in/out
+- `build` / `push` / `pull` — cannot manage images
+- `network` / `volume` — cannot manage infrastructure
+
+If you need these operations, ask the user to run them directly on the host.
+
+## Prerequisites
+
+Requires container socket mounted with group access:
+
+```bash
+# Docker
+-v /var/run/docker.sock:/var/run/docker.sock:ro \
+--group-add $(stat -c '%g' /var/run/docker.sock)
+
+# Podman
+-v /var/run/podman/podman.sock:/var/run/podman/podman.sock:ro
+```


### PR DESCRIPTION
- docker-safe wrapper: read-only Docker/Podman inspection
- docker-safe skill: deterministic usage instructions
- Enforcement: blocks direct docker/podman, forces docker-safe
- Dockerfile: Docker CLI (latest) + Podman CLI
- package.json: register skills/ for pi discovery
- Supports `--runtime docker|podman` flag