### PR TITLE
fix: remove duplicate text causing parse error in enforcement.ts

### DIFF
--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -89,9 +89,6 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
           }
         }
       }
-            "⛔ 'git add .' / 'git add -A' forbidden. Stage specific files.",
-        };
-      }
 
       // Block --no-verify
       if (hasGitSub(command, "commit") && command.includes("--no-verify")) {


### PR DESCRIPTION
Leftover duplicate reason string from the git add block caused ParseError at line 93.