### PR TITLE
feat(memory): dreaming extracts memories from session context, drops dreams.md

### DIFF
--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -30,14 +30,30 @@ export function registerDreaming(
   let lastCwd = "";
 
   let dreamInFlight = false;
+  let lastSessionFile = "";
 
   function runDreamAsync(cwd: string) {
     if (dreamInFlight) return; // Prevent concurrent dreams
     dreamInFlight = true;
     const { agents } = discoverAgents(cwd, "user");
+    const sessionArg = lastSessionFile ? `\n\nSession file to analyze: ${lastSessionFile}` : "";
     const { id } = spawnAsyncAgent(
       "worker",
-      "Run memory consolidation: `uv run myk-pi-tools memory dream`.",
+      `Memory dreaming — analyze and consolidate.${sessionArg}\n\n` +
+      `Steps:\n` +
+      `1. If a session file is provided, read it and look for things worth remembering:\n` +
+      `   - User corrections ("no, do it this way") → category: lesson, sentiment: negative\n` +
+      `   - User preferences ("I prefer X", "always do Y") → category: preference, sentiment: neutral\n` +
+      `   - Mistakes or repeated fix attempts → category: mistake, sentiment: negative\n` +
+      `   - Completed features/PRs merged → category: done, sentiment: positive\n` +
+      `   - Patterns or conventions discovered → category: pattern, sentiment: neutral\n` +
+      `   For each memory found, check existing memories first to avoid duplicates:\n` +
+      `   uv run myk-pi-tools memory search "<relevant keywords>"\n` +
+      `   Only add if not already captured:\n` +
+      `   uv run myk-pi-tools memory add -c <category> -s "<one-line summary>" -t "<tags>" --sentiment <sentiment>\n` +
+      `   Memory rules: one line only, max ~100 chars, specific and actionable, no fluff.\n` +
+      `2. Run maintenance: uv run myk-pi-tools memory dream\n` +
+      `3. Done. Do not report output.`,
       cwd,
       agents,
       { fireAndForget: true },
@@ -88,6 +104,7 @@ export function registerDreaming(
   // Update cwd on session start
   pi.on("session_start", (_event, ctx) => {
     lastCwd = ctx.cwd;
+    lastSessionFile = ctx.sessionFile || "";
     if (enabled) startTimer(ctx.cwd);
   });
 

--- a/myk_pi_tools/memory/commands.py
+++ b/myk_pi_tools/memory/commands.py
@@ -1,6 +1,5 @@
 """Memory CLI commands."""
 
-import fcntl
 import json
 import sys
 from pathlib import Path
@@ -259,17 +258,14 @@ def memory_prune(ctx: click.Context, min_score: float, max_age: int, apply: bool
                 click.echo(f"  #{m['id']} ({m['category']}) {m['summary']} — {m.get('prune_reason', '')}")
 
 
-_MAX_DREAM_REPORTS = 10
-
-
 @memory.command("dream")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 @click.pass_context
 def memory_dream(ctx: click.Context, output_json: bool) -> None:
-    """Run memory consolidation and generate dream report.
+    """Run memory consolidation — prune, merge duplicates, report.
 
-    Scores all memories, identifies prune candidates, and writes
-    a report to .pi/memory/dreams.md. Keeps only the last 10 reports.
+    Scores all memories, prunes low-value ones, merges duplicates.
+    All changes are made directly in the database.
 
     Examples:
 
@@ -279,33 +275,7 @@ def memory_dream(ctx: click.Context, output_json: bool) -> None:
     db = ctx.obj["db"]
     report = db.dream()
 
-    # Write dream report to file, rotating to keep only last N reports.
-    # Uses advisory file lock to prevent concurrent write races
-    # (e.g., /dream manual + auto-dream timer running simultaneously).
-    dream_path = db.db_path.parent / "dreams.md"
-    lock_path = dream_path.with_suffix(".lock")
-
-    wrote_file = False
-    try:
-        with open(lock_path, "w") as lock_fd:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            try:
-                existing = dream_path.read_text() if dream_path.exists() else ""
-                parts = [report] + [p for p in existing.split("\n---\n\n") if p.strip()]
-                parts = parts[:_MAX_DREAM_REPORTS]
-                dream_path.write_text("\n---\n\n".join(parts) + "\n")
-                wrote_file = True
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-    except BlockingIOError:
-        click.echo("Another dream is running — skipped file write.", err=True)
-    except OSError as e:
-        click.echo(f"Failed to write dream report: {e}", err=True)
-        sys.exit(1)
-
     if output_json:
-        click.echo(json.dumps({"report": report, "path": str(dream_path), "wrote_file": wrote_file}, indent=2))
+        click.echo(json.dumps({"report": report}, indent=2))
     else:
         click.echo(report)
-        if wrote_file:
-            click.echo(f"\nDream report written to {dream_path}", err=True)

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -16,10 +16,10 @@ Run memory consolidation as a **background async agent** — never block the ses
 
 Dreaming is a **self-contained action** — one command does everything:
 
-1. Scores all memories by recall frequency, recency, age, and category
-2. Prunes low-value memories (actually deletes them)
-3. Merges duplicate memories (detects via text similarity)
-4. Generates a report of everything done
+1. Analyzes the current session for things worth remembering
+2. Scores all memories by recall frequency, recency, age, and category
+3. Prunes low-value memories (actually deletes them)
+4. Merges duplicate memories (detects via text similarity)
 
 Delegate to a `worker` agent with `async: true` and `fireAndForget: true` (no result injection into conversation):
 

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -70,10 +70,10 @@ Memory consolidation runs as a **background async agent** — never blocking the
 
 Dreaming is a **self-contained action** — one command does everything:
 
-1. **Scores** all memories by recall frequency, recency, age, and category
-2. **Prunes** low-value memories (actually deletes them)
-3. **Merges** duplicate memories (detects via text similarity)
-4. **Writes** a dream report to `.pi/memory/dreams.md`
+1. **Extracts** useful memories from the current session (user corrections, preferences, lessons, completed work)
+2. **Scores** all memories by recall frequency, recency, age, and category
+3. **Prunes** low-value memories (actually deletes them)
+4. **Merges** duplicate memories (detects via text similarity)
 
 ### CLI Commands
 


### PR DESCRIPTION
## Summary

Dreaming now behaves like actual sleep — processes the session's experiences and consolidates useful knowledge into long-term memory (the db).

## Changes

### Session context extraction (`dreaming.ts`)
- Dream worker reads the current session JSONL file and looks for things worth remembering:
  - User corrections → lesson (negative)
  - User preferences → preference (neutral)
  - Mistakes/repeated fix attempts → mistake (negative)
  - Completed features/PRs → done (positive)
  - Patterns discovered → pattern (neutral)
- Checks existing memories to avoid duplicates before adding
- Then runs maintenance (prune + merge) via `myk-pi-tools memory dream`
- Shutdown dream remains lightweight (maintenance only, no session analysis)

### Drop dreams.md (`commands.py`)
- Removed file writing, fcntl locking, `_MAX_DREAM_REPORTS`
- Dream command just runs consolidation and prints report
- All results live in the memory db — loaded at session start automatically

### Documentation
- `rules/35-memory.md` — updated "What it does" to include session extraction
- `prompts/dream.md` — updated description

## Tests
52 tests pass

Fixes #153