### PR TITLE
feat: leverage pi 0.67.x — argument hints, lighter subagents, pidash provider info

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -203,7 +203,7 @@ export function registerAsyncAgents(
     fs.mkdirSync(ASYNC_RESULTS_DIR, { recursive: true, mode: 0o700 });
 
     // Build pi args
-    const piArgs: string[] = ["--mode", "json", "-p", "--no-session"];
+    const piArgs: string[] = ["--mode", "json", "-p", "--no-session", "-nc"];
     if (agent.model) piArgs.push("--model", agent.model);
     if (agent.tools?.length) piArgs.push("--tools", agent.tools.join(","));
 

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -20,7 +20,7 @@ const DREAM_INTERVAL_MS = DREAM_INTERVAL_HOURS * 60 * 60 * 1000;
 
 export function registerDreaming(
   pi: ExtensionAPI,
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: any[]) => { id: string; error?: string },
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: any[], options?: { fireAndForget?: boolean }) => { id: string; error?: string },
 ): void {
   // Only the orchestrator (top-level pi) runs dreaming — skip in subagent children
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
@@ -37,9 +37,10 @@ export function registerDreaming(
     const { agents } = discoverAgents(cwd, "user");
     const { id } = spawnAsyncAgent(
       "worker",
-      "Run memory consolidation: `uv run myk-pi-tools memory dream`. Report the output.",
+      "Run memory consolidation: `uv run myk-pi-tools memory dream`.",
       cwd,
       agents,
+      { fireAndForget: true },
     );
     // Reset flag after reasonable timeout (dream should complete in <5 min)
     if (id) setTimeout(() => { dreamInFlight = false; }, 5 * 60 * 1000);

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -724,6 +724,22 @@ export function registerPidash(pi: ExtensionAPI): void {
     }
   });
 
+  // Forward provider response info to pidash
+  pi.on("after_provider_response" as any, (event: any) => {
+    if (!ws || !connected) return;
+    try {
+      const info: any = { type: "provider_response" };
+      if (event.status) info.status = event.status;
+      if (event.headers) {
+        if (event.headers["x-ratelimit-remaining"]) info.rateLimitRemaining = event.headers["x-ratelimit-remaining"];
+        if (event.headers["x-ratelimit-reset"]) info.rateLimitReset = event.headers["x-ratelimit-reset"];
+        if (event.headers["retry-after"]) info.retryAfter = event.headers["retry-after"];
+        if (event.headers["x-request-id"]) info.requestId = event.headers["x-request-id"];
+      }
+      ws.send(JSON.stringify(info));
+    } catch {}
+  });
+
   // Periodically update git status
   const statusInterval = setInterval(() => {
     if (!ws || !connected || !lastCtx) return;

--- a/prompts/acpx-prompt.md
+++ b/prompts/acpx-prompt.md
@@ -1,5 +1,6 @@
 ---
 description: "Run a prompt via acpx to any coding agent (cursor, codex, gemini, claude, copilot, droid, kiro, opencode, qwen, etc.). Use for peer review, code review, or any task involving an external AI agent — /acpx-prompt <agent> <prompt>"
+argument-hint: "<agent[:model]> [--fix|--peer] <prompt>"
 ---
 
 ## Raw Arguments

--- a/prompts/coderabbit-rate-limit.md
+++ b/prompts/coderabbit-rate-limit.md
@@ -1,5 +1,6 @@
 ---
 description: Handle CodeRabbit rate limits - waits and re-triggers review automatically
+argument-hint: "[PR number]"
 ---
 
 ## Raw Arguments

--- a/prompts/implement-and-review.md
+++ b/prompts/implement-and-review.md
@@ -1,5 +1,6 @@
 ---
 description: "Implement → 3 parallel reviewers → fix — /implement-and-review <task>"
+argument-hint: "<task>"
 ---
 
 ## Raw Arguments

--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -1,5 +1,6 @@
 ---
 description: "Scout → plan → implement a task — /implement <task>"
+argument-hint: "<task>"
 ---
 
 ## Raw Arguments

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -1,5 +1,6 @@
 ---
 description: Review a GitHub PR and post inline comments on selected findings
+argument-hint: "[PR number or URL]"
 ---
 
 ## Raw Arguments

--- a/prompts/query-db.md
+++ b/prompts/query-db.md
@@ -1,5 +1,6 @@
 ---
 description: Query the reviews database for analytics and insights
+argument-hint: "<query>"
 ---
 
 ## Raw Arguments

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -1,5 +1,6 @@
 ---
 description: Refine pending PR review comments with AI before submitting
+argument-hint: "[instructions]"
 ---
 
 ## Raw Arguments

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -1,5 +1,6 @@
 ---
 description: Create a GitHub release with automatic changelog generation
+argument-hint: "[version]"
 ---
 
 ## Raw Arguments

--- a/prompts/remember.md
+++ b/prompts/remember.md
@@ -1,5 +1,6 @@
 ---
 description: "Save a memory for future sessions — /remember <what to remember>"
+argument-hint: "<what to remember>"
 ---
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -1,5 +1,6 @@
 ---
 description: Process ALL review sources (human, Qodo, CodeRabbit) from current PR
+argument-hint: "[--autorabbit]"
 ---
 
 ## Raw Arguments

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -1,5 +1,6 @@
 ---
 description: Review uncommitted changes or changes compared to a branch
+argument-hint: "[base branch]"
 ---
 
 ## Raw Arguments

--- a/prompts/scout-and-plan.md
+++ b/prompts/scout-and-plan.md
@@ -1,5 +1,6 @@
 ---
 description: "Scout → plan without implementing — /scout-and-plan <task>"
+argument-hint: "<task>"
 ---
 
 ## Raw Arguments


### PR DESCRIPTION
## Summary

Adopts features from pi 0.67.0–0.67.68 to improve UX and efficiency.

## Changes

### 1. Argument hints for all prompt templates (12 files)
Added `argument-hint` frontmatter (pi 0.67.6) to all prompts that accept args. Shows in `/` autocomplete:
- `acpx-prompt` → `<agent[:model]> [--fix|--peer] <prompt>`
- `implement` → `<task>`
- `pr-review` → `[PR number or URL]`
- `remember` → `<what to remember>`
- etc.

### 2. Lighter async agents (`async-agents.ts`)
Added `-nc` (no context files) flag to async agent spawning (pi 0.67.4). Agents already get instructions via `--append-system-prompt`, so AGENTS.md discovery is unnecessary overhead.

### 3. Provider response info in pidash (`pidash.ts`)
Uses `after_provider_response` hook (pi 0.67.4) to forward rate limit headers and status codes to the pidash dashboard.

### 4. Fire-and-forget auto-dreaming (`dreaming.ts`)
Timer-triggered dreams now use `fireAndForget: true` so they don't inject results into the conversation or interrupt active work.

## Note
Auto-dream on shutdown was already implemented in `dreaming.ts` — no changes needed there.

Fixes #151