### PR TITLE
fix(enforcement): block standalone sleep > 30s — force async subagent

### DIFF
--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -67,6 +67,14 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       };
     }
 
+    // Block standalone sleep > 30s — use async subagent instead of blocking
+    if (!hasLoop && sleepMatch && parseInt(sleepMatch[1], 10) > 30) {
+      return {
+        block: true,
+        reason: `⚠️ sleep ${sleepMatch[1]}s blocked — too long. Use subagent with async: true instead of blocking the session.`,
+      };
+    }
+
     // Git protection
     if (isGitRepo(ctx.cwd)) {
       // Block git add . / git add -A


### PR DESCRIPTION
## Summary

Extends the sleep enforcement rule. Previously only `sleep` inside loops (`while`/`for`/`until`) with sleep > 5s was blocked. Now standalone `sleep > 30s` is also blocked — these should use async subagents instead of blocking the session.

## Changes

- `extensions/orchestrator/enforcement.ts` — added check for standalone `sleep` commands over 30 seconds