### PR TITLE
fix(diffity): improve port scanning with time-based timeout and health check

### DIFF
--- a/extensions/orchestrator/diffity.ts
+++ b/extensions/orchestrator/diffity.ts
@@ -4,20 +4,26 @@
  * Works both in container and native — requires diffity to be installed.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
-import { execSync } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import * as net from "node:net";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { ICON_DIFF } from "./icons.js";
 
 const DIFFITY_START_PORT = 8090;
-const DIFFITY_MAX_PORT_TRIES = 10;
+const DIFFITY_MAX_PORT = 8190;
+const DIFFITY_PORT_TIMEOUT_MS = 5000;
+const PORT_CHECK_TIMEOUT_MS = 1000;
+const DIFFITY_READY_TIMEOUT_MS = 3000;
+const DIFFITY_READY_POLL_MS = 100;
+const SOCKET_CONNECT_TIMEOUT_MS = 1000;
 
 function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer();
-    server.once("error", () => resolve(false));
+    const timeout = setTimeout(() => { server.close(); resolve(false); }, PORT_CHECK_TIMEOUT_MS);
+    server.once("error", () => { clearTimeout(timeout); resolve(false); });
     server.once("listening", () => {
+      clearTimeout(timeout);
       server.close(() => resolve(true));
     });
     server.listen(port, "127.0.0.1");
@@ -25,16 +31,57 @@ function isPortAvailable(port: number): Promise<boolean> {
 }
 
 async function findAvailablePort(): Promise<number | null> {
-  for (let i = 0; i < DIFFITY_MAX_PORT_TRIES; i++) {
-    const port = DIFFITY_START_PORT + i;
+  const start = Date.now();
+  let port = DIFFITY_START_PORT;
+  while (port <= DIFFITY_MAX_PORT && Date.now() - start < DIFFITY_PORT_TIMEOUT_MS) {
     if (await isPortAvailable(port)) return port;
+    port++;
   }
   return null;
 }
 
+function waitForPort(port: number, timeoutMs: number = DIFFITY_READY_TIMEOUT_MS): Promise<boolean> {
+  return new Promise((resolve) => {
+    let resolved = false;
+    const done = (result: boolean) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(result);
+    };
+    const start = Date.now();
+    const check = () => {
+      if (resolved) return;
+      const socket = new net.Socket();
+      socket.setTimeout(SOCKET_CONNECT_TIMEOUT_MS);
+      socket.once("connect", () => {
+        socket.destroy();
+        done(true);
+      });
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() - start >= timeoutMs) {
+          done(false);
+        } else {
+          setTimeout(check, DIFFITY_READY_POLL_MS);
+        }
+      });
+      socket.once("timeout", () => {
+        socket.destroy();
+        if (Date.now() - start >= timeoutMs) {
+          done(false);
+        } else {
+          setTimeout(check, DIFFITY_READY_POLL_MS);
+        }
+      });
+      socket.connect(port, "127.0.0.1");
+    };
+    check();
+  });
+}
+
 function hasDiffity(): boolean {
   try {
-    execSync("which diffity", { stdio: "ignore" });
+    execFileSync("which", ["diffity"], { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -54,13 +101,18 @@ export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: stri
   if (!hasDiffity()) return;
 
   let diffityProc: ChildProcess | null = null;
+  let starting = false;
 
   pi.on("session_start", async (_event, ctx) => {
     if (!ctx.hasUI) return;
-    if (diffityProc) return; // Already running
+    if (diffityProc || starting) return; // Already running or starting
+    starting = true;
 
     const port = await findAvailablePort();
-    if (!port) return;
+    if (!port) {
+      starting = false;
+      return;
+    }
 
     try {
       diffityProc = spawn("diffity", [
@@ -74,6 +126,15 @@ export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: stri
         stdio: "ignore",
       });
       diffityProc.unref();
+      starting = false;
+
+      // Wait for diffity to be ready before showing the URL
+      const isUp = await waitForPort(port);
+      if (!isUp) {
+        killProcessTree(diffityProc);
+        diffityProc = null;
+        return;
+      }
 
       // Show link in status line
       const statusText = ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${port}?theme=dark`);
@@ -85,11 +146,16 @@ export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: stri
         ctx.ui.setStatus("diffity", statusText);
       }
     } catch {
-      // diffity failed to start, ignore silently
+      if (diffityProc) {
+        killProcessTree(diffityProc);
+      }
+      diffityProc = null;
+      starting = false;
     }
   });
 
   pi.on("session_shutdown", () => {
+    starting = false;
     if (diffityProc) {
       killProcessTree(diffityProc);
       diffityProc = null;


### PR DESCRIPTION
## Problem

The diffity port scanner only tried 10 ports (8090–8099), which wasn't enough when running many pi sessions in parallel. Additionally, the status line URL was shown immediately after spawning diffity without confirming it was actually listening.

## Changes

### Port scanning improvements
- Replace fixed 10-port limit with time-based scanning (5s timeout, port range 8090–8190)
- Add per-call timeout (1s) to `isPortAvailable()` to prevent hangs on unresponsive ports

### Health check
- Add `waitForPort()` — polls every 100ms for up to 3s to confirm diffity is actually listening
- URL is only shown in the status line after the health check passes
- If diffity fails to start, the process is cleaned up and the user sees no broken link

### Bug fixes
- Fix process cleanup in all error/early-return paths (catch block, no-port, not-up)
- Replace `true as any` sentinel with a separate `starting` boolean flag to prevent race conditions between `session_start` and `session_shutdown`

### Style
- Merge two `node:child_process` imports into one
- Use `execFileSync` instead of `execSync` (matches codebase convention)
- Extract all magic numbers to named constants