### PR TITLE
fix(docker): ensure /home/node is owned by node user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     npm install -g acpx agent-browser pi-web-access diffity
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
+RUN chown node:node /home/node
 USER node
 RUN mkdir -p /home/node/.npm-global && npm config set prefix /home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:/home/node/.pi/agent/bin:/home/node/.local/bin:$PATH"


### PR DESCRIPTION
Follow-up to #110 — the chown fix was lost during squash merge.

## Problem
The base `node:22-slim` image has `/home/node` owned by `root:root`. The `node` user (UID 1000) can't create new files/directories there, causing tools like diffity to crash with `EACCES: permission denied, mkdir '\/home/node/.diffity'`.

## Fix
Added `RUN chown node:node /home/node` before `USER node` in the Dockerfile.