### PR TITLE
fix(extensions): fix async result race — poller marks job complete before result delivery

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -33,6 +33,7 @@ interface AsyncJob {
   output?: string;
   exitCode?: number | null;
   durationMs?: number;
+  delivered?: boolean;
 }
 
 interface AsyncState {
@@ -135,7 +136,7 @@ export function registerAsyncAgents(
       const data = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
       const job = asyncState.jobs.get(data.id);
       if (!job) return;
-      if (job.status === "complete" || job.status === "failed") return; // Already processed
+      if (job.delivered) return; // Already delivered to user
 
       // Notify user
       terminalNotify("pi", `Async agent ${data.agent} ${data.success ? "completed" : "failed"} (${formatDuration(data.durationMs)})`);
@@ -151,7 +152,8 @@ export function registerAsyncAgents(
         }, { triggerTurn: true, deliverAs: "followUp" });
       }
 
-      // Mark as processed AFTER delivery succeeds
+      // Mark as delivered AFTER delivery succeeds
+      job.delivered = true;
       job.status = data.success ? "complete" : "failed";
       job.output = data.output;
       job.exitCode = data.exitCode;


### PR DESCRIPTION
## Root cause

The poller reads `status.json` (state: "complete") and sets `job.status = "complete"` BEFORE the async runner writes the result file. When the result file appears moments later, `processResultFile()` checks `job.status === "complete"` and returns early — silently dropping the result.

Timeline:
1. Runner finishes pi → writes `status.json` with `state: "complete"` 
2. **Poller fires** → reads status.json → sets `job.status = "complete"`
3. Runner writes result file to `results-<pid>/`
4. Poller/watcher calls `processResultFile()` → `job.status === "complete"` → **skips** ❌

## Fix

Added a `delivered` boolean flag to `AsyncJob`. The idempotency guard now checks `job.delivered` (was the result actually sent to the user via `sendMessage`?) instead of `job.status` (which the poller sets independently from status.json).

Closes #135