### PR TITLE
fix: complete memory system integration — rules, session hook, and /remember command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ pi-config/
 │   │   ├── enforcement.ts           # Python/git/dangerous command enforcement
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
-│   │   ├── rules.ts                 # Rule injection (before_agent_start)
+│   │   ├── rules.ts                 # Rule + memory injection (before_agent_start)
 │   │   ├── session-validation.ts    # Session start tool checks
 │   │   ├── status-line.ts           # Git status, notifications, container indicator
 │   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent
@@ -62,6 +62,7 @@ pi-config/
 │   ├── query-db.md
 │   ├── refine-review.md
 │   ├── release.md
+│   ├── remember.md
 │   ├── review-handler.md
 │   ├── review-local.md
 │   └── scout-and-plan.md
@@ -71,8 +72,11 @@ pi-config/
 │   ├── 10-agent-routing.md
 │   ├── 15-mcp-launchpad.md
 │   ├── 20-code-review-loop.md
+│   ├── 25-documentation-updates.md
 │   ├── 30-prompt-templates.md
+│   ├── 35-memory.md
 │   ├── 40-critical-rules.md
+│   ├── 45-file-preview.md
 │   └── 50-agent-bug-reporting.md
 ├── myk_pi_tools/                    # Python CLI tooling package
 │   ├── __init__.py

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -41,6 +41,14 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         reason: "Direct pre-commit forbidden. Use: prek run --all-files",
       };
 
+    // Block memory writes from specialist agents — only orchestrator can write
+    if (process.env.PI_SUBAGENT_CHILD === "1" && /\bmyk-pi-tools\b.*\bmemory\s+(add|delete)\b/.test(command)) {
+      return {
+        block: true,
+        reason: "Memory writes are restricted to the orchestrator. Specialists can only search/list memories.",
+      };
+    }
+
     // Block direct docker/podman CLI in container — force docker-safe wrapper
     if (inContainer && /(?:^|[|;&]\s*)(?:docker|podman)\s/.test(cmdLower) && !cmdLower.includes("docker-safe")) {
       return {

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -1,34 +1,89 @@
 /**
- * Rule injection — loads rules/*.md and appends them to the system prompt.
+ * Rule & memory injection — loads rules/*.md for the orchestrator
+ * and recent project memories for all agents.
  */
 
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 export function registerRules(pi: ExtensionAPI): void {
-  // Skip orchestrator rules in child processes — they are specialists, not managers
-  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+  const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
 
-  pi.on("before_agent_start", async (event, _ctx) => {
-    // Load rules from rules/ directory (sorted alphabetically)
-    const rulesDir = path.resolve(__dirname, "..", "..", "rules");
-    let rules = "";
-    try {
-      const files = fs
-        .readdirSync(rulesDir)
-        .filter((f) => f.endsWith(".md"))
-        .sort();
-      rules =
-        "\n\n" +
-        files
-          .map((f) => fs.readFileSync(path.join(rulesDir, f), "utf-8"))
-          .join("\n\n");
-    } catch {
-      // Fallback if rules dir not found
-      rules =
-        "\n\n[ORCHESTRATOR RULES] You are a MANAGER. Delegate work to subagents.\n";
+  pi.on("before_agent_start", async (event, ctx) => {
+    let extra = "";
+
+    // Orchestrator rules — skip for specialist agents
+    if (!isSubagent) {
+      const rulesDir = path.resolve(__dirname, "..", "..", "rules");
+      try {
+        const files = fs
+          .readdirSync(rulesDir)
+          .filter((f) => f.endsWith(".md"))
+          .sort();
+        extra +=
+          "\n\n" +
+          files
+            .map((f) => fs.readFileSync(path.join(rulesDir, f), "utf-8"))
+            .join("\n\n");
+      } catch {
+        extra +=
+          "\n\n[ORCHESTRATOR RULES] You are a MANAGER. Delegate work to subagents.\n";
+      }
     }
-    return { systemPrompt: event.systemPrompt + rules };
+
+    // Project memories — injected for ALL agents (orchestrator + specialists)
+    const memories = loadRecentMemories(ctx.cwd);
+    if (memories) {
+      extra += memories;
+      if (isSubagent) {
+        extra +=
+          "\n\nYou can search for more project memories with:" +
+          " `uv run myk-pi-tools memory search \"<query>\"`" +
+          " — use this before implementing if the task relates to a past lesson or mistake." +
+          " **Do NOT write to memory** — only the orchestrator writes memories.\n";
+      }
+    }
+
+    if (!extra) return;
+    return { systemPrompt: event.systemPrompt + extra };
   });
+}
+
+interface Memory {
+  category: string;
+  summary: string;
+  tags?: string;
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + "…" : text;
+}
+
+// Loads recent memories from the per-repo SQLite DB (best-effort, non-critical)
+function loadRecentMemories(cwd: string): string {
+  try {
+    const result = execFileSync(
+      "uv",
+      ["run", "myk-pi-tools", "memory", "list", "--last", "30", "-n", "10", "--json"],
+      { cwd, encoding: "utf-8", timeout: 5000, maxBuffer: 64 * 1024, stdio: ["ignore", "pipe", "ignore"] },
+    );
+    const memories: unknown[] = JSON.parse(result);
+    if (!Array.isArray(memories) || memories.length === 0) return "";
+
+    const SKIP_CATEGORIES = new Set(["done", "pattern"]);
+    const lines = memories
+      .filter((m): m is Memory => !!m && typeof m === "object" && "category" in m && "summary" in m)
+      .filter((m) => !SKIP_CATEGORIES.has(m.category))
+      .map(
+        (m) => `- [${m.category}] ${truncate(m.summary, 120)}${m.tags ? ` (${m.tags})` : ""}`,
+      );
+    if (lines.length === 0) return "";
+
+    return "\n\n# Project Memories\n\n" + lines.join("\n") + "\n";
+  } catch {
+    // Memory loading is best-effort — silently skip if CLI unavailable or DB empty
+    return "";
+  }
 }

--- a/prompts/remember.md
+++ b/prompts/remember.md
@@ -1,0 +1,32 @@
+---
+description: "Save a memory for future sessions — /remember <what to remember>"
+---
+
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
+> or reproducible bug while executing this command — DO NOT work around it
+> silently. Ask the user: "Should I create a GitHub issue for this?"
+> Route to `myk-org/pi-config` for prompt/extension issues,
+> or to the relevant tool's repository for CLI issues.
+
+## What to remember
+
+```text
+$ARGUMENTS
+```
+
+Save this as a project memory. Determine the best category and sentiment from the content:
+
+- `lesson` — something learned (how things work, gotchas, tips)
+- `decision` — an architectural or design choice made
+- `mistake` — something that went wrong and should be avoided
+- `pattern` — a recurring approach or convention
+- `done` — a completed task or milestone
+- `preference` — user preference for how things should be done
+
+Run:
+
+```bash
+uv run myk-pi-tools memory add -c <category> -s "<concise one-line summary>" [-d "<details if the input is long>"] [-t "<relevant,tags>"] [--sentiment <positive|negative|neutral>]
+```
+
+After saving, confirm what was stored and show the memory ID.

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -107,9 +107,19 @@ The `github-expert` agent handles issue formatting. When delegating issue creati
 - Type (fix/feat/refactor/docs)
 - Problem/feature description
 - Requirements list
-- Deliverables checklist
+- **Deliverables checklist (MANDATORY)** — every issue MUST have a `## Done` section with checkboxes
 
-The agent will format the title and body according to its template.
+**Every issue MUST include a `## Done` section with checkboxes** that define what "done" means:
+
+```markdown
+## Done
+
+- [ ] Deliverable 1
+- [ ] Deliverable 2
+- [ ] Deliverable 3
+```
+
+These checkboxes are the **contract** for when the issue can be closed.
 
 ---
 
@@ -123,10 +133,13 @@ The agent will format the title and body according to its template.
 
 **When all deliverables are complete:**
 
-1. Verify all checklist items are checked
+1. **Verify ALL checkboxes in the `## Done` section are checked** — if any are unchecked, the issue MUST NOT be closed
 2. Ensure code review passed
 3. Ensure tests pass (if applicable)
 4. Close the issue with a summary comment
+
+🚨 **NEVER close an issue with unchecked deliverables.** An issue with unchecked boxes is NOT done.
+If deliverables are no longer needed, explicitly remove them or mark as N/A before closing.
 
 ---
 

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -1,0 +1,54 @@
+# Project Memory
+
+Persistent per-repo memory in `.pi/memory/memories.db`. Loaded automatically at session start.
+
+**CLI:** `uv run myk-pi-tools memory <command>`
+
+---
+
+## Memory Quality Rules (CRITICAL)
+
+- **One line only** — summaries MUST be a single short sentence, max ~100 chars
+- **Specific and actionable** — not vague observations, but concrete "do X" or "don't do Y"
+- **No fluff** — no context, no background, no explanation. Just the fact.
+- **Tags are mandatory** — always add relevant tags for searchability
+
+### Good vs Bad
+
+| ❌ Bad | ✅ Good |
+|--------|---------|
+| "We had issues with buildah and Docker caching and tried several approaches before finding the right one" | "buildah chown -R breaks cache mounts — use --mount=type=cache with correct uid instead" |
+| "The memory system was implemented but the integration was incomplete" | "Never close issues with unchecked deliverables in Done section" |
+| "User prefers a certain approach to handling processes" | "Attach child processes to pi (no detached:true) — kills on exit" |
+
+---
+
+## When to Write
+
+| Trigger | Category | Sentiment |
+|---------|----------|-----------|
+| PR merged | `done` | positive |
+| User corrects you | `lesson` | negative |
+| Multiple fix attempts | `mistake` | negative |
+| User states a preference | `preference` | neutral |
+| User says "remember" / `/remember` | best fit | best fit |
+
+---
+
+## When to Read
+
+- **Before implementation** — `uv run myk-pi-tools memory search "<keywords>"`
+- **User asks about past work** — `uv run myk-pi-tools memory list -c done`
+
+---
+
+## CLI
+
+```bash
+uv run myk-pi-tools memory add -c <category> -s "summary" [-t "tags"] [--sentiment positive|negative|neutral]
+uv run myk-pi-tools memory search "<query>"
+uv run myk-pi-tools memory list [--last <days>] [-c <category>]
+uv run myk-pi-tools memory delete <id>
+```
+
+**Categories:** `lesson`, `decision`, `mistake`, `pattern`, `done`, `preference`


### PR DESCRIPTION
## Summary

Completes the missing deliverables from #125. The memory CLI existed but the orchestrator had zero awareness of it — no rules, no session loading, no /remember command.

## Changes

### New files
- **`rules/35-memory.md`** — Orchestrator rule defining when to read/write memories, with strict quality rules (one line, specific, actionable, tagged)
- **`prompts/remember.md`** — `/remember` prompt template for quick memory saves

### Modified files
- **`extensions/orchestrator/rules.ts`** — Restructured: rules remain orchestrator-only, but memories are now injected into ALL agents (orchestrator + specialists). Specialists get read-only search access. Filters out `done` and `pattern` categories from preload (low-signal for active work).
- **`extensions/orchestrator/enforcement.ts`** — Blocks specialist agents from `memory add` and `memory delete` (enforced, not just advisory)
- **`rules/05-issue-first-workflow.md`** — Every issue must have a `## Done` section with checkboxes. Issues cannot be closed with unchecked deliverables.
- **`AGENTS.md`** — Updated repository structure (added missing entries: `25-documentation-updates.md`, `35-memory.md`, `45-file-preview.md`, `icons.ts`, `remember.md`)

## How it works

1. **Session start** — `rules.ts` loads last 30 days of memories (max 10, skip `done`/`pattern`), injects into system prompt for all agents
2. **Orchestrator** — gets full memory rules (when to write, when to search)
3. **Specialists** — get preloaded memories + can `memory search` but CANNOT write (enforced in `enforcement.ts`)
4. **User** — can `/remember <thing>` to save memories manually

Closes #130