### PR TITLE
fix(docker): add psmisc for pstree in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     git \
     openssh-client \
     procps \
+    psmisc \
     && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (signed repo, uses curl+gpg from above)


### PR DESCRIPTION
## Problem

The `/async-kill` command uses `pstree` to discover the full process tree of async agents before killing them. In container environments, `psmisc` (which provides `pstree`) is not installed, causing the kill to fall back to only killing the runner PID and direct child PID — leaving grandchildren (bash, sleep, tool processes) alive as orphans.

## Root Cause

The kill handler in `async-agents.ts` runs `pstree -p <pid>` to find all descendant PIDs. When `pstree` is missing, the catch block only kills `status.pid` (runner) and `status.childPid` (pi agent), missing any processes spawned by pi (bash commands, sleep, tool processes).

## Fix

Add `psmisc` to the base system dependencies in the Dockerfile. This package provides `pstree`, `killall`, and `fuser`.

## Testing

Verified on native Linux:
- Spawned async agent running a long-running sleep command
- Confirmed `pstree` correctly captures the full tree: runner, pi, bash, sleep
- `/async-kill` successfully killed all processes including bash and sleep children
- Zero survivors, no zombies
