### PR TITLE
fix: isolate raw arguments at top of all prompt templates

### DIFF
--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -2,6 +2,12 @@
 description: "Run a prompt via acpx to any coding agent (cursor, codex, gemini, claude, copilot, droid, kiro, opencode, qwen, etc.). Use for peer review, code review, or any task involving an external AI agent — /acpx-prompt <agent> <prompt>"
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # acpx Multi-Agent Prompt Command
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
@@ -86,7 +92,7 @@ The underlying coding agent must be installed separately. acpx auto-downloads AC
 
 ### Step 2: Parse Arguments
 
-Parse `$ARGUMENTS` to extract the agent name(s) and prompt:
+Read the **Raw Arguments** section above. Parse the text to extract the agent name(s) and prompt:
 
 1. The **first token** is the agent specification (required). Format:
    `agent[:model]` or comma-separated `agent1[:model1],agent2[:model2],...`

--- a/prompts/coderabbit-rate-limit.md
+++ b/prompts/coderabbit-rate-limit.md
@@ -2,6 +2,12 @@
 description: Handle CodeRabbit rate limits - waits and re-triggers review automatically
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # CodeRabbit Rate Limit Handler
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
@@ -40,15 +46,15 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 ### Phase 1: Detect PR
 
-If `$ARGUMENTS` contains a URL, extract owner/repo and PR number from it.
+If the raw arguments contain a URL, extract owner/repo and PR number from it.
 
-If `$ARGUMENTS` contains a number, detect the repository:
+If the raw arguments contain a number, detect the repository:
 
 ```bash
 gh repo view --json nameWithOwner -q .nameWithOwner
 ```
 
-If `$ARGUMENTS` is empty, detect PR from current branch:
+If the raw arguments are empty, detect PR from current branch:
 
 ```bash
 gh pr view --json number,url -q '.number'

--- a/prompts/implement-and-review.md
+++ b/prompts/implement-and-review.md
@@ -1,9 +1,16 @@
 ---
 description: "Implement → 3 parallel reviewers → fix — /implement-and-review <task>"
 ---
+
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 Use the subagent tool with a chain of agents:
 
-1. **worker** — Implement: {{task}}
+1. **worker** — Implement the task from the raw arguments above.
    Make all necessary code changes following project conventions.
 
 2. Run 3 review subagents **in parallel**:
@@ -13,5 +20,3 @@ Use the subagent tool with a chain of agents:
 
 3. **worker** — Based on the review feedback from {previous}, fix all issues found.
    Then report what was fixed.
-
-Task: {{task}}

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -1,9 +1,16 @@
 ---
 description: "Scout → plan → implement a task — /implement <task>"
 ---
+
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 Use the subagent tool with a chain of 3 agents:
 
-1. **scout** — Explore the codebase to find all relevant code for: {{task}}
+1. **scout** — Explore the codebase to find all relevant code for the task described in the raw arguments above.
    Return a compressed summary of file locations, key functions, and dependencies.
 
 2. **planner** — Based on {previous}, create a detailed implementation plan:
@@ -16,5 +23,3 @@ Use the subagent tool with a chain of 3 agents:
    - Make all code changes
    - Follow project conventions
    - Handle edge cases identified in the plan
-
-Task: {{task}}

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -2,6 +2,12 @@
 description: Review a GitHub PR and post inline comments on selected findings
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # GitHub PR Review Command
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
@@ -47,7 +53,7 @@ If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool ins
 
 ### Phase 0: PR Detection (when no arguments provided)
 
-If `$ARGUMENTS` is empty:
+If the raw arguments are empty:
 
 1. Detect PR from current branch:
 
@@ -79,7 +85,7 @@ If `$ARGUMENTS` is empty:
 
 4. Use `{pr_number}` for subsequent CLI commands
 
-If `$ARGUMENTS` contains a PR number or URL, use it directly.
+If the raw arguments contain a PR number or URL, use it directly.
 
 ### Phase 1a: Data Fetching
 
@@ -94,7 +100,7 @@ myk-pi-tools pr diff {pr_number}
 Otherwise:
 
 ```bash
-myk-pi-tools pr diff $ARGUMENTS
+myk-pi-tools pr diff <raw_arguments>
 ```
 
 Store the JSON output containing metadata, diff, and files.
@@ -112,7 +118,7 @@ myk-pi-tools pr claude-md {pr_number}
 Otherwise:
 
 ```bash
-myk-pi-tools pr claude-md $ARGUMENTS
+myk-pi-tools pr claude-md <raw_arguments>
 ```
 
 Store the output as `claude_md_content`.

--- a/prompts/query-db.md
+++ b/prompts/query-db.md
@@ -2,6 +2,12 @@
 description: Query the reviews database for analytics and insights
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # Review Database Query Command
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
@@ -141,7 +147,7 @@ The reviews database is located at `<project-root>/.claude/data/reviews.db`.
 
 ## Workflow
 
-1. Parse $ARGUMENTS to determine which query to run
+1. Parse the raw arguments above to determine which query to run
 2. Execute the appropriate myk-pi-tools db command
 3. Present results in a clear, formatted way
 4. For natural language questions, compose the appropriate query

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -2,6 +2,12 @@
 description: Refine pending PR review comments with AI before submitting
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # Refine Pending Review Command
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
@@ -38,7 +44,7 @@ If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool ins
 
 ### Phase 1: Fetch Pending Review
 
-Parse `$ARGUMENTS` as the PR URL. If empty, abort with: "PR URL required. Usage: `/refine-review https://github.com/owner/repo/pull/123`"
+Parse the raw arguments above as the PR URL. If empty, abort with: "PR URL required. Usage: `/refine-review https://github.com/owner/repo/pull/123`"
 
 ```bash
 myk-pi-tools reviews pending-fetch "<PR_URL>"

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -2,6 +2,12 @@
 description: Create a GitHub release with automatic changelog generation
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # GitHub Release Command
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -2,6 +2,12 @@
 description: Process ALL review sources (human, Qodo, CodeRabbit) from current PR
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # GitHub Review Handler
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
@@ -36,12 +42,6 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 - `/review-handler` - Process reviews from current PR
 - `/review-handler https://github.com/owner/repo/pull/123#pullrequestreview-456` - With specific review URL
 - `/review-handler --autorabbit` - Auto-fix CodeRabbit comments in a loop
-
-## Raw Arguments
-
-```text
-$ARGUMENTS
-```
 
 ## Workflow
 

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -2,6 +2,12 @@
 description: Review uncommitted changes or changes compared to a branch
 ---
 
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 # Local Code Review Command
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
@@ -24,12 +30,12 @@ Review uncommitted changes or changes compared to a specified branch.
 
 ### Step 1: Get the diff
 
-**If argument is provided (`$ARGUMENTS` is not empty):**
+**If the raw arguments are not empty:**
 
 Compare current branch against the specified branch:
 
 ```bash
-git diff "$ARGUMENTS"...HEAD
+git diff "<raw_arguments>"...HEAD
 ```
 
 **If no argument provided:**

--- a/prompts/scout-and-plan.md
+++ b/prompts/scout-and-plan.md
@@ -1,9 +1,16 @@
 ---
 description: "Scout → plan without implementing — /scout-and-plan <task>"
 ---
+
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
 Use the subagent tool with a chain of 2 agents:
 
-1. **scout** — Explore the codebase to find all relevant code for: {{task}}
+1. **scout** — Explore the codebase to find all relevant code for the task from the raw arguments above.
    Return a compressed summary of file locations, key functions, and dependencies.
 
 2. **planner** — Based on {previous}, create a detailed implementation plan:
@@ -11,5 +18,3 @@ Use the subagent tool with a chain of 2 agents:
    - Step-by-step changes
    - Edge cases to handle
    - Testing approach
-
-Task: {{task}}


### PR DESCRIPTION
Move Raw Arguments to line 5 in all 11 prompts. AI sees args first. Fix invalid {{task}} syntax.