### PR TITLE
fix(subagent): require cwd parameter + vertex-claude 1M support

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,10 +13,16 @@ else
     pi update git:github.com/myk-org/pi-config
 fi
 
-if [ ! -d "$PI_PKG_DIR/isaacraja/pi-vertex-claude" ]; then
-    pi install git:github.com/isaacraja/pi-vertex-claude
+# TODO: Switch back to upstream once PR is merged: https://github.com/isaacraja/pi-vertex-claude/pull/3
+# if [ ! -d "$PI_PKG_DIR/isaacraja/pi-vertex-claude" ]; then
+#     pi install git:github.com/isaacraja/pi-vertex-claude
+# else
+#     pi update git:github.com/isaacraja/pi-vertex-claude
+# fi
+if [ ! -d "$PI_PKG_DIR/myk-org/pi-vertex-claude" ]; then
+    pi install git:github.com/myk-org/pi-vertex-claude@feat/1m-context-window-support
 else
-    pi update git:github.com/isaacraja/pi-vertex-claude
+    pi update git:github.com/myk-org/pi-vertex-claude@feat/1m-context-window-support
 fi
 
 # pi-web-access: register in pi settings if not already present

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -34,20 +34,21 @@ import { getPiInvocation } from "./utils.js";
 const MAX_PARALLEL_TASKS = 8;
 const MAX_CONCURRENCY = 4;
 const COLLAPSED_ITEM_COUNT = 10;
+const MISSING_CWD_ERROR = "Missing required parameter: cwd. Always specify the working directory for subagent tasks.";
 
 // ── Schemas ──────────────────────────────────────────────────────────────
 
 const TaskItem = Type.Object({
   agent: Type.String({ description: "Agent name" }),
   task: Type.String({ description: "Task to delegate" }),
-  cwd: Type.Optional(Type.String({ description: "Working directory" })),
+  cwd: Type.String({ description: "Working directory" }),
 });
 const ChainItem = Type.Object({
   agent: Type.String({ description: "Agent name" }),
   task: Type.String({
     description: "Task with optional {previous} placeholder",
   }),
-  cwd: Type.Optional(Type.String({ description: "Working directory" })),
+  cwd: Type.String({ description: "Working directory" }),
 });
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
   description: 'Agent directories to use. Default: "user".',
@@ -75,7 +76,7 @@ const SubagentParams = Type.Object({
     }),
   ),
   cwd: Type.Optional(
-    Type.String({ description: "Working directory (single mode)" }),
+    Type.String({ description: "Working directory. Required for single/async mode." }),
   ),
   async: Type.Optional(
     Type.Boolean({ description: "Run in background (default: false). Agent runs detached, results surface when complete.", default: false }),
@@ -287,11 +288,10 @@ type OnUpdate = (partial: AgentToolResult<SubagentDetails>) => void;
 // ── runSingleAgent ───────────────────────────────────────────────────────
 
 export async function runSingleAgent(
-  defaultCwd: string,
   agents: AgentConfig[],
   agentName: string,
   task: string,
-  cwd: string | undefined,
+  cwd: string,
   step: number | undefined,
   signal: AbortSignal | undefined,
   onUpdate: OnUpdate | undefined,
@@ -374,7 +374,7 @@ export async function runSingleAgent(
     const exitCode = await new Promise<number>((resolve) => {
       const inv = getPiInvocation(args);
       const proc = spawn(inv.command, inv.args, {
-        cwd: cwd ?? defaultCwd,
+        cwd: cwd,
         shell: false,
         stdio: ["ignore", "pipe", "pipe"],
         env: { ...process.env, PI_SUBAGENT_CHILD: "1" },
@@ -485,6 +485,7 @@ export function registerSubagentTool(
       "For multi-step workflows, use chain mode with {previous} placeholder.",
       "Set async: true when you don't need the result immediately for your next step. The result will surface automatically when complete. Use sync (default) only when the next step depends on this agent's output.",
       "ALWAYS use async: true for independent tasks that can run in parallel — code reviews, opening issues, research, analysis. Only use sync when the very next step depends on this agent's output (e.g., chain where step 2 needs step 1's result).",
+      "ALWAYS pass cwd — use the project directory for current repo work, or the target path for external repos (e.g., /tmp/pi-work/...).",
     ],
     parameters: SubagentParams,
 
@@ -567,7 +568,14 @@ export function registerSubagentTool(
             isError: true,
           };
         }
-        const result = spawnAsyncAgent(params.agent, params.task, params.cwd ?? ctx.cwd, agents);
+        if (!params.cwd) {
+          return {
+            content: [{ type: "text", text: MISSING_CWD_ERROR }],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
+        const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents);
         if (result.error) {
           return {
             content: [{ type: "text", text: result.error }],
@@ -585,6 +593,22 @@ export function registerSubagentTool(
       if (params.chain && params.chain.length > 0) {
         const results: SingleResult[] = [];
         let prev = "";
+
+        for (let i = 0; i < params.chain.length; i++) {
+          if (!params.chain[i].cwd) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `${MISSING_CWD_ERROR} (chain step ${i + 1}, agent: ${params.chain[i].agent})`,
+                },
+              ],
+              details: mkd("chain")([]),
+              isError: true,
+            };
+          }
+        }
+
         for (let i = 0; i < params.chain.length; i++) {
           const s = params.chain[i];
           const t = s.task.replace(/\{previous\}/g, prev);
@@ -599,7 +623,6 @@ export function registerSubagentTool(
               }
             : undefined;
           const r = await runSingleAgent(
-            ctx.cwd,
             agents,
             s.agent,
             t,
@@ -685,12 +708,25 @@ export function registerSubagentTool(
             });
           }
         };
+        for (let i = 0; i < params.tasks.length; i++) {
+          if (!params.tasks[i].cwd) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `${MISSING_CWD_ERROR} (parallel task ${i + 1}, agent: ${params.tasks[i].agent})`,
+                },
+              ],
+              details: mkd("parallel")([]),
+              isError: true,
+            };
+          }
+        }
         const results = await mapWithConcurrency(
           params.tasks,
           MAX_CONCURRENCY,
           async (t, i) => {
             const r = await runSingleAgent(
-              ctx.cwd,
               agents,
               t.agent,
               t.task,
@@ -729,8 +765,19 @@ export function registerSubagentTool(
 
       // Single mode
       if (params.agent && params.task) {
+        if (!params.cwd) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: MISSING_CWD_ERROR,
+              },
+            ],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
         const r = await runSingleAgent(
-          ctx.cwd,
           agents,
           params.agent,
           params.task,

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -23,6 +23,16 @@ Only use sync (default) when the **very next step** depends on this agent's outp
 ❌ **WRONG:** Spawn 3 sync reviewers → wait for all → respond
 ✅ **RIGHT:** Spawn 3 async reviewers → continue → results surface when complete
 
+### Subagent cwd (MANDATORY)
+
+**ALWAYS pass `cwd`** when delegating to subagents — in ALL modes (single, parallel, chain, async).
+
+- Use the project directory when working in the current repo
+- Use the target repo path when working in external repos (e.g., `/tmp/pi-work/...`)
+
+❌ **WRONG:** Omit cwd (subagent inherits session cwd, enforcement checks wrong repo)
+✅ **RIGHT:** Always pass explicit cwd
+
 ---
 
 ## User Interaction (MANDATORY)


### PR DESCRIPTION
## Problem

### Subagent cwd bug
Git enforcement checks `ctx.cwd` (session repo) for branch protection, but subagents working in external repos (e.g., `/tmp/pi-work/...`) inherited the orchestrator's cwd. This caused enforcement to check the wrong repo and block legitimate operations.

### Vertex Claude 1M
Claude Opus 4.6 and Sonnet 4.6 support 1M context windows, but the pi-vertex-claude extension only registered 200K models.

## Changes

### Subagent cwd enforcement
- Make `cwd` required in `TaskItem`/`ChainItem` schemas (parallel/chain modes)
- Add runtime cwd validation for all modes (single/async/chain/parallel)
- Remove dead `defaultCwd` parameter from `runSingleAgent`
- Validate chain cwds upfront (all-or-nothing, matches parallel pattern)
- Add cwd requirement to `promptGuidelines`
- Document in `rules/40-critical-rules.md`

### Vertex Claude fork
- Point `entrypoint.sh` to `myk-org/pi-vertex-claude` fork with 1M context support
- TODO: switch back to upstream once [PR #3](https://github.com/isaacraja/pi-vertex-claude/pull/3) is merged
