### PR TITLE
feat: memory dreaming — usage tracking, scoring, pruning, and background consolidation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ pi-config/
 │   │   ├── async-runner.ts          # Standalone async runner (spawned detached)
 │   │   ├── btw.ts                   # /btw command
 │   │   ├── diffity.ts               # Auto-start diffity diff viewer
+│   │   ├── dreaming.ts              # Background memory consolidation (inspired by OpenClaw)
 │   │   ├── enforcement.ts           # Command enforcement (python/pip, git, security, dangerous)
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
@@ -56,6 +57,7 @@ pi-config/
 ├── prompts/                         # Prompt templates (slash commands)
 │   ├── acpx-prompt.md
 │   ├── coderabbit-rate-limit.md
+│   ├── dream.md
 │   ├── implement-and-review.md
 │   ├── implement.md
 │   ├── pr-review.md

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -1,0 +1,110 @@
+/**
+ * Memory dreaming — background memory consolidation on a timer.
+ *
+ * Inspired by OpenClaw's dreaming system (v2026.4.5).
+ * See: https://docs.openclaw.ai/concepts/dreaming
+ *
+ * When enabled, runs "uv run myk-pi-tools memory dream" every 3 hours
+ * as an async background agent, plus on session shutdown as a detached process.
+ * Users toggle with /dream-auto on|off.
+ */
+
+import { spawn } from "node:child_process";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { discoverAgents } from "./agents.js";
+
+// Default: 3 hours. Override with PI_DREAM_INTERVAL_HOURS env var (0.5–24).
+const _rawHours = parseFloat(process.env.PI_DREAM_INTERVAL_HOURS || "3");
+const DREAM_INTERVAL_HOURS = Number.isFinite(_rawHours) && _rawHours >= 0.5 && _rawHours <= 24 ? _rawHours : 3;
+const DREAM_INTERVAL_MS = DREAM_INTERVAL_HOURS * 60 * 60 * 1000;
+
+export function registerDreaming(
+  pi: ExtensionAPI,
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: any[]) => { id: string; error?: string },
+): void {
+  // Only the orchestrator (top-level pi) runs dreaming — skip in subagent children
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
+  let dreamTimer: ReturnType<typeof setInterval> | null = null;
+  let enabled = true;
+  let lastCwd = "";
+
+  let dreamInFlight = false;
+
+  function runDreamAsync(cwd: string) {
+    if (dreamInFlight) return; // Prevent concurrent dreams
+    dreamInFlight = true;
+    const { agents } = discoverAgents(cwd, "user");
+    const { id } = spawnAsyncAgent(
+      "worker",
+      "Run memory consolidation: `uv run myk-pi-tools memory dream`. Report the output.",
+      cwd,
+      agents,
+    );
+    // Reset flag after reasonable timeout (dream should complete in <5 min)
+    if (id) setTimeout(() => { dreamInFlight = false; }, 5 * 60 * 1000);
+    else dreamInFlight = false;
+  }
+
+  function startTimer(cwd: string) {
+    lastCwd = cwd;
+    if (dreamTimer) return;
+    dreamTimer = setInterval(() => {
+      if (enabled && lastCwd) runDreamAsync(lastCwd);
+    }, DREAM_INTERVAL_MS);
+    if (dreamTimer.unref) dreamTimer.unref();
+  }
+
+  function stopTimer() {
+    if (dreamTimer) {
+      clearInterval(dreamTimer);
+      dreamTimer = null;
+    }
+  }
+
+  // /dream-auto command — toggle auto-dreaming
+  pi.registerCommand("dream-auto", {
+    description: "Toggle automatic memory dreaming (every 3h + session end)",
+    handler: async (args, ctx) => {
+      const arg = (args || "").trim().toLowerCase();
+
+      if (arg === "on") {
+        enabled = true;
+        lastCwd = ctx.cwd;
+        startTimer(ctx.cwd);
+        ctx.ui.notify("🌙 Auto-dreaming enabled (every 3h + session end)", "info");
+      } else if (arg === "off") {
+        enabled = false;
+        stopTimer();
+        ctx.ui.notify("Auto-dreaming disabled", "info");
+      } else {
+        const status = enabled ? "enabled" : "disabled";
+        ctx.ui.notify(`Auto-dreaming is ${status}. Use: /dream-auto on|off`, "info");
+      }
+    },
+  });
+
+  // Update cwd on session start
+  pi.on("session_start", (_event, ctx) => {
+    lastCwd = ctx.cwd;
+    if (enabled) startTimer(ctx.cwd);
+  });
+
+  // Fire-and-forget dream on session shutdown.
+  // Uses detached spawn (not async agent) because the session is ending —
+  // async agents need the pi process alive to deliver results.
+  pi.on("session_shutdown", () => {
+    stopTimer();
+    if (!enabled || !lastCwd || dreamInFlight) return;
+
+    try {
+      const proc = spawn(
+        "uv",
+        ["run", "myk-pi-tools", "memory", "dream"],
+        { cwd: lastCwd, detached: true, stdio: "ignore" },
+      );
+      proc.on("error", () => {}); // Swallow async spawn errors (best-effort)
+      proc.unref();
+    } catch {}
+  });
+}

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -4,12 +4,13 @@
  * Bundles:
  * - Subagent tool (based on pi's subagent example, with package agent discovery)
  * - Enforcement handlers (python/pip, git protection, dangerous commands)
- * - Rule injection (before_agent_start)
- * - Slash commands (/btw, /async-status)
+ * - Rule injection & memory loading (before_agent_start)
+ * - Slash commands (/btw, /async-status, /dream-auto)
  * - Notifications and status line
  * - Session validation (required tools check)
  * - Async agent infrastructure
  * - ask_user tool
+ * - Memory dreaming (background consolidation)
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -17,6 +18,7 @@ import { registerAskUser } from "./ask-user.js";
 import { registerAsyncAgents } from "./async-agents.js";
 import { registerBtw } from "./btw.js";
 import { registerDiffity } from "./diffity.js";
+import { registerDreaming } from "./dreaming.js";
 import { registerEnforcement } from "./enforcement.js";
 import { registerRules } from "./rules.js";
 import { registerSessionValidation } from "./session-validation.js";
@@ -36,5 +38,6 @@ export default function (pi: ExtensionAPI) {
   registerStatusLine(pi, IN_CONTAINER, terminalNotify);
   registerBtw(pi);
   registerDiffity(pi);
+  registerDreaming(pi, spawnAsyncAgent);
   registerSessionValidation(pi);
 }

--- a/myk_pi_tools/memory/commands.py
+++ b/myk_pi_tools/memory/commands.py
@@ -1,5 +1,6 @@
 """Memory CLI commands."""
 
+import fcntl
 import json
 import sys
 from pathlib import Path
@@ -167,3 +168,144 @@ def memory_delete(ctx: click.Context, memory_id: int) -> None:
     else:
         click.echo(f"Memory #{memory_id} not found.", err=True)
         sys.exit(1)
+
+
+@memory.command("stats")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def memory_stats(ctx: click.Context, output_json: bool) -> None:
+    """Show memory statistics.
+
+    Examples:
+
+        myk-pi-tools memory stats
+        myk-pi-tools memory stats --json
+    """
+    db = ctx.obj["db"]
+    result = db.stats()
+
+    if output_json:
+        click.echo(json.dumps(result, indent=2))
+    else:
+        click.echo(f"Total memories: {result['total']}")
+        click.echo(f"Recalled at least once: {result['recalled']}")
+        click.echo(f"Never recalled: {result['never_recalled']}")
+        if result.get("categories"):
+            click.echo(f"Categories: {', '.join(f'{k}={v}' for k, v in sorted(result['categories'].items()))}")
+        if result.get("top_recalled"):
+            click.echo("\nMost recalled:")
+            for tr in result["top_recalled"]:
+                click.echo(f"  #{tr['id']} ({tr['recall_count']}x) {tr['summary']}")
+
+
+@memory.command("score")
+@click.option("--limit", "-n", default=20, help="Maximum results")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def memory_score(ctx: click.Context, limit: int, output_json: bool) -> None:
+    """Show memories ranked by score.
+
+    Examples:
+
+        myk-pi-tools memory score
+        myk-pi-tools memory score -n 10
+    """
+    db = ctx.obj["db"]
+    results = db.score_memories(limit=limit)
+
+    if output_json:
+        click.echo(json.dumps(results, indent=2))
+    else:
+        if not results:
+            click.echo("No memories found.")
+        else:
+            click.echo(_format_table(results, ["id", "score", "recall_count", "category", "summary", "tags"]))
+
+
+@memory.command("prune")
+@click.option("--min-score", default=0.1, type=float, help="Minimum score threshold")
+@click.option("--max-age", default=90, type=int, help="Max age in days for unrecalled memories")
+@click.option("--apply", is_flag=True, help="Actually delete (default is dry-run)")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def memory_prune(ctx: click.Context, min_score: float, max_age: int, apply: bool, output_json: bool) -> None:
+    """Prune low-value memories.
+
+    Default is dry-run — shows what would be deleted. Use --apply to actually delete.
+
+    Examples:
+
+        # Preview what would be pruned
+        myk-pi-tools memory prune
+
+        # Actually prune
+        myk-pi-tools memory prune --apply
+
+        # Custom thresholds
+        myk-pi-tools memory prune --min-score 0.2 --max-age 60
+    """
+    db = ctx.obj["db"]
+    results = db.prune(min_score=min_score, max_age_days=max_age, dry_run=not apply)
+
+    if output_json:
+        click.echo(json.dumps(results, indent=2))
+    else:
+        if not results:
+            click.echo("No memories to prune." if not apply else "Nothing pruned.")
+        else:
+            mode = "Pruned" if apply else "Would prune"
+            click.echo(f"{mode} {len(results)} memories:", err=True)
+            for m in results:
+                click.echo(f"  #{m['id']} ({m['category']}) {m['summary']} — {m.get('prune_reason', '')}")
+
+
+_MAX_DREAM_REPORTS = 10
+
+
+@memory.command("dream")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@click.pass_context
+def memory_dream(ctx: click.Context, output_json: bool) -> None:
+    """Run memory consolidation and generate dream report.
+
+    Scores all memories, identifies prune candidates, and writes
+    a report to .pi/memory/dreams.md. Keeps only the last 10 reports.
+
+    Examples:
+
+        myk-pi-tools memory dream
+        myk-pi-tools memory dream --json
+    """
+    db = ctx.obj["db"]
+    report = db.dream()
+
+    # Write dream report to file, rotating to keep only last N reports.
+    # Uses advisory file lock to prevent concurrent write races
+    # (e.g., /dream manual + auto-dream timer running simultaneously).
+    dream_path = db.db_path.parent / "dreams.md"
+    lock_path = dream_path.with_suffix(".lock")
+
+    wrote_file = False
+    try:
+        with open(lock_path, "w") as lock_fd:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                existing = dream_path.read_text() if dream_path.exists() else ""
+                parts = [report] + [p for p in existing.split("\n---\n\n") if p.strip()]
+                parts = parts[:_MAX_DREAM_REPORTS]
+                dream_path.write_text("\n---\n\n".join(parts) + "\n")
+                wrote_file = True
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+    except BlockingIOError:
+        click.echo("Another dream is running — skipped file write.", err=True)
+    except OSError as e:
+        click.echo(f"Failed to write dream report: {e}", err=True)
+        sys.exit(1)
+
+    if output_json:
+        click.echo(json.dumps({"report": report, "path": str(dream_path), "wrote_file": wrote_file}, indent=2))
+    else:
+        click.echo(report)
+        if wrote_file:
+            click.echo(f"\nDream report written to {dream_path}", err=True)

--- a/myk_pi_tools/memory/store.py
+++ b/myk_pi_tools/memory/store.py
@@ -1,6 +1,10 @@
 """Memory store — SQLite-backed per-repo memory.
 
 Database location: <git-root>/.pi/memory/memories.db
+
+The scoring, pruning, and dreaming features are inspired by OpenClaw's
+"Dreaming" memory consolidation system (v2026.4.5).
+See: https://docs.openclaw.ai/concepts/dreaming
 """
 
 import sqlite3
@@ -17,6 +21,11 @@ def log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
+def _parse_utc(date_str: str) -> datetime:
+    """Parse a UTC datetime string from the database."""
+    return datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+
+
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS memories (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -25,9 +34,22 @@ CREATE TABLE IF NOT EXISTS memories (
     sentiment TEXT DEFAULT 'neutral',
     summary TEXT NOT NULL,
     details TEXT,
-    tags TEXT
+    tags TEXT,
+    recall_count INTEGER DEFAULT 0,
+    last_recalled TEXT
 );
 """
+
+# Scoring weights — inspired by OpenClaw's deep-phase ranking signals
+# See: https://docs.openclaw.ai/concepts/dreaming
+_WEIGHT_RECALL_FREQ = 0.30
+_WEIGHT_RECALL_RECENCY = 0.25
+_WEIGHT_AGE_VALUE = 0.20
+_WEIGHT_CATEGORY = 0.15
+_WEIGHT_FRESHNESS = 0.10
+_RECALL_RECENCY_WINDOW_DAYS = 90
+_FRESHNESS_WINDOW_DAYS = 60
+_AGE_VALUE_WINDOW_DAYS = 30
 
 
 class MemoryDB:
@@ -55,8 +77,23 @@ class MemoryDB:
         conn = sqlite3.connect(str(self.db_path))
         try:
             conn.executescript(_SCHEMA)
+            self._migrate_schema(conn)
         finally:
             conn.close()
+
+    def _migrate_schema(self, conn: sqlite3.Connection) -> None:
+        """Apply forward-compatible schema migrations.
+
+        Uses PRAGMA table_info to check for missing columns before adding,
+        consistent with the ReviewDB migration pattern in db/query.py.
+        """
+        cursor = conn.execute("PRAGMA table_info(memories)")
+        columns = {row[1] for row in cursor.fetchall()}
+        if "recall_count" not in columns:
+            conn.execute("ALTER TABLE memories ADD COLUMN recall_count INTEGER DEFAULT 0")
+        if "last_recalled" not in columns:
+            conn.execute("ALTER TABLE memories ADD COLUMN last_recalled TEXT")
+        conn.commit()
 
     def _connect(self, readonly: bool = True) -> sqlite3.Connection:
         """Create a database connection."""
@@ -128,7 +165,7 @@ class MemoryDB:
         try:
             escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
             sql = """
-                SELECT id, date, category, sentiment, summary, details, tags
+                SELECT id, date, category, sentiment, summary, details, tags, recall_count, last_recalled
                 FROM memories
                 WHERE (summary LIKE ? ESCAPE '\\' OR details LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')
             """
@@ -142,12 +179,32 @@ class MemoryDB:
             params.append(limit)
 
             cursor = conn.execute(sql, params)
-            return [dict(row) for row in cursor.fetchall()]
+            results = [dict(row) for row in cursor.fetchall()]
         except sqlite3.Error as e:
             log(f"Database error: {e}")
             return []
         finally:
             conn.close()
+
+        # Track recall for returned results
+        if results:
+            now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            write_conn = self._connect(readonly=False)
+            try:
+                ids = [r["id"] for r in results]
+                placeholders = ",".join("?" * len(ids))
+                sql = (
+                    "UPDATE memories SET recall_count = recall_count + 1,"
+                    f" last_recalled = ? WHERE id IN ({placeholders})"
+                )
+                write_conn.execute(sql, [now, *ids])
+                write_conn.commit()
+            except sqlite3.Error:
+                pass  # Best-effort tracking
+            finally:
+                write_conn.close()
+
+        return results
 
     def list_memories(
         self,
@@ -170,7 +227,10 @@ class MemoryDB:
 
         conn = self._connect()
         try:
-            sql = "SELECT id, date, category, sentiment, summary, details, tags FROM memories WHERE 1=1"
+            sql = (
+                "SELECT id, date, category, sentiment, summary, details, tags,"
+                " recall_count, last_recalled FROM memories WHERE 1=1"
+            )
             params: list[Any] = []
 
             if category:
@@ -191,6 +251,233 @@ class MemoryDB:
             return []
         finally:
             conn.close()
+
+    def score_memories(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Score all memories by weighted signals.
+
+        Scoring approach inspired by OpenClaw's deep-phase ranking signals.
+        See: https://docs.openclaw.ai/concepts/dreaming
+
+        Signals:
+        - recall_frequency (0.30): recall_count normalized
+        - recency (0.25): days since last recalled (inverse)
+        - age_value (0.20): older memories that are still recalled are valuable
+        - category_weight (0.15): lessons/mistakes > decisions > preferences > done/pattern
+        - freshness (0.10): days since created (inverse)
+
+        Returns:
+            List of memory dicts with 'score' field, sorted by score descending.
+        """
+        if not self.db_path.exists():
+            return []
+
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                "SELECT id, date, category, sentiment, summary, details, tags,"
+                " recall_count, last_recalled FROM memories"
+            )
+            memories = [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            log(f"Database error: {e}")
+            return []
+        finally:
+            conn.close()
+
+        if not memories:
+            return []
+
+        category_weights = {
+            "lesson": 1.0,
+            "mistake": 1.0,
+            "decision": 0.8,
+            "preference": 0.7,
+            "pattern": 0.5,
+            "done": 0.3,
+        }
+
+        now = datetime.now(timezone.utc)
+        max_recall = max((m.get("recall_count") or 0) for m in memories) or 1
+
+        for m in memories:
+            recall_count = m.get("recall_count") or 0
+            created = _parse_utc(m["date"])
+            age_days = (now - created).days
+
+            # Recall frequency (normalized)
+            recall_freq = recall_count / max_recall
+
+            # Recency of last recall
+            if m.get("last_recalled"):
+                last_recalled = _parse_utc(m["last_recalled"])
+                recall_recency = max(0, 1 - (now - last_recalled).days / _RECALL_RECENCY_WINDOW_DAYS)
+            else:
+                recall_recency = 0.0
+
+            # Age value: older + recalled = valuable
+            age_value = min(age_days / _AGE_VALUE_WINDOW_DAYS, 1.0) * (1 if recall_count > 0 else 0.2)
+
+            # Category weight
+            cat_weight = category_weights.get(m["category"], 0.5)
+
+            # Freshness (inverse age, for new memories)
+            freshness = max(0, 1 - age_days / _FRESHNESS_WINDOW_DAYS)
+
+            score = (
+                _WEIGHT_RECALL_FREQ * recall_freq
+                + _WEIGHT_RECALL_RECENCY * recall_recency
+                + _WEIGHT_AGE_VALUE * age_value
+                + _WEIGHT_CATEGORY * cat_weight
+                + _WEIGHT_FRESHNESS * freshness
+            )
+            m["score"] = round(score, 3)
+
+        memories.sort(key=lambda m: m["score"], reverse=True)
+        return memories[:limit]
+
+    def prune(self, min_score: float = 0.1, max_age_days: int = 90, dry_run: bool = True) -> list[dict[str, Any]]:
+        """Prune low-value memories.
+
+        Removes memories that:
+        - Score below min_score AND are older than 30 days
+        - Are category 'done' and older than max_age_days with no recalls
+        - Have never been recalled and are older than max_age_days
+
+        Args:
+            min_score: Minimum score threshold
+            max_age_days: Maximum age for unrecalled memories
+            dry_run: If True, return candidates without deleting
+
+        Returns:
+            List of pruned (or to-be-pruned) memory dicts.
+        """
+        scored = self.score_memories(limit=10000)
+        now = datetime.now(timezone.utc)
+
+        to_prune = []
+        for m in scored:
+            created = _parse_utc(m["date"])
+            age_days = (now - created).days
+            recall_count = m.get("recall_count") or 0
+
+            should_prune = False
+            reason = ""
+
+            # Low score + old enough
+            if m["score"] < min_score and age_days > 30:
+                should_prune = True
+                reason = f"low score ({m['score']}) and {age_days} days old"
+
+            # Done category, old, never recalled
+            elif m["category"] == "done" and age_days > max_age_days and recall_count == 0:
+                should_prune = True
+                reason = f"done category, {age_days} days old, never recalled"
+
+            # Never recalled and very old
+            elif recall_count == 0 and age_days > max_age_days:
+                should_prune = True
+                reason = f"never recalled, {age_days} days old"
+
+            if should_prune:
+                m["prune_reason"] = reason
+                to_prune.append(m)
+
+        if not dry_run and to_prune:
+            conn = self._connect(readonly=False)
+            try:
+                ids = [m["id"] for m in to_prune]
+                placeholders = ",".join("?" * len(ids))
+                conn.execute(f"DELETE FROM memories WHERE id IN ({placeholders})", ids)
+                conn.commit()
+            finally:
+                conn.close()
+
+        return to_prune
+
+    def stats(self) -> dict[str, Any]:
+        """Get memory statistics.
+
+        Returns:
+            Dict with total count, category breakdown, recall stats.
+        """
+        if not self.db_path.exists():
+            return {"total": 0, "categories": {}, "recalled": 0, "never_recalled": 0}
+
+        conn = self._connect()
+        try:
+            total = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
+            categories = {}
+            for row in conn.execute("SELECT category, COUNT(*) as cnt FROM memories GROUP BY category"):
+                categories[row[0]] = row[1]
+            recalled = conn.execute("SELECT COUNT(*) FROM memories WHERE recall_count > 0").fetchone()[0]
+            never_recalled = conn.execute(
+                "SELECT COUNT(*) FROM memories WHERE recall_count = 0 OR recall_count IS NULL"
+            ).fetchone()[0]
+            top_recalled = conn.execute(
+                "SELECT id, summary, recall_count FROM memories"
+                " WHERE recall_count > 0 ORDER BY recall_count DESC LIMIT 5"
+            ).fetchall()
+
+            return {
+                "total": total,
+                "categories": categories,
+                "recalled": recalled,
+                "never_recalled": never_recalled,
+                "top_recalled": [{"id": r[0], "summary": r[1], "recall_count": r[2]} for r in top_recalled],
+            }
+        except sqlite3.Error as e:
+            log(f"Database error: {e}")
+            return {"total": 0, "categories": {}, "recalled": 0, "never_recalled": 0}
+        finally:
+            conn.close()
+
+    def dream(self) -> str:
+        """Run memory consolidation — score, analyze, generate dream report.
+
+        Inspired by OpenClaw's dreaming system which consolidates short-term
+        signals into durable memory. See: https://docs.openclaw.ai/concepts/dreaming
+
+        Returns:
+            Dream report as markdown string.
+        """
+
+        scored = self.score_memories(limit=10000)
+        stats = self.stats()
+        pruned = self.prune(dry_run=True)
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+        lines = [f"# Dream Report — {now}", ""]
+
+        # Stats
+        lines.append("## Stats")
+        lines.append(f"- Total memories: {stats['total']}")
+        lines.append(f"- Recalled at least once: {stats['recalled']}")
+        lines.append(f"- Never recalled: {stats['never_recalled']}")
+        if stats.get("categories"):
+            cats = ", ".join(f"{k}: {v}" for k, v in sorted(stats["categories"].items()))
+            lines.append(f"- Categories: {cats}")
+        lines.append("")
+
+        # Top memories
+        if scored:
+            lines.append("## Top memories by score")
+            for m in scored[:10]:
+                lines.append(f"- [{m['score']}] ({m['category']}) {m['summary']}")
+            lines.append("")
+
+        # Prune candidates
+        if pruned:
+            lines.append(f"## Prune candidates ({len(pruned)})")
+            for m in pruned:
+                lines.append(f"- #{m['id']} ({m['category']}) {m['summary']} — {m['prune_reason']}")
+            lines.append("")
+        else:
+            lines.append("## Prune candidates")
+            lines.append("None — all memories are healthy.")
+            lines.append("")
+
+        return "\n".join(lines)
 
     def delete(self, memory_id: int) -> bool:
         """Delete a memory by ID.

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -1,0 +1,28 @@
+---
+description: "Run memory consolidation — score, prune, generate dream report — /dream"
+---
+
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
+> or reproducible bug while executing this command — DO NOT work around it
+> silently. Ask the user: "Should I create a GitHub issue for this?"
+> Route to `myk-org/pi-config` for prompt/extension issues,
+> or to the relevant tool's repository for CLI issues.
+
+## Memory Dreaming
+
+Inspired by [OpenClaw's dreaming system](https://docs.openclaw.ai/concepts/dreaming).
+
+Run memory consolidation as a **background async agent** — never block the session.
+
+Delegate to a `worker` agent with `async: true`:
+
+```text
+Task:
+1. Run: uv run myk-pi-tools memory dream
+2. Run: uv run myk-pi-tools memory prune (dry-run, report candidates)
+3. Report the dream output and prune candidates
+```
+
+Tell the user: "Running memory consolidation in background..."
+
+The async agent result will surface automatically when complete.

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -52,3 +52,37 @@ uv run myk-pi-tools memory delete <id>
 ```
 
 **Categories:** `lesson`, `decision`, `mistake`, `pattern`, `done`, `preference`
+
+---
+
+## Dreaming (Background Consolidation)
+
+Inspired by [OpenClaw's dreaming system](https://docs.openclaw.ai/concepts/dreaming).
+
+Memory consolidation runs as a **background async agent** — never blocking the session.
+
+### Triggers
+
+- `/dream` command — manual trigger
+- Session shutdown — automatic lightweight pass
+
+### What it does
+
+1. **Scores** all memories by recall frequency, recency, age, and category
+2. **Identifies** prune candidates (low-score, never-recalled, stale)
+3. **Writes** a dream report to `.pi/memory/dreams.md`
+
+### CLI Commands
+
+```bash
+uv run myk-pi-tools memory stats           # Memory statistics
+uv run myk-pi-tools memory score           # Ranked memories by score
+uv run myk-pi-tools memory prune           # Preview prune candidates
+uv run myk-pi-tools memory prune --apply   # Actually prune
+uv run myk-pi-tools memory dream           # Run consolidation + report
+```
+
+### Rules
+
+- **ALWAYS run dreaming as async agent** — never block the session
+- Tell the user: "Running memory consolidation in background..."

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -103,3 +103,157 @@ class TestMemoryDB:
         # Most recent first
         assert results[0]["summary"] == "Second"
         assert results[1]["summary"] == "First"
+
+
+class TestRecallTracking:
+    def test_search_increments_recall_count(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
+        memory_db.search("buildah")
+        results = memory_db.list_memories()
+        assert results[0]["recall_count"] == 1
+
+    def test_search_increments_multiple_times(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
+        memory_db.search("buildah")
+        memory_db.search("buildah")
+        memory_db.search("buildah")
+        results = memory_db.list_memories()
+        assert results[0]["recall_count"] == 3
+
+    def test_search_sets_last_recalled(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
+        memory_db.search("buildah")
+        results = memory_db.list_memories()
+        assert results[0]["last_recalled"] is not None
+
+    def test_search_no_match_no_recall(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
+        memory_db.search("nonexistent")
+        results = memory_db.list_memories()
+        assert results[0]["recall_count"] == 0
+
+    def test_new_memory_has_zero_recall(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="test")
+        results = memory_db.list_memories()
+        assert results[0]["recall_count"] == 0
+        assert results[0]["last_recalled"] is None
+
+
+class TestScoring:
+    def test_score_empty_db(self, memory_db: MemoryDB) -> None:
+        assert memory_db.score_memories() == []
+
+    def test_score_returns_scores(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Test lesson")
+        results = memory_db.score_memories()
+        assert len(results) == 1
+        assert "score" in results[0]
+        assert isinstance(results[0]["score"], float)
+
+    def test_recalled_memory_scores_higher(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="recalled lesson", tags="test")
+        memory_db.add(category="lesson", summary="forgotten lesson", tags="other")
+        # Recall the first one several times
+        for _ in range(5):
+            memory_db.search("recalled")
+        results = memory_db.score_memories()
+        recalled = next(m for m in results if "recalled" in m["summary"])
+        forgotten = next(m for m in results if "forgotten" in m["summary"])
+        assert recalled["score"] > forgotten["score"]
+
+    def test_score_respects_limit(self, memory_db: MemoryDB) -> None:
+        for i in range(10):
+            memory_db.add(category="done", summary=f"Task {i}")
+        results = memory_db.score_memories(limit=3)
+        assert len(results) == 3
+
+
+class TestPruning:
+    def test_prune_empty_db(self, memory_db: MemoryDB) -> None:
+        assert memory_db.prune() == []
+
+    def test_prune_dry_run_doesnt_delete(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="done", summary="Old task")
+        # Force old date
+        conn = memory_db._connect(readonly=False)
+        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
+        conn.commit()
+        conn.close()
+        pruned = memory_db.prune(dry_run=True)
+        assert len(pruned) > 0
+        # Still exists
+        assert len(memory_db.list_memories()) == 1
+
+    def test_prune_apply_deletes(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="done", summary="Old task")
+        conn = memory_db._connect(readonly=False)
+        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
+        conn.commit()
+        conn.close()
+        pruned = memory_db.prune(dry_run=False)
+        assert len(pruned) > 0
+        assert len(memory_db.list_memories()) == 0
+
+    def test_prune_keeps_recalled_memories(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Important lesson", tags="test")
+        # Make it old
+        conn = memory_db._connect(readonly=False)
+        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
+        conn.commit()
+        conn.close()
+        # But recall it frequently
+        for _ in range(10):
+            memory_db.search("Important")
+        pruned = memory_db.prune(dry_run=True)
+        # Should not be pruned because it's frequently recalled
+        assert all("Important" not in p["summary"] for p in pruned)
+
+
+class TestStats:
+    def test_stats_empty(self, memory_db: MemoryDB) -> None:
+        result = memory_db.stats()
+        assert result["total"] == 0
+
+    def test_stats_with_data(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="L1")
+        memory_db.add(category="lesson", summary="L2")
+        memory_db.add(category="done", summary="D1")
+        result = memory_db.stats()
+        assert result["total"] == 3
+        assert result["categories"]["lesson"] == 2
+        assert result["categories"]["done"] == 1
+
+    def test_stats_recall_tracking(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
+        memory_db.add(category="lesson", summary="not searched")
+        memory_db.search("buildah")
+        result = memory_db.stats()
+        assert result["recalled"] == 1
+        assert result["never_recalled"] == 1
+
+
+class TestDream:
+    def test_dream_empty_db(self, memory_db: MemoryDB) -> None:
+        report = memory_db.dream()
+        assert "Dream Report" in report
+        assert "Total memories: 0" in report
+
+    def test_dream_with_data(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Test lesson")
+        report = memory_db.dream()
+        assert "Dream Report" in report
+        assert "Total memories: 1" in report
+
+    def test_dream_shows_prune_candidates(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="done", summary="Old task")
+        # Make it old so it becomes a prune candidate
+        conn = memory_db._connect(readonly=False)
+        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
+        conn.commit()
+        conn.close()
+        report = memory_db.dream()
+        assert "Prune candidates" in report
+
+    def test_dream_returns_string(self, memory_db: MemoryDB) -> None:
+        report = memory_db.dream()
+        assert isinstance(report, str)


### PR DESCRIPTION
## Summary

Inspired by [OpenClaw's dreaming system](https://docs.openclaw.ai/concepts/dreaming) (v2026.4.5). Adds memory consolidation with usage tracking, scoring, pruning, and background auto-dreaming.

## Changes

### Python — `myk_pi_tools/memory/`

**store.py:**
- Schema migration: `recall_count`, `last_recalled` columns (PRAGMA table_info pattern matching ReviewDB)
- `search()` auto-tracks recall count and timestamp on hits
- `score_memories()` — 5 weighted signals (recall frequency, recency, age value, category, freshness)
- `prune()` — dry-run + apply for low-value memories
- `stats()` — counts, categories, recall stats, top recalled
- `dream()` — consolidation report generation

**commands.py:**
- `memory stats` / `memory score` / `memory prune` / `memory dream` commands with `--json` support
- Dream report rotation (keeps last 10 reports)
- `fcntl.flock` advisory locking on `dreams.md` to prevent concurrent write races
- Proper error handling: `BlockingIOError` for lock contention, `OSError` exits non-zero

### Extension — `extensions/orchestrator/dreaming.ts`

- Auto-dream every 3 hours via async agent (default: enabled)
- `PI_DREAM_INTERVAL_HOURS` env var (0.5–24, default 3)
- `/dream-auto on|off` toggle command
- Dream on session shutdown via detached process
- `PI_SUBAGENT_CHILD` guard — only orchestrator runs dreaming
- `dreamInFlight` guard — prevents concurrent dreams
- `proc.on("error")` listener on shutdown spawn

### Orchestrator

- `/dream` prompt template
- Updated `rules/35-memory.md` with dreaming section
- Updated `AGENTS.md` with `dreaming.ts` entry

### Tests

- 20 new tests (34 total): recall tracking, scoring, pruning, stats, dream report

### Peer reviewed by Cursor (3 rounds)

Closes #138