### PR TITLE
fix(docker): workaround buildah #6747 — re-chown /home/node after cache mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,7 @@ RUN --mount=type=cache,target=/root/.npm,sharing=locked \
     npm install -g acpx agent-browser pi-web-access diffity
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
-# Note: node:22 base image creates /home/node as root — fix ownership
-# of the directory itself and all contents before switching to non-root
-# Explicit chown of /home/node is needed because buildah's chown -R
-# may skip the target directory itself
-RUN chown node:node /home/node && chown -R node:node /home/node
+RUN chown -R node:node /home/node
 USER node
 RUN mkdir -p /home/node/.npm-global && npm config set prefix /home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:/home/node/.pi/agent/bin:/home/node/.local/bin:$PATH"
@@ -103,6 +99,13 @@ RUN --mount=type=cache,target=/home/node/.cache/uv,sharing=locked,uid=1000,gid=1
 RUN /bin/bash -o pipefail -c "curl -fsSL https://cursor.com/install | bash"
 
 COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Workaround for buildah bug #6747: RUN --mount=type=cache resets
+# ownership of parent directories. Re-chown /home/node after all
+# mount-cached RUN instructions have completed.
+USER root
+RUN chown node:node /home/node
+USER node
 
 WORKDIR /workspace
 


### PR DESCRIPTION
## Root Cause

Buildah bug [containers/buildah#6747](https://github.com/containers/buildah/issues/6747): `RUN --mount=type=cache` targeting paths under `/home/node` resets ownership of parent directories back to `root:root`.

Our Dockerfile has two cache-mounted RUN instructions for uv tools:
```dockerfile
RUN --mount=type=cache,target=/home/node/.cache/uv ...
```

These run after the `chown -R node:node /home/node`, undoing the ownership fix.

## Fix

Add a final `USER root` + `chown node:node /home/node` + `USER node` at the very end of the Dockerfile, after all cache-mounted RUN instructions have completed.

Works locally with docker build. Previous attempts failed because the chown was placed before the cache mounts.

Fixes #119