### PR TITLE
fix: check GitHub protected branches via API

### DIFF
--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -8,6 +8,7 @@ import {
   DANGEROUS,
   getCurrentBranch,
   getMainBranch,
+  getProtectedBranches,
   getPrMergeStatus,
   hasGitSub,
   isBranchAhead,
@@ -81,6 +82,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
       const branch = getCurrentBranch(ctx.cwd);
       const mainBranch = getMainBranch(ctx.cwd);
+      const protectedBranches = getProtectedBranches(ctx.cwd);
 
       // Block commits to protected branches
       if (hasGitSub(command, "commit")) {
@@ -90,10 +92,10 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             reason:
               "⛔ Detached HEAD. Create a branch first: git checkout -b my-branch",
           };
-        if (branch === "main" || branch === "master")
+        if (protectedBranches.has(branch))
           return {
             block: true,
-            reason: `⛔ Cannot commit to '${branch}'. Create a feature branch.`,
+            reason: `⛔ Cannot commit to '${branch}' (protected). Create a feature branch.`,
           };
 
         const pr = getPrMergeStatus(branch, ctx.cwd);
@@ -115,18 +117,20 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
       // Block pushes to protected branches
       if (hasGitSub(command, "push")) {
-        // Block if currently on main/master
-        if (branch === "main" || branch === "master")
+        // Block if currently on a protected branch
+        if (branch && protectedBranches.has(branch))
           return {
             block: true,
-            reason: `⛔ Cannot push to '${branch}'. Create a feature branch.`,
+            reason: `⛔ Cannot push to '${branch}' (protected). Create a feature branch.`,
           };
-        // Block explicit push to main/master (e.g., git push origin main)
-        if (/\bgit\b.*\bpush\b.*\b(main|master)\b/.test(command))
-          return {
-            block: true,
-            reason: "⛔ Cannot push to main/master. Create a feature branch.",
-          };
+        // Block explicit push to any protected branch (e.g., git push origin v2.10)
+        for (const pb of protectedBranches) {
+          if (new RegExp(`\\bgit\\b.*\\bpush\\b.*\\b${pb.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(command))
+            return {
+              block: true,
+              reason: `⛔ Cannot push to '${pb}' (protected). Create a feature branch.`,
+            };
+        }
         if (branch) {
           const pr = getPrMergeStatus(branch, ctx.cwd);
           if (pr.merged)

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -95,6 +95,53 @@ export function getPrMergeStatus(
   }
 }
 
+// Cache protected branches per repo (fetched once per session)
+const protectedBranchesCache = new Map<string, Set<string>>();
+
+export function getProtectedBranches(cwd?: string): Set<string> {
+  const repoKey = cwd || process.cwd();
+  if (protectedBranchesCache.has(repoKey)) return protectedBranchesCache.get(repoKey)!;
+
+  const fallback = new Set(["main", "master"]);
+
+  if (!isGithubRepo(cwd)) {
+    protectedBranchesCache.set(repoKey, fallback);
+    return fallback;
+  }
+
+  // Get owner/repo from remote URL
+  const remote = runGit(["remote", "get-url", "origin"], cwd);
+  if (remote.code !== 0) {
+    protectedBranchesCache.set(repoKey, fallback);
+    return fallback;
+  }
+
+  const match = remote.stdout.match(/github\.com[:/]([^/]+\/[^/.]+)/);
+  if (!match) {
+    protectedBranchesCache.set(repoKey, fallback);
+    return fallback;
+  }
+
+  const repo = match[1];
+  try {
+    const out = execSync(
+      `gh api repos/${repo}/branches --paginate --jq '.[] | select(.protected==true) | .name'`,
+      { cwd, timeout: 10000, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
+    );
+    const branches = new Set(
+      out.split("\n").map((b) => b.trim()).filter(Boolean),
+    );
+    // Always include main/master as fallback
+    branches.add("main");
+    branches.add("master");
+    protectedBranchesCache.set(repoKey, branches);
+    return branches;
+  } catch {
+    protectedBranchesCache.set(repoKey, fallback);
+    return fallback;
+  }
+}
+
 export function hasGitSub(command: string, sub: string): boolean {
   return new RegExp(
     `\\bgit\\b(?:\\s+(?:-[a-zA-Z]\\s+\\S+|-\\S+))*\\s+${sub}\\b`,


### PR DESCRIPTION
Fetch protected branches from GitHub API, cache per session. Blocks commits/pushes to any protected branch. Falls back to main/master if API fails or non-GitHub repo.