### PR TITLE
feat: add per-repo memory system for persistent learning across sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ pi-config/
 │   ├── cli.py
 │   ├── coderabbit/
 │   ├── db/
+│   ├── memory/
 │   ├── pr/
 │   ├── release/
 │   └── reviews/

--- a/README.md
+++ b/README.md
@@ -249,6 +249,18 @@ GEMINI_API_KEY=xxx
 
 Pass via `--env-file /path/to/.env` in the docker run command.
 
+### Project memory
+
+The memory system stores per-repo lessons and patterns in `.pi/memory/memories.db`.
+This file is auto-added to the global gitignore in the container.
+
+For **native** (non-container) usage, add it to your global gitignore:
+
+```bash
+echo '.pi/memory/' >> ~/.gitignore-global
+git config --global core.excludesFile ~/.gitignore-global
+```
+
 ### Optional mounts
 
 | Mount | Purpose |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,4 +45,10 @@ fi
 # ConnectTimeout: fail if can't connect within 10s
 export GIT_SSH_COMMAND="ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ConnectTimeout=10"
 
+# Ensure .pi/memory/ is in global gitignore (memory DB must not be committed)
+GITIGNORE_FILE="$(git config --global core.excludesFile 2>/dev/null || echo "$HOME/.gitignore-global")"
+if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.pi/memory/' "$GITIGNORE_FILE" 2>/dev/null; then
+    echo '.pi/memory/' >> "$GITIGNORE_FILE"
+fi
+
 exec pi "$@"

--- a/myk_pi_tools/cli.py
+++ b/myk_pi_tools/cli.py
@@ -4,6 +4,7 @@ import click
 
 from myk_pi_tools.coderabbit import commands as coderabbit_commands
 from myk_pi_tools.db import commands as db_commands
+from myk_pi_tools.memory import commands as memory_commands
 from myk_pi_tools.pr import commands as pr_commands
 from myk_pi_tools.release import commands as release_commands
 from myk_pi_tools.reviews import commands as reviews_commands
@@ -17,6 +18,7 @@ def cli() -> None:
 
 cli.add_command(coderabbit_commands.coderabbit, name="coderabbit")
 cli.add_command(db_commands.db, name="db")
+cli.add_command(memory_commands.memory, name="memory")
 cli.add_command(pr_commands.pr, name="pr")
 cli.add_command(release_commands.release, name="release")
 cli.add_command(reviews_commands.reviews, name="reviews")

--- a/myk_pi_tools/memory/__init__.py
+++ b/myk_pi_tools/memory/__init__.py
@@ -1,0 +1,14 @@
+"""Project memory module.
+
+Persistent per-repo memory for lessons learned, decisions, mistakes, and patterns.
+Database location: <git-root>/.pi/memory/memories.db
+
+Usage:
+    from myk_pi_tools.memory import MemoryDB
+    db = MemoryDB()
+    db.add(category="lesson", summary="buildah chown -R skips target dir with cache mounts", tags="docker,buildah")
+"""
+
+from myk_pi_tools.memory.store import MemoryDB
+
+__all__ = ["MemoryDB"]

--- a/myk_pi_tools/memory/commands.py
+++ b/myk_pi_tools/memory/commands.py
@@ -1,0 +1,169 @@
+"""Memory CLI commands."""
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from myk_pi_tools.db.query import _format_table
+from myk_pi_tools.memory.store import MemoryDB
+
+
+@click.group()
+@click.option("--db-path", default=None, help="Path to database file")
+@click.pass_context
+def memory(ctx: click.Context, db_path: str | None) -> None:
+    """Project memory commands — persistent per-repo learning."""
+    ctx.ensure_object(dict)
+    ctx.obj["db"] = MemoryDB(db_path=Path(db_path) if db_path else None)
+
+
+@memory.command("add")
+@click.option(
+    "--category",
+    "-c",
+    required=True,
+    type=click.Choice(["lesson", "decision", "mistake", "pattern", "done", "preference"]),
+    help="Memory category",
+)
+@click.option("--summary", "-s", required=True, help="Short description (one line)")
+@click.option("--details", "-d", default=None, help="Longer description")
+@click.option(
+    "--sentiment",
+    default="neutral",
+    type=click.Choice(["positive", "negative", "neutral"]),
+    help="Sentiment (default: neutral)",
+)
+@click.option("--tags", "-t", default=None, help="Comma-separated tags")
+@click.pass_context
+def memory_add(
+    ctx: click.Context,
+    category: str,
+    summary: str,
+    details: str | None,
+    sentiment: str,
+    tags: str | None,
+) -> None:
+    """Add a memory entry.
+
+    Examples:
+
+        # Add a lesson
+        myk-pi-tools memory add -c lesson -s "buildah chown -R skips target dir" -t docker,buildah
+
+        # Add a completed task
+        myk-pi-tools memory add -c done -s "Added security-auditor agent" --sentiment positive
+
+        # Add a mistake
+        myk-pi-tools memory add -c mistake -s "Used sleep for polling instead of async agent" --sentiment negative
+    """
+    db = ctx.obj["db"]
+    memory_id = db.add(category=category, summary=summary, details=details, sentiment=sentiment, tags=tags)
+    click.echo(f"Memory #{memory_id} added.", err=True)
+
+
+@memory.command("search")
+@click.argument("query")
+@click.option(
+    "--category",
+    "-c",
+    default=None,
+    type=click.Choice(["lesson", "decision", "mistake", "pattern", "done", "preference"]),
+    help="Filter by category",
+)
+@click.option("--limit", "-n", default=20, help="Maximum results")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def memory_search(
+    ctx: click.Context,
+    query: str,
+    category: str | None,
+    limit: int,
+    output_json: bool,
+) -> None:
+    """Search memories by text.
+
+    Examples:
+
+        # Search for docker-related memories
+        myk-pi-tools memory search docker
+
+        # Search lessons only
+        myk-pi-tools memory search docker -c lesson
+
+        # JSON output
+        myk-pi-tools memory search docker --json
+    """
+    db = ctx.obj["db"]
+    results = db.search(query, category=category, limit=limit)
+
+    if output_json:
+        click.echo(json.dumps(results, indent=2))
+    else:
+        if not results:
+            click.echo("No memories found.")
+        else:
+            click.echo(_format_table(results, ["id", "date", "category", "sentiment", "summary", "tags"]))
+
+
+@memory.command("list")
+@click.option(
+    "--category",
+    "-c",
+    default=None,
+    type=click.Choice(["lesson", "decision", "mistake", "pattern", "done", "preference"]),
+    help="Filter by category",
+)
+@click.option("--last", "last_days", default=None, type=click.IntRange(min=1), help="Show last N days")
+@click.option("--limit", "-n", default=50, help="Maximum results")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def memory_list(
+    ctx: click.Context,
+    category: str | None,
+    last_days: int | None,
+    limit: int,
+    output_json: bool,
+) -> None:
+    """List memories with optional filters.
+
+    Examples:
+
+        # List all memories
+        myk-pi-tools memory list
+
+        # List lessons from last 7 days
+        myk-pi-tools memory list -c lesson --last 7
+
+        # JSON output
+        myk-pi-tools memory list --json
+    """
+    db = ctx.obj["db"]
+    results = db.list_memories(category=category, last_days=last_days, limit=limit)
+
+    if output_json:
+        click.echo(json.dumps(results, indent=2))
+    else:
+        if not results:
+            click.echo("No memories found.")
+        else:
+            click.echo(_format_table(results, ["id", "date", "category", "sentiment", "summary", "tags"]))
+
+
+@memory.command("delete")
+@click.argument("memory_id", type=int)
+@click.pass_context
+def memory_delete(ctx: click.Context, memory_id: int) -> None:
+    """Delete a memory by ID.
+
+    Examples:
+
+        myk-pi-tools memory delete 42
+    """
+    db = ctx.obj["db"]
+    if db.delete(memory_id):
+        click.echo(f"Memory #{memory_id} deleted.", err=True)
+    else:
+        click.echo(f"Memory #{memory_id} not found.", err=True)
+        sys.exit(1)

--- a/myk_pi_tools/memory/store.py
+++ b/myk_pi_tools/memory/store.py
@@ -1,0 +1,207 @@
+"""Memory store — SQLite-backed per-repo memory.
+
+Database location: <git-root>/.pi/memory/memories.db
+"""
+
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from myk_pi_tools.db.query import _get_git_root
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS memories (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    date TEXT NOT NULL,
+    category TEXT NOT NULL,
+    sentiment TEXT DEFAULT 'neutral',
+    summary TEXT NOT NULL,
+    details TEXT,
+    tags TEXT
+);
+"""
+
+
+class MemoryDB:
+    """Per-repo memory database.
+
+    Stores lessons, decisions, mistakes, patterns, and completed work
+    for a specific repository. Data persists across sessions.
+
+    Attributes:
+        db_path: Path to the SQLite database file.
+    """
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        if db_path is None:
+            git_root = _get_git_root()
+            self.db_path = git_root / ".pi" / "memory" / "memories.db"
+        else:
+            self.db_path = db_path
+
+        self._ensure_db()
+
+    def _ensure_db(self) -> None:
+        """Create database and table if they don't exist."""
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path))
+        try:
+            conn.executescript(_SCHEMA)
+        finally:
+            conn.close()
+
+    def _connect(self, readonly: bool = True) -> sqlite3.Connection:
+        """Create a database connection."""
+        if readonly:
+            db_uri = f"file:{quote(self.db_path.resolve().as_posix(), safe='/:')}?mode=ro"
+            conn = sqlite3.connect(db_uri, uri=True)
+        else:
+            conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def add(
+        self,
+        category: str,
+        summary: str,
+        details: str | None = None,
+        sentiment: str = "neutral",
+        tags: str | None = None,
+    ) -> int:
+        """Add a memory entry.
+
+        Args:
+            category: One of 'lesson', 'decision', 'mistake', 'pattern', 'done', 'preference'
+            summary: Short description (one line)
+            details: Optional longer description
+            sentiment: One of 'positive', 'negative', 'neutral'
+            tags: Optional comma-separated tags
+
+        Returns:
+            The ID of the inserted memory.
+        """
+        valid_categories = {"lesson", "decision", "mistake", "pattern", "done", "preference"}
+        if category not in valid_categories:
+            raise ValueError(f"Invalid category '{category}'. Must be one of: {', '.join(sorted(valid_categories))}")
+
+        valid_sentiments = {"positive", "negative", "neutral"}
+        if sentiment not in valid_sentiments:
+            raise ValueError(f"Invalid sentiment '{sentiment}'. Must be one of: {', '.join(sorted(valid_sentiments))}")
+
+        date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+        conn = self._connect(readonly=False)
+        try:
+            cursor = conn.execute(
+                "INSERT INTO memories (date, category, sentiment, summary, details, tags) VALUES (?, ?, ?, ?, ?, ?)",
+                (date, category, sentiment, summary, details, tags),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            assert row_id is not None
+            return row_id
+        finally:
+            conn.close()
+
+    def search(self, query: str, category: str | None = None, limit: int = 20) -> list[dict[str, Any]]:
+        """Search memories by text (summary + details + tags).
+
+        Args:
+            query: Search text (matched against summary, details, and tags)
+            category: Optional filter by category
+            limit: Maximum results to return
+
+        Returns:
+            List of matching memory dicts.
+        """
+        if not self.db_path.exists():
+            return []
+
+        conn = self._connect()
+        try:
+            escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            sql = """
+                SELECT id, date, category, sentiment, summary, details, tags
+                FROM memories
+                WHERE (summary LIKE ? ESCAPE '\\' OR details LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')
+            """
+            params: list[Any] = [f"%{escaped}%", f"%{escaped}%", f"%{escaped}%"]
+
+            if category:
+                sql += " AND category = ?"
+                params.append(category)
+
+            sql += " ORDER BY date DESC, id DESC LIMIT ?"
+            params.append(limit)
+
+            cursor = conn.execute(sql, params)
+            return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            log(f"Database error: {e}")
+            return []
+        finally:
+            conn.close()
+
+    def list_memories(
+        self,
+        category: str | None = None,
+        last_days: int | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """List memories with optional filters.
+
+        Args:
+            category: Optional filter by category
+            last_days: Optional filter to last N days
+            limit: Maximum results to return
+
+        Returns:
+            List of memory dicts.
+        """
+        if not self.db_path.exists():
+            return []
+
+        conn = self._connect()
+        try:
+            sql = "SELECT id, date, category, sentiment, summary, details, tags FROM memories WHERE 1=1"
+            params: list[Any] = []
+
+            if category:
+                sql += " AND category = ?"
+                params.append(category)
+
+            if last_days is not None and last_days > 0:
+                sql += " AND date >= datetime('now', ?)"
+                params.append(f"-{last_days} days")
+
+            sql += " ORDER BY date DESC, id DESC LIMIT ?"
+            params.append(limit)
+
+            cursor = conn.execute(sql, params)
+            return [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            log(f"Database error: {e}")
+            return []
+        finally:
+            conn.close()
+
+    def delete(self, memory_id: int) -> bool:
+        """Delete a memory by ID.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        conn = self._connect(readonly=False)
+        try:
+            cursor = conn.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,105 @@
+"""Tests for the memory module."""
+
+from pathlib import Path
+
+import pytest
+
+from myk_pi_tools.memory.store import MemoryDB
+
+
+@pytest.fixture
+def memory_db(tmp_path: Path) -> MemoryDB:
+    """Create a MemoryDB with a temporary database."""
+    db_path = tmp_path / "memories.db"
+    return MemoryDB(db_path=db_path)
+
+
+class TestMemoryDB:
+    def test_add_and_list(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Test lesson")
+        results = memory_db.list_memories()
+        assert len(results) == 1
+        assert results[0]["summary"] == "Test lesson"
+        assert results[0]["category"] == "lesson"
+
+    def test_add_with_all_fields(self, memory_db: MemoryDB) -> None:
+        mid = memory_db.add(
+            category="mistake",
+            summary="Used sleep for polling",
+            details="Should have used async agent",
+            sentiment="negative",
+            tags="async,polling",
+        )
+        assert mid is not None
+        results = memory_db.list_memories()
+        assert len(results) == 1
+        assert results[0]["sentiment"] == "negative"
+        assert results[0]["tags"] == "async,polling"
+        assert results[0]["details"] == "Should have used async agent"
+
+    def test_invalid_category(self, memory_db: MemoryDB) -> None:
+        with pytest.raises(ValueError, match="Invalid category"):
+            memory_db.add(category="invalid", summary="test")
+
+    def test_invalid_sentiment(self, memory_db: MemoryDB) -> None:
+        with pytest.raises(ValueError, match="Invalid sentiment"):
+            memory_db.add(category="lesson", summary="test", sentiment="angry")
+
+    def test_search(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="buildah chown bug", tags="docker,buildah")
+        memory_db.add(category="done", summary="Added security auditor")
+        results = memory_db.search("buildah")
+        assert len(results) == 1
+        assert "buildah" in results[0]["summary"]
+
+    def test_search_by_tags(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Some lesson", tags="docker,buildah")
+        results = memory_db.search("docker")
+        assert len(results) == 1
+
+    def test_search_with_category_filter(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Docker lesson", tags="docker")
+        memory_db.add(category="done", summary="Docker task done", tags="docker")
+        results = memory_db.search("docker", category="lesson")
+        assert len(results) == 1
+        assert results[0]["category"] == "lesson"
+
+    def test_list_by_category(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Lesson 1")
+        memory_db.add(category="done", summary="Done 1")
+        memory_db.add(category="lesson", summary="Lesson 2")
+        results = memory_db.list_memories(category="lesson")
+        assert len(results) == 2
+        assert all(r["category"] == "lesson" for r in results)
+
+    def test_list_limit(self, memory_db: MemoryDB) -> None:
+        for i in range(10):
+            memory_db.add(category="done", summary=f"Task {i}")
+        results = memory_db.list_memories(limit=5)
+        assert len(results) == 5
+
+    def test_delete(self, memory_db: MemoryDB) -> None:
+        mid = memory_db.add(category="lesson", summary="To delete")
+        assert memory_db.delete(mid) is True
+        results = memory_db.list_memories()
+        assert len(results) == 0
+
+    def test_delete_nonexistent(self, memory_db: MemoryDB) -> None:
+        assert memory_db.delete(999) is False
+
+    def test_empty_search(self, memory_db: MemoryDB) -> None:
+        results = memory_db.search("nonexistent")
+        assert results == []
+
+    def test_db_created_on_init(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "subdir" / "memories.db"
+        MemoryDB(db_path=db_path)
+        assert db_path.exists()
+
+    def test_order_by_date_desc(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="done", summary="First")
+        memory_db.add(category="done", summary="Second")
+        results = memory_db.list_memories()
+        # Most recent first
+        assert results[0]["summary"] == "Second"
+        assert results[1]["summary"] == "First"


### PR DESCRIPTION
Per-repo SQLite memory system that persists lessons, decisions, mistakes, and patterns across sessions.

## What it does

Stores memories at `.pi/memory/memories.db` inside each project. The AI can log learnings during work and retrieve them in future sessions to avoid repeating mistakes.

## CLI

```bash
# Add a memory
myk-pi-tools memory add -c lesson -s "buildah chown -R skips target dir with cache mounts" -t docker,buildah

# Search
myk-pi-tools memory search docker

# List recent
myk-pi-tools memory list --last 7

# List by category
myk-pi-tools memory list -c mistake

# Delete
myk-pi-tools memory delete 42
```

## Categories

`lesson`, `decision`, `mistake`, `pattern`, `done`, `preference`

## Gitignore

- Container: auto-added to global gitignore via `entrypoint.sh`
- Native: documented in README

## Files

- `myk_pi_tools/memory/` — MemoryDB store + CLI commands
- `tests/test_memory.py` — 14 tests
- `entrypoint.sh` — gitignore auto-setup
- `AGENTS.md` + `README.md` — docs updated

Fixes #125