### PR TITLE
feat(extensions): pidash — live web dashboard for pi sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ pi-config/
 │   │   ├── btw.ts                   # /btw command
 │   │   ├── diffity.ts               # Auto-start diffity diff viewer
 │   │   ├── dreaming.ts              # Background memory consolidation (inspired by OpenClaw)
+│   │   ├── pidash.ts                # Live web dashboard extension (connects to pidash daemon)
+│   │   ├── pidash-ui/               # React + shadcn/ui web dashboard
+│   │   │   ├── src/                 # React source (components, hooks, types)
+│   │   │   └── dist/               # Built output (generated, gitignored)
 │   │   ├── enforcement.ts           # Command enforcement (python/pip, git, security, dangerous)
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
@@ -90,7 +94,8 @@ pi-config/
 │   ├── release/
 │   └── reviews/
 ├── scripts/                         # Utility scripts
-│   └── docker-safe                  # Restricted Docker/Podman CLI wrapper (container only)
+│   ├── docker-safe                  # Restricted Docker/Podman CLI wrapper (container only)
+│   └── pidash-server.ts             # Pidash daemon (WebSocket hub for all pi sessions)
 ├── Dockerfile                       # Container image definition
 ├── entrypoint.sh                    # Container entrypoint
 ├── README.md                        # Project README

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ Single extension that provides:
 | **Git status** | Live git status in status line with colored icons — updates after every tool call |
 | **Desktop notifications** | Notifies via `notify-send` on task completion, waiting for input, and action required |
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
-| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status` |
+| **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
+| **Dreaming** | Background memory consolidation — scores, prunes, and generates dream reports |
+| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status`, `/dream`, `/remember` |
 
-### Agents (23)
+### Agents (24)
 
 | Category | Agents |
 |----------|--------|
@@ -33,6 +35,7 @@ Single extension that provides:
 | Dev workflow | git-expert, github-expert, test-runner, test-automator, debugger |
 | Documentation | technical-documentation-writer, api-documenter, docs-fetcher |
 | Code review | code-reviewer-quality, code-reviewer-guidelines, code-reviewer-security |
+| Security | security-auditor |
 | Workflow | scout, planner, worker, reviewer |
 
 ### Prompt Templates
@@ -50,6 +53,8 @@ Single extension that provides:
 | `/coderabbit-rate-limit [number\|url]` | Handle CodeRabbit rate limiting on PRs |
 | `/query-db <command>` | Query the review comments database |
 | `/acpx-prompt <agent> [--fix\|--peer] <prompt>` | Run prompts via external AI agents (cursor, codex, gemini, etc.) |
+| `/dream` | Run memory consolidation — score, prune, generate dream report |
+| `/remember <what>` | Save a memory for future sessions |
 
 ## Installation
 
@@ -260,6 +265,60 @@ For **native** (non-container) usage, add it to your global gitignore:
 echo '.pi/memory/' >> ~/.gitignore-global
 git config --global core.excludesFile ~/.gitignore-global
 ```
+
+### Pidash — live web dashboard
+
+Pidash is a web-based dashboard that runs alongside the TUI, accessible from any browser including mobile phones.
+
+**How it works:**
+
+- A daemon (`pidash-server.ts`) runs on port `19190` and aggregates all pi sessions
+- Each pi session's extension (`pidash.ts`) connects to the daemon and forwards events
+- The React web UI shows live conversations, tool calls, and session status
+
+**Features:**
+
+- Multi-session dashboard with sidebar grouped by project
+- Live conversation streaming (user, assistant, tool, thinking)
+- Send messages from browser to pi
+- Model and thinking level switching from browser
+- Extension commands (`/release`, `/dream`, `/remember`, etc.) work from browser
+- Info bar: model, tokens, context %, git status, diffity link
+- Collapsible thinking and tool blocks with copy buttons
+- ask_user tool bridging (answer from browser or TUI)
+- Mobile responsive
+- Event buffering for message replay on refresh
+
+**Access:**
+
+```bash
+# Automatically starts with pi — open in browser:
+http://localhost:19190
+
+# From other devices on your network:
+http://<your-ip>:19190
+
+# Custom port:
+PI_PIDASH_PORT=9999 pi
+```
+
+**Management:**
+
+```bash
+/pidash status    # Check server status
+/pidash stop      # Stop the daemon
+/pidash start     # Start the daemon
+/pidash restart   # Restart the daemon
+```
+
+**Building the UI (first run only — auto-built):**
+
+```bash
+cd extensions/orchestrator/pidash-ui
+npm install && npm run build
+```
+
+> **Note:** Session switching (`/resume`) and new sessions (`/new`) from the browser are not yet supported due to a pi API limitation. Use the TUI for these operations.
 
 ### Optional mounts
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,4 +51,5 @@ if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.pi/memory/' "$GITIGNORE_FILE" 2>/dev
     echo '.pi/memory/' >> "$GITIGNORE_FILE"
 fi
 
+
 exec pi "$@"

--- a/extensions/orchestrator/ask-user.ts
+++ b/extensions/orchestrator/ask-user.ts
@@ -52,8 +52,35 @@ export function registerAskUser(
       }
 
       terminalNotify("pi", "Action required");
+
+      // Emit ask request for pidash browser clients
+      const askId = `ask-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      pi.events.emit("pidash:ui-request", {
+        id: askId,
+        type: "extension_ui_request",
+        method: params.options?.length ? "select" : "input",
+        title: params.question,
+        options: params.options,
+      });
+
+      // Track if resolved (from TUI or browser)
+      let externalDone: ((value: string | null) => void) | null = null;
+
+      // Listen for browser response
+      const unsubscribe = pi.events.on("pidash:ui-response", (data: unknown) => {
+        const resp = data as any;
+        if (resp.id === askId && externalDone) {
+          if (resp.cancelled) externalDone(null);
+          else if (resp.value) externalDone(resp.value);
+          else if (resp.confirmed !== undefined) externalDone(resp.confirmed ? "Yes" : "No");
+        }
+      });
+
       const result = await ctx.ui.custom<string | null>(
         (tui, theme, _kb, done) => {
+          // Allow browser to resolve this dialog
+          externalDone = done;
+
           let mode: "select" | "input" = params.options?.length
             ? "select"
             : "input";
@@ -62,8 +89,14 @@ export function registerAskUser(
           const resolve = (value: string | null) => {
             if (resolved) return;
             resolved = true;
+            externalDone = null;
+            // Dismiss browser dialog if TUI answered
+            pi.events.emit("pidash:ui-dismiss", { type: "ui-dismiss", id: askId });
             done(value);
           };
+
+          // Override externalDone to use resolve (prevents double-resolve)
+          externalDone = resolve;
 
           // Free-text input with built-in callbacks
           const input = new Input();
@@ -185,6 +218,8 @@ export function registerAskUser(
         },
         { overlay: true },
       );
+
+      unsubscribe();
 
       if (result === null) {
         return { content: [{ type: "text", text: "User cancelled" }] };

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -80,8 +80,10 @@ export function registerAsyncAgents(
     if (running.length > 0) {
       const names = running.map(j => j.agent).join(", ");
       ctx.ui.setStatus("async-agents", ctx.ui.theme.fg("warning", `⏳ ${running.length} async: ${names}`));
+      pi.events.emit("pidash:async-status", { count: running.length, agents: names });
     } else {
       ctx.ui.setStatus("async-agents", undefined);
+      pi.events.emit("pidash:async-status", { count: 0, agents: "" });
     }
   }
 

--- a/extensions/orchestrator/diffity.ts
+++ b/extensions/orchestrator/diffity.ts
@@ -154,6 +154,8 @@ export function registerDiffity(pi: ExtensionAPI): void {
       // Show link in status line
       const statusText = ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${port}?theme=dark`);
       ctx.ui.setStatus("diffity", statusText);
+      // Notify pidash of the diffity port
+      pi.events?.emit("diffity:port", port);
     } catch {
       if (diffityProc) {
         killProcess(diffityProc);

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -219,6 +219,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
           block: true,
           reason: "Dangerous command blocked (no UI for confirmation)",
         };
+
       const ok = await ctx.ui.select(
         `⚠️ Dangerous command:\n\n  ${command}\n\nAllow?`,
         ["Yes", "No"],

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -11,6 +11,7 @@
  * - Async agent infrastructure
  * - ask_user tool
  * - Memory dreaming (background consolidation)
+ * - Pidash web UI (live session viewer)
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -19,6 +20,7 @@ import { registerAsyncAgents } from "./async-agents.js";
 import { registerBtw } from "./btw.js";
 import { registerDiffity } from "./diffity.js";
 import { registerDreaming } from "./dreaming.js";
+import { registerPidash } from "./pidash.js";
 import { registerEnforcement } from "./enforcement.js";
 import { registerRules } from "./rules.js";
 import { registerSessionValidation } from "./session-validation.js";
@@ -29,7 +31,19 @@ import { ensureGitSshTimeout, isRunningInContainer, terminalNotify } from "./uti
 const IN_CONTAINER = isRunningInContainer();
 ensureGitSshTimeout();
 
+// Shared command handler registry — pidash uses this to execute commands from the browser
+export const commandHandlerRegistry = new Map<string, (args: string, ctx: any) => Promise<void>>();
+
 export default function (pi: ExtensionAPI) {
+  // Wrap registerCommand to capture all handler functions
+  const originalRegisterCommand = pi.registerCommand.bind(pi);
+  pi.registerCommand = (name: string, options: any) => {
+    if (options?.handler) {
+      commandHandlerRegistry.set(name, options.handler);
+    }
+    return originalRegisterCommand(name, options);
+  };
+
   registerAskUser(pi, terminalNotify);
   const { spawnAsyncAgent } = registerAsyncAgents(pi, terminalNotify);
   registerSubagentTool(pi, spawnAsyncAgent);
@@ -39,5 +53,6 @@ export default function (pi: ExtensionAPI) {
   registerBtw(pi);
   registerDiffity(pi);
   registerDreaming(pi, spawnAsyncAgent);
+  registerPidash(pi);
   registerSessionValidation(pi);
 }

--- a/extensions/orchestrator/pidash-ui/.gitignore
+++ b/extensions/orchestrator/pidash-ui/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/extensions/orchestrator/pidash-ui/components.json
+++ b/extensions/orchestrator/pidash-ui/components.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/styles.css",
+    "baseColor": "neutral",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "iconLibrary": "lucide",
+  "rtl": false,
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "menuColor": "default",
+  "menuAccent": "subtle",
+  "registries": {}
+}

--- a/extensions/orchestrator/pidash-ui/index.html
+++ b/extensions/orchestrator/pidash-ui/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>pidash</title>
+</head>
+<body class="overflow-hidden">
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/extensions/orchestrator/pidash-ui/package.json
+++ b/extensions/orchestrator/pidash-ui/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "pidash-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@base-ui/react": "^1.4.0",
+    "@fontsource-variable/geist": "^5.2.8",
+    "@tailwindcss/vite": "^4.2.2",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^1.8.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "react-resizable-panels": "^4.10.0",
+    "shadcn": "^4.3.0",
+    "tailwind-merge": "^3.5.0",
+    "tailwindcss": "^4.2.2",
+    "tw-animate-css": "^1.4.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.8"
+  }
+}

--- a/extensions/orchestrator/pidash-ui/src/App.tsx
+++ b/extensions/orchestrator/pidash-ui/src/App.tsx
@@ -1,0 +1,369 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { PanelLeftOpen, Search } from "lucide-react";
+import { SessionSidebar } from "@/components/SessionSidebar";
+import { InfoBar } from "@/components/InfoBar";
+import { MessageList } from "@/components/MessageList";
+import { InputBar } from "@/components/InputBar";
+import { useWebSocket } from "@/hooks/useWebSocket";
+import { useSessions } from "@/hooks/useSessions";
+import type { ChatMessage, PiEvent, SessionInfo, TokenUsage } from "@/types";
+
+const STORAGE_KEY = "pidash-state";
+
+function loadState(): { sidebarWidth: number; sidebarCollapsed: boolean; watchPid: number | null } {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  return { sidebarWidth: 280, sidebarCollapsed: false, watchPid: null };
+}
+
+function saveState(state: { sidebarWidth: number; sidebarCollapsed: boolean; watchPid: number | null }) {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch {}
+}
+
+let counter = 0;
+const nextId = () => `m-${++counter}`;
+const textFrom = (msg: any): string =>
+  (msg?.content || []).filter((c: any) => c.type === "text").map((c: any) => c.text).join("\n");
+
+export function App() {
+  const { connected, send, onMessage } = useWebSocket("/ws/browser");
+  const sessions = useSessions(connected, onMessage);
+
+  const [session, setSession] = useState<SessionInfo | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [model, setModel] = useState("");
+  const [tokens, setTokens] = useState<TokenUsage | null>(null);
+  const [streaming, setStreaming] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchType, setSearchType] = useState("all");
+  const [availableCommands, setAvailableCommands] = useState<Array<{ name: string; description: string }>>([]);
+  const saved = useRef(loadState());
+  const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(isMobile ? true : saved.current.sidebarCollapsed);
+
+  const [sidebarWidth, setSidebarWidth] = useState(saved.current.sidebarWidth);
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  const startResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const onMove = (ev: MouseEvent) => {
+      const w = Math.max(200, Math.min(500, ev.clientX));
+      setSidebarWidth(w);
+    };
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, []);
+
+  const thinkRef = useRef({ id: "", text: "" });
+  const assistRef = useRef({ id: "", text: "" });
+  const lastUserRef = useRef("");
+  const toolRef = useRef({ id: "", name: "" });
+  const restoredRef = useRef(false);
+  const replayingRef = useRef(false);
+
+  const addMsg = useCallback((role: ChatMessage["role"], text: string, className?: string): string => {
+    const id = nextId();
+    setMessages((p) => [...p, { id, role, text, className }]);
+    return id;
+  }, []);
+
+  const updMsg = useCallback((id: string, text: string) => {
+    setMessages((p) => p.map((m) => m.id === id ? { ...m, text } : m));
+  }, []);
+
+  const updCls = useCallback((id: string, className?: string) => {
+    setMessages((p) => p.map((m) => m.id === id ? { ...m, className } : m));
+  }, []);
+
+  useEffect(() => {
+    return onMessage((ev: PiEvent) => {
+      if (ev.type === "session_added" || ev.type === "session_removed") return;
+          if (ev.type === "session_updated" && ev.session) {
+            // Update active session if it's the one we're watching
+            setSession((prev) => {
+              if (prev?.pid === ev.session.pid) {
+                if (ev.session.model !== undefined) setModel(ev.session.model);
+                return { ...prev, ...ev.session };
+              }
+              return prev;
+            });
+            return;
+          }
+
+      switch (ev.type) {
+        case "agent_start": setStreaming(true); break;
+        case "agent_end":
+          setStreaming(false);
+          thinkRef.current = { id: "", text: "" };
+          assistRef.current = { id: "", text: "" };
+          lastUserRef.current = "";
+          break;
+
+        case "message_start": {
+          const msg = ev.message;
+          if (!msg) break;
+          if (msg.role === "user") {
+            const t = textFrom(msg);
+            if (t && t !== lastUserRef.current) { lastUserRef.current = t; addMsg("user", t); }
+          }
+          if (msg.role === "assistant") {
+            thinkRef.current = { id: "", text: "" };
+            assistRef.current = { id: "", text: "" };
+          }
+          if (msg.role === "custom" && msg.display) {
+            const content = msg.content || "";
+            addMsg("system", typeof content === "string" ? content : JSON.stringify(content));
+          }
+          break;
+        }
+
+        case "message_update": {
+          const ae = ev.assistantMessageEvent;
+          if (!ae) break;
+          if (ae.type === "thinking_delta" && ae.delta) {
+            thinkRef.current.text += ae.delta;
+            if (!thinkRef.current.id) thinkRef.current.id = addMsg("thinking", thinkRef.current.text);
+            else updMsg(thinkRef.current.id, thinkRef.current.text);
+          }
+          if ((ae.type === "text_start" || ae.type === "text_delta") && thinkRef.current.id && !assistRef.current.id) {
+            updCls(thinkRef.current.id, undefined);
+          }
+          if (ae.type === "text_delta" && ae.delta) {
+            assistRef.current.text += ae.delta;
+            if (!assistRef.current.id) assistRef.current.id = addMsg("assistant", assistRef.current.text, "streaming");
+            else updMsg(assistRef.current.id, assistRef.current.text);
+          }
+          if (ae.type === "text_end" && assistRef.current.id) updCls(assistRef.current.id, undefined);
+          const p = ae.partial;
+          if (p?.model) setModel(p.model);
+          if (p?.usage) setTokens({ ...p.usage });
+          break;
+        }
+
+        case "message_end":
+          if (thinkRef.current.id) updCls(thinkRef.current.id, undefined);
+          if (assistRef.current.id) updCls(assistRef.current.id, undefined);
+          thinkRef.current = { id: "", text: "" };
+          assistRef.current = { id: "", text: "" };
+          if (ev.message?.model) setModel(ev.message.model);
+          if (ev.message?.usage) setTokens({ ...ev.message.usage });
+          break;
+
+        case "turn_end":
+          if (ev.message?.model) setModel(ev.message.model);
+          if (ev.message?.usage) setTokens({ ...ev.message.usage });
+          break;
+
+        case "tool_execution_start": {
+          const name = ev.toolName || "tool";
+          const id = addMsg(name as any, `${ev.args?.command ? ev.args.command : ""}`, "tool-call");
+          toolRef.current = { id, name };
+          break;
+        }
+
+        case "tool_execution_update":
+          if (toolRef.current.id && ev.partialResult?.content?.[0]?.text) {
+            updMsg(toolRef.current.id, `${toolRef.current.name}: ${ev.partialResult.content[0].text}`);
+          }
+          break;
+
+        case "tool_execution_end": {
+          const toolName = toolRef.current.name || ev.toolName || "tool";
+          toolRef.current = { id: "", name: "" };
+          if (ev.result?.content?.[0]?.text) {
+            const t = ev.result.content[0].text;
+            addMsg(toolName as any, `${ev.isError ? "✗ " : "✓ "}${t}`, "tool-result");
+          }
+          break;
+        }
+
+        case "extension_ui_request":
+          // Skip stale UI requests from replay (older than 10 seconds)
+          if (ev.timestamp && Date.now() - ev.timestamp > 10000) break;
+          if (ev.id && (ev.method === "select" || ev.method === "confirm" || ev.method === "input")) {
+            // Add as inline message with options
+            const askId = ev.id;
+            const title = ev.title || "Input needed";
+            const opts = ev.method === "confirm" ? ["Yes", "No"] : ev.options || [];
+            addMsg("ask_user" as any, `${title}${ev.message ? "\n" + ev.message : ""}`, `ask|${askId}|${ev.method}|${opts.join("|||")}`)
+          }
+          break;
+
+        case "commands-list":
+          if (ev.commands) setAvailableCommands(ev.commands);
+          break;
+
+        case "ui-dismiss":
+          // Mark the inline ask message as answered
+          setMessages((prev) => prev.map((m) => {
+            if (m.className?.startsWith(`ask|${ev.id}|`)) {
+              return { ...m, className: `ask-answered|${ev.id}` };
+            }
+            return m;
+          }));
+          break;
+      }
+    });
+  }, [onMessage, addMsg, updMsg, updCls]);
+
+  const watchSession = useCallback((s: SessionInfo) => {
+    setSession(s);
+    setMessages([{ id: nextId(), role: "system", text: `Watching session — ${s.cwd}` }]);
+    setModel(s.model || "");
+    setTokens(null);
+    setStreaming(false);
+    setSearchQuery("");
+    setSearchType("all");
+    thinkRef.current = { id: "", text: "" };
+    assistRef.current = { id: "", text: "" };
+    lastUserRef.current = "";
+    replayingRef.current = true;
+    send({ type: "watch", pid: s.pid });
+    send({ type: "pidash-command", pid: s.pid, command: "list-commands" });
+    // Events from buffer replay arrive synchronously — mark replay done after a short delay
+    setTimeout(() => { replayingRef.current = false; }, 2000);
+    location.hash = `#session/${s.pid}`;
+    // Auto-collapse sidebar on mobile
+    if (typeof window !== 'undefined' && window.innerWidth <= 768) setSidebarCollapsed(true);
+  }, [send]);
+
+  // Persist UI state to localStorage
+  useEffect(() => {
+    const mobile = typeof window !== 'undefined' && window.innerWidth <= 768;
+    saveState({
+      sidebarWidth,
+      sidebarCollapsed: mobile ? true : sidebarCollapsed,
+      watchPid: session?.pid ?? null,
+    });
+  }, [sidebarWidth, sidebarCollapsed, session]);
+
+  useEffect(() => {
+    if (!connected || !sessions.length || restoredRef.current) return;
+    // Restore from hash first, then from localStorage
+    const hashMatch = location.hash.match(/^#session\/(\d+)$/);
+    const pid = hashMatch ? parseInt(hashMatch[1], 10) : saved.current.watchPid;
+    if (pid) {
+      const s = sessions.find((x) => x.pid === pid);
+      if (s) { restoredRef.current = true; watchSession(s); }
+    }
+  }, [connected, sessions, watchSession]);
+
+
+
+
+  const handleAbort = useCallback(() => {
+    if (session) send({ type: "pidash-command", pid: session.pid, command: "abort" });
+  }, [session, send]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && streaming && session) handleAbort();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [streaming, session, handleAbort]);
+
+  const handleSend = useCallback((text: string) => {
+    if (!session) return;
+    lastUserRef.current = text;
+    addMsg("user", text);
+    send({ type: "prompt", pid: session.pid, text });
+  }, [session, send, addMsg]);
+
+  return (
+    <div className="flex w-screen overflow-hidden" style={{ height: '100dvh' }}>
+      {!sidebarCollapsed && (
+        <>
+          {/* Mobile overlay backdrop */}
+          <div
+            className="fixed inset-0 bg-black/50 z-10 hidden max-md:block"
+            onClick={() => setSidebarCollapsed(true)}
+          />
+          <div
+            className="flex-shrink-0 border-r border-border relative max-md:fixed max-md:inset-y-0 max-md:left-0 max-md:z-20 max-md:w-[85vw] max-md:max-w-[320px] bg-background"
+            style={{ width: typeof window !== 'undefined' && window.innerWidth <= 768 ? undefined : sidebarWidth }}
+            ref={sidebarRef}
+          >
+            <SessionSidebar
+            sessions={sessions}
+            activePid={session?.pid ?? null}
+            connected={connected}
+            onSelect={watchSession}
+            collapsed={false}
+            onToggle={() => setSidebarCollapsed(true)}
+          />
+          <div
+            className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/30 z-10 max-md:hidden"
+            onMouseDown={startResize}
+          />
+        </div>
+        </>
+      )}
+      {sidebarCollapsed && (
+        <div
+          className="w-12 md:w-10 flex-shrink-0 border-r border-border flex flex-col items-center pt-[env(safe-area-inset-top,12px)] cursor-pointer hover:bg-accent/30"
+          onClick={() => setSidebarCollapsed(false)}
+          title="Expand sidebar"
+        >
+          <PanelLeftOpen className="h-4 w-4 text-muted-foreground" />
+        </div>
+      )}
+      <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+        {!session ? (
+          <div className="flex-1 flex items-center justify-center text-muted-foreground">
+            ← Select a session
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center gap-2 px-4 py-1.5 border-b border-border">
+              <Search className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+              <input
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground min-w-0"
+                placeholder="Search messages..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+              <select
+                className="bg-card text-xs text-muted-foreground border border-border rounded px-1.5 py-0.5 outline-none cursor-pointer"
+                value={searchType}
+                onChange={(e) => setSearchType(e.target.value)}
+              >
+                <option value="all">All</option>
+                {[...new Set(messages.map(m => m.role))].sort().map(role => (
+                  <option key={role} value={role}>{role}</option>
+                ))}
+              </select>
+              {(searchQuery || searchType !== "all") && (
+                <button className="text-muted-foreground hover:text-foreground text-xs" onClick={() => { setSearchQuery(""); setSearchType("all"); }}>✕</button>
+              )}
+            </div>
+            <MessageList
+              messages={messages}
+              searchQuery={searchQuery}
+              searchType={searchType}
+              streaming={streaming}
+              onAskResponse={(id, value) => {
+                if (value === "__confirmed__") {
+                  send({ type: "extension_ui_response", pid: session!.pid, id, confirmed: true });
+                } else if (value === "__denied__") {
+                  send({ type: "extension_ui_response", pid: session!.pid, id, confirmed: false });
+                } else {
+                  send({ type: "extension_ui_response", pid: session!.pid, id, value });
+                }
+              }}
+            />
+            <InputBar disabled={!session.active} streaming={streaming} onSend={handleSend} onAbort={handleAbort} commands={availableCommands} />
+            <InfoBar session={session} model={model} tokens={tokens} streaming={streaming} send={send} onMessage={onMessage} />
+          </>
+        )}
+      </div>
+
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
@@ -1,0 +1,214 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { GitBranch, Circle, ExternalLink, Brain, Bot, ChevronDown } from "lucide-react";
+import type { SessionInfo, TokenUsage } from "@/types";
+
+function fk(n: number): string {
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + "K";
+  return String(n);
+}
+
+interface ModelInfo {
+  id: string;
+  name: string;
+  provider: string;
+}
+
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high"];
+
+interface Props {
+  session: SessionInfo;
+  model: string;
+  tokens: TokenUsage | null;
+  streaming: boolean;
+  send: (data: object) => void;
+  onMessage: (handler: (data: any) => void) => () => void;
+}
+
+export function InfoBar({ session, model, tokens, streaming, send, onMessage }: Props) {
+  const [models, setModels] = useState<ModelInfo[]>([]);
+  const [thinkingLevel, setThinkingLevel] = useState(session.thinkingLevel || "medium");
+
+  // Sync thinkingLevel from session prop when it changes
+  useEffect(() => {
+    if (session.thinkingLevel) setThinkingLevel(session.thinkingLevel);
+  }, [session.thinkingLevel]);
+  const [openMenu, setOpenMenu] = useState<string | null>(null);
+  const [filter, setFilter] = useState("");
+  const [asyncAgents, setAsyncAgents] = useState<{ count: number; agents: string }>({ count: 0, agents: "" });
+  const filterRef = useRef<HTMLInputElement>(null);
+
+  const ctxWin = session.contextWindow || 1000000;
+  const input = tokens?.input || 0;
+  const output = tokens?.output || 0;
+  const cache = tokens?.cacheRead || 0;
+  const pct = Math.round((input / ctxWin) * 100);
+  const pctColor = pct > 80 ? "text-red-500" : pct > 50 ? "text-orange-400" : "";
+  const displayModel = model || session.model || "—";
+
+  useEffect(() => {
+    return onMessage((ev: any) => {
+      if (ev.type === "models-list" && ev.models) {
+        setModels(ev.models);
+        setOpenMenu("models"); // Auto-open the models dropdown
+      }
+      if (ev.type === "update_info") {
+        if (ev.thinkingLevel) setThinkingLevel(ev.thinkingLevel);
+      }
+      if (ev.type === "async-status") {
+        setAsyncAgents({ count: ev.count || 0, agents: ev.agents || "" });
+      }
+    });
+  }, [onMessage]);
+
+  // Close menu on outside click
+  useEffect(() => {
+    if (!openMenu) { setFilter(""); return; }
+    // Focus the filter input when dropdown opens
+    setTimeout(() => filterRef.current?.focus(), 50);
+    const close = () => { setOpenMenu(null); setFilter(""); };
+    document.addEventListener("click", close);
+    return () => document.removeEventListener("click", close);
+  }, [openMenu]);
+
+  const toggleMenu = useCallback((name: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (openMenu === name) { setOpenMenu(null); return; }
+    setOpenMenu(name);
+    if (name === "models") send({ type: "pidash-command", command: "list-models", pid: session.pid });
+  }, [openMenu, send, session.pid]);
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 border-t border-border text-sm text-muted-foreground relative max-md:flex-wrap max-md:gap-2 max-md:text-xs md:overflow-x-auto md:whitespace-nowrap md:scrollbar-none">
+      {/* Model */}
+      <div className="relative">
+        <button
+          className="flex items-center gap-1 font-semibold text-foreground hover:text-primary transition-colors"
+          onClick={(e) => toggleMenu("models", e)}
+        >
+          <Bot className="h-3.5 w-3.5" /> {displayModel} <ChevronDown className="h-3 w-3" />
+        </button>
+        {openMenu === "models" && (
+          <div className="absolute bottom-full left-0 mb-1 z-50 bg-card border border-border rounded-lg shadow-xl py-1 min-w-[200px] max-h-60 overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+            <div className="px-2 py-1">
+              <input
+                ref={openMenu === "models" ? filterRef : undefined}
+                className="w-full px-2 py-1.5 text-sm bg-background border border-border rounded outline-none focus:border-primary font-mono"
+                placeholder="Search models..."
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </div>
+            {models.length === 0 && <div className="px-3 py-2 text-xs text-muted-foreground">Loading...</div>}
+            {models.filter((m) => {
+              if (!filter) return true;
+              const f = filter.toLowerCase();
+              return m.name?.toLowerCase().includes(f) || m.id?.toLowerCase().includes(f) || m.provider?.toLowerCase().includes(f);
+            }).map((m) => (
+              <button
+                key={m.id}
+                className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent transition-colors flex justify-between ${(m.name === displayModel || m.id === displayModel) ? "bg-accent/50" : ""}`}
+                onClick={() => {
+                  send({ type: "pidash-command", pid: session.pid, command: "set-model", modelId: m.id });
+                  setOpenMenu(null);
+                }}
+              >
+                <span className="truncate">{m.name || m.id}</span>
+                <span className="text-[10px] text-muted-foreground ml-2">{m.provider}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <span className="text-border">|</span>
+
+      {/* Thinking */}
+      <div className="relative">
+        <button
+          className="flex items-center gap-1 hover:text-primary transition-colors"
+          onClick={(e) => toggleMenu("thinking", e)}
+        >
+          <Brain className="h-3.5 w-3.5" /> {thinkingLevel} <ChevronDown className="h-3 w-3" />
+        </button>
+        {openMenu === "thinking" && (
+          <div className="absolute bottom-full left-0 mb-1 z-50 bg-card border border-border rounded-lg shadow-xl py-1 min-w-[120px]" onClick={(e) => e.stopPropagation()}>
+            <div className="px-3 py-1 text-xs text-muted-foreground font-medium">Thinking level</div>
+            {THINKING_LEVELS.map((lvl) => (
+              <button
+                key={lvl}
+                className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent transition-colors ${lvl === thinkingLevel ? "bg-accent/50" : ""}`}
+                onClick={() => {
+                  setThinkingLevel(lvl);
+                  send({ type: "pidash-command", pid: session.pid, command: "set-thinking", level: lvl });
+                  setOpenMenu(null);
+                }}
+              >
+                {lvl}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <span className="text-border">|</span>
+
+      {/* Tokens */}
+      <span>↑{fk(input)} ↓{fk(output)}{cache > 0 && ` 📦${fk(cache)}`}</span>
+
+      <span className="text-border">|</span>
+
+      {/* Context */}
+      <span className={pctColor}>ctx {pct}%</span>
+
+      {/* Git */}
+      {session.branch && (
+        <>
+          <span className="text-border">|</span>
+          <span className="flex items-center gap-1">
+            <GitBranch className="h-3.5 w-3.5" />
+            <span className={session.gitDirty ? "text-red-500" : "text-green-500"}>
+              {session.gitDirty ? "●" : "✓"}
+            </span>
+            {session.branch}
+            {session.gitChanges ? ` ~${session.gitChanges}` : ""}
+          </span>
+        </>
+      )}
+
+      {/* Diffity */}
+      {session.diffityPort && (
+        <>
+          <span className="text-border">|</span>
+          <a href={`http://localhost:${session.diffityPort}?theme=dark`} target="_blank" rel="noreferrer" className="flex items-center gap-0.5 text-primary hover:underline">
+             diff <ExternalLink className="h-3 w-3" />
+          </a>
+        </>
+      )}
+
+      {/* Container */}
+      {session.container && (
+        <>
+          <span className="text-border">|</span>
+          <span className="text-[10px] px-1.5 py-0.5 border border-border rounded">📦</span>
+        </>
+      )}
+
+      {/* Async agents */}
+      {asyncAgents.count > 0 && (
+        <>
+          <span className="text-border">|</span>
+          <span className="text-yellow-400">⏳ {asyncAgents.count} async: {asyncAgents.agents}</span>
+        </>
+      )}
+
+      {/* Status */}
+      <span className="flex items-center gap-1">
+        <Circle className={`h-2 w-2 fill-current ${streaming ? "text-cyan-400" : "text-green-500"}`} />
+        {streaming ? "streaming" : "idle"}
+      </span>
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/InputBar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/InputBar.tsx
@@ -1,0 +1,138 @@
+import { useRef, useCallback, useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Send, Square } from "lucide-react";
+
+interface Props {
+  disabled: boolean;
+  streaming?: boolean;
+  onSend: (text: string) => void;
+  onAbort?: () => void;
+  commands?: Array<{ name: string; description: string }>;
+}
+
+export function InputBar({ disabled, streaming, onSend, onAbort, commands = [] }: Props) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [suggestions, setSuggestions] = useState<Array<{ name: string; description: string }>>([]);
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const [history, setHistory] = useState<string[]>([]);
+  const [historyIdx, setHistoryIdx] = useState(-1);
+  const [savedInput, setSavedInput] = useState("");
+
+  const handleSend = useCallback(() => {
+    const text = ref.current?.value.trim();
+    if (!text) return;
+    setHistory((prev) => [text, ...prev.filter(h => h !== text)].slice(0, 50));
+    setHistoryIdx(-1);
+    onSend(text);
+    if (ref.current) {
+      ref.current.value = "";
+      ref.current.style.height = "auto";
+    }
+    setShowSuggestions(false);
+  }, [onSend]);
+
+  const autoResize = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 200) + "px";
+  }, []);
+
+  const updateSuggestions = useCallback(() => {
+    const text = ref.current?.value || "";
+    if (text.startsWith("/") && !text.includes(" ")) {
+      const query = text.slice(1).toLowerCase();
+      const filtered = commands.filter(c => c.name.toLowerCase().includes(query));
+      setSuggestions(filtered.slice(0, 10));
+      setShowSuggestions(filtered.length > 0);
+      setSelectedIdx(0);
+    } else {
+      setShowSuggestions(false);
+    }
+  }, [commands]);
+
+  const selectSuggestion = useCallback((cmd: { name: string; description: string }) => {
+    if (ref.current) {
+      ref.current.value = `/${cmd.name} `;
+      ref.current.focus();
+    }
+    setShowSuggestions(false);
+  }, []);
+
+  return (
+    <div className="relative">
+      {showSuggestions && suggestions.length > 0 && (
+        <div className="absolute bottom-full left-0 right-0 mx-3 mb-1 bg-card border border-border rounded-lg shadow-xl py-1 max-h-48 overflow-y-auto z-50">
+          {suggestions.map((cmd, i) => (
+            <button
+              key={cmd.name}
+              className={`w-full text-left px-3 py-1.5 hover:bg-accent transition-colors ${i === selectedIdx ? "bg-accent" : ""}`}
+              onMouseDown={(e) => { e.preventDefault(); selectSuggestion(cmd); }}
+            >
+              <span className="text-sm font-mono text-foreground">/{cmd.name}</span>
+              {cmd.description && <span className="text-xs text-muted-foreground ml-2">{cmd.description}</span>}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="flex items-end gap-2 p-3 border-t border-border">
+        <textarea
+          ref={ref}
+          rows={1}
+          placeholder={disabled ? "Session inactive" : streaming ? "Press Esc to stop..." : "Send a message... (/ for commands)"}
+          disabled={disabled}
+          autoComplete="off"
+          className="flex-1 font-mono text-sm bg-card border border-border rounded-md px-3 py-2 outline-none focus:border-primary resize-none text-base md:text-sm"
+          onKeyDown={(e) => {
+            if (showSuggestions) {
+              if (e.key === "ArrowDown") { e.preventDefault(); setSelectedIdx(i => Math.min(i + 1, suggestions.length - 1)); return; }
+              if (e.key === "ArrowUp") { e.preventDefault(); setSelectedIdx(i => Math.max(i - 1, 0)); return; }
+              if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+                e.preventDefault();
+                if (suggestions[selectedIdx]) selectSuggestion(suggestions[selectedIdx]);
+                return;
+              }
+              if (e.key === "Escape") { setShowSuggestions(false); return; }
+            }
+            if (e.key === "ArrowUp" && !showSuggestions && ref.current?.selectionStart === 0) {
+              e.preventDefault();
+              if (historyIdx === -1) setSavedInput(ref.current?.value || "");
+              const newIdx = Math.min(historyIdx + 1, history.length - 1);
+              setHistoryIdx(newIdx);
+              if (ref.current && history[newIdx]) ref.current.value = history[newIdx];
+              return;
+            }
+            if (e.key === "ArrowDown" && !showSuggestions && ref.current?.selectionStart === (ref.current?.value.length || 0)) {
+              e.preventDefault();
+              if (historyIdx <= 0) {
+                setHistoryIdx(-1);
+                if (ref.current) ref.current.value = savedInput;
+              } else {
+                const newIdx = historyIdx - 1;
+                setHistoryIdx(newIdx);
+                if (ref.current && history[newIdx]) ref.current.value = history[newIdx];
+              }
+              return;
+            }
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              handleSend();
+            }
+          }}
+          onInput={() => { autoResize(); updateSuggestions(); }}
+          onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+        />
+        {streaming ? (
+          <Button size="sm" variant="destructive" onClick={onAbort} title="Stop (Esc)" className="mb-0.5">
+            <Square className="h-4 w-4" />
+          </Button>
+        ) : (
+          <Button size="sm" onClick={handleSend} disabled={disabled} className="mb-0.5">
+            <Send className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useRef, useState } from "react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
+import { ChevronRight, ChevronDown, Copy, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ChatMessage } from "@/types";
+
+interface Props {
+  messages: ChatMessage[];
+  searchQuery?: string;
+  searchType?: string;
+  streaming?: boolean;
+  onAskResponse?: (id: string, value: string) => void;
+}
+
+const roleColors: Record<string, string> = {
+  user: "text-green-500",
+  assistant: "text-blue-400",
+  thinking: "text-purple-400",
+  system: "text-cyan-400",
+  // Tool types
+  bash: "text-orange-400",
+  read: "text-yellow-500",
+  edit: "text-yellow-400",
+  write: "text-yellow-300",
+  subagent: "text-pink-400",
+  ask_user: "text-cyan-300",
+  tool: "text-orange-400",
+};
+
+function getRoleColor(role: string): string {
+  return roleColors[role] || "text-orange-400";
+}
+
+export function MessageList({ messages, searchQuery, searchType, streaming, onAskResponse }: Props) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [autoScroll, setAutoScroll] = useState(true);
+
+  useEffect(() => {
+    if (autoScroll) bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, autoScroll]);
+
+  return (
+    <div
+      className="flex-1 overflow-y-auto"
+      ref={viewportRef}
+      onScroll={() => {
+        const el = viewportRef.current;
+        if (el) setAutoScroll(el.scrollTop + el.clientHeight >= el.scrollHeight - 50);
+      }}
+    >
+      <div className="p-4 space-y-2">
+        {messages
+          .filter((msg) => {
+            // Type filter
+            if (searchType && searchType !== "all" && msg.role !== searchType) return false;
+            // Text filter
+            if (searchQuery && !msg.text.toLowerCase().includes(searchQuery.toLowerCase())) return false;
+            return true;
+          })
+          .map((msg) => (
+            <MessageItem key={msg.id} msg={msg} searchQuery={searchQuery} onAskResponse={onAskResponse} />
+          ))}
+        {streaming && (
+          <div className="flex items-center gap-2 py-2 text-muted-foreground text-xs">
+            <div className="flex gap-1">
+              <span className="w-1.5 h-1.5 bg-cyan-400 rounded-full animate-bounce" style={{ animationDelay: "0ms" }} />
+              <span className="w-1.5 h-1.5 bg-cyan-400 rounded-full animate-bounce" style={{ animationDelay: "150ms" }} />
+              <span className="w-1.5 h-1.5 bg-cyan-400 rounded-full animate-bounce" style={{ animationDelay: "300ms" }} />
+            </div>
+            AI is working...
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}
+
+function CopyBtn({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {}
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity absolute top-1.5 right-1.5 text-muted-foreground hover:text-foreground"
+      onClick={handleCopy}
+      title="Copy"
+    >
+      {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+    </Button>
+  );
+}
+
+function MessageItem({ msg, searchQuery, onAskResponse }: { msg: ChatMessage; searchQuery?: string; onAskResponse?: (id: string, value: string) => void }) {
+  // Inline ask_user with clickable options
+  if (msg.className?.startsWith("ask|") || msg.className?.startsWith("ask-answered|")) {
+    const isAnswered = msg.className?.startsWith("ask-answered|");
+    const parts = msg.className.split("|");
+    const askId = parts[1];
+    const method = parts[2] || "select";
+    const options = isAnswered ? [] : parts.slice(3).join("|").split("|||").filter(Boolean);
+    const [answered, setAnswered] = useState(isAnswered || false);
+    const [selectedOpt, setSelectedOpt] = useState("");
+
+    return (
+      <div>
+        <div className={cn("text-[10px] font-bold uppercase tracking-wider mb-0.5", getRoleColor("ask_user"))}>
+          action required
+        </div>
+        <div className="rounded-md bg-card p-3 text-[13px] whitespace-pre-wrap break-words border-l-2 border-cyan-400">
+          <div className="mb-2">{msg.text}</div>
+          {answered ? (
+            <div className="text-xs text-muted-foreground">✓ Answered: {selectedOpt || "dismissed"}</div>
+          ) : method === "input" ? (
+            <form className="flex gap-2 mt-2" onSubmit={(e) => {
+              e.preventDefault();
+              const input = (e.target as HTMLFormElement).elements.namedItem("answer") as HTMLInputElement;
+              const val = input?.value.trim();
+              if (val) { setAnswered(true); setSelectedOpt(val); onAskResponse?.(askId, val); }
+            }}>
+              <input name="answer" className="flex-1 px-2 py-1.5 text-sm rounded-md bg-background border border-border outline-none focus:border-primary font-mono" autoFocus />
+              <button type="submit" className="px-3 py-1.5 text-sm rounded-md bg-accent/50 hover:bg-accent transition-colors">Submit</button>
+            </form>
+          ) : (
+            <div className="flex flex-wrap gap-2 mt-2">
+              {options.map((opt) => (
+                <button
+                  key={opt}
+                  className="px-3 py-1.5 text-sm rounded-md bg-accent/50 hover:bg-accent transition-colors"
+                  onClick={() => {
+                    setAnswered(true);
+                    setSelectedOpt(opt);
+                    if (method === "confirm") {
+                      onAskResponse?.(askId, opt === "Yes" ? "__confirmed__" : "__denied__");
+                    } else {
+                      onAskResponse?.(askId, opt);
+                    }
+                  }}
+                >
+                  {opt}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (msg.role !== "user" && msg.role !== "assistant") {
+    return <CollapsibleMessage msg={msg} searchQuery={searchQuery} />;
+  }
+
+  if (msg.role === "system") {
+    return <div className="text-xs text-muted-foreground py-1">{msg.text}</div>;
+  }
+
+  return (
+    <div>
+      <div className={cn("text-[10px] font-bold uppercase tracking-wider mb-0.5", getRoleColor(msg.role))}>
+        {msg.role}
+      </div>
+      <div className={cn(
+        "rounded-md bg-card p-2.5 text-[13px] whitespace-pre-wrap break-words relative group",
+        msg.className === "streaming" && "border-l-2 border-cyan-400",
+      )}>
+        <HighlightText text={msg.text} query={searchQuery} />
+        <CopyBtn text={msg.text} />
+      </div>
+    </div>
+  );
+}
+
+function CollapsibleMessage({ msg, searchQuery }: { msg: ChatMessage; searchQuery?: string }) {
+  const [open, setOpen] = useState(false);
+  const matchesSearch = searchQuery && msg.text.toLowerCase().includes(searchQuery.toLowerCase());
+  const color = getRoleColor(msg.role);
+  const isResult = msg.className === "tool-result";
+  const isError = isResult && msg.text.startsWith("✗");
+  const borderColor = msg.role === "thinking" ? "border-purple-500" : isResult ? (isError ? "border-red-500" : "border-green-600") : "border-orange-500";
+  const summary = msg.text.split("\n")[0].slice(0, 100);
+
+  return (
+    <Collapsible open={open || !!matchesSearch} onOpenChange={setOpen}>
+      <CollapsibleTrigger className={cn(
+        "flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider cursor-pointer select-none hover:opacity-80 w-full text-left",
+        color,
+      )}>
+        {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {msg.role}
+        {!open && <span className="font-normal normal-case tracking-normal text-muted-foreground ml-1 truncate">{summary}</span>}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className={cn(
+          "mt-1 rounded-md bg-card p-2.5 text-[13px] whitespace-pre-wrap break-words border-l-2 relative group",
+          borderColor,
+          msg.role === "thinking" && "text-muted-foreground italic",
+          (msg.className === "tool-call" || msg.className === "tool-result") && "text-[11px]",
+        )}>
+          <HighlightText text={msg.text} query={searchQuery} />
+          <CopyBtn text={msg.text} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function HighlightText({ text, query }: { text: string; query?: string }) {
+  if (!query) return <>{text}</>;
+  const regex = new RegExp(`(${query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`, "gi");
+  const parts = text.split(regex);
+  return (
+    <>
+      {parts.map((part, i) =>
+        regex.test(part) ? (
+          <mark key={i} className="bg-yellow-500/30 text-inherit rounded-sm px-0.5">{part}</mark>
+        ) : (
+          <span key={i}>{part}</span>
+        )
+      )}
+    </>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
@@ -1,0 +1,151 @@
+import { useState } from "react";
+import { GitBranch, Circle, Pause, PanelLeftClose, ChevronRight, ChevronDown, Folder } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+import type { SessionInfo } from "@/types";
+
+function ago(iso: string): string {
+  const m = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (m < 1) return "now";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return h < 24 ? `${h}h` : `${Math.floor(h / 24)}d`;
+}
+
+interface Props {
+  sessions: SessionInfo[];
+  activePid: number | null;
+  connected: boolean;
+  onSelect: (s: SessionInfo) => void;
+  collapsed: boolean;
+  onToggle: () => void;
+}
+
+export function SessionSidebar({ sessions, activePid, connected, onSelect, collapsed, onToggle }: Props) {
+  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
+  const [initialized, setInitialized] = useState(false);
+
+  // Auto-expand all groups when sessions first load
+  if (!initialized && sessions.length > 0) {
+    setInitialized(true);
+    const all = new Set<string>();
+    for (const s of sessions) all.add(s.cwd.split("/").pop() || s.cwd);
+    setExpandedProjects(all);
+  }
+
+  if (collapsed) return null;
+
+  // Group sessions by project name (last segment of cwd)
+  const groups = new Map<string, { cwd: string; sessions: SessionInfo[] }>();
+  for (const s of sessions) {
+    const name = s.cwd.split("/").pop() || s.cwd;
+    if (!groups.has(name)) groups.set(name, { cwd: s.cwd, sessions: [] });
+    groups.get(name)!.sessions.push(s);
+  }
+
+  // Sort: active sessions first within each group
+  for (const g of groups.values()) {
+    g.sessions.sort((a, b) => (b.active ? 1 : 0) - (a.active ? 1 : 0));
+  }
+
+  // Sort groups: groups with active sessions first
+  const sortedGroups = [...groups.entries()].sort((a, b) => {
+    const aActive = a[1].sessions.some(s => s.active);
+    const bActive = b[1].sessions.some(s => s.active);
+    if (aActive !== bActive) return bActive ? 1 : -1;
+    return a[0].localeCompare(b[0]);
+  });
+
+  const toggleProject = (name: string) => {
+    setExpandedProjects(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+
+  // Auto-expand groups that contain the active session
+  const activeGroup = sessions.find(s => s.pid === activePid);
+  const activeGroupName = activeGroup ? (activeGroup.cwd.split("/").pop() || activeGroup.cwd) : null;
+
+  return (
+    <div className="flex flex-col h-full border-r border-border">
+      <div className="flex items-center justify-between px-3 py-2.5 border-b border-border">
+        <span className="text-sm font-bold text-primary">pidash</span>
+        <span className="flex items-center gap-2">
+          <Circle className={cn("h-2 w-2 fill-current", connected ? "text-green-500" : "text-red-500")} />
+          <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-muted-foreground" onClick={onToggle}>
+            <PanelLeftClose className="h-3.5 w-3.5" />
+          </Button>
+        </span>
+      </div>
+      <ScrollArea className="flex-1">
+        {sessions.length === 0 && (
+          <p className="p-4 text-center text-xs text-muted-foreground">No sessions</p>
+        )}
+        {sortedGroups.map(([name, group]) => {
+          const isExpanded = expandedProjects.has(name);
+          const hasActive = group.sessions.some(s => s.active);
+          const count = group.sessions.length;
+
+          return (
+            <div key={name}>
+              {/* Project header */}
+              <div
+                className={cn(
+                  "flex items-center gap-1.5 px-3 py-2 cursor-pointer text-sm font-semibold border-b border-border",
+                  hasActive ? "text-primary" : "text-muted-foreground",
+                  "hover:bg-accent/30",
+                )}
+                onClick={() => toggleProject(name)}
+              >
+                {isExpanded ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+                <Folder className="h-3 w-3" />
+                <span className="truncate">{name}</span>
+                <span className="ml-auto text-[10px] font-normal">{count}</span>
+              </div>
+
+              {/* Sessions in this group */}
+              {isExpanded && group.sessions.map((s) => {
+                const isActive = s.pid === activePid;
+                return (
+                  <div
+                    key={s.pid}
+                    className={cn(
+                      "pl-7 pr-3 py-2 cursor-pointer transition-colors border-b border-border/50",
+                      isActive && "bg-accent border-l-3 border-l-primary",
+                      !isActive && "hover:bg-accent/30",
+                      !s.active && "opacity-35",
+                    )}
+                    onClick={() => onSelect(s)}
+                  >
+                    <div className={cn("text-xs font-medium truncate flex items-center gap-1.5", s.active ? "text-primary" : "text-muted-foreground")}>
+                      {!s.active && <Pause className="h-3 w-3 flex-shrink-0 text-muted-foreground" />}
+                      <span className="truncate">{s.model || "—"}</span>
+                    </div>
+                    <div className="flex items-center gap-1.5 mt-0.5 text-[10px] text-muted-foreground">
+                      {s.branch && (
+                        <span className="flex items-center gap-0.5">
+                          <GitBranch className="h-2.5 w-2.5" />
+                          <span className={s.gitDirty ? "text-red-500" : "text-green-500"}>
+                            {s.gitDirty ? "●" : "✓"}
+                          </span>
+                          <span className="truncate max-w-[80px]">{s.branch}</span>
+                        </span>
+                      )}
+                      <span>{ago(s.startedAt)}</span>
+                      {s.container && <Badge variant="outline" className="text-[8px] px-1 py-0 h-3">📦</Badge>}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          );
+        })}
+      </ScrollArea>
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/Sidebar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/Sidebar.tsx
@@ -1,0 +1,83 @@
+import { useRef, useState, useCallback, useEffect } from "react";
+import type { SessionInfo } from "../types";
+
+function ago(iso: string): string {
+  const m = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
+  if (m < 1) return "now";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+interface Props {
+  sessions: SessionInfo[];
+  activePid: number | null;
+  connected: boolean;
+  onSelect: (s: SessionInfo) => void;
+}
+
+export function Sidebar({ sessions, activePid, connected, onSelect }: Props) {
+  const [collapsed, setCollapsed] = useState(false);
+  const [width, setWidth] = useState(260);
+  const resizing = useRef(false);
+
+  const onMouseDown = useCallback(() => { resizing.current = true; }, []);
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!resizing.current) return;
+      setWidth(Math.max(180, Math.min(500, e.clientX)));
+    };
+    const onUp = () => { resizing.current = false; };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    return () => { document.removeEventListener("mousemove", onMove); document.removeEventListener("mouseup", onUp); };
+  }, []);
+
+  if (collapsed) {
+    return (
+      <button className="expand-btn" onClick={() => setCollapsed(false)} title="Expand sidebar">▶</button>
+    );
+  }
+
+  return (
+    <div className="sidebar" style={{ width }}>
+      <div className="sidebar-head">
+        <span className="title">pidash</span>
+        <span>
+          <span className={`conn ${connected ? "ok" : "err"}`}>●</span>
+          {" "}
+          <button className="collapse-btn" onClick={() => setCollapsed(true)} title="Collapse">◀</button>
+        </span>
+      </div>
+      <div className="sess-list">
+        {sessions.length === 0 && <div className="no-sess">No sessions</div>}
+        {sessions.map((s) => {
+          const name = s.cwd.split("/").pop() || s.cwd;
+          const gitIcon = s.gitDirty ? <span className="git-dirty">●</span> : <span className="git-clean">✓</span>;
+          const parts: string[] = [];
+          if (s.model) parts.push(s.model);
+          parts.push(ago(s.startedAt));
+          if (!s.active) parts.push("⏸");
+          if (s.container) parts.push("📦");
+
+          return (
+            <div
+              key={s.pid}
+              className={`si${!s.active ? " inactive" : ""}${s.pid === activePid ? " active" : ""}`}
+              onClick={() => onSelect(s)}
+            >
+              <div className="si-name">{name}</div>
+              <div className="si-detail">
+                {s.branch && <>{gitIcon} {s.branch}{s.gitChanges ? ` ~${s.gitChanges}` : ""} · </>}
+                {parts.join(" · ")}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="resize-handle" onMouseDown={onMouseDown} />
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/ui/badge.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/badge.tsx
@@ -1,0 +1,52 @@
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  render,
+  ...props
+}: useRender.ComponentProps<"span"> & VariantProps<typeof badgeVariants>) {
+  return useRender({
+    defaultTagName: "span",
+    props: mergeProps<"span">(
+      {
+        className: cn(badgeVariants({ variant }), className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "badge",
+      variant,
+    },
+  })
+}
+
+export { Badge, badgeVariants }

--- a/extensions/orchestrator/pidash-ui/src/components/ui/button.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/button.tsx
@@ -1,0 +1,58 @@
+import { Button as ButtonPrimitive } from "@base-ui/react/button"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        outline:
+          "border-border bg-background hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+        ghost:
+          "hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default:
+          "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-8",
+        "icon-xs":
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+        "icon-sm":
+          "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+        "icon-lg": "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/extensions/orchestrator/pidash-ui/src/components/ui/collapsible.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/collapsible.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { Collapsible as CollapsiblePrimitive } from "@base-ui/react/collapsible"
+
+function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({ ...props }: CollapsiblePrimitive.Trigger.Props) {
+  return (
+    <CollapsiblePrimitive.Trigger data-slot="collapsible-trigger" {...props} />
+  )
+}
+
+function CollapsibleContent({ ...props }: CollapsiblePrimitive.Panel.Props) {
+  return (
+    <CollapsiblePrimitive.Panel data-slot="collapsible-content" {...props} />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/extensions/orchestrator/pidash-ui/src/components/ui/dropdown-menu.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,266 @@
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/extensions/orchestrator/pidash-ui/src/components/ui/input.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/extensions/orchestrator/pidash-ui/src/components/ui/resizable.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/resizable.tsx
@@ -1,0 +1,48 @@
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: ResizablePrimitive.GroupProps) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full aria-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: ResizablePrimitive.SeparatorProps & {
+  withHandle?: boolean
+}) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "relative flex w-px items-center justify-center bg-border ring-offset-background after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="z-10 flex h-6 w-1 shrink-0 rounded-lg bg-border" />
+      )}
+    </ResizablePrimitive.Separator>
+  )
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/extensions/orchestrator/pidash-ui/src/components/ui/scroll-area.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/scroll-area.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: ScrollAreaPrimitive.Root.Props) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/extensions/orchestrator/pidash-ui/src/components/ui/select.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/select.tsx
@@ -1,0 +1,201 @@
+"use client"
+
+import * as React from "react"
+import { Select as SelectPrimitive } from "@base-ui/react/select"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
+
+const Select = SelectPrimitive.Root
+
+function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
+  return (
+    <SelectPrimitive.Group
+      data-slot="select-group"
+      className={cn("scroll-my-1 p-1", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
+  return (
+    <SelectPrimitive.Value
+      data-slot="select-value"
+      className={cn("flex flex-1 text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectTrigger({
+  className,
+  size = "default",
+  children,
+  ...props
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot="select-trigger"
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon
+        render={
+          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
+        }
+      />
+    </SelectPrimitive.Trigger>
+  )
+}
+
+function SelectContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  alignItemWithTrigger = true,
+  ...props
+}: SelectPrimitive.Popup.Props &
+  Pick<
+    SelectPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset" | "alignItemWithTrigger"
+  >) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        alignItemWithTrigger={alignItemWithTrigger}
+        className="isolate z-50"
+      >
+        <SelectPrimitive.Popup
+          data-slot="select-content"
+          data-align-trigger={alignItemWithTrigger}
+          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        >
+          <SelectScrollUpButton />
+          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectScrollDownButton />
+        </SelectPrimitive.Popup>
+      </SelectPrimitive.Positioner>
+    </SelectPrimitive.Portal>
+  )
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: SelectPrimitive.GroupLabel.Props) {
+  return (
+    <SelectPrimitive.GroupLabel
+      data-slot="select-label"
+      className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: SelectPrimitive.Item.Props) {
+  return (
+    <SelectPrimitive.Item
+      data-slot="select-item"
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <SelectPrimitive.ItemText className="flex flex-1 shrink-0 gap-2 whitespace-nowrap">
+        {children}
+      </SelectPrimitive.ItemText>
+      <SelectPrimitive.ItemIndicator
+        render={
+          <span className="pointer-events-none absolute right-2 flex size-4 items-center justify-center" />
+        }
+      >
+        <CheckIcon className="pointer-events-none" />
+      </SelectPrimitive.ItemIndicator>
+    </SelectPrimitive.Item>
+  )
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: SelectPrimitive.Separator.Props) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot="select-separator"
+      className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpArrow>) {
+  return (
+    <SelectPrimitive.ScrollUpArrow
+      data-slot="select-scroll-up-button"
+      className={cn(
+        "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon
+      />
+    </SelectPrimitive.ScrollUpArrow>
+  )
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownArrow>) {
+  return (
+    <SelectPrimitive.ScrollDownArrow
+      data-slot="select-scroll-down-button"
+      className={cn(
+        "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon
+      />
+    </SelectPrimitive.ScrollDownArrow>
+  )
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+}

--- a/extensions/orchestrator/pidash-ui/src/components/ui/separator.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorPrimitive.Props) {
+  return (
+    <SeparatorPrimitive
+      data-slot="separator"
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/extensions/orchestrator/pidash-ui/src/components/ui/tooltip.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/tooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/extensions/orchestrator/pidash-ui/src/hooks/useSessions.ts
+++ b/extensions/orchestrator/pidash-ui/src/hooks/useSessions.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from "react";
+import type { SessionInfo } from "../types";
+
+export function useSessions(wsConnected: boolean, onMessage: (h: (d: any) => void) => () => void) {
+  const [sessions, setSessions] = useState<SessionInfo[]>([]);
+
+  const load = useCallback(async () => {
+    try {
+      setSessions(await (await fetch("/api/sessions")).json());
+    } catch {}
+  }, []);
+
+  useEffect(() => { if (wsConnected) load(); }, [wsConnected, load]);
+
+  useEffect(() => {
+    return onMessage((ev) => {
+      if (["session_added", "session_removed", "session_updated"].includes(ev.type)) load();
+    });
+  }, [onMessage, load]);
+
+  useEffect(() => { const t = setInterval(load, 10000); return () => clearInterval(t); }, [load]);
+
+  return sessions;
+}

--- a/extensions/orchestrator/pidash-ui/src/hooks/useWebSocket.ts
+++ b/extensions/orchestrator/pidash-ui/src/hooks/useWebSocket.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useWebSocket(url: string) {
+  const wsRef = useRef<WebSocket | null>(null);
+  const [connected, setConnected] = useState(false);
+  const handlersRef = useRef<Set<(data: any) => void>>(new Set());
+
+  useEffect(() => {
+    let dead = false;
+    function connect() {
+      if (dead) return;
+      const proto = location.protocol === "https:" ? "wss:" : "ws:";
+      const ws = new WebSocket(`${proto}//${location.host}${url}`);
+      wsRef.current = ws;
+      ws.onopen = () => setConnected(true);
+      ws.onclose = () => { setConnected(false); if (!dead) setTimeout(connect, 3000); };
+      ws.onerror = () => {};
+      ws.onmessage = (e) => {
+        try {
+          const data = JSON.parse(e.data);
+          handlersRef.current.forEach((h) => h(data));
+        } catch {}
+      };
+    }
+    connect();
+    return () => { dead = true; wsRef.current?.close(); };
+  }, [url]);
+
+  const send = useCallback((data: object) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) wsRef.current.send(JSON.stringify(data));
+  }, []);
+
+  const onMessage = useCallback((handler: (data: any) => void) => {
+    handlersRef.current.add(handler);
+    return () => { handlersRef.current.delete(handler); };
+  }, []);
+
+  return { connected, send, onMessage };
+}

--- a/extensions/orchestrator/pidash-ui/src/lib/utils.ts
+++ b/extensions/orchestrator/pidash-ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx"
+import { twMerge } from "tailwind-merge"
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/extensions/orchestrator/pidash-ui/src/main.tsx
+++ b/extensions/orchestrator/pidash-ui/src/main.tsx
@@ -1,0 +1,5 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(<App />);

--- a/extensions/orchestrator/pidash-ui/src/styles.css
+++ b/extensions/orchestrator/pidash-ui/src/styles.css
@@ -1,0 +1,184 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+@import "shadcn/tailwind.css";
+@import "@fontsource-variable/geist";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+    --font-heading: var(--font-sans);
+    --font-sans: 'Geist Variable', sans-serif;
+    --color-sidebar-ring: var(--sidebar-ring);
+    --color-sidebar-border: var(--sidebar-border);
+    --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+    --color-sidebar-accent: var(--sidebar-accent);
+    --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+    --color-sidebar-primary: var(--sidebar-primary);
+    --color-sidebar-foreground: var(--sidebar-foreground);
+    --color-sidebar: var(--sidebar);
+    --color-chart-5: var(--chart-5);
+    --color-chart-4: var(--chart-4);
+    --color-chart-3: var(--chart-3);
+    --color-chart-2: var(--chart-2);
+    --color-chart-1: var(--chart-1);
+    --color-ring: var(--ring);
+    --color-input: var(--input);
+    --color-border: var(--border);
+    --color-destructive: var(--destructive);
+    --color-accent-foreground: var(--accent-foreground);
+    --color-accent: var(--accent);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-muted: var(--muted);
+    --color-secondary-foreground: var(--secondary-foreground);
+    --color-secondary: var(--secondary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-primary: var(--primary);
+    --color-popover-foreground: var(--popover-foreground);
+    --color-popover: var(--popover);
+    --color-card-foreground: var(--card-foreground);
+    --color-card: var(--card);
+    --color-foreground: var(--foreground);
+    --color-background: var(--background);
+    --radius-sm: calc(var(--radius) * 0.6);
+    --radius-md: calc(var(--radius) * 0.8);
+    --radius-lg: var(--radius);
+    --radius-xl: calc(var(--radius) * 1.4);
+    --radius-2xl: calc(var(--radius) * 1.8);
+    --radius-3xl: calc(var(--radius) * 2.2);
+    --radius-4xl: calc(var(--radius) * 2.6);
+}
+
+:root {
+    --background: oklch(1 0 0);
+    --foreground: oklch(0.145 0 0);
+    --card: oklch(1 0 0);
+    --card-foreground: oklch(0.145 0 0);
+    --popover: oklch(1 0 0);
+    --popover-foreground: oklch(0.145 0 0);
+    --primary: oklch(0.205 0 0);
+    --primary-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.97 0 0);
+    --secondary-foreground: oklch(0.205 0 0);
+    --muted: oklch(0.97 0 0);
+    --muted-foreground: oklch(0.556 0 0);
+    --accent: oklch(0.97 0 0);
+    --accent-foreground: oklch(0.205 0 0);
+    --destructive: oklch(0.577 0.245 27.325);
+    --border: oklch(0.922 0 0);
+    --input: oklch(0.922 0 0);
+    --ring: oklch(0.708 0 0);
+    --chart-1: oklch(0.87 0 0);
+    --chart-2: oklch(0.556 0 0);
+    --chart-3: oklch(0.439 0 0);
+    --chart-4: oklch(0.371 0 0);
+    --chart-5: oklch(0.269 0 0);
+    --radius: 0.625rem;
+    --sidebar: oklch(0.985 0 0);
+    --sidebar-foreground: oklch(0.145 0 0);
+    --sidebar-primary: oklch(0.205 0 0);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.97 0 0);
+    --sidebar-accent-foreground: oklch(0.205 0 0);
+    --sidebar-border: oklch(0.922 0 0);
+    --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+    --chart-1: oklch(0.87 0 0);
+    --chart-2: oklch(0.556 0 0);
+    --chart-3: oklch(0.439 0 0);
+    --chart-4: oklch(0.371 0 0);
+    --chart-5: oklch(0.269 0 0);
+    --sidebar: oklch(0.205 0 0);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.269 0 0);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.556 0 0);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+    }
+  body {
+    @apply bg-background text-foreground;
+    }
+  html {
+    @apply font-sans;
+    }
+}
+
+body {
+  font-family: 'SF Mono', 'Fira Code', 'JetBrains Mono', 'Cascadia Code', monospace !important;
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  body { font-size: 16px; }
+  .body { font-size: 15px; padding: 10px 12px; }
+  .role { font-size: 12px; }
+  .think-toggle { font-size: 12px; }
+
+}
+
+/* Custom scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: oklch(0.4 0 0);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: oklch(0.5 0 0);
+}
+* {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.4 0 0) transparent;
+}
+
+/* Mobile viewport fix — use dvh (dynamic viewport height) to account for browser chrome */
+html, body, #root {
+  height: 100dvh;
+  height: 100vh; /* fallback */
+}
+
+@supports (height: 100dvh) {
+  html, body, #root {
+    height: 100dvh;
+  }
+}
+
+/* Hide scrollbar but keep scroll */
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}

--- a/extensions/orchestrator/pidash-ui/src/types.ts
+++ b/extensions/orchestrator/pidash-ui/src/types.ts
@@ -1,0 +1,55 @@
+export interface SessionInfo {
+  pid: number;
+  cwd: string;
+  branch: string;
+  model: string;
+  startedAt: string;
+  lastActivity: number;
+  active: boolean;
+  sessionFile?: string;
+  gitDirty?: boolean;
+  gitChanges?: number;
+  container?: boolean;
+  diffityPort?: number | null;
+  contextWindow?: number;
+  thinkingLevel?: string;
+}
+
+export interface PiEvent {
+  type: string;
+  message?: any;
+  id?: string;
+  method?: string;
+  title?: string;
+  options?: string[];
+  sessions?: any[];
+  session?: SessionInfo;
+  models?: any[];
+  timestamp?: number;
+  assistantMessageEvent?: {
+    type: string;
+    delta?: string;
+    partial?: { model?: string; usage?: TokenUsage };
+  };
+  toolName?: string;
+  args?: { command?: string };
+  result?: { content?: Array<{ type: string; text: string }> };
+  isError?: boolean;
+}
+
+export interface TokenUsage {
+  input: number;
+  output: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+  totalTokens?: number;
+}
+
+export type MessageRole = "user" | "assistant" | "tool" | "thinking" | "system";
+
+export interface ChatMessage {
+  id: string;
+  role: MessageRole;
+  text: string;
+  className?: string;
+}

--- a/extensions/orchestrator/pidash-ui/tsconfig.json
+++ b/extensions/orchestrator/pidash-ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/extensions/orchestrator/pidash-ui/vite.config.ts
+++ b/extensions/orchestrator/pidash-ui/vite.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      "/api": "http://localhost:19190",
+      "/ws": { target: "ws://localhost:19190", ws: true },
+    },
+  },
+});

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -1,0 +1,879 @@
+/**
+ * Pidash extension — connects to the pidash daemon to expose this session.
+ *
+ * On session_start:
+ * 1. Check if pidash daemon is running (HTTP health check)
+ * 2. If not, spawn it as a detached process
+ * 3. Connect via WebSocket, register this session
+ * 4. Forward all pi events to the daemon
+ * 5. Receive prompts from the daemon (browser → daemon → here → pi)
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { commandHandlerRegistry } from "./index.js";
+
+const DEFAULT_PORT = 19190;
+const PIDASH_PORT = parseInt(process.env.PI_PIDASH_PORT || "", 10) || DEFAULT_PORT;
+const RECONNECT_INTERVAL_MS = 5000;
+const HEALTH_CHECK_TIMEOUT_MS = 2000;
+
+const PIDASH_LOG = path.join(process.env.HOME || "/tmp", ".pi", "pidash-debug.log");
+function debugLog(msg: string) {
+  try { fs.appendFileSync(PIDASH_LOG, `${new Date().toISOString()} [ext] ${msg}\n`); } catch {}
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function isDaemonRunning(): Promise<boolean> {
+  return new Promise((resolve) => {
+    const req = http.request(
+      { hostname: "127.0.0.1", port: PIDASH_PORT, path: "/api/health", timeout: HEALTH_CHECK_TIMEOUT_MS },
+      (res) => {
+        let body = "";
+        res.on("data", (d) => { body += d; });
+        res.on("end", () => {
+          try { resolve(JSON.parse(body).status === "ok"); } catch { resolve(false); }
+        });
+      },
+    );
+    req.on("error", () => resolve(false));
+    req.on("timeout", () => { req.destroy(); resolve(false); });
+    req.end();
+  });
+}
+
+function ensurePidashUiBuilt(): void {
+  const uiDir = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    "pidash-ui",
+  );
+  const distDir = path.join(uiDir, "dist");
+  if (fs.existsSync(distDir)) return;
+  if (!fs.existsSync(path.join(uiDir, "package.json"))) return;
+
+  debugLog("pidash-ui dist/ not found, building...");
+  try {
+    const { execSync: ex } = require("node:child_process");
+    ex("npm install --production=false && npm run build", {
+      cwd: uiDir,
+      stdio: "ignore",
+      timeout: 60000,
+    });
+    debugLog("pidash-ui build complete");
+  } catch (e: any) {
+    debugLog(`pidash-ui build failed: ${e.message}`);
+  }
+}
+
+function spawnDaemon(): void {
+  ensurePidashUiBuilt();
+  const serverPath = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    "..", "..", "scripts", "pidash-server.ts",
+  );
+
+  let jitiPath: string | undefined;
+  try {
+    // Walk up from this file to find node_modules/@mariozechner/jiti
+    let dir = path.dirname(new URL(import.meta.url).pathname);
+    for (let i = 0; i < 10; i++) {
+      const candidate = path.join(dir, "node_modules", "@mariozechner", "jiti", "lib", "jiti-cli.mjs");
+      if (fs.existsSync(candidate)) { jitiPath = candidate; break; }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    // Also check pi's global install
+    if (!jitiPath) {
+      const globalCandidate = path.join(
+        path.dirname(process.execPath), "..", "lib", "node_modules",
+        "@mariozechner", "pi-coding-agent", "node_modules",
+        "@mariozechner", "jiti", "lib", "jiti-cli.mjs",
+      );
+      if (fs.existsSync(globalCandidate)) jitiPath = globalCandidate;
+    }
+  } catch {}
+  debugLog(`jiti path: ${jitiPath || "NOT FOUND"}`);
+
+  const nodeCmd = process.execPath;
+  const args = jitiPath ? `"${jitiPath}" "${serverPath}"` : `"${serverPath}"`;
+  const logFile = path.join(process.env.HOME || "/tmp", ".pi", "pidash-server.log");
+  // Use nohup + shell to fully detach from pi's process group
+  const cmd = `nohup "${nodeCmd}" ${args} > "${logFile}" 2>&1 &`;
+  debugLog(`spawning daemon via shell: ${cmd}`);
+
+  try {
+    const { execSync } = require("node:child_process");
+    execSync(cmd, {
+      stdio: "ignore",
+      env: { ...process.env, PI_PIDASH_PORT: String(PIDASH_PORT) },
+    });
+  } catch (e: any) {
+    debugLog(`daemon spawn error: ${e.message}`);
+  }
+}
+
+function getGitStatus(cwd: string): { branch: string; dirty: boolean; changes: number } {
+  try {
+    const branch = execFileSync("git", ["branch", "--show-current"], {
+      cwd, encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const status = execFileSync("git", ["status", "--porcelain"], {
+      cwd, encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const changes = status ? status.split("\n").length : 0;
+    return { branch, dirty: changes > 0, changes };
+  } catch { return { branch: "", dirty: false, changes: 0 }; }
+}
+
+function isContainer(): boolean {
+  try {
+    return fs.existsSync("/.dockerenv") || fs.existsSync("/run/.containerenv");
+  } catch { return false; }
+}
+
+let diffityPort: number | null = null;
+
+function getCurrentBranch(cwd: string): string {
+  try {
+    return execFileSync("git", ["branch", "--show-current"], {
+      cwd, encoding: "utf-8", timeout: 3000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch { return ""; }
+}
+
+// ── Registration ─────────────────────────────────────────────────────
+
+export function registerPidash(pi: ExtensionAPI): void {
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
+  let ws: any = null;
+  let connected = false;
+  let connecting = false;
+  let shuttingDown = false;
+  let spawning = false;
+  const MAX_EVENT_BUFFER = 5000;
+  let lastCtx: any = null;
+  const eventBuffer: string[] = []; // Buffer events for replay on daemon reconnect
+
+  async function connect(ctx: any) {
+    debugLog(`connect() called, connected=${connected}, connecting=${connecting}, shuttingDown=${shuttingDown}, cwd=${ctx?.cwd}`);
+    if (connected || connecting || shuttingDown) return;
+    connecting = true;
+    lastCtx = ctx;
+
+    const running = await isDaemonRunning();
+    debugLog(`daemon running: ${running}`);
+    if (!running) {
+      if (spawning) {
+        debugLog("daemon already spawning, waiting...");
+      } else {
+        spawning = true;
+        debugLog("spawning daemon...");
+        spawnDaemon();
+      }
+      // jiti cold compilation can take 30+ seconds on first run
+      for (let i = 0; i < 60; i++) {
+        await new Promise(r => setTimeout(r, 1000));
+        if (await isDaemonRunning()) {
+          debugLog(`daemon ready after ${i + 1}s`);
+          break;
+        }
+      }
+      if (!(await isDaemonRunning())) {
+        debugLog("daemon failed to start after 60s");
+        spawning = false;
+        return;
+      }
+      spawning = false;
+    }
+
+    try {
+      const WebSocket = require("ws");
+      debugLog("creating WebSocket client...");
+      const wsClient = new WebSocket(`ws://127.0.0.1:${PIDASH_PORT}/ws/pi`);
+
+      wsClient.on("open", () => {
+        debugLog("WebSocket connected!");
+        ws = wsClient;
+        connected = true;
+        connecting = false;
+
+        // Register this session
+        const git = getGitStatus(ctx.cwd);
+        const m = ctx.model;
+        // Read thinking level from session entries
+        let thinking = "medium";
+        try {
+          thinking = (pi as any).getThinkingLevel?.() || "medium";
+        } catch {}
+        const reg = JSON.stringify({
+          type: "register",
+          pid: process.pid,
+          cwd: ctx.cwd,
+          branch: git.branch,
+          gitDirty: git.dirty,
+          gitChanges: git.changes,
+          container: isContainer(),
+          diffityPort,
+          model: m?.name || m?.id || "",
+          contextWindow: m?.contextWindow || 0,
+          startedAt: new Date().toISOString(),
+          sessionFile: ctx.sessionFile || "",
+          thinkingLevel: thinking,
+        });
+        debugLog(`sending register: ${reg}`);
+        wsClient.send(reg);
+
+        // Replay buffered events to restore history on daemon reconnect
+        // Send in batches with yields to prevent WebSocket overload
+        if (eventBuffer.length > 0) {
+          debugLog(`replaying ${eventBuffer.length} buffered events`);
+          const BATCH_SIZE = 50;
+          let i = 0;
+          const replayBatch = () => {
+            const end = Math.min(i + BATCH_SIZE, eventBuffer.length);
+            for (; i < end; i++) {
+              try { wsClient.send(eventBuffer[i]); } catch {}
+            }
+            if (i < eventBuffer.length) {
+              setTimeout(replayBatch, 10);
+            } else {
+              debugLog(`replay complete: ${eventBuffer.length} events`);
+            }
+          };
+          replayBatch();
+        }
+
+        // Load existing session history (for --continue / resumed sessions)
+        if (eventBuffer.length === 0) {
+          try {
+            const entries = ctx.sessionManager?.getEntries?.() || [];
+            let historyCount = 0;
+            for (const entry of entries) {
+              const e = entry as any;
+              if (e.type !== "message" || !e.message) continue;
+              const msg = e.message;
+              const ts = e.timestamp ? new Date(e.timestamp).getTime() : Date.now();
+
+              if (msg.role === "user") {
+                const ev = JSON.stringify({ type: "message_start", message: msg, timestamp: ts });
+                wsClient.send(ev);
+                eventBuffer.push(ev);
+              }
+
+              if (msg.role === "assistant" && msg.content) {
+                // Send thinking blocks
+                for (const part of msg.content) {
+                  if (part.type === "thinking" && part.thinking) {
+                    const thinkEv = JSON.stringify({
+                      type: "message_update",
+                      assistantMessageEvent: { type: "thinking_delta", delta: part.thinking, partial: { model: msg.model, usage: msg.usage } },
+                      timestamp: ts,
+                    });
+                    wsClient.send(thinkEv);
+                    eventBuffer.push(thinkEv);
+                  }
+                }
+
+                // Send text blocks
+                for (const part of msg.content) {
+                  if (part.type === "text" && part.text) {
+                    const textEv = JSON.stringify({
+                      type: "message_update",
+                      assistantMessageEvent: { type: "text_delta", delta: part.text, partial: { model: msg.model, usage: msg.usage } },
+                      timestamp: ts,
+                    });
+                    wsClient.send(textEv);
+                    eventBuffer.push(textEv);
+                  }
+                }
+
+                // Send tool calls
+                for (const part of msg.content) {
+                  if (part.type === "toolCall") {
+                    const toolEv = JSON.stringify({
+                      type: "tool_execution_start",
+                      toolName: part.name,
+                      args: part.arguments,
+                      timestamp: ts,
+                    });
+                    wsClient.send(toolEv);
+                    eventBuffer.push(toolEv);
+                  }
+                }
+
+                // Send message_end
+                const endEv = JSON.stringify({ type: "message_end", message: msg, timestamp: ts });
+                wsClient.send(endEv);
+                eventBuffer.push(endEv);
+              }
+
+              // Tool results
+              if (msg.role === "toolResult") {
+                const resultEv = JSON.stringify({
+                  type: "tool_execution_end",
+                  toolName: msg.toolName,
+                  result: { content: msg.content },
+                  isError: msg.isError || false,
+                  timestamp: ts,
+                });
+                wsClient.send(resultEv);
+                eventBuffer.push(resultEv);
+              }
+
+              // Custom messages (async agent results, etc.)
+              if (msg.role === "custom" && msg.display) {
+                const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content || "");
+                const ev = JSON.stringify({
+                  type: "message_start",
+                  message: { role: "custom", display: true, content, customType: msg.customType },
+                  timestamp: ts,
+                });
+                wsClient.send(ev);
+                eventBuffer.push(ev);
+              }
+
+              // Catch-all: any other message role — forward as-is
+              if (!["user", "assistant", "toolResult", "custom"].includes(msg.role)) {
+                const ev = JSON.stringify({ type: "message_start", message: msg, timestamp: ts });
+                wsClient.send(ev);
+                eventBuffer.push(ev);
+              }
+
+              historyCount++;
+            }
+            if (historyCount > 0) debugLog(`loaded ${historyCount} entries from session history`);
+          } catch (e: any) {
+            debugLog(`session history load error: ${e.message}`);
+          }
+        }
+
+        // Respond to pings (keepalive)
+        wsClient.on("ping", () => {
+          try { wsClient.pong(); } catch {}
+        });
+
+        // Send heartbeat every 30s to prevent idle disconnects
+        const heartbeat = setInterval(() => {
+          if (wsClient.readyState === 1) { // WebSocket.OPEN
+            try { wsClient.ping(); } catch {}
+          } else {
+            clearInterval(heartbeat);
+          }
+        }, 30000);
+        if ((heartbeat as any).unref) (heartbeat as any).unref();
+
+        // Show status
+        if (ctx.hasUI) {
+          ctx.ui.setStatus("pidash", ctx.ui.theme.fg("accent", `🌐 http://localhost:${PIDASH_PORT}`));
+        }
+      });
+
+      wsClient.on("message", async (data: Buffer) => {
+        try {
+          const parsed = JSON.parse(data.toString());
+          if (parsed.type === "prompt" && parsed.text) {
+            debugLog(`received prompt from browser: ${parsed.text.slice(0, 100)}`);
+            pi.sendUserMessage(parsed.text, { deliverAs: "followUp" });
+          }
+          if (parsed.type === "extension_ui_response" && parsed.id) {
+            debugLog(`received UI response from browser: ${JSON.stringify(parsed).slice(0, 100)}`);
+            pi.events.emit("pidash:ui-response", parsed);
+          }
+          if (parsed.type === "pidash-command") {
+            debugLog(`received command from browser: ${parsed.command}`);
+
+            if (parsed.command === "list-sessions") {
+              try {
+                const sessionsDir = path.join(process.env.HOME || "~", ".pi", "agent", "sessions");
+                const cwd = lastCtx?.cwd || "";
+                // Pi encodes paths as --path-parts-- in the sessions directory
+                const dirs = fs.readdirSync(sessionsDir);
+                debugLog(`list-sessions: cwd=${cwd}, sessionsDir=${sessionsDir}, dirs=${dirs.length}`);
+                // Find matching project dir — try exact match on cwd segments
+                const cwdParts = cwd.split("/").filter(Boolean).join("-");
+                const projDir = dirs.find((d: string) => d.includes(cwdParts));
+                debugLog(`list-sessions: cwdParts=${cwdParts}, projDir=${projDir || "NOT FOUND"}`);
+                if (projDir) {
+                  const fullDir = path.join(sessionsDir, projDir);
+                  const files = fs.readdirSync(fullDir)
+                    .filter((f: string) => f.endsWith(".jsonl"))
+                    .sort()
+                    .reverse()
+                    .slice(0, 20)
+                    .map((f: string) => {
+                      const filePath = path.join(fullDir, f);
+                      let sessionName = "";
+                      let firstMsg = "";
+                      let modelId = "";
+                      let date = "";
+                      try {
+                        const content = fs.readFileSync(filePath, "utf-8");
+                        const lines = content.split("\n").slice(0, 30); // Read first 30 lines
+                        for (const line of lines) {
+                          if (!line.trim()) continue;
+                          try {
+                            const entry = JSON.parse(line);
+                            if (entry.type === "session") {
+                              date = entry.timestamp || "";
+                            }
+                            if (entry.type === "session_info" && entry.name) {
+                              sessionName = entry.name;
+                            }
+                            if (entry.type === "model_change" && !modelId) {
+                              modelId = entry.modelId || "";
+                            }
+                            if (entry.type === "message" && entry.message?.role === "user" && !firstMsg) {
+                              const texts = (entry.message.content || [])
+                                .filter((c: any) => c.type === "text")
+                                .map((c: any) => c.text);
+                              firstMsg = texts.join(" ").slice(0, 100);
+                            }
+                          } catch {}
+                        }
+                      } catch {}
+                      return {
+                        file: f,
+                        path: filePath,
+                        name: sessionName || firstMsg || f.replace(/\.jsonl$/, ""),
+                        model: modelId,
+                        date,
+                      };
+                    });
+                  debugLog(`list-sessions: found ${files.length} sessions`);
+                  if (ws && connected) ws.send(JSON.stringify({ type: "sessions-list", sessions: files }));
+                } else {
+                  debugLog("list-sessions: no matching project dir");
+                  if (ws && connected) ws.send(JSON.stringify({ type: "sessions-list", sessions: [] }));
+                }
+              } catch (e: any) { debugLog(`list-sessions error: ${e.message}`); }
+            }
+
+            if (parsed.command === "list-models") {
+              try {
+                if (lastCtx?.modelRegistry) {
+                  const available = lastCtx.modelRegistry.getAvailable();
+                  const list = available.map((m: any) => ({
+                    id: m.id,
+                    name: m.name,
+                    provider: typeof m.provider === "string" ? m.provider : m.provider?.name || "",
+                  }));
+                  debugLog(`models found: ${list.length}`);
+                  if (ws && connected) ws.send(JSON.stringify({ type: "models-list", models: list }));
+                } else {
+                  debugLog("list-models: no modelRegistry on ctx");
+                }
+              } catch (e: any) { debugLog(`list-models error: ${e.message}`); }
+            }
+
+            if (parsed.command === "set-model" && parsed.modelId) {
+              try {
+                const model = lastCtx?.modelRegistry?.getAvailable()?.find((m: any) =>
+                  m.id === parsed.modelId || m.name === parsed.modelId || m.id.includes(parsed.modelId) || m.name.includes(parsed.modelId));
+                if (model) {
+                  await (pi as any).setModel(model);
+                  debugLog(`model set to: ${model.name}`);
+                  ws.send(JSON.stringify({ type: "update_info", model: model.name, contextWindow: model.contextWindow || 0 }));
+                }
+              } catch (e: any) { debugLog(`set-model error: ${e.message}`); }
+            }
+
+            if (parsed.command === "set-thinking" && parsed.level) {
+              try {
+                (pi as any).setThinkingLevel(parsed.level);
+                debugLog(`thinking set to: ${parsed.level}`);
+                ws.send(JSON.stringify({ type: "update_info", thinkingLevel: parsed.level }));
+              } catch (e: any) { debugLog(`set-thinking error: ${e.message}`); }
+            }
+
+            // TODO: switch-session and new-session require switchSession/newSession
+            // which are only on ExtensionCommandContext (not available from extensions).
+            // Waiting for pi to expose these on the extension runtime API.
+            if (parsed.command === "switch-session") {
+              debugLog("switch-session: not available — pi API limitation");
+            }
+            if (parsed.command === "new-session") {
+              debugLog("new-session: not available — pi API limitation");
+            }
+
+            if (parsed.command === "abort") {
+              if (lastCtx) {
+                try { lastCtx.abort(); debugLog("abort sent"); } catch {}
+              }
+            }
+
+            if (parsed.command === "list-commands") {
+              try {
+                const cmds = (pi as any).getCommands?.() || [];
+                const list = cmds.map((c: any) => ({ name: c.name, description: c.description || "" }));
+                if (ws && connected) ws.send(JSON.stringify({ type: "commands-list", commands: list }));
+              } catch {}
+            }
+          }
+        } catch {}
+      });
+
+      wsClient.on("close", (code: number, reason: Buffer) => {
+        debugLog(`WebSocket closed: code=${code} reason=${reason?.toString() || 'none'}`);
+        connecting = false;
+        debugLog("WebSocket closed");
+        connected = false;
+        ws = null;
+        if (!shuttingDown) {
+          setTimeout(() => { if (lastCtx && !shuttingDown) connect(lastCtx); }, RECONNECT_INTERVAL_MS);
+        }
+      });
+
+      wsClient.on("error", (e: Error) => {
+        debugLog(`WebSocket error: ${e.message}`);
+      });
+    } catch (e: any) {
+      debugLog(`connect error: ${e.message}`);
+    }
+  }
+
+  // Forward events to daemon
+  function forward(type: string) {
+    pi.on(type as any, (event: any, ctx: any) => {
+      lastCtx = ctx;
+      let payload: any = { type, ...event, timestamp: Date.now() };
+
+      // Optimize message_update: strip the full accumulated partial message
+      // to prevent events growing larger as streaming progresses.
+      // Keep only delta + essential metadata (model, usage).
+      if (type === "message_update" && payload.assistantMessageEvent?.partial) {
+        const ae = payload.assistantMessageEvent;
+        payload = {
+          type,
+          assistantMessageEvent: {
+            type: ae.type,
+            delta: ae.delta,
+            contentIndex: ae.contentIndex,
+            content: ae.content,
+            partial: ae.partial ? {
+              model: ae.partial.model,
+              usage: ae.partial.usage,
+              provider: ae.partial.provider,
+            } : undefined,
+          },
+          timestamp: payload.timestamp,
+        };
+      }
+
+      // Strip full message from message_end (can be large for resumed sessions)
+      // Keep only role and essential content
+      if (type === "message_end" && payload.message) {
+        const m = payload.message;
+        payload = {
+          type,
+          message: {
+            role: m.role,
+            model: m.model,
+            usage: m.usage,
+            provider: m.provider,
+            customType: m.customType,
+            display: m.display,
+          },
+          timestamp: payload.timestamp,
+        };
+      }
+
+      const msg = JSON.stringify(payload);
+      if (type !== "extension_ui_request") {
+        eventBuffer.push(msg);
+        // Prevent unbounded growth — drop oldest events
+        while (eventBuffer.length > MAX_EVENT_BUFFER) eventBuffer.shift();
+      }
+      if (ws && connected) {
+        try { ws.send(msg); } catch (e: any) { debugLog(`forward ${type} error: ${e.message}`); }
+      } else if (!connected) {
+        debugLog(`forward ${type}: ws not connected`);
+      }
+    });
+  }
+
+  // Wrap ALL ctx.ui dialog methods for pidash bridging
+  const wrapCtx = (_event: any, ctx: any) => {
+    if (!ctx?.ui || ctx.ui.__pidashWrapped) return;
+    ctx.ui.__pidashWrapped = true;
+    const origSelect = ctx.ui.select.bind(ctx.ui);
+    const origConfirm = ctx.ui.confirm.bind(ctx.ui);
+
+    ctx.ui.select = async (title: string, options: string[], opts?: any) => {
+      const askId = `dialog-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      if (ws && connected) {
+        ws.send(JSON.stringify({ id: askId, type: "extension_ui_request", method: "select", title, options }));
+      }
+      const ac = new AbortController();
+      let browserResolve: ((v: string | undefined) => void) | null = null;
+      const unsub = pi.events.on("pidash:ui-response", (data: unknown) => {
+        const r = data as any;
+        if (r.id === askId && browserResolve) { browserResolve(r.cancelled ? undefined : r.value); ac.abort(); }
+      });
+      const result = await Promise.race([
+        origSelect(title, options, { ...opts, signal: opts?.signal || ac.signal }).then((v: any) => {
+          browserResolve = null;
+          pi.events.emit("pidash:ui-dismiss", { type: "ui-dismiss", id: askId });
+          return v;
+        }),
+        new Promise<string | undefined>((resolve) => { browserResolve = resolve; }),
+      ]);
+      unsub();
+      return result;
+    };
+
+    ctx.ui.confirm = async (title: string, message: string, opts?: any) => {
+      const askId = `dialog-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      if (ws && connected) {
+        ws.send(JSON.stringify({ id: askId, type: "extension_ui_request", method: "confirm", title, message }));
+      }
+      const ac = new AbortController();
+      let browserResolve: ((v: boolean) => void) | null = null;
+      const unsub = pi.events.on("pidash:ui-response", (data: unknown) => {
+        const r = data as any;
+        if (r.id === askId && browserResolve) { browserResolve(r.confirmed ?? false); ac.abort(); }
+      });
+      const result = await Promise.race([
+        origConfirm(title, message, { ...opts, signal: opts?.signal || ac.signal }).then((v: any) => {
+          browserResolve = null;
+          pi.events.emit("pidash:ui-dismiss", { type: "ui-dismiss", id: askId });
+          return v;
+        }),
+        new Promise<boolean>((resolve) => { browserResolve = resolve; }),
+      ]);
+      unsub();
+      return result;
+    };
+  };
+
+  // Register wrapper on all events that provide ctx
+  for (const evt of ["tool_call", "tool_result", "agent_start", "turn_start"] as const) {
+    pi.on(evt as any, wrapCtx);
+  }
+
+  forward("agent_start");
+  forward("agent_end");
+  forward("turn_start");
+  forward("turn_end");
+  forward("message_start");
+  forward("message_update");
+  forward("message_end");
+  forward("tool_execution_start");
+  forward("tool_execution_update");
+  forward("tool_execution_end");
+  forward("tool_call");
+  forward("tool_result");
+
+  pi.on("model_select", (event: any) => {
+    if (ws && connected) {
+      ws.send(JSON.stringify({
+        type: "update_info",
+        model: event.model?.name || event.model?.id || "",
+        contextWindow: event.model?.contextWindow || 0,
+      }));
+    }
+  });
+
+  // Sync thinking level on every turn
+  pi.on("turn_end", () => {
+    if (!ws || !connected) return;
+    try {
+      const level = (pi as any).getThinkingLevel?.();
+      if (level) ws.send(JSON.stringify({ type: "update_info", thinkingLevel: level }));
+    } catch {}
+  });
+
+  // Track diffity port from diffity extension
+  pi.events.on("diffity:port", (port: unknown) => {
+    if (typeof port === "number") {
+      diffityPort = port;
+      if (ws && connected) {
+        ws.send(JSON.stringify({ type: "update_info", diffityPort: port }));
+      }
+    }
+  });
+
+  // Forward ask_user requests to the daemon for browser display
+  pi.events.on("pidash:ui-request", (data: unknown) => {
+    if (ws && connected) {
+      try { ws.send(JSON.stringify(data)); } catch {}
+    }
+  });
+
+  // Forward dialog dismissals to the browser
+  pi.events.on("pidash:ui-dismiss", (data: unknown) => {
+    if (ws && connected) {
+      try { ws.send(JSON.stringify(data)); } catch {}
+    }
+  });
+
+  // Forward async agent status to browser
+  pi.events.on("pidash:async-status", (data: unknown) => {
+    if (ws && connected) {
+      try { ws.send(JSON.stringify({ type: "async-status", ...(data as any) })); } catch {}
+    }
+  });
+
+  // Periodically update git status
+  const statusInterval = setInterval(() => {
+    if (!ws || !connected || !lastCtx) return;
+    const git = getGitStatus(lastCtx.cwd);
+    ws.send(JSON.stringify({
+      type: "update_info",
+      branch: git.branch,
+      gitDirty: git.dirty,
+      gitChanges: git.changes,
+    }));
+  }, 10000);
+  if (statusInterval.unref) statusInterval.unref();
+
+  // Store command context from the first command invocation
+  let execCtx: any = null;
+
+  pi.on("session_start", (_event, ctx) => {
+    if (!execCtx) {
+      execCtx = ctx;
+      debugLog("execCtx created from session_start");
+    }
+    if (!connected) {
+      connect(ctx);
+    } else if (ws) {
+      // Already connected — session switched (e.g., /resume, /new)
+      ws.send(JSON.stringify({
+        type: "session_switch",
+        cwd: ctx.cwd,
+        branch: getCurrentBranch(ctx.cwd),
+        sessionFile: ctx.sessionFile || "",
+      }));
+      debugLog(`session_switch sent: cwd=${ctx.cwd}`);
+    }
+  });
+
+  // Fallback for /reload — connect on first tool_result if not connected
+  pi.on("tool_result", (_event, ctx) => {
+    if (!connected && !shuttingDown) connect(ctx);
+  });
+
+  // ── Command execution from browser ────────────────────────────────
+  //
+  // Problem: pi.sendUserMessage() disables command handling (expandPromptTemplates: false).
+  // Solution: Register a command that can execute other commands, and intercept
+  // browser-sourced / messages in the input event to route through it.
+
+  // Hidden command that captures ExtensionCommandContext
+  // Called once at startup via /pidash, then reused for all browser commands
+  pi.registerCommand("pidash", {
+    description: "Manage pidash server — /pidash start|stop|restart|status",
+    handler: async (args, ctx) => {
+      // Capture command context (for future use when pi exposes switchSession/newSession)
+      execCtx = ctx;
+
+      const cmd = (args || "").trim().toLowerCase();
+
+      if (cmd === "stop") {
+        if (ws) { try { ws.close(); } catch {} ws = null; }
+        connected = false;
+        try {
+          const { execSync: ex } = require("node:child_process");
+          ex("pkill -f pidash-server", { stdio: "ignore" });
+        } catch {}
+        if (ctx.hasUI) {
+          ctx.ui.setStatus("pidash", undefined);
+          ctx.ui.notify("pidash server stopped", "info");
+        }
+        return;
+      }
+
+      if (cmd === "start") {
+        if (await isDaemonRunning()) {
+          if (ctx.hasUI) ctx.ui.notify(`pidash already running at http://localhost:${PIDASH_PORT}`, "info");
+          if (!connected) connect(ctx);
+          return;
+        }
+        spawnDaemon();
+        if (ctx.hasUI) ctx.ui.notify("Starting pidash server...", "info");
+        for (let i = 0; i < 60; i++) {
+          await new Promise(r => setTimeout(r, 1000));
+          if (await isDaemonRunning()) break;
+        }
+        if (await isDaemonRunning()) {
+          connect(ctx);
+          if (ctx.hasUI) ctx.ui.notify(`pidash server started at http://localhost:${PIDASH_PORT}`, "info");
+        } else {
+          if (ctx.hasUI) ctx.ui.notify("pidash server failed to start — check ~/.pi/pidash-server.log", "warning");
+        }
+        return;
+      }
+
+      if (cmd === "restart") {
+        if (ws) { try { ws.close(); } catch {} ws = null; }
+        connected = false;
+        try {
+          const { execSync: ex } = require("node:child_process");
+          ex("pkill -f pidash-server", { stdio: "ignore" });
+        } catch {}
+        await new Promise(r => setTimeout(r, 1000));
+        spawnDaemon();
+        if (ctx.hasUI) ctx.ui.notify("Restarting pidash server...", "info");
+        for (let i = 0; i < 60; i++) {
+          await new Promise(r => setTimeout(r, 1000));
+          if (await isDaemonRunning()) break;
+        }
+        if (await isDaemonRunning()) {
+          connect(ctx);
+          if (ctx.hasUI) ctx.ui.notify(`pidash server restarted at http://localhost:${PIDASH_PORT}`, "info");
+        } else {
+          if (ctx.hasUI) ctx.ui.notify("pidash server failed to restart — check ~/.pi/pidash-server.log", "warning");
+        }
+        return;
+      }
+
+      if (cmd === "status" || cmd === "") {
+        const running = await isDaemonRunning();
+        let msg = `Server: ${running ? "running" : "stopped"}\n`;
+        msg += `Port: ${PIDASH_PORT}\n`;
+        msg += `Extension: ${connected ? "connected" : "disconnected"}\n`;
+        msg += `URL: http://localhost:${PIDASH_PORT}`;
+        if (ctx.hasUI) ctx.ui.notify(msg, "info");
+        return;
+      }
+
+      if (ctx.hasUI) ctx.ui.notify("Usage: /pidash start|stop|restart|status", "info");
+    },
+  });
+
+  // Intercept extension commands from browser
+  pi.on("input", async (event, _ctx) => {
+    if (event.source !== "extension") return;
+    if (!event.text.startsWith("/")) return;
+
+    const text = event.text.trim();
+    const spaceIdx = text.indexOf(" ");
+    const cmdName = (spaceIdx > 0 ? text.slice(1, spaceIdx) : text.slice(1)).toLowerCase();
+    const arg = spaceIdx > 0 ? text.slice(spaceIdx + 1).trim() : "";
+
+    debugLog(`browser command: /${cmdName} ${arg.slice(0, 80)}`);
+
+    const handler = commandHandlerRegistry.get(cmdName);
+    if (handler) {
+      try {
+        await handler(arg, execCtx);
+      } catch (e: any) {
+        debugLog(`command /${cmdName} error: ${e.message}`);
+      }
+      return { action: "handled" as const };
+    }
+  });
+
+  pi.on("session_shutdown", () => {
+    shuttingDown = true;
+    if (ws) { try { ws.close(); } catch {} ws = null; }
+    connected = false;
+  });
+}

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+/**
+ * Pidash server — standalone daemon that aggregates all pi sessions.
+ *
+ * Spawned automatically by the pidash extension on first pi session start.
+ * Listens on a fixed port (default 19190) for:
+ * - Pi session WebSocket clients at /ws/pi (extensions forward events here)
+ * - Browser WebSocket clients at /ws/browser (viewers watch/interact here)
+ * - HTTP requests (web UI at /, API at /api/*)
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const DEFAULT_PORT = 19190;
+const port = parseInt(process.env.PI_PIDASH_PORT || "", 10) || DEFAULT_PORT;
+
+const LOG_PATH = path.join(process.env.HOME || "/tmp", ".pi", "pidash-debug.log");
+function log(msg: string) {
+  const line = `${new Date().toISOString()} [srv] ${msg}\n`;
+  console.log(msg);
+  try { fs.appendFileSync(LOG_PATH, line); } catch {}
+}
+
+// ── Session state ───────────────────────────────────────────────────
+
+interface SessionInfo {
+  pid: number;
+  cwd: string;
+  branch: string;
+  model: string;
+  startedAt: string;
+  lastActivity: number;
+  active: boolean;
+  sessionFile?: string;
+  gitDirty?: boolean;
+  gitChanges?: number;
+  container?: boolean;
+  diffityPort?: number | null;
+  contextWindow?: number;
+  thinkingLevel?: string;
+}
+
+interface PiClient {
+  ws: any;
+  session: SessionInfo;
+  eventBuffer: string[];
+}
+
+const piClients = new Map<number, PiClient>();
+const browserClients = new Set<any>();
+const browserWatchMap = new WeakMap<any, number | null>();
+
+// ── HTTP Server ─────────────────────────────────────────────────────
+
+const UI_DIR = path.join(
+  path.dirname(process.argv[1] || __filename),
+  "..", "extensions", "orchestrator", "pidash-ui", "dist",
+);
+
+const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+  const url = new URL(req.url || "/", `http://localhost:${port}`);
+
+  res.setHeader("Access-Control-Allow-Origin", req.headers.origin || `http://localhost:${port}`);
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+  if (req.method === "OPTIONS") { res.writeHead(204); res.end(); return; }
+
+  if (url.pathname === "/api/sessions") {
+    const sessions = Array.from(piClients.values()).map(c => c.session);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(sessions));
+    return;
+  }
+
+  if (url.pathname === "/api/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({
+      status: "ok",
+      port,
+      sessions: piClients.size,
+      browsers: browserClients.size,
+      uptime: process.uptime(),
+    }));
+    return;
+  }
+
+  // Serve static files from dist/
+  const MIME: Record<string, string> = {
+    ".html": "text/html", ".js": "application/javascript",
+    ".css": "text/css", ".json": "application/json",
+    ".woff2": "font/woff2", ".woff": "font/woff",
+    ".svg": "image/svg+xml", ".png": "image/png",
+  };
+
+  let filePath = url.pathname === "/" ? "/index.html" : url.pathname;
+  const absPath = path.join(UI_DIR, filePath);
+
+  // Security: prevent directory traversal
+  if (!absPath.startsWith(UI_DIR)) {
+    res.writeHead(403); res.end("Forbidden"); return;
+  }
+
+  try {
+    const data = fs.readFileSync(absPath);
+    const ext = path.extname(absPath).toLowerCase();
+    res.writeHead(200, { "Content-Type": MIME[ext] || "application/octet-stream" });
+    res.end(data);
+  } catch {
+    // SPA fallback — serve index.html for unknown routes
+    try {
+      const html = fs.readFileSync(path.join(UI_DIR, "index.html"));
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(html);
+    } catch {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end("<h1>pidash</h1><p>UI not found. Run: cd extensions/orchestrator/pidash-ui && npm run build</p>");
+    }
+  }
+});
+
+// ── WebSocket Server ────────────────────────────────────────────────
+
+const WebSocket = require("ws");
+
+// Pi session clients
+const piWss = new WebSocket.Server({ noServer: true });
+piWss.on("connection", (ws: any) => {
+  let piClient: PiClient | null = null;
+
+  ws.on("message", (data: Buffer) => {
+    try {
+      const parsed = JSON.parse(data.toString());
+
+      if (parsed.type === "register") {
+        const session: SessionInfo = {
+          pid: parsed.pid,
+          cwd: parsed.cwd || "",
+          branch: parsed.branch || "",
+          model: parsed.model || "",
+          startedAt: parsed.startedAt || new Date().toISOString(),
+          lastActivity: Date.now(),
+          active: true,
+          sessionFile: parsed.sessionFile || "",
+          gitDirty: parsed.gitDirty || false,
+          gitChanges: parsed.gitChanges || 0,
+          container: parsed.container || false,
+          diffityPort: parsed.diffityPort || null,
+          contextWindow: parsed.contextWindow || 0,
+          thinkingLevel: parsed.thinkingLevel || "medium",
+        };
+        // Re-registration: update existing inactive session (keep event buffer)
+        const existing = piClients.get(parsed.pid);
+        if (existing) {
+          existing.ws = ws;
+          existing.session = session;
+          existing.eventBuffer = []; // Clear stale buffer — extension will replay current events
+          piClient = existing;
+        } else {
+          piClient = { ws, session, eventBuffer: [] };
+        }
+        piClients.set(parsed.pid, piClient);
+        log(`session registered: PID ${parsed.pid}, cwd: ${parsed.cwd}`);
+        broadcastToBrowsers({ type: "session_added", session });
+        return;
+      }
+
+      if (parsed.type === "update_info" && piClient) {
+        if (parsed.model !== undefined) piClient.session.model = parsed.model;
+        if (parsed.branch !== undefined) piClient.session.branch = parsed.branch;
+        if (parsed.gitDirty !== undefined) piClient.session.gitDirty = parsed.gitDirty;
+        if (parsed.gitChanges !== undefined) piClient.session.gitChanges = parsed.gitChanges;
+        if (parsed.contextWindow !== undefined) piClient.session.contextWindow = parsed.contextWindow;
+        if (parsed.diffityPort !== undefined) piClient.session.diffityPort = parsed.diffityPort;
+        if (parsed.thinkingLevel !== undefined) piClient.session.thinkingLevel = parsed.thinkingLevel;
+        piClient.session.lastActivity = Date.now();
+        broadcastToBrowsers({ type: "session_updated", session: piClient.session });
+        return;
+      }
+
+      // Session switch (e.g., /resume) — update session info
+      if (parsed.type === "session_switch" && piClient) {
+        if (parsed.cwd) piClient.session.cwd = parsed.cwd;
+        if (parsed.branch) piClient.session.branch = parsed.branch;
+        if (parsed.sessionFile) piClient.session.sessionFile = parsed.sessionFile;
+        piClient.session.lastActivity = Date.now();
+        broadcastToBrowsers({ type: "session_updated", session: piClient.session });
+        log(`session switched: PID ${piClient.session.pid}, cwd: ${parsed.cwd}`);
+        return;
+      }
+
+      // Forward pi event to browsers watching this session + buffer
+      if (piClient) {
+        piClient.session.lastActivity = Date.now();
+        const pid = piClient.session.pid;
+        const raw = data.toString();
+
+        // Buffer the event for replay on browser connect
+        // Skip extension_ui_request — these are one-time interactions
+        if (parsed.type !== "extension_ui_request") {
+          piClient.eventBuffer.push(raw);
+          if (piClient.eventBuffer.length > 5000) piClient.eventBuffer.shift();
+        }
+
+        for (const browser of browserClients) {
+          if (browserWatchMap.get(browser) === pid) {
+            try { browser.send(raw); } catch {}
+          }
+        }
+      }
+    } catch (e: any) {
+      log(`pi message parse error: ${e.message}`);
+    }
+  });
+
+  ws.on("close", () => {
+    if (piClient) {
+      const pid = piClient.session.pid;
+      piClient.session.active = false;
+      piClient.ws = null;
+      log(`session disconnected: PID ${pid} (kept as inactive)`);
+      broadcastToBrowsers({ type: "session_updated", session: piClient.session });
+    }
+  });
+
+  ws.on("error", (e: Error) => {
+    log(`pi ws error: ${e.message}`);
+    if (piClient) {
+      piClient.session.active = false;
+      piClient.ws = null;
+    }
+  });
+});
+
+// Browser clients
+const browserWss = new WebSocket.Server({ noServer: true });
+browserWss.on("connection", (ws: any) => {
+  browserClients.add(ws);
+  browserWatchMap.set(ws, null);
+  log(`browser connected (total: ${browserClients.size})`);
+
+  ws.on("message", (data: Buffer) => {
+    try {
+      const parsed = JSON.parse(data.toString());
+
+      if (parsed.type === "watch") {
+        browserWatchMap.set(ws, parsed.pid ?? null);
+        log(`browser watching PID: ${parsed.pid}`);
+        // Replay buffered events
+        if (parsed.pid) {
+          const client = piClients.get(parsed.pid);
+          if (client) {
+            for (const event of client.eventBuffer) {
+              try { ws.send(event); } catch {}
+            }
+            log(`replayed ${client.eventBuffer.length} events for PID ${parsed.pid}`);
+          }
+        }
+        return;
+      }
+
+      if (parsed.type === "prompt" && parsed.pid && parsed.text) {
+        const piClient = piClients.get(parsed.pid);
+        if (piClient) {
+          piClient.ws.send(JSON.stringify({ type: "prompt", text: parsed.text }));
+          log(`prompt forwarded to PID ${parsed.pid}: ${parsed.text.slice(0, 50)}`);
+        }
+        return;
+      }
+
+      // Forward extension UI responses (ask_user answers) to pi session
+      if (parsed.type === "extension_ui_response" && parsed.pid && parsed.id) {
+        const piClient = piClients.get(parsed.pid);
+        if (piClient && piClient.ws) {
+          const response: any = { type: "extension_ui_response", id: parsed.id };
+          if (parsed.value !== undefined) response.value = parsed.value;
+          if (parsed.confirmed !== undefined) response.confirmed = parsed.confirmed;
+          if (parsed.cancelled) response.cancelled = true;
+          piClient.ws.send(JSON.stringify(response));
+          log(`UI response forwarded to PID ${parsed.pid}: ${JSON.stringify(response).slice(0, 100)}`);
+        }
+        return;
+      }
+
+      // Forward pidash commands to pi session
+      if (parsed.type === "pidash-command" && parsed.pid) {
+        const piClient = piClients.get(parsed.pid);
+        if (piClient && piClient.ws) {
+          piClient.ws.send(JSON.stringify(parsed));
+          log(`command forwarded to PID ${parsed.pid}: ${parsed.command}`);
+        }
+        return;
+      }
+    } catch {}
+  });
+
+  ws.on("close", () => {
+    browserClients.delete(ws);
+    log(`browser disconnected (total: ${browserClients.size})`);
+  });
+
+  ws.on("error", () => browserClients.delete(ws));
+});
+
+function broadcastToBrowsers(event: object) {
+  const data = JSON.stringify(event);
+  for (const browser of browserClients) {
+    try { browser.send(data); } catch { browserClients.delete(browser); }
+  }
+}
+
+// Route upgrade requests to the correct WS server
+server.on("upgrade", (req: IncomingMessage, socket: any, head: Buffer) => {
+  const url = new URL(req.url || "/", `http://localhost:${port}`);
+
+  if (url.pathname === "/ws/pi") {
+    piWss.handleUpgrade(req, socket, head, (ws: any) => piWss.emit("connection", ws, req));
+  } else if (url.pathname === "/ws/browser") {
+    browserWss.handleUpgrade(req, socket, head, (ws: any) => browserWss.emit("connection", ws, req));
+  } else {
+    socket.destroy();
+  }
+});
+
+// Ping all pi clients every 30s to keep connections alive
+const pingInterval = setInterval(() => {
+  for (const [pid, client] of piClients) {
+    if (client.ws) {
+      try { client.ws.ping(); } catch {}
+    }
+  }
+}, 30000);
+if (pingInterval.unref) pingInterval.unref();
+
+// ── Start ───────────────────────────────────────────────────────────
+
+server.listen(port, "0.0.0.0", () => {
+  log(`pidash server listening on http://0.0.0.0:${port}`);
+});
+
+server.on("error", (err: any) => {
+  if (err.code === "EADDRINUSE") {
+    log(`port ${port} already in use — daemon likely already running`);
+    process.exit(0);
+  }
+  log(`server error: ${err.message}`);
+  process.exit(1);
+});
+
+process.on("SIGTERM", () => { log("SIGTERM received"); server.close(); process.exit(0); });
+process.on("SIGINT", () => { log("SIGINT received"); server.close(); process.exit(0); });


### PR DESCRIPTION
## Summary

Adds pidash — a web-based dashboard that runs alongside the TUI, accessible from any browser including phones. Monitor and interact with all running pi sessions from one place.

## Architecture

- **pidash-server.ts** — standalone daemon on port 19190 (auto-spawned by extension)
- **pidash.ts** — extension that connects to daemon, forwards events, handles commands
- **pidash-ui/** — React + Vite + shadcn/ui web application (built on first run)

## Features

### Core
- Multi-session dashboard with sidebar grouped by project
- Live conversation streaming (user, assistant, tool calls, thinking)
- Send messages from browser to pi
- Session history loaded on --continue and daemon reconnect
- Event buffering with batched replay

### Controls
- Model selector dropdown with fuzzy search
- Thinking level selector
- Extension commands work from browser (/release, /dream, /remember, etc.)
- Command autocomplete with descriptions (type / to see all)
- Abort/stop button during streaming (Esc key)
- Up/down arrow history navigation in chat input
- Shift+Enter for multiline input

### UI/UX
- Info bar: model, tokens, context %, git status, diffity link, async agent status
- Collapsible thinking and tool blocks (collapsed by default)
- Per-tool-type colors (bash=orange, subagent=pink, read=yellow, etc.)
- Copy button on all messages
- Search with text filter + type filter (dynamic from actual message roles)
- Resizable and collapsible sidebar
- State persistence across refresh (localStorage)
- Inactive session tracking (grayed out)
- Mobile responsive (sidebar overlay, safe areas, pull-to-refresh)

### Dialog bridging
- ask_user tool: inline clickable options in chat (not popup)
- Dangerous command dialogs: answer from browser or TUI (synced both ways via AbortController)
- Free-text input support for input dialogs
- Confirm dialogs properly send confirmed: true/false
- All ctx.ui.select/confirm wrapped globally — works for any extension

### Other changes
- diffity.ts: emits port via pi.events for pidash
- async-agents.ts: emits status via pi.events for pidash
- ask-user.ts: bridges to browser via pi.events
- enforcement.ts: restored to simple ctx.ui.select (global wrapper handles bridging)
- index.ts: wraps registerCommand to capture handlers for browser command execution
- README.md + AGENTS.md: documentation updated

## Peer reviewed
- 3 internal reviewers (quality, security, guidelines)
- Cursor peer review (6 rounds, all findings resolved)

Closes #145