### PR TITLE
fix(extensions): decouple diffity status from git status line and attach process to pi

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,10 @@ pi-config/
 │   │   ├── async-agents.ts          # Async background agent infrastructure
 │   │   ├── async-runner.ts          # Standalone async runner (spawned detached)
 │   │   ├── btw.ts                   # /btw command
-│   │   ├── diffity.ts               # Auto-start diffity diff viewer (container)
+│   │   ├── diffity.ts               # Auto-start diffity diff viewer
 │   │   ├── enforcement.ts           # Python/git/dangerous command enforcement
 │   │   ├── git-helpers.ts           # Git utility functions
+│   │   ├── icons.ts                 # Shared Nerd Font icon constants
 │   │   ├── rules.ts                 # Rule injection (before_agent_start)
 │   │   ├── session-validation.ts    # Session start tool checks
 │   │   ├── status-line.ts           # Git status, notifications, container indicator

--- a/extensions/orchestrator/diffity.ts
+++ b/extensions/orchestrator/diffity.ts
@@ -16,6 +16,7 @@ const PORT_CHECK_TIMEOUT_MS = 1000;
 const DIFFITY_READY_TIMEOUT_MS = 3000;
 const DIFFITY_READY_POLL_MS = 100;
 const SOCKET_CONNECT_TIMEOUT_MS = 1000;
+const KILL_SETTLE_MS = 500;
 
 function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve) => {
@@ -88,16 +89,32 @@ function hasDiffity(): boolean {
   }
 }
 
-function killProcessTree(proc: ChildProcess): void {
-  try {
-    // Kill the process group (negative PID kills the group)
-    if (proc.pid) process.kill(-proc.pid, "SIGTERM");
-  } catch {
-    try { proc.kill("SIGTERM"); } catch {}
-  }
+function killProcess(proc: ChildProcess): void {
+  try { proc.kill("SIGTERM"); } catch {}
 }
 
-export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: string) => void): void {
+// Linux-only: uses /proc to resolve process working directories
+function killExistingDiffity(cwd: string): void {
+  try {
+    const resolvedCwd = execFileSync("readlink", ["-f", cwd], { encoding: "utf-8" }).trim();
+    const result = execFileSync("ps", ["-eo", "pid,args"], { encoding: "utf-8" });
+    for (const line of result.split("\n")) {
+      if (!/\bdiffity\s+.*--port\b/.test(line)) continue;
+      const match = line.trim().match(/^(\d+)/);
+      if (!match) continue;
+      const pid = parseInt(match[1], 10);
+      if (pid === process.pid) continue;
+      try {
+        const cwdLink = execFileSync("readlink", ["-f", `/proc/${pid}/cwd`], { encoding: "utf-8" }).trim();
+        if (cwdLink === resolvedCwd) {
+          process.kill(pid, "SIGTERM");
+        }
+      } catch {}
+    }
+  } catch {}
+}
+
+export function registerDiffity(pi: ExtensionAPI): void {
   if (!hasDiffity()) return;
 
   let diffityProc: ChildProcess | null = null;
@@ -108,13 +125,14 @@ export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: stri
     if (diffityProc || starting) return; // Already running or starting
     starting = true;
 
-    const port = await findAvailablePort();
-    if (!port) {
-      starting = false;
-      return;
-    }
-
     try {
+      killExistingDiffity(ctx.cwd);
+      // Brief delay to let killed processes release their ports
+      await new Promise((r) => setTimeout(r, KILL_SETTLE_MS));
+
+      const port = await findAvailablePort();
+      if (!port) return;
+
       diffityProc = spawn("diffity", [
         "--dark",
         "--no-open",
@@ -122,34 +140,26 @@ export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: stri
         "--port", String(port),
       ], {
         cwd: ctx.cwd,
-        detached: true,
         stdio: "ignore",
       });
-      diffityProc.unref();
-      starting = false;
 
       // Wait for diffity to be ready before showing the URL
       const isUp = await waitForPort(port);
       if (!isUp) {
-        killProcessTree(diffityProc);
+        killProcess(diffityProc);
         diffityProc = null;
         return;
       }
 
       // Show link in status line
       const statusText = ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${port}?theme=dark`);
-      if (setDiffityStatus) {
-        setDiffityStatus(statusText);
-        // Trigger a git status refresh to rebuild combined status
-        pi.events?.emit("diffity:ready");
-      } else {
-        ctx.ui.setStatus("diffity", statusText);
-      }
+      ctx.ui.setStatus("diffity", statusText);
     } catch {
       if (diffityProc) {
-        killProcessTree(diffityProc);
+        killProcess(diffityProc);
       }
       diffityProc = null;
+    } finally {
       starting = false;
     }
   });
@@ -157,7 +167,7 @@ export function registerDiffity(pi: ExtensionAPI, setDiffityStatus?: (text: stri
   pi.on("session_shutdown", () => {
     starting = false;
     if (diffityProc) {
-      killProcessTree(diffityProc);
+      killProcess(diffityProc);
       diffityProc = null;
     }
   });

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -33,8 +33,8 @@ export default function (pi: ExtensionAPI) {
   registerSubagentTool(pi, spawnAsyncAgent);
   registerEnforcement(pi, IN_CONTAINER);
   registerRules(pi);
-  const { setDiffityStatus } = registerStatusLine(pi, IN_CONTAINER, terminalNotify) as any;
+  registerStatusLine(pi, IN_CONTAINER, terminalNotify);
   registerBtw(pi);
-  registerDiffity(pi, setDiffityStatus);
+  registerDiffity(pi);
   registerSessionValidation(pi);
 }

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -11,28 +11,18 @@ export function registerStatusLine(
   IN_CONTAINER: boolean,
   terminalNotify: (title: string, body: string) => void,
 ): void {
-  // Track diffity URL so we can include it in the combined status
-  let diffityStatus = "";
-
-  // Called by diffity module to set its status text
-  const setDiffityStatus = (text: string) => {
-    diffityStatus = text;
-  };
-
   // ── Combined status line builder ───────────────────────────────────────
 
   const buildStatus = (ctx: any, gitPart: string) => {
     const parts: string[] = [];
 
     if (IN_CONTAINER) parts.push(ICON_CONTAINER);
-    if (diffityStatus) parts.push(diffityStatus);
     parts.push(gitPart);
 
     ctx.ui.setStatus("combined", parts.join(ctx.ui.theme.fg("dim", ICON_SEP)));
     // Clear individual statuses to avoid duplicates
     ctx.ui.setStatus("container", undefined);
     ctx.ui.setStatus("git", undefined);
-    ctx.ui.setStatus("diffity", undefined);
   };
 
   // ── Git branch status line ─────────────────────────────────────────────
@@ -103,5 +93,4 @@ export function registerStatusLine(
     terminalNotify("pi", "Task completed");
   });
 
-  return { setDiffityStatus } as any;
 }


### PR DESCRIPTION
## Summary

Fixes three bugs in the diffity/status-line integration:

1. **Diffity status was coupled to git events** — `setDiffityStatus` only set a variable, but the status line only rebuilt on git events. If diffity started between git events, it never showed in the status line.
2. **Diffity process was detached** — `detached: true` + `.unref()` meant orphan processes survived pi exit, accumulating across sessions.
3. **Unnecessary coupling** — `setDiffityStatus` callback created tight coupling between `diffity.ts` and `status-line.ts`.

## Changes

- **`diffity.ts`**: Removed `detached: true` and `.unref()` — process now attached to pi. Diffity manages its own status line directly via `ctx.ui.setStatus("diffity", ...)`. Added `killExistingDiffity()` to kill stale diffity processes for the same repo before spawning. Simplified process cleanup. Wrapped session_start handler in try/finally for reliable `starting` flag reset.
- **`status-line.ts`**: Removed all diffity-related state tracking (`diffityStatus`, `setDiffityStatus` callback). Git status line is now fully independent.
- **`index.ts`**: Removed coupling plumbing between status-line and diffity.
- **`AGENTS.md`**: Removed `(container)` from diffity description (works in both environments). Added missing `icons.ts` to repository structure.

Closes #128