### PR TITLE
feat: extend security audit to cover skills, packages, MCP servers, images, and remote scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ pi-config/
 │   │   ├── async-runner.ts          # Standalone async runner (spawned detached)
 │   │   ├── btw.ts                   # /btw command
 │   │   ├── diffity.ts               # Auto-start diffity diff viewer
-│   │   ├── enforcement.ts           # Python/git/dangerous command enforcement
+│   │   ├── enforcement.ts           # Command enforcement (python/pip, git, security, dangerous)
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
 │   │   ├── rules.ts                 # Rule + memory injection (before_agent_start)

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -1,5 +1,6 @@
 /**
- * Enforcement handler — blocks forbidden commands (python/pip, git protection, dangerous).
+ * Enforcement handler — blocks forbidden commands (python/pip, git protection,
+ * remote script execution, memory writes, dangerous).
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -73,6 +74,25 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         block: true,
         reason: `⚠️ sleep ${sleepMatch[1]}s blocked — too long. Use subagent with async: true instead of blocking the session.`,
       };
+    }
+
+    // Block remote script execution — download first, audit, then run
+    const remoteExecReason = "⛔ Remote script execution is forbidden. Download the script first, audit it with security-auditor, then run if safe.";
+    // Pipe to shell or interpreter: curl ... | sh, curl ... | /bin/bash, curl ... | sudo python3
+    if (/\b(curl|wget)\b.*\|(?!\|)\s*(?:sudo\s+(?:-\S+\s+)*|env\s+(?:-\S+\s+)*)*(?:\/\S+\/)*(ba|c|da|[akz]|fi|tc)?sh\b/.test(cmdLower) ||
+        /\b(curl|wget)\b.*\|(?!\|)\s*(?:sudo\s+(?:-\S+\s+)*|env\s+(?:-\S+\s+)*)*(python[23]?|perl|ruby|node|deno|bun)\b/.test(cmdLower)) {
+      return { block: true, reason: remoteExecReason };
+    }
+    // Process substitution: bash <(curl ...), source <(curl ...), . <(curl ...)
+    if (/\b(ba|c|da|[akz]|fi|tc)?sh\b.*<\(\s*\b(curl|wget)\b/.test(cmdLower) ||
+        /\bsource\s+<\(\s*\b(curl|wget)\b/.test(cmdLower) ||
+        /(?:^|[\s;&|])\.\s+<\(\s*\b(curl|wget)\b/.test(cmdLower)) {
+      return { block: true, reason: remoteExecReason };
+    }
+    // Command substitution / eval: sh -c "$(curl ...)", eval $(curl ...), `curl ...`
+    if (/\$\(\s*\b(curl|wget)\b/.test(cmdLower) || /`\s*(curl|wget)\b/.test(cmdLower) ||
+        /\beval\b.*\b(curl|wget)\b/.test(cmdLower)) {
+      return { block: true, reason: remoteExecReason };
     }
 
     // Git protection

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -62,26 +62,32 @@ Provide clear, concise options. Include a 'no' or 'cancel' option when appropria
 
 ---
 
-## External Repo Security Audit (MANDATORY)
+## External Code Security Audit (MANDATORY)
 
-**Before adopting any external repository, tool, or library:**
+**Before adopting any external code from an untrusted source:**
 
-1. Clone to `/tmp/pi-work/`
+1. Obtain the source code (clone repo, download package source, inspect skill files)
 2. Delegate a full security audit to `security-auditor`
 3. Only proceed if the audit verdict is ✅ SAFE or ⚠️ CAUTION with acceptable risks
 4. If ❌ UNSAFE — do not use, inform the user with findings
 
-**This applies to:**
+### What triggers an audit
 
-- CLI tools being considered for installation
-- Libraries being evaluated for integration
-- External extensions or plugins
-- Any third-party code that will run in our environment
+| Source | Trigger | Audit approach |
+|--------|---------|----------------|
+| **Git repos** | Adopting external repo/tool/library | Clone to `/tmp/pi-work/`, run `security-auditor` |
+| **Pi skills** | `pi skill install`, adding skill files | Clone/download source to `/tmp/pi-work/`, run `security-auditor` |
+| **PyPI packages** | `uv add <unknown-pkg>`, `uv run --with <unknown-pkg>` | Clone source repo from PyPI metadata, check install hooks, scan code |
+| **npm packages** | `npm install <unknown-pkg>` | Download source, check `postinstall` scripts, scan code |
+| **MCP servers** | Adding new server to `mcp.json` | Audit the server source code before adding config |
+| **Docker images** | `FROM unknown-registry/image` in Dockerfile | Inspect Dockerfile source, check base image provenance |
+| **Remote scripts** | `curl \| bash`, `wget \| sh` | **ALWAYS block** — download first, audit, then run if safe |
 
-**Skip when:**
+### Skip when
 
 - User explicitly says "skip audit" or "I already reviewed it"
-- The tool is from a trusted source the user has previously approved
+- The tool/package is from a trusted source the user has previously approved
+- Well-known, widely-used packages (e.g., `requests`, `flask`, `react`, `lodash`)
 
 ---
 


### PR DESCRIPTION
## Summary

Extends the security audit rule from covering only external Git repos to all untrusted code sources entering our environment.

## Changes

- Renamed External Repo Security Audit to External Code Security Audit in rules
- Added audit triggers for Pi skills, PyPI/npm packages, MCP servers, Docker images, remote scripts
- Added comprehensive remote script execution blocking in enforcement.ts
- Updated AGENTS.md enforcement.ts description

Closes #133
