### PR TITLE
fix(pidash): robust ws module resolution, connecting flag reset, and acpx timeout rule

### DIFF
--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -12,6 +12,7 @@
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as http from "node:http";
+import { createRequire } from "node:module";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { commandHandlerRegistry } from "./index.js";
@@ -194,7 +195,8 @@ export function registerPidash(pi: ExtensionAPI): void {
     }
 
     try {
-      const WebSocket = require("ws");
+      const _require = createRequire(import.meta.url);
+      const WebSocket = _require("ws");
       debugLog("creating WebSocket client...");
       const wsClient = new WebSocket(`ws://127.0.0.1:${PIDASH_PORT}/ws/pi`);
 
@@ -535,6 +537,7 @@ export function registerPidash(pi: ExtensionAPI): void {
       });
     } catch (e: any) {
       debugLog(`connect error: ${e.message}`);
+      connecting = false;
     }
   }
 

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -189,6 +189,7 @@ export function registerPidash(pi: ExtensionAPI): void {
       if (!(await isDaemonRunning())) {
         debugLog("daemon failed to start after 60s");
         spawning = false;
+        connecting = false;
         return;
       }
       spawning = false;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Orchestrator pattern for pi: specialist subagents, enforcement, code review loop, workflow commands",
   "keywords": ["pi-package"],
   "license": "MIT",
+  "dependencies": {
+    "ws": "^8.0.0"
+  },
   "pi": {
     "extensions": ["./extensions"],
     "prompts": ["./prompts"]

--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -17,9 +17,11 @@ $ARGUMENTS
 > `openclaw/acpx` for acpx CLI issues.
 > Do not silently skip steps or apply manual fixes that hide the root cause.
 
-🚨 **CRITICAL: NEVER set a timeout on any acpx command.** External agents can take
-minutes to complete (reading files, thinking, multi-step tool calls). Any bash call
-running acpx MUST NOT include a timeout parameter. Let it run until it finishes.
+🚨 **CRITICAL: NEVER set a timeout on acpx agent execution commands** (Step 5 and Step 9).
+External agents can take minutes to complete (reading files, thinking, multi-step tool calls).
+Any bash call running an acpx prompt MUST NOT include a timeout parameter. Let it run
+until it finishes. Quick probes (`acpx --version`, `sessions ensure/new`) may use
+bounded timeouts (e.g., 30s).
 
 Run a prompt through [acpx](https://github.com/openclaw/acpx) to any ACP-compatible coding agent.
 
@@ -273,9 +275,9 @@ When multiple agents are specified (without `--peer`), run all agents **in paral
 
 **Shell safety:** Single-quote the prompt to prevent shell expansion. Replace any single quotes in the prompt with `'\''` before interpolation.
 
-**No timeout:** NEVER pass a timeout parameter to bash when running acpx commands.
-Agents need time to read files, think, and execute multi-step tool calls. Let the
-command run until completion.
+**No timeout:** NEVER pass a timeout parameter to bash when running acpx agent
+execution commands (this step and Step 9). Agents need time to read files, think,
+and execute multi-step tool calls. Let the command run until completion.
 
 **Error handling:**
 

--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -17,6 +17,10 @@ $ARGUMENTS
 > `openclaw/acpx` for acpx CLI issues.
 > Do not silently skip steps or apply manual fixes that hide the root cause.
 
+🚨 **CRITICAL: NEVER set a timeout on any acpx command.** External agents can take
+minutes to complete (reading files, thinking, multi-step tool calls). Any bash call
+running acpx MUST NOT include a timeout parameter. Let it run until it finishes.
+
 Run a prompt through [acpx](https://github.com/openclaw/acpx) to any ACP-compatible coding agent.
 
 ## Supported Agents
@@ -268,6 +272,10 @@ When multiple agents are specified (without `--peer`), run all agents **in paral
 ```
 
 **Shell safety:** Single-quote the prompt to prevent shell expansion. Replace any single quotes in the prompt with `'\''` before interpolation.
+
+**No timeout:** NEVER pass a timeout parameter to bash when running acpx commands.
+Agents need time to read files, think, and execute multi-step tool calls. Let the
+command run until completion.
 
 **Error handling:**
 


### PR DESCRIPTION
## Problem

After running `pi update` and relaunching, the pidash extension fails to connect to the daemon. The dashboard shows no active session.

**Root causes:**
1. `require("ws")` fails under jiti's module resolution after pi update
2. `connecting` flag never resets on error, permanently blocking reconnection
3. `ws` was an undeclared ambient dependency
4. acpx prompt template had no timeout guidance, causing agent commands to be killed mid-execution

## Changes

### `extensions/orchestrator/pidash.ts`
- Use `createRequire(import.meta.url)` for ws module resolution — works reliably with jiti
- Reset `connecting = false` on daemon startup timeout (60s) early return path
- Reset `connecting = false` in the catch block of `connect()`

### `package.json`
- Declare `ws: ^8.0.0` as explicit dependency instead of relying on hoisting

### `prompts/acpx-prompt.md`
- Add no-timeout rule scoped to agent execution commands (Step 5/9)
- Quick probes (`acpx --version`, `sessions ensure/new`) may use bounded timeouts

## Review

- Peer reviewed by Cursor (2 rounds, all findings addressed)

Fixes #148