### PR TITLE
feat(memory): self-contained dreaming — auto-prune, merge duplicates, single command

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -34,6 +34,7 @@ interface AsyncJob {
   exitCode?: number | null;
   durationMs?: number;
   delivered?: boolean;
+  fireAndForget?: boolean;
 }
 
 interface AsyncState {
@@ -65,7 +66,7 @@ export function formatDuration(ms: number): string {
 export function registerAsyncAgents(
   pi: ExtensionAPI,
   terminalNotify: (title: string, body: string) => void,
-): { spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[]) => { id: string; error?: string } } {
+): { spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean }) => { id: string; error?: string } } {
   const asyncState: AsyncState = {
     jobs: new Map(),
     poller: null,
@@ -143,8 +144,8 @@ export function registerAsyncAgents(
       // Notify user
       terminalNotify("pi", `Async agent ${data.agent} ${data.success ? "completed" : "failed"} (${formatDuration(data.durationMs)})`);
 
-      // Surface result in conversation
-      if (asyncState.lastCtx) {
+      // Surface result in conversation (skip for fire-and-forget jobs)
+      if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
         const output = (data.output || "").slice(0, 3000);
         pi.sendMessage({
@@ -189,6 +190,7 @@ export function registerAsyncAgents(
     task: string,
     cwd: string,
     agents: AgentConfig[],
+    options?: { fireAndForget?: boolean },
   ): { id: string; error?: string } {
     const agent = agents.find(a => a.name === agentName);
     if (!agent) return { id: "", error: `Unknown agent: "${agentName}"` };
@@ -260,6 +262,7 @@ export function registerAsyncAgents(
       asyncDir,
       startedAt: Date.now(),
       updatedAt: Date.now(),
+      fireAndForget: options?.fireAndForget,
     };
     asyncState.jobs.set(id, job);
     updateAsyncWidget();

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -81,6 +81,9 @@ const SubagentParams = Type.Object({
   async: Type.Optional(
     Type.Boolean({ description: "Run in background (default: false). Agent runs detached, results surface when complete.", default: false }),
   ),
+  fireAndForget: Type.Optional(
+    Type.Boolean({ description: "When true with async, skip result delivery to conversation. Agent runs silently — only terminal notification on completion. Use for maintenance tasks like memory dreaming.", default: false }),
+  ),
 });
 
 // ── Interfaces ───────────────────────────────────────────────────────────
@@ -462,7 +465,7 @@ export async function runSingleAgent(
 
 export function registerSubagentTool(
   pi: ExtensionAPI,
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[]) => { id: string; error?: string },
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean }) => { id: string; error?: string },
 ): void {
   // Only the orchestrator (top-level pi) can spawn subagents.
   // Child processes set PI_SUBAGENT_CHILD=1 to prevent infinite recursion.
@@ -575,7 +578,7 @@ export function registerSubagentTool(
             isError: true,
           };
         }
-        const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents);
+        const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents, { fireAndForget: params.fireAndForget });
         if (result.error) {
           return {
             content: [{ type: "text", text: result.error }],

--- a/myk_pi_tools/memory/store.py
+++ b/myk_pi_tools/memory/store.py
@@ -7,6 +7,7 @@ The scoring, pruning, and dreaming features are inspired by OpenClaw's
 See: https://docs.openclaw.ai/concepts/dreaming
 """
 
+import re
 import sqlite3
 import sys
 from datetime import datetime, timezone
@@ -431,8 +432,133 @@ class MemoryDB:
         finally:
             conn.close()
 
+    def _find_duplicates(self) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+        """Find duplicate memory pairs using exact and fuzzy matching.
+
+        Compares every pair of memories for similarity:
+        - Exact match: normalized summaries identical (case-insensitive, stripped)
+        - Fuzzy match: Jaccard similarity of word sets >= 0.75
+
+        Returns:
+            List of (keep, remove) tuples. The memory with higher recall_count
+            is kept; ties broken by higher id (newer).
+        """
+        if not self.db_path.exists():
+            return []
+
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                "SELECT id, date, category, sentiment, summary, details, tags,"
+                " recall_count, last_recalled FROM memories"
+            )
+            memories = [dict(row) for row in cursor.fetchall()]
+        except sqlite3.Error as e:
+            log(f"Database error: {e}")
+            return []
+        finally:
+            conn.close()
+
+        if len(memories) < 2:
+            return []
+
+        def _normalize(text: str) -> str:
+            return text.strip().lower()
+
+        def _tokenize(text: str) -> set[str]:
+            tokens = set()
+            for word in text.lower().split():
+                cleaned = re.sub(r"[^a-z0-9]", "", word)
+                if cleaned:
+                    tokens.add(cleaned)
+            return tokens
+
+        def _jaccard(set_a: set[str], set_b: set[str]) -> float:
+            if not set_a and not set_b:
+                return 1.0
+            union = set_a | set_b
+            if not union:
+                return 0.0
+            return len(set_a & set_b) / len(union)
+
+        def _pick_keep_remove(a: dict[str, Any], b: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+            rc_a = a.get("recall_count") or 0
+            rc_b = b.get("recall_count") or 0
+            if rc_a > rc_b:
+                return a, b
+            if rc_b > rc_a:
+                return b, a
+            # Equal recall_count — keep newer (higher id)
+            return (a, b) if a["id"] > b["id"] else (b, a)
+
+        # Pre-compute normalized summaries and token sets
+        norm_cache: dict[int, str] = {}
+        token_cache: dict[int, set[str]] = {}
+        for m in memories:
+            norm_cache[m["id"]] = _normalize(m["summary"])
+            token_cache[m["id"]] = _tokenize(m["summary"])
+
+        matched_ids: set[int] = set()
+        pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+
+        for i, a in enumerate(memories):
+            if a["id"] in matched_ids:
+                continue
+            for b in memories[i + 1 :]:
+                if b["id"] in matched_ids:
+                    continue
+
+                is_dup = False
+                # Exact match
+                if norm_cache[a["id"]] == norm_cache[b["id"]]:
+                    is_dup = True
+                # Fuzzy match
+                elif _jaccard(token_cache[a["id"]], token_cache[b["id"]]) >= 0.75:
+                    is_dup = True
+
+                if is_dup:
+                    keep, remove = _pick_keep_remove(a, b)
+                    pairs.append((keep, remove))
+                    matched_ids.add(a["id"])
+                    matched_ids.add(b["id"])
+                    break  # a is matched, move to next i
+
+        return pairs
+
+    def merge_duplicates(self, dry_run: bool = True) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+        """Detect and merge duplicate memories.
+
+        Args:
+            dry_run: If True, return duplicate pairs without deleting.
+
+        Returns:
+            List of (keep, remove) pairs.
+        """
+        pairs = self._find_duplicates()
+
+        if not dry_run and pairs:
+            conn = self._connect(readonly=False)
+            try:
+                ids_to_delete = [remove["id"] for _, remove in pairs]
+                placeholders = ",".join("?" * len(ids_to_delete))
+                conn.execute(
+                    f"DELETE FROM memories WHERE id IN ({placeholders})",
+                    ids_to_delete,
+                )
+                conn.commit()
+            finally:
+                conn.close()
+
+        return pairs
+
     def dream(self) -> str:
-        """Run memory consolidation — score, analyze, generate dream report.
+        """Run full memory consolidation — score, prune, merge duplicates, report.
+
+        Self-contained action that performs ALL maintenance in one call:
+        1. Score all memories
+        2. Prune low-value memories (actually deletes them)
+        3. Merge duplicate memories (actually deletes duplicates)
+        4. Generate a report of everything done
 
         Inspired by OpenClaw's dreaming system which consolidates short-term
         signals into durable memory. See: https://docs.openclaw.ai/concepts/dreaming
@@ -443,7 +569,7 @@ class MemoryDB:
 
         scored = self.score_memories(limit=10000)
         stats = self.stats()
-        pruned = self.prune(dry_run=True)
+        pruned = self.prune(dry_run=False)
 
         now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
@@ -466,15 +592,32 @@ class MemoryDB:
                 lines.append(f"- [{m['score']}] ({m['category']}) {m['summary']}")
             lines.append("")
 
-        # Prune candidates
+        # Pruned
         if pruned:
-            lines.append(f"## Prune candidates ({len(pruned)})")
+            lines.append(f"## Pruned ({len(pruned)})")
             for m in pruned:
                 lines.append(f"- #{m['id']} ({m['category']}) {m['summary']} — {m['prune_reason']}")
             lines.append("")
         else:
-            lines.append("## Prune candidates")
+            lines.append("## Pruned")
             lines.append("None — all memories are healthy.")
+            lines.append("")
+
+        # Duplicates
+        merged_pairs = self.merge_duplicates(dry_run=False)
+        if merged_pairs:
+            lines.append(f"## Duplicates merged ({len(merged_pairs)})")
+            for keep, remove in merged_pairs:
+                keep_rc = keep.get("recall_count") or 0
+                remove_rc = remove.get("recall_count") or 0
+                lines.append(
+                    f'- Kept #{keep["id"]} "{keep["summary"]}" (recall: {keep_rc}),'
+                    f' removed #{remove["id"]} "{remove["summary"]}" (recall: {remove_rc})'
+                )
+            lines.append("")
+        else:
+            lines.append("## Duplicates merged")
+            lines.append("No duplicates found.")
             lines.append("")
 
         return "\n".join(lines)

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -14,13 +14,18 @@ Inspired by [OpenClaw's dreaming system](https://docs.openclaw.ai/concepts/dream
 
 Run memory consolidation as a **background async agent** — never block the session.
 
-Delegate to a `worker` agent with `async: true`:
+Dreaming is a **self-contained action** — one command does everything:
+
+1. Scores all memories by recall frequency, recency, age, and category
+2. Prunes low-value memories (actually deletes them)
+3. Merges duplicate memories (detects via text similarity)
+4. Generates a report of everything done
+
+Delegate to a `worker` agent with `async: true` and `fireAndForget: true` (no result injection into conversation):
 
 ```text
 Task:
-1. Run: uv run myk-pi-tools memory dream
-2. Run: uv run myk-pi-tools memory prune (dry-run, report candidates)
-3. Report the dream output and prune candidates
+Run: uv run myk-pi-tools memory dream
 ```
 
 Tell the user: "Running memory consolidation in background..."

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -68,9 +68,12 @@ Memory consolidation runs as a **background async agent** — never blocking the
 
 ### What it does
 
+Dreaming is a **self-contained action** — one command does everything:
+
 1. **Scores** all memories by recall frequency, recency, age, and category
-2. **Identifies** prune candidates (low-score, never-recalled, stale)
-3. **Writes** a dream report to `.pi/memory/dreams.md`
+2. **Prunes** low-value memories (actually deletes them)
+3. **Merges** duplicate memories (detects via text similarity)
+4. **Writes** a dream report to `.pi/memory/dreams.md`
 
 ### CLI Commands
 
@@ -84,5 +87,5 @@ uv run myk-pi-tools memory dream           # Run consolidation + report
 
 ### Rules
 
-- **ALWAYS run dreaming as async agent** — never block the session
+- **ALWAYS run dreaming as async + fireAndForget** — never block the session, never inject results into conversation
 - Tell the user: "Running memory consolidation in background..."

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -244,7 +244,7 @@ class TestDream:
         assert "Dream Report" in report
         assert "Total memories: 1" in report
 
-    def test_dream_shows_prune_candidates(self, memory_db: MemoryDB) -> None:
+    def test_dream_prunes_low_value_memories(self, memory_db: MemoryDB) -> None:
         memory_db.add(category="done", summary="Old task")
         # Make it old so it becomes a prune candidate
         conn = memory_db._connect(readonly=False)
@@ -252,8 +252,156 @@ class TestDream:
         conn.commit()
         conn.close()
         report = memory_db.dream()
-        assert "Prune candidates" in report
+        assert "Pruned" in report
+        # Verify it was actually deleted
+        assert len(memory_db.list_memories()) == 0
 
     def test_dream_returns_string(self, memory_db: MemoryDB) -> None:
         report = memory_db.dream()
         assert isinstance(report, str)
+
+    def test_dream_no_duplicates(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Unique lesson")
+        report = memory_db.dream()
+        assert "## Duplicates merged" in report
+        assert "No duplicates found." in report
+
+    def test_dream_merges_exact_duplicates(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Same lesson")
+        memory_db.add(category="lesson", summary="Same lesson")
+        report = memory_db.dream()
+        assert "## Duplicates merged (1)" in report
+        assert "removed #" in report
+        # Should have deleted the duplicate
+        assert len(memory_db.list_memories()) == 1
+
+
+class TestFindDuplicates:
+    def test_no_duplicates(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="First unique lesson")
+        memory_db.add(category="lesson", summary="Completely different topic")
+        pairs = memory_db._find_duplicates()
+        assert pairs == []
+
+    def test_empty_db(self, memory_db: MemoryDB) -> None:
+        pairs = memory_db._find_duplicates()
+        assert pairs == []
+
+    def test_single_memory(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Only one")
+        pairs = memory_db._find_duplicates()
+        assert pairs == []
+
+    def test_exact_match(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Use uv run for Python")
+        memory_db.add(category="lesson", summary="Use uv run for Python")
+        pairs = memory_db._find_duplicates()
+        assert len(pairs) == 1
+        keep, remove = pairs[0]
+        # Same recall_count (0), so keep newer (higher id)
+        assert keep["id"] > remove["id"]
+
+    def test_exact_match_case_insensitive(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Use UV Run")
+        memory_db.add(category="lesson", summary="use uv run")
+        pairs = memory_db._find_duplicates()
+        assert len(pairs) == 1
+
+    def test_exact_match_whitespace_stripped(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="  spaced out  ")
+        memory_db.add(category="lesson", summary="spaced out")
+        pairs = memory_db._find_duplicates()
+        assert len(pairs) == 1
+
+    def test_fuzzy_match_high_similarity(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="use uv run for python scripts")
+        memory_db.add(category="lesson", summary="use uv run for python scripts always")
+        # 5/6 words overlap = Jaccard ~0.83
+        pairs = memory_db._find_duplicates()
+        assert len(pairs) == 1
+
+    def test_fuzzy_match_below_threshold(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="use uv run for python")
+        memory_db.add(category="lesson", summary="docker build container image deploy")
+        pairs = memory_db._find_duplicates()
+        assert pairs == []
+
+    def test_keeps_higher_recall_count(self, memory_db: MemoryDB) -> None:
+        _id1 = memory_db.add(category="lesson", summary="duplicate lesson", tags="dup")
+        memory_db.add(category="lesson", summary="duplicate lesson", tags="dup")
+        # Recall id1 several times to boost its recall count
+        for _ in range(5):
+            memory_db.search("duplicate")
+        pairs = memory_db._find_duplicates()
+        assert len(pairs) == 1
+        keep, remove = pairs[0]
+        # id1 was recalled more (both get recalled on search, but id1 has more total)
+        assert keep.get("recall_count", 0) >= remove.get("recall_count", 0)
+
+    def test_keeps_newer_on_equal_recall(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="same thing")
+        id2 = memory_db.add(category="lesson", summary="same thing")
+        pairs = memory_db._find_duplicates()
+        assert len(pairs) == 1
+        keep, _remove = pairs[0]
+        assert keep["id"] == id2  # newer (higher id) kept
+
+    def test_each_memory_appears_once(self, memory_db: MemoryDB) -> None:
+        # Add 3 identical memories — only 1 pair should be formed
+        # (the third is already matched in a pair)
+        memory_db.add(category="lesson", summary="triple dup")
+        memory_db.add(category="lesson", summary="triple dup")
+        memory_db.add(category="lesson", summary="triple dup")
+        pairs = memory_db._find_duplicates()
+        # Each memory appears in at most one pair
+        seen_ids: set[int] = set()
+        for keep, remove in pairs:
+            assert keep["id"] not in seen_ids
+            assert remove["id"] not in seen_ids
+            seen_ids.add(keep["id"])
+            seen_ids.add(remove["id"])
+
+    def test_punctuation_handling(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="don't use pip! ever.")
+        memory_db.add(category="lesson", summary="don't use pip ever")
+        pairs = memory_db._find_duplicates()
+        assert len(pairs) == 1
+
+
+class TestMergeDuplicates:
+    def test_dry_run_no_delete(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="dup entry")
+        memory_db.add(category="lesson", summary="dup entry")
+        pairs = memory_db.merge_duplicates(dry_run=True)
+        assert len(pairs) == 1
+        # Both still exist
+        assert len(memory_db.list_memories()) == 2
+
+    def test_merge_deletes_duplicates(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="dup entry")
+        memory_db.add(category="lesson", summary="dup entry")
+        pairs = memory_db.merge_duplicates(dry_run=False)
+        assert len(pairs) == 1
+        remaining = memory_db.list_memories()
+        assert len(remaining) == 1
+        # The kept one should still be there
+        keep, _remove = pairs[0]
+        assert remaining[0]["id"] == keep["id"]
+
+    def test_merge_no_duplicates(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="Unique A")
+        memory_db.add(category="lesson", summary="Unique B")
+        pairs = memory_db.merge_duplicates(dry_run=False)
+        assert pairs == []
+        assert len(memory_db.list_memories()) == 2
+
+    def test_merge_multiple_pairs(self, memory_db: MemoryDB) -> None:
+        memory_db.add(category="lesson", summary="alpha duplicate")
+        memory_db.add(category="lesson", summary="alpha duplicate")
+        memory_db.add(category="mistake", summary="beta duplicate")
+        memory_db.add(category="mistake", summary="beta duplicate")
+        memory_db.add(category="done", summary="unique entry")
+        pairs = memory_db.merge_duplicates(dry_run=False)
+        assert len(pairs) == 2
+        remaining = memory_db.list_memories()
+        assert len(remaining) == 3  # 2 kept + 1 unique


### PR DESCRIPTION
## Summary

Makes dreaming a fully self-contained action and adds a `fireAndForget` async mode to prevent background tasks from interrupting active work.

## Changes

### Self-contained dreaming (`myk_pi_tools/memory/store.py`)
- `dream()` now performs ALL maintenance in one call: score, prune, merge duplicates, report
- `_find_duplicates()` — detect duplicates via exact match and Jaccard similarity (≥0.75)
- `merge_duplicates(dry_run)` — merge pairs, keeping higher recall_count
- `prune()` now actually deletes in dream (was preview-only)

### Fire-and-forget async mode (`extensions/orchestrator/`)
- `async-agents.ts` — `fireAndForget` option on `AsyncJob` and `spawnAsyncAgent`
  - Skips `sendMessage` + `triggerTurn` for fire-and-forget jobs
  - Terminal notification still shows completion status
- `subagent-tool.ts` — exposed `fireAndForget` parameter in subagent tool schema

### Documentation
- `prompts/dream.md` — uses `fireAndForget: true`, single command
- `rules/35-memory.md` — documents self-contained behavior and fireAndForget rule

### Tests
- 18 new tests (52 total): `TestFindDuplicates` (12), `TestMergeDuplicates` (4), `TestDream` (2)

Fixes #146