### PR TITLE
fix(ask-user): add overlay mode to prevent scroll capture on long questions

### DIFF
--- a/extensions/orchestrator/ask-user.ts
+++ b/extensions/orchestrator/ask-user.ts
@@ -183,6 +183,7 @@ export function registerAskUser(
             },
           };
         },
+        { overlay: true },
       );
 
       if (result === null) {


### PR DESCRIPTION
## Problem

When `ask_user` is called with a long question (e.g., `/release` changelog with 25+ lines), arrow keys scroll the chat buffer instead of navigating the SelectList options. The user sees options but can't select them — has to close and resume the session.

## Root cause

`ctx.ui.custom()` was called without `overlay: true`. The TUI's scroll handler captures arrow key input before the custom component receives it when the content exceeds the visible area.

## Fix

One-line change: add `{ overlay: true }` to the `ctx.ui.custom()` call. The component now floats on top with guaranteed keyboard focus regardless of content height.

Closes #143