### PR TITLE
feat(memory): replace SQLite DB with memory.md — LLM-native memory system

### DIFF
--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -10,6 +10,7 @@
  */
 
 import { spawn } from "node:child_process";
+import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { discoverAgents } from "./agents.js";
 
@@ -31,13 +32,37 @@ export function registerDreaming(
 
   let dreamInFlight = false;
 
-  function runDreamAsync(cwd: string) {
+  function runDreamAsync(cwd: string, lastSessionFile?: string) {
     if (dreamInFlight) return; // Prevent concurrent dreams
     dreamInFlight = true;
     const { agents } = discoverAgents(cwd, "user");
+    const memPath = path.join(cwd, ".pi", "memory", "memory.md");
+    const sessionArg = lastSessionFile ? `\nSession file: ${lastSessionFile}` : "";
     const { id } = spawnAsyncAgent(
       "worker",
-      "Run memory consolidation: `uv run myk-pi-tools memory dream`.",
+      `Memory dreaming — analyze session and maintain memory.md.${sessionArg}\nMemory file: ${memPath}\n\n` +
+      `Steps:\n` +
+      `1. Read the memory file (${memPath}).\n` +
+      `2. If a session file is provided, read it and extract things worth remembering:\n` +
+      `   - User corrections → [lesson]\n` +
+      `   - User preferences → [preference]\n` +
+      `   - Mistakes or repeated fix attempts → [mistake]\n` +
+      `   - Completed features/PRs merged → [done]\n` +
+      `   - Patterns or conventions → [pattern]\n` +
+      `   Add new entries to the Learned section. Do NOT add duplicates of existing entries.\n` +
+      `3. Reorganize the memory file:\n` +
+      `   - Remove duplicate or near-duplicate entries from Learned\n` +
+      `   - Remove stale/useless entries from Learned\n` +
+      `   - Keep file at a reasonable size (aim for under 50 entries)\n` +
+      `   - NEVER remove or modify entries in the Pinned section\n` +
+      `4. Write the updated file. Use the write tool to overwrite ${memPath}.\n` +
+      `   Keep the exact format:\n` +
+      `   # Memories\n` +
+      `   ## Pinned (user requested — never auto-remove)\n` +
+      `   - [category] summary\n` +
+      `   ## Learned (auto-extracted — dream may reorganize/remove)\n` +
+      `   - [category] summary\n` +
+      `5. Memory rules: one line per entry, max ~100 chars, specific and actionable, no fluff.`,
       cwd,
       agents,
       { fireAndForget: true },
@@ -98,14 +123,10 @@ export function registerDreaming(
     stopTimer();
     if (!enabled || !lastCwd || dreamInFlight) return;
 
+    // On shutdown, run a lightweight dream via detached async runner
+    // (can't use spawnAsyncAgent since the session is ending)
     try {
-      const proc = spawn(
-        "uv",
-        ["run", "myk-pi-tools", "memory", "dream"],
-        { cwd: lastCwd, detached: true, stdio: "ignore" },
-      );
-      proc.on("error", () => {}); // Swallow async spawn errors (best-effort)
-      proc.unref();
+      runDreamAsync(lastCwd);
     } catch {}
   });
 }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -1,6 +1,6 @@
 /**
  * Rule & memory injection — loads rules/*.md for the orchestrator
- * and recent project memories for all agents.
+ * and project memories from memory.md for all agents.
  */
 
 import { execFileSync } from "node:child_process";
@@ -10,6 +10,7 @@ import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 
 export function registerRules(pi: ExtensionAPI): void {
   const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
+  let migrationChecked = false;
 
   pi.on("before_agent_start", async (event, ctx) => {
     let extra = "";
@@ -33,16 +34,29 @@ export function registerRules(pi: ExtensionAPI): void {
       }
     }
 
-    // Project memories — injected for ALL agents (orchestrator + specialists)
-    const memories = loadRecentMemories(ctx.cwd);
+    // One-time migration: if memories.db exists, migrate to memory.md
+    if (!migrationChecked) {
+      migrationChecked = true;
+      try {
+        const memDir = path.join(ctx.cwd, ".pi", "memory");
+        const dbPath = path.join(memDir, "memories.db");
+        if (fs.existsSync(dbPath)) {
+          execFileSync(
+            "uv",
+            ["run", "myk-pi-tools", "memory", "migrate"],
+            { cwd: ctx.cwd, timeout: 10000, stdio: "ignore" },
+          );
+        }
+      } catch {}
+    }
+
+    // Project memories — read memory.md directly (no subprocess needed)
+    const memories = loadMemories(ctx.cwd);
     if (memories) {
       extra += memories;
       if (isSubagent) {
         extra +=
-          "\n\nYou can search for more project memories with:" +
-          " `uv run myk-pi-tools memory search \"<query>\"`" +
-          " — use this before implementing if the task relates to a past lesson or mistake." +
-          " **Do NOT write to memory** — only the orchestrator writes memories.\n";
+          "\n\n **Do NOT write to memory** — only the orchestrator writes memories.\n";
       }
     }
 
@@ -51,39 +65,15 @@ export function registerRules(pi: ExtensionAPI): void {
   });
 }
 
-interface Memory {
-  category: string;
-  summary: string;
-  tags?: string;
-}
-
-function truncate(text: string, max: number): string {
-  return text.length > max ? text.slice(0, max) + "…" : text;
-}
-
-// Loads recent memories from the per-repo SQLite DB (best-effort, non-critical)
-function loadRecentMemories(cwd: string): string {
+// Reads .pi/memory/memory.md directly — zero dependencies, instant
+function loadMemories(cwd: string): string {
   try {
-    const result = execFileSync(
-      "uv",
-      ["run", "myk-pi-tools", "memory", "list", "--last", "30", "-n", "10", "--json"],
-      { cwd, encoding: "utf-8", timeout: 5000, maxBuffer: 64 * 1024, stdio: ["ignore", "pipe", "ignore"] },
-    );
-    const memories: unknown[] = JSON.parse(result);
-    if (!Array.isArray(memories) || memories.length === 0) return "";
-
-    const SKIP_CATEGORIES = new Set(["done", "pattern"]);
-    const lines = memories
-      .filter((m): m is Memory => !!m && typeof m === "object" && "category" in m && "summary" in m)
-      .filter((m) => !SKIP_CATEGORIES.has(m.category))
-      .map(
-        (m) => `- [${m.category}] ${truncate(m.summary, 120)}${m.tags ? ` (${m.tags})` : ""}`,
-      );
-    if (lines.length === 0) return "";
-
-    return "\n\n# Project Memories\n\n" + lines.join("\n") + "\n";
+    const memPath = path.join(cwd, ".pi", "memory", "memory.md");
+    if (!fs.existsSync(memPath)) return "";
+    const content = fs.readFileSync(memPath, "utf-8").trim();
+    if (!content || content === "# Memories") return "";
+    return "\n\n" + content + "\n";
   } catch {
-    // Memory loading is best-effort — silently skip if CLI unavailable or DB empty
     return "";
   }
 }

--- a/myk_pi_tools/memory/__init__.py
+++ b/myk_pi_tools/memory/__init__.py
@@ -1,14 +1,14 @@
 """Project memory module.
 
-Persistent per-repo memory for lessons learned, decisions, mistakes, and patterns.
-Database location: <git-root>/.pi/memory/memories.db
+Persistent per-repo memory stored as a plain markdown file.
+File location: <git-root>/.pi/memory/memory.md
 
 Usage:
-    from myk_pi_tools.memory import MemoryDB
-    db = MemoryDB()
-    db.add(category="lesson", summary="buildah chown -R skips target dir with cache mounts", tags="docker,buildah")
+    from myk_pi_tools.memory import MemoryFile
+    mem = MemoryFile()
+    mem.add_pinned(category="lesson", summary="Always use uv run, never python directly")
 """
 
-from myk_pi_tools.memory.store import MemoryDB
+from myk_pi_tools.memory.store import MemoryFile
 
-__all__ = ["MemoryDB"]
+__all__ = ["MemoryFile"]

--- a/myk_pi_tools/memory/commands.py
+++ b/myk_pi_tools/memory/commands.py
@@ -1,23 +1,19 @@
 """Memory CLI commands."""
 
-import fcntl
-import json
-import sys
 from pathlib import Path
 
 import click
 
-from myk_pi_tools.db.query import _format_table
-from myk_pi_tools.memory.store import MemoryDB
+from myk_pi_tools.memory.store import MemoryFile
 
 
 @click.group()
-@click.option("--db-path", default=None, help="Path to database file")
+@click.option("--file-path", default=None, help="Path to memory file")
 @click.pass_context
-def memory(ctx: click.Context, db_path: str | None) -> None:
+def memory(ctx: click.Context, file_path: str | None) -> None:
     """Project memory commands — persistent per-repo learning."""
     ctx.ensure_object(dict)
-    ctx.obj["db"] = MemoryDB(db_path=Path(db_path) if db_path else None)
+    ctx.obj["mem"] = MemoryFile(file_path=Path(file_path) if file_path else None)
 
 
 @memory.command("add")
@@ -29,283 +25,74 @@ def memory(ctx: click.Context, db_path: str | None) -> None:
     help="Memory category",
 )
 @click.option("--summary", "-s", required=True, help="Short description (one line)")
-@click.option("--details", "-d", default=None, help="Longer description")
 @click.option(
-    "--sentiment",
-    default="neutral",
-    type=click.Choice(["positive", "negative", "neutral"]),
-    help="Sentiment (default: neutral)",
+    "--pinned",
+    is_flag=True,
+    default=False,
+    help="Add to Pinned section (user-requested, protected from dreaming)",
 )
-@click.option("--tags", "-t", default=None, help="Comma-separated tags")
 @click.pass_context
-def memory_add(
-    ctx: click.Context,
-    category: str,
-    summary: str,
-    details: str | None,
-    sentiment: str,
-    tags: str | None,
-) -> None:
+def memory_add(ctx: click.Context, category: str, summary: str, pinned: bool) -> None:
     """Add a memory entry.
 
     Examples:
 
-        # Add a lesson
-        myk-pi-tools memory add -c lesson -s "buildah chown -R skips target dir" -t docker,buildah
+        # Add a learned memory
+        myk-pi-tools memory add -c lesson -s "buildah chown -R skips target dir"
 
-        # Add a completed task
-        myk-pi-tools memory add -c done -s "Added security-auditor agent" --sentiment positive
-
-        # Add a mistake
-        myk-pi-tools memory add -c mistake -s "Used sleep for polling instead of async agent" --sentiment negative
+        # Add a pinned memory (user-requested, never auto-removed)
+        myk-pi-tools memory add -c preference -s "Always use uv run" --pinned
     """
-    db = ctx.obj["db"]
-    memory_id = db.add(category=category, summary=summary, details=details, sentiment=sentiment, tags=tags)
-    click.echo(f"Memory #{memory_id} added.", err=True)
+    mem = ctx.obj["mem"]
+    if pinned:
+        mem.add_pinned(category, summary)
+    else:
+        mem.add_learned(category, summary)
+    section = "Pinned" if pinned else "Learned"
+    click.echo(f"Memory added to {section}: [{category}] {summary}", err=True)
 
 
-@memory.command("search")
-@click.argument("query")
-@click.option(
-    "--category",
-    "-c",
-    default=None,
-    type=click.Choice(["lesson", "decision", "mistake", "pattern", "done", "preference"]),
-    help="Filter by category",
-)
-@click.option("--limit", "-n", default=20, help="Maximum results")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@memory.command("show")
 @click.pass_context
-def memory_search(
-    ctx: click.Context,
-    query: str,
-    category: str | None,
-    limit: int,
-    output_json: bool,
-) -> None:
-    """Search memories by text.
+def memory_show(ctx: click.Context) -> None:
+    """Show the memory file contents.
 
     Examples:
 
-        # Search for docker-related memories
-        myk-pi-tools memory search docker
-
-        # Search lessons only
-        myk-pi-tools memory search docker -c lesson
-
-        # JSON output
-        myk-pi-tools memory search docker --json
+        myk-pi-tools memory show
     """
-    db = ctx.obj["db"]
-    results = db.search(query, category=category, limit=limit)
-
-    if output_json:
-        click.echo(json.dumps(results, indent=2))
-    else:
-        if not results:
-            click.echo("No memories found.")
-        else:
-            click.echo(_format_table(results, ["id", "date", "category", "sentiment", "summary", "tags"]))
+    mem = ctx.obj["mem"]
+    click.echo(mem.read())
 
 
-@memory.command("list")
-@click.option(
-    "--category",
-    "-c",
-    default=None,
-    type=click.Choice(["lesson", "decision", "mistake", "pattern", "done", "preference"]),
-    help="Filter by category",
-)
-@click.option("--last", "last_days", default=None, type=click.IntRange(min=1), help="Show last N days")
-@click.option("--limit", "-n", default=50, help="Maximum results")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+@memory.command("migrate")
 @click.pass_context
-def memory_list(
-    ctx: click.Context,
-    category: str | None,
-    last_days: int | None,
-    limit: int,
-    output_json: bool,
-) -> None:
-    """List memories with optional filters.
+def memory_migrate(ctx: click.Context) -> None:
+    """Migrate from SQLite DB to memory.md (one-time).
+
+    Reads all memories from memories.db, writes them to memory.md,
+    then deletes the DB and related files.
 
     Examples:
 
-        # List all memories
-        myk-pi-tools memory list
-
-        # List lessons from last 7 days
-        myk-pi-tools memory list -c lesson --last 7
-
-        # JSON output
-        myk-pi-tools memory list --json
+        myk-pi-tools memory migrate
     """
-    db = ctx.obj["db"]
-    results = db.list_memories(category=category, last_days=last_days, limit=limit)
-
-    if output_json:
-        click.echo(json.dumps(results, indent=2))
+    mem = ctx.obj["mem"]
+    count = mem.migrate_from_db()
+    if count > 0:
+        click.echo(f"Migrated {count} memories from DB to {mem.file_path}", err=True)
     else:
-        if not results:
-            click.echo("No memories found.")
-        else:
-            click.echo(_format_table(results, ["id", "date", "category", "sentiment", "summary", "tags"]))
+        click.echo("No DB found or empty — nothing to migrate.", err=True)
 
 
-@memory.command("delete")
-@click.argument("memory_id", type=int)
+@memory.command("path")
 @click.pass_context
-def memory_delete(ctx: click.Context, memory_id: int) -> None:
-    """Delete a memory by ID.
+def memory_path(ctx: click.Context) -> None:
+    """Print the memory file path.
 
     Examples:
 
-        myk-pi-tools memory delete 42
+        myk-pi-tools memory path
     """
-    db = ctx.obj["db"]
-    if db.delete(memory_id):
-        click.echo(f"Memory #{memory_id} deleted.", err=True)
-    else:
-        click.echo(f"Memory #{memory_id} not found.", err=True)
-        sys.exit(1)
-
-
-@memory.command("stats")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-@click.pass_context
-def memory_stats(ctx: click.Context, output_json: bool) -> None:
-    """Show memory statistics.
-
-    Examples:
-
-        myk-pi-tools memory stats
-        myk-pi-tools memory stats --json
-    """
-    db = ctx.obj["db"]
-    result = db.stats()
-
-    if output_json:
-        click.echo(json.dumps(result, indent=2))
-    else:
-        click.echo(f"Total memories: {result['total']}")
-        click.echo(f"Recalled at least once: {result['recalled']}")
-        click.echo(f"Never recalled: {result['never_recalled']}")
-        if result.get("categories"):
-            click.echo(f"Categories: {', '.join(f'{k}={v}' for k, v in sorted(result['categories'].items()))}")
-        if result.get("top_recalled"):
-            click.echo("\nMost recalled:")
-            for tr in result["top_recalled"]:
-                click.echo(f"  #{tr['id']} ({tr['recall_count']}x) {tr['summary']}")
-
-
-@memory.command("score")
-@click.option("--limit", "-n", default=20, help="Maximum results")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-@click.pass_context
-def memory_score(ctx: click.Context, limit: int, output_json: bool) -> None:
-    """Show memories ranked by score.
-
-    Examples:
-
-        myk-pi-tools memory score
-        myk-pi-tools memory score -n 10
-    """
-    db = ctx.obj["db"]
-    results = db.score_memories(limit=limit)
-
-    if output_json:
-        click.echo(json.dumps(results, indent=2))
-    else:
-        if not results:
-            click.echo("No memories found.")
-        else:
-            click.echo(_format_table(results, ["id", "score", "recall_count", "category", "summary", "tags"]))
-
-
-@memory.command("prune")
-@click.option("--min-score", default=0.1, type=float, help="Minimum score threshold")
-@click.option("--max-age", default=90, type=int, help="Max age in days for unrecalled memories")
-@click.option("--apply", is_flag=True, help="Actually delete (default is dry-run)")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-@click.pass_context
-def memory_prune(ctx: click.Context, min_score: float, max_age: int, apply: bool, output_json: bool) -> None:
-    """Prune low-value memories.
-
-    Default is dry-run — shows what would be deleted. Use --apply to actually delete.
-
-    Examples:
-
-        # Preview what would be pruned
-        myk-pi-tools memory prune
-
-        # Actually prune
-        myk-pi-tools memory prune --apply
-
-        # Custom thresholds
-        myk-pi-tools memory prune --min-score 0.2 --max-age 60
-    """
-    db = ctx.obj["db"]
-    results = db.prune(min_score=min_score, max_age_days=max_age, dry_run=not apply)
-
-    if output_json:
-        click.echo(json.dumps(results, indent=2))
-    else:
-        if not results:
-            click.echo("No memories to prune." if not apply else "Nothing pruned.")
-        else:
-            mode = "Pruned" if apply else "Would prune"
-            click.echo(f"{mode} {len(results)} memories:", err=True)
-            for m in results:
-                click.echo(f"  #{m['id']} ({m['category']}) {m['summary']} — {m.get('prune_reason', '')}")
-
-
-_MAX_DREAM_REPORTS = 10
-
-
-@memory.command("dream")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-@click.pass_context
-def memory_dream(ctx: click.Context, output_json: bool) -> None:
-    """Run memory consolidation and generate dream report.
-
-    Scores all memories, identifies prune candidates, and writes
-    a report to .pi/memory/dreams.md. Keeps only the last 10 reports.
-
-    Examples:
-
-        myk-pi-tools memory dream
-        myk-pi-tools memory dream --json
-    """
-    db = ctx.obj["db"]
-    report = db.dream()
-
-    # Write dream report to file, rotating to keep only last N reports.
-    # Uses advisory file lock to prevent concurrent write races
-    # (e.g., /dream manual + auto-dream timer running simultaneously).
-    dream_path = db.db_path.parent / "dreams.md"
-    lock_path = dream_path.with_suffix(".lock")
-
-    wrote_file = False
-    try:
-        with open(lock_path, "w") as lock_fd:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            try:
-                existing = dream_path.read_text() if dream_path.exists() else ""
-                parts = [report] + [p for p in existing.split("\n---\n\n") if p.strip()]
-                parts = parts[:_MAX_DREAM_REPORTS]
-                dream_path.write_text("\n---\n\n".join(parts) + "\n")
-                wrote_file = True
-            finally:
-                fcntl.flock(lock_fd, fcntl.LOCK_UN)
-    except BlockingIOError:
-        click.echo("Another dream is running — skipped file write.", err=True)
-    except OSError as e:
-        click.echo(f"Failed to write dream report: {e}", err=True)
-        sys.exit(1)
-
-    if output_json:
-        click.echo(json.dumps({"report": report, "path": str(dream_path), "wrote_file": wrote_file}, indent=2))
-    else:
-        click.echo(report)
-        if wrote_file:
-            click.echo(f"\nDream report written to {dream_path}", err=True)
+    mem = ctx.obj["mem"]
+    click.echo(str(mem.file_path))

--- a/myk_pi_tools/memory/store.py
+++ b/myk_pi_tools/memory/store.py
@@ -1,19 +1,15 @@
-"""Memory store — SQLite-backed per-repo memory.
+"""Memory store — plain markdown file per-repo memory.
 
-Database location: <git-root>/.pi/memory/memories.db
+File location: <git-root>/.pi/memory/memory.md
 
-The scoring, pruning, and dreaming features are inspired by OpenClaw's
-"Dreaming" memory consolidation system (v2026.4.5).
-See: https://docs.openclaw.ai/concepts/dreaming
+The file has two sections:
+- Pinned: user-requested memories (never auto-removed by dreaming)
+- Learned: auto-extracted memories (dream may reorganize/remove)
 """
 
-import re
 import sqlite3
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
-from urllib.parse import quote
 
 from myk_pi_tools.db.query import _get_git_root
 
@@ -22,616 +18,154 @@ def log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
-def _parse_utc(date_str: str) -> datetime:
-    """Parse a UTC datetime string from the database."""
-    return datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+_TEMPLATE = """# Memories
 
+## Pinned (user requested — never auto-remove)
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS memories (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    date TEXT NOT NULL,
-    category TEXT NOT NULL,
-    sentiment TEXT DEFAULT 'neutral',
-    summary TEXT NOT NULL,
-    details TEXT,
-    tags TEXT,
-    recall_count INTEGER DEFAULT 0,
-    last_recalled TEXT
-);
+## Learned (auto-extracted — dream may reorganize/remove)
 """
 
-# Scoring weights — inspired by OpenClaw's deep-phase ranking signals
-# See: https://docs.openclaw.ai/concepts/dreaming
-_WEIGHT_RECALL_FREQ = 0.30
-_WEIGHT_RECALL_RECENCY = 0.25
-_WEIGHT_AGE_VALUE = 0.20
-_WEIGHT_CATEGORY = 0.15
-_WEIGHT_FRESHNESS = 0.10
-_RECALL_RECENCY_WINDOW_DAYS = 90
-_FRESHNESS_WINDOW_DAYS = 60
-_AGE_VALUE_WINDOW_DAYS = 30
 
+class MemoryFile:
+    """Per-repo memory file.
 
-class MemoryDB:
-    """Per-repo memory database.
-
-    Stores lessons, decisions, mistakes, patterns, and completed work
-    for a specific repository. Data persists across sessions.
-
-    Attributes:
-        db_path: Path to the SQLite database file.
+    Manages a plain markdown file with two sections:
+    - Pinned: user-requested memories, protected from dreaming
+    - Learned: auto-extracted memories, dream can modify
     """
 
-    def __init__(self, db_path: Path | None = None) -> None:
-        if db_path is None:
+    def __init__(self, file_path: Path | None = None) -> None:
+        if file_path is None:
             git_root = _get_git_root()
-            self.db_path = git_root / ".pi" / "memory" / "memories.db"
+            self.file_path = git_root / ".pi" / "memory" / "memory.md"
         else:
-            self.db_path = db_path
+            self.file_path = file_path
 
-        self._ensure_db()
+    def _ensure_file(self) -> None:
+        """Create memory file with template if it doesn't exist."""
+        if not self.file_path.exists():
+            self.file_path.parent.mkdir(parents=True, exist_ok=True)
+            self.file_path.write_text(_TEMPLATE)
 
-    def _ensure_db(self) -> None:
-        """Create database and table if they don't exist."""
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(str(self.db_path))
-        try:
-            conn.executescript(_SCHEMA)
-            self._migrate_schema(conn)
-        finally:
-            conn.close()
+    def read(self) -> str:
+        """Read the memory file contents."""
+        self._ensure_file()
+        return self.file_path.read_text()
 
-    def _migrate_schema(self, conn: sqlite3.Connection) -> None:
-        """Apply forward-compatible schema migrations.
+    def write(self, content: str) -> None:
+        """Write content to the memory file."""
+        self._ensure_file()
+        self.file_path.write_text(content)
 
-        Uses PRAGMA table_info to check for missing columns before adding,
-        consistent with the ReviewDB migration pattern in db/query.py.
-        """
-        cursor = conn.execute("PRAGMA table_info(memories)")
-        columns = {row[1] for row in cursor.fetchall()}
-        if "recall_count" not in columns:
-            conn.execute("ALTER TABLE memories ADD COLUMN recall_count INTEGER DEFAULT 0")
-        if "last_recalled" not in columns:
-            conn.execute("ALTER TABLE memories ADD COLUMN last_recalled TEXT")
-        conn.commit()
+    def add_pinned(self, category: str, summary: str) -> None:
+        """Add a memory to the Pinned section."""
+        content = self.read()
+        entry = f"- [{category}] {summary}"
 
-    def _connect(self, readonly: bool = True) -> sqlite3.Connection:
-        """Create a database connection."""
-        if readonly:
-            db_uri = f"file:{quote(self.db_path.resolve().as_posix(), safe='/:')}?mode=ro"
-            conn = sqlite3.connect(db_uri, uri=True)
+        # Find the Pinned section and append after its header
+        pinned_header = "## Pinned (user requested — never auto-remove)"
+        if pinned_header in content:
+            # Insert after the pinned header line
+            lines = content.split("\n")
+            insert_pos = None
+            for i, line in enumerate(lines):
+                if line.strip() == pinned_header:
+                    # Find the insertion point — after header and any existing entries
+                    insert_at = i + 1
+                    while insert_at < len(lines) and (
+                        lines[insert_at].startswith("- ") or lines[insert_at].strip() == ""
+                    ):
+                        if lines[insert_at].startswith("## "):
+                            break
+                        insert_at += 1
+                    # Insert before the blank line or next section
+                    if insert_at > i + 1 and lines[insert_at - 1].strip() == "":
+                        insert_pos = insert_at - 1
+                    else:
+                        insert_pos = insert_at
+                    break
+            if insert_pos is not None:
+                lines.insert(insert_pos, entry)
+            self.write("\n".join(lines))
         else:
-            conn = sqlite3.connect(str(self.db_path))
-        conn.row_factory = sqlite3.Row
-        return conn
-
-    def add(
-        self,
-        category: str,
-        summary: str,
-        details: str | None = None,
-        sentiment: str = "neutral",
-        tags: str | None = None,
-    ) -> int:
-        """Add a memory entry.
-
-        Args:
-            category: One of 'lesson', 'decision', 'mistake', 'pattern', 'done', 'preference'
-            summary: Short description (one line)
-            details: Optional longer description
-            sentiment: One of 'positive', 'negative', 'neutral'
-            tags: Optional comma-separated tags
-
-        Returns:
-            The ID of the inserted memory.
-        """
-        valid_categories = {"lesson", "decision", "mistake", "pattern", "done", "preference"}
-        if category not in valid_categories:
-            raise ValueError(f"Invalid category '{category}'. Must be one of: {', '.join(sorted(valid_categories))}")
-
-        valid_sentiments = {"positive", "negative", "neutral"}
-        if sentiment not in valid_sentiments:
-            raise ValueError(f"Invalid sentiment '{sentiment}'. Must be one of: {', '.join(sorted(valid_sentiments))}")
-
-        date = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-        conn = self._connect(readonly=False)
-        try:
-            cursor = conn.execute(
-                "INSERT INTO memories (date, category, sentiment, summary, details, tags) VALUES (?, ?, ?, ?, ?, ?)",
-                (date, category, sentiment, summary, details, tags),
-            )
-            conn.commit()
-            row_id = cursor.lastrowid
-            assert row_id is not None
-            return row_id
-        finally:
-            conn.close()
-
-    def search(self, query: str, category: str | None = None, limit: int = 20) -> list[dict[str, Any]]:
-        """Search memories by text (summary + details + tags).
-
-        Args:
-            query: Search text (matched against summary, details, and tags)
-            category: Optional filter by category
-            limit: Maximum results to return
-
-        Returns:
-            List of matching memory dicts.
-        """
-        if not self.db_path.exists():
-            return []
-
-        conn = self._connect()
-        try:
-            escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            sql = """
-                SELECT id, date, category, sentiment, summary, details, tags, recall_count, last_recalled
-                FROM memories
-                WHERE (summary LIKE ? ESCAPE '\\' OR details LIKE ? ESCAPE '\\' OR tags LIKE ? ESCAPE '\\')
-            """
-            params: list[Any] = [f"%{escaped}%", f"%{escaped}%", f"%{escaped}%"]
-
-            if category:
-                sql += " AND category = ?"
-                params.append(category)
-
-            sql += " ORDER BY date DESC, id DESC LIMIT ?"
-            params.append(limit)
-
-            cursor = conn.execute(sql, params)
-            results = [dict(row) for row in cursor.fetchall()]
-        except sqlite3.Error as e:
-            log(f"Database error: {e}")
-            return []
-        finally:
-            conn.close()
-
-        # Track recall for returned results
-        if results:
-            now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
-            write_conn = self._connect(readonly=False)
-            try:
-                ids = [r["id"] for r in results]
-                placeholders = ",".join("?" * len(ids))
-                sql = (
-                    "UPDATE memories SET recall_count = recall_count + 1,"
-                    f" last_recalled = ? WHERE id IN ({placeholders})"
-                )
-                write_conn.execute(sql, [now, *ids])
-                write_conn.commit()
-            except sqlite3.Error:
-                pass  # Best-effort tracking
-            finally:
-                write_conn.close()
-
-        return results
-
-    def list_memories(
-        self,
-        category: str | None = None,
-        last_days: int | None = None,
-        limit: int = 50,
-    ) -> list[dict[str, Any]]:
-        """List memories with optional filters.
-
-        Args:
-            category: Optional filter by category
-            last_days: Optional filter to last N days
-            limit: Maximum results to return
-
-        Returns:
-            List of memory dicts.
-        """
-        if not self.db_path.exists():
-            return []
-
-        conn = self._connect()
-        try:
-            sql = (
-                "SELECT id, date, category, sentiment, summary, details, tags,"
-                " recall_count, last_recalled FROM memories WHERE 1=1"
-            )
-            params: list[Any] = []
-
-            if category:
-                sql += " AND category = ?"
-                params.append(category)
-
-            if last_days is not None and last_days > 0:
-                sql += " AND date >= datetime('now', ?)"
-                params.append(f"-{last_days} days")
-
-            sql += " ORDER BY date DESC, id DESC LIMIT ?"
-            params.append(limit)
-
-            cursor = conn.execute(sql, params)
-            return [dict(row) for row in cursor.fetchall()]
-        except sqlite3.Error as e:
-            log(f"Database error: {e}")
-            return []
-        finally:
-            conn.close()
-
-    def score_memories(self, limit: int = 50) -> list[dict[str, Any]]:
-        """Score all memories by weighted signals.
-
-        Scoring approach inspired by OpenClaw's deep-phase ranking signals.
-        See: https://docs.openclaw.ai/concepts/dreaming
-
-        Signals:
-        - recall_frequency (0.30): recall_count normalized
-        - recency (0.25): days since last recalled (inverse)
-        - age_value (0.20): older memories that are still recalled are valuable
-        - category_weight (0.15): lessons/mistakes > decisions > preferences > done/pattern
-        - freshness (0.10): days since created (inverse)
-
-        Returns:
-            List of memory dicts with 'score' field, sorted by score descending.
-        """
-        if not self.db_path.exists():
-            return []
-
-        conn = self._connect()
-        try:
-            cursor = conn.execute(
-                "SELECT id, date, category, sentiment, summary, details, tags,"
-                " recall_count, last_recalled FROM memories"
-            )
-            memories = [dict(row) for row in cursor.fetchall()]
-        except sqlite3.Error as e:
-            log(f"Database error: {e}")
-            return []
-        finally:
-            conn.close()
-
-        if not memories:
-            return []
-
-        category_weights = {
-            "lesson": 1.0,
-            "mistake": 1.0,
-            "decision": 0.8,
-            "preference": 0.7,
-            "pattern": 0.5,
-            "done": 0.3,
-        }
-
-        now = datetime.now(timezone.utc)
-        max_recall = max((m.get("recall_count") or 0) for m in memories) or 1
-
-        for m in memories:
-            recall_count = m.get("recall_count") or 0
-            created = _parse_utc(m["date"])
-            age_days = (now - created).days
-
-            # Recall frequency (normalized)
-            recall_freq = recall_count / max_recall
-
-            # Recency of last recall
-            if m.get("last_recalled"):
-                last_recalled = _parse_utc(m["last_recalled"])
-                recall_recency = max(0, 1 - (now - last_recalled).days / _RECALL_RECENCY_WINDOW_DAYS)
-            else:
-                recall_recency = 0.0
-
-            # Age value: older + recalled = valuable
-            age_value = min(age_days / _AGE_VALUE_WINDOW_DAYS, 1.0) * (1 if recall_count > 0 else 0.2)
-
-            # Category weight
-            cat_weight = category_weights.get(m["category"], 0.5)
-
-            # Freshness (inverse age, for new memories)
-            freshness = max(0, 1 - age_days / _FRESHNESS_WINDOW_DAYS)
-
-            score = (
-                _WEIGHT_RECALL_FREQ * recall_freq
-                + _WEIGHT_RECALL_RECENCY * recall_recency
-                + _WEIGHT_AGE_VALUE * age_value
-                + _WEIGHT_CATEGORY * cat_weight
-                + _WEIGHT_FRESHNESS * freshness
-            )
-            m["score"] = round(score, 3)
-
-        memories.sort(key=lambda m: m["score"], reverse=True)
-        return memories[:limit]
-
-    def prune(self, min_score: float = 0.1, max_age_days: int = 90, dry_run: bool = True) -> list[dict[str, Any]]:
-        """Prune low-value memories.
-
-        Removes memories that:
-        - Score below min_score AND are older than 30 days
-        - Are category 'done' and older than max_age_days with no recalls
-        - Have never been recalled and are older than max_age_days
-
-        Args:
-            min_score: Minimum score threshold
-            max_age_days: Maximum age for unrecalled memories
-            dry_run: If True, return candidates without deleting
-
-        Returns:
-            List of pruned (or to-be-pruned) memory dicts.
-        """
-        scored = self.score_memories(limit=10000)
-        now = datetime.now(timezone.utc)
-
-        to_prune = []
-        for m in scored:
-            created = _parse_utc(m["date"])
-            age_days = (now - created).days
-            recall_count = m.get("recall_count") or 0
-
-            should_prune = False
-            reason = ""
-
-            # Low score + old enough
-            if m["score"] < min_score and age_days > 30:
-                should_prune = True
-                reason = f"low score ({m['score']}) and {age_days} days old"
-
-            # Done category, old, never recalled
-            elif m["category"] == "done" and age_days > max_age_days and recall_count == 0:
-                should_prune = True
-                reason = f"done category, {age_days} days old, never recalled"
-
-            # Never recalled and very old
-            elif recall_count == 0 and age_days > max_age_days:
-                should_prune = True
-                reason = f"never recalled, {age_days} days old"
-
-            if should_prune:
-                m["prune_reason"] = reason
-                to_prune.append(m)
-
-        if not dry_run and to_prune:
-            conn = self._connect(readonly=False)
-            try:
-                ids = [m["id"] for m in to_prune]
-                placeholders = ",".join("?" * len(ids))
-                conn.execute(f"DELETE FROM memories WHERE id IN ({placeholders})", ids)
-                conn.commit()
-            finally:
-                conn.close()
-
-        return to_prune
-
-    def stats(self) -> dict[str, Any]:
-        """Get memory statistics.
-
-        Returns:
-            Dict with total count, category breakdown, recall stats.
-        """
-        if not self.db_path.exists():
-            return {"total": 0, "categories": {}, "recalled": 0, "never_recalled": 0}
-
-        conn = self._connect()
-        try:
-            total = conn.execute("SELECT COUNT(*) FROM memories").fetchone()[0]
-            categories = {}
-            for row in conn.execute("SELECT category, COUNT(*) as cnt FROM memories GROUP BY category"):
-                categories[row[0]] = row[1]
-            recalled = conn.execute("SELECT COUNT(*) FROM memories WHERE recall_count > 0").fetchone()[0]
-            never_recalled = conn.execute(
-                "SELECT COUNT(*) FROM memories WHERE recall_count = 0 OR recall_count IS NULL"
-            ).fetchone()[0]
-            top_recalled = conn.execute(
-                "SELECT id, summary, recall_count FROM memories"
-                " WHERE recall_count > 0 ORDER BY recall_count DESC LIMIT 5"
-            ).fetchall()
-
-            return {
-                "total": total,
-                "categories": categories,
-                "recalled": recalled,
-                "never_recalled": never_recalled,
-                "top_recalled": [{"id": r[0], "summary": r[1], "recall_count": r[2]} for r in top_recalled],
-            }
-        except sqlite3.Error as e:
-            log(f"Database error: {e}")
-            return {"total": 0, "categories": {}, "recalled": 0, "never_recalled": 0}
-        finally:
-            conn.close()
-
-    def _find_duplicates(self) -> list[tuple[dict[str, Any], dict[str, Any]]]:
-        """Find duplicate memory pairs using exact and fuzzy matching.
-
-        Compares every pair of memories for similarity:
-        - Exact match: normalized summaries identical (case-insensitive, stripped)
-        - Fuzzy match: Jaccard similarity of word sets >= 0.75
-
-        Returns:
-            List of (keep, remove) tuples. The memory with higher recall_count
-            is kept; ties broken by higher id (newer).
-        """
-        if not self.db_path.exists():
-            return []
-
-        conn = self._connect()
-        try:
-            cursor = conn.execute(
-                "SELECT id, date, category, sentiment, summary, details, tags,"
-                " recall_count, last_recalled FROM memories"
-            )
-            memories = [dict(row) for row in cursor.fetchall()]
-        except sqlite3.Error as e:
-            log(f"Database error: {e}")
-            return []
-        finally:
-            conn.close()
-
-        if len(memories) < 2:
-            return []
-
-        def _normalize(text: str) -> str:
-            return text.strip().lower()
-
-        def _tokenize(text: str) -> set[str]:
-            tokens = set()
-            for word in text.lower().split():
-                cleaned = re.sub(r"[^a-z0-9]", "", word)
-                if cleaned:
-                    tokens.add(cleaned)
-            return tokens
-
-        def _jaccard(set_a: set[str], set_b: set[str]) -> float:
-            if not set_a and not set_b:
-                return 1.0
-            union = set_a | set_b
-            if not union:
-                return 0.0
-            return len(set_a & set_b) / len(union)
-
-        def _pick_keep_remove(a: dict[str, Any], b: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
-            rc_a = a.get("recall_count") or 0
-            rc_b = b.get("recall_count") or 0
-            if rc_a > rc_b:
-                return a, b
-            if rc_b > rc_a:
-                return b, a
-            # Equal recall_count — keep newer (higher id)
-            return (a, b) if a["id"] > b["id"] else (b, a)
-
-        # Pre-compute normalized summaries and token sets
-        norm_cache: dict[int, str] = {}
-        token_cache: dict[int, set[str]] = {}
-        for m in memories:
-            norm_cache[m["id"]] = _normalize(m["summary"])
-            token_cache[m["id"]] = _tokenize(m["summary"])
-
-        matched_ids: set[int] = set()
-        pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
-
-        for i, a in enumerate(memories):
-            if a["id"] in matched_ids:
-                continue
-            for b in memories[i + 1 :]:
-                if b["id"] in matched_ids:
-                    continue
-
-                is_dup = False
-                # Exact match
-                if norm_cache[a["id"]] == norm_cache[b["id"]]:
-                    is_dup = True
-                # Fuzzy match
-                elif _jaccard(token_cache[a["id"]], token_cache[b["id"]]) >= 0.75:
-                    is_dup = True
-
-                if is_dup:
-                    keep, remove = _pick_keep_remove(a, b)
-                    pairs.append((keep, remove))
-                    matched_ids.add(a["id"])
-                    matched_ids.add(b["id"])
-                    break  # a is matched, move to next i
-
-        return pairs
-
-    def merge_duplicates(self, dry_run: bool = True) -> list[tuple[dict[str, Any], dict[str, Any]]]:
-        """Detect and merge duplicate memories.
-
-        Args:
-            dry_run: If True, return duplicate pairs without deleting.
-
-        Returns:
-            List of (keep, remove) pairs.
-        """
-        pairs = self._find_duplicates()
-
-        if not dry_run and pairs:
-            conn = self._connect(readonly=False)
-            try:
-                ids_to_delete = [remove["id"] for _, remove in pairs]
-                placeholders = ",".join("?" * len(ids_to_delete))
-                conn.execute(
-                    f"DELETE FROM memories WHERE id IN ({placeholders})",
-                    ids_to_delete,
-                )
-                conn.commit()
-            finally:
-                conn.close()
-
-        return pairs
-
-    def dream(self) -> str:
-        """Run full memory consolidation — score, prune, merge duplicates, report.
-
-        Self-contained action that performs ALL maintenance in one call:
-        1. Score all memories
-        2. Prune low-value memories (actually deletes them)
-        3. Merge duplicate memories (actually deletes duplicates)
-        4. Generate a report of everything done
-
-        Inspired by OpenClaw's dreaming system which consolidates short-term
-        signals into durable memory. See: https://docs.openclaw.ai/concepts/dreaming
-
-        Returns:
-            Dream report as markdown string.
-        """
-
-        scored = self.score_memories(limit=10000)
-        stats = self.stats()
-        pruned = self.prune(dry_run=False)
-
-        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-
-        lines = [f"# Dream Report — {now}", ""]
-
-        # Stats
-        lines.append("## Stats")
-        lines.append(f"- Total memories: {stats['total']}")
-        lines.append(f"- Recalled at least once: {stats['recalled']}")
-        lines.append(f"- Never recalled: {stats['never_recalled']}")
-        if stats.get("categories"):
-            cats = ", ".join(f"{k}: {v}" for k, v in sorted(stats["categories"].items()))
-            lines.append(f"- Categories: {cats}")
-        lines.append("")
-
-        # Top memories
-        if scored:
-            lines.append("## Top memories by score")
-            for m in scored[:10]:
-                lines.append(f"- [{m['score']}] ({m['category']}) {m['summary']}")
-            lines.append("")
-
-        # Pruned
-        if pruned:
-            lines.append(f"## Pruned ({len(pruned)})")
-            for m in pruned:
-                lines.append(f"- #{m['id']} ({m['category']}) {m['summary']} — {m['prune_reason']}")
-            lines.append("")
+            # Fallback: just append
+            content = content.rstrip() + "\n" + entry + "\n"
+            self.write(content)
+
+    def add_learned(self, category: str, summary: str) -> None:
+        """Add a memory to the Learned section."""
+        content = self.read()
+        entry = f"- [{category}] {summary}"
+
+        # Find the Learned section and append
+        learned_header = "## Learned (auto-extracted — dream may reorganize/remove)"
+        if learned_header in content:
+            lines = content.split("\n")
+            insert_pos = None
+            for i, line in enumerate(lines):
+                if line.strip() == learned_header:
+                    insert_at = i + 1
+                    while insert_at < len(lines) and (
+                        lines[insert_at].startswith("- ") or lines[insert_at].strip() == ""
+                    ):
+                        if lines[insert_at].startswith("## "):
+                            break
+                        insert_at += 1
+                    if insert_at > i + 1 and lines[insert_at - 1].strip() == "":
+                        insert_pos = insert_at - 1
+                    else:
+                        insert_pos = insert_at
+                    break
+            if insert_pos is not None:
+                lines.insert(insert_pos, entry)
+            self.write("\n".join(lines))
         else:
-            lines.append("## Pruned")
-            lines.append("None — all memories are healthy.")
-            lines.append("")
+            content = content.rstrip() + "\n" + entry + "\n"
+            self.write(content)
 
-        # Duplicates
-        merged_pairs = self.merge_duplicates(dry_run=False)
-        if merged_pairs:
-            lines.append(f"## Duplicates merged ({len(merged_pairs)})")
-            for keep, remove in merged_pairs:
-                keep_rc = keep.get("recall_count") or 0
-                remove_rc = remove.get("recall_count") or 0
-                lines.append(
-                    f'- Kept #{keep["id"]} "{keep["summary"]}" (recall: {keep_rc}),'
-                    f' removed #{remove["id"]} "{remove["summary"]}" (recall: {remove_rc})'
-                )
-            lines.append("")
-        else:
-            lines.append("## Duplicates merged")
-            lines.append("No duplicates found.")
-            lines.append("")
+    def migrate_from_db(self) -> int:
+        """One-time migration: read memories.db, write to memory.md, delete db files.
 
-        return "\n".join(lines)
-
-    def delete(self, memory_id: int) -> bool:
-        """Delete a memory by ID.
-
-        Returns:
-            True if deleted, False if not found.
+        Returns number of memories migrated.
         """
-        conn = self._connect(readonly=False)
+        db_path = self.file_path.parent / "memories.db"
+        if not db_path.exists():
+            return 0
+
         try:
-            cursor = conn.execute("DELETE FROM memories WHERE id = ?", (memory_id,))
-            conn.commit()
-            return cursor.rowcount > 0
-        finally:
+            conn = sqlite3.connect(str(db_path))
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute("SELECT category, summary FROM memories ORDER BY date ASC")
+            rows = cursor.fetchall()
             conn.close()
+        except (sqlite3.Error, Exception) as e:
+            log(f"Migration error reading DB: {e}")
+            return 0
+
+        if not rows:
+            # Empty DB — just clean up
+            self._cleanup_db_files()
+            return 0
+
+        # Ensure memory.md exists
+        self._ensure_file()
+
+        # Add all DB memories to Learned section
+        for row in rows:
+            self.add_learned(row["category"], row["summary"])
+
+        # Clean up DB files
+        self._cleanup_db_files()
+
+        return len(rows)
+
+    def _cleanup_db_files(self) -> None:
+        """Remove SQLite DB and related files."""
+        db_dir = self.file_path.parent
+        for filename in ["memories.db", "dreams.md", "dreams.lock"]:
+            path = db_dir / filename
+            if path.exists():
+                try:
+                    path.unlink()
+                except OSError as e:
+                    log(f"Failed to delete {path}: {e}")

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -1,5 +1,5 @@
 ---
-description: "Run memory consolidation — score, prune, generate dream report — /dream"
+description: "Run memory consolidation — extract, deduplicate, reorganize memories — /dream"
 ---
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
@@ -14,20 +14,22 @@ Inspired by [OpenClaw's dreaming system](https://docs.openclaw.ai/concepts/dream
 
 Run memory consolidation as a **background async agent** — never block the session.
 
-Dreaming is a **self-contained action** — one command does everything:
+Dreaming is a **self-contained action** — the LLM worker:
 
-1. Scores all memories by recall frequency, recency, age, and category
-2. Prunes low-value memories (actually deletes them)
-3. Merges duplicate memories (detects via text similarity)
-4. Generates a report of everything done
+1. Reads the session file and extracts things worth remembering
+2. Adds new entries to the Learned section of memory.md
+3. Reorganizes — deduplicates, removes stale entries from Learned
+4. NEVER removes Pinned entries
 
 Delegate to a `worker` agent with `async: true` and `fireAndForget: true` (no result injection into conversation):
 
 ```text
 Task:
-Run: uv run myk-pi-tools memory dream
+1. Read the current session file to find things worth remembering
+2. Read the memory file: uv run myk-pi-tools memory show
+3. Add new entries: uv run myk-pi-tools memory add -c <category> -s "<summary>"
+4. Reorganize the memory file — deduplicate and remove stale Learned entries
+5. NEVER remove or modify Pinned entries
 ```
 
 Tell the user: "Running memory consolidation in background..."
-
-The async agent result will surface automatically when complete.

--- a/prompts/remember.md
+++ b/prompts/remember.md
@@ -15,7 +15,7 @@ argument-hint: "<what to remember>"
 $ARGUMENTS
 ```
 
-Save this as a project memory. Determine the best category and sentiment from the content:
+Save this as a **Pinned** project memory. Determine the best category:
 
 - `lesson` — something learned (how things work, gotchas, tips)
 - `decision` — an architectural or design choice made
@@ -27,7 +27,7 @@ Save this as a project memory. Determine the best category and sentiment from th
 Run:
 
 ```bash
-uv run myk-pi-tools memory add -c <category> -s "<concise one-line summary>" [-d "<details if the input is long>"] [-t "<relevant,tags>"] [--sentiment <positive|negative|neutral>]
+uv run myk-pi-tools memory add -c <category> -s "<concise one-line summary>" --pinned
 ```
 
-After saving, confirm what was stored and show the memory ID.
+After saving, confirm what was stored.

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -1,17 +1,37 @@
 # Project Memory
 
-Persistent per-repo memory in `.pi/memory/memories.db`. Loaded automatically at session start.
+Persistent per-repo memory in `.pi/memory/memory.md`. Loaded automatically at session start.
 
 **CLI:** `uv run myk-pi-tools memory <command>`
 
 ---
 
+## Memory File Format
+
+The memory file has two sections:
+
+```markdown
+# Memories
+
+## Pinned (user requested — never auto-remove)
+- [preference] Always use uv run, never python directly
+- [lesson] Never merge PRs without asking first
+
+## Learned (auto-extracted — dream may reorganize/remove)
+- [lesson] buildah chown -R breaks cache mounts — use --mount=type=cache with correct uid
+- [mistake] Closed issue with incomplete deliverables — check Done section before closing
+```
+
+**Pinned** — user explicitly said "remember this". Dream must NEVER remove these.
+**Learned** — auto-extracted by dreaming. Dream can reorganize, deduplicate, remove.
+
+---
+
 ## Memory Quality Rules (CRITICAL)
 
-- **One line only** — summaries MUST be a single short sentence, max ~100 chars
+- **One line only** — entries MUST be a single short sentence, max ~100 chars
 - **Specific and actionable** — not vague observations, but concrete "do X" or "don't do Y"
 - **No fluff** — no context, no background, no explanation. Just the fact.
-- **Tags are mandatory** — always add relevant tags for searchability
 
 ### Good vs Bad
 
@@ -25,30 +45,24 @@ Persistent per-repo memory in `.pi/memory/memories.db`. Loaded automatically at 
 
 ## When to Write
 
-| Trigger | Category | Sentiment |
-|---------|----------|-----------|
-| PR merged | `done` | positive |
-| User corrects you | `lesson` | negative |
-| Multiple fix attempts | `mistake` | negative |
-| User states a preference | `preference` | neutral |
-| User says "remember" / `/remember` | best fit | best fit |
-
----
-
-## When to Read
-
-- **Before implementation** — `uv run myk-pi-tools memory search "<keywords>"`
-- **User asks about past work** — `uv run myk-pi-tools memory list -c done`
+| Trigger | Category | Section |
+|---------|----------|--------|
+| User says "remember" / `/remember` | best fit | **Pinned** |
+| PR merged | `done` | Learned |
+| User corrects you | `lesson` | Learned |
+| Multiple fix attempts | `mistake` | Learned |
+| User states a preference | `preference` | Learned |
 
 ---
 
 ## CLI
 
 ```bash
-uv run myk-pi-tools memory add -c <category> -s "summary" [-t "tags"] [--sentiment positive|negative|neutral]
-uv run myk-pi-tools memory search "<query>"
-uv run myk-pi-tools memory list [--last <days>] [-c <category>]
-uv run myk-pi-tools memory delete <id>
+uv run myk-pi-tools memory add -c <category> -s "summary"             # Add to Learned
+uv run myk-pi-tools memory add -c <category> -s "summary" --pinned    # Add to Pinned
+uv run myk-pi-tools memory show                                       # Show memory file
+uv run myk-pi-tools memory migrate                                    # One-time DB→md migration
+uv run myk-pi-tools memory path                                       # Print file path
 ```
 
 **Categories:** `lesson`, `decision`, `mistake`, `pattern`, `done`, `preference`
@@ -68,22 +82,13 @@ Memory consolidation runs as a **background async agent** — never blocking the
 
 ### What it does
 
-Dreaming is a **self-contained action** — one command does everything:
+Dreaming is a **self-contained action** — the LLM worker:
 
-1. **Scores** all memories by recall frequency, recency, age, and category
-2. **Prunes** low-value memories (actually deletes them)
-3. **Merges** duplicate memories (detects via text similarity)
-4. **Writes** a dream report to `.pi/memory/dreams.md`
-
-### CLI Commands
-
-```bash
-uv run myk-pi-tools memory stats           # Memory statistics
-uv run myk-pi-tools memory score           # Ranked memories by score
-uv run myk-pi-tools memory prune           # Preview prune candidates
-uv run myk-pi-tools memory prune --apply   # Actually prune
-uv run myk-pi-tools memory dream           # Run consolidation + report
-```
+1. **Reads** the session file and extracts things worth remembering
+2. **Adds** new entries to the Learned section
+3. **Reorganizes** the memory file — deduplicates, removes stale entries
+4. **Writes** the updated memory.md
+5. **NEVER** removes or modifies Pinned entries
 
 ### Rules
 

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -1,5 +1,19 @@
 # Critical Rules
 
+## Task Focus (MANDATORY)
+
+**When executing a multi-step workflow** (e.g., implement → review → commit → push → PR):
+
+- **NEVER abandon the workflow** when the user asks a side question
+- Answer the side question, then **IMMEDIATELY resume** the original workflow from where you left off
+- Side questions, async agent results, and interruptions do NOT end the current task
+- The workflow is complete ONLY when all steps are done (e.g., PR created, issue closed)
+
+❌ **WRONG:** User asks a question mid-workflow → answer → stop (forget the workflow)
+✅ **RIGHT:** User asks a question mid-workflow → answer → resume workflow from the next pending step
+
+**After EVERY response, ask yourself:** "Was I in the middle of a workflow? If yes, what's the next step?"
+
 ## Parallel Execution (MANDATORY)
 
 **Before EVERY response:** Can operations run in parallel?

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,407 +1,175 @@
 """Tests for the memory module."""
 
+import sqlite3
 from pathlib import Path
 
 import pytest
 
-from myk_pi_tools.memory.store import MemoryDB
+from myk_pi_tools.memory.store import _TEMPLATE, MemoryFile
 
 
 @pytest.fixture
-def memory_db(tmp_path: Path) -> MemoryDB:
-    """Create a MemoryDB with a temporary database."""
-    db_path = tmp_path / "memories.db"
-    return MemoryDB(db_path=db_path)
+def memory_file(tmp_path: Path) -> MemoryFile:
+    """Create a MemoryFile with a temporary path."""
+    file_path = tmp_path / "memory.md"
+    return MemoryFile(file_path=file_path)
 
 
-class TestMemoryDB:
-    def test_add_and_list(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Test lesson")
-        results = memory_db.list_memories()
-        assert len(results) == 1
-        assert results[0]["summary"] == "Test lesson"
-        assert results[0]["category"] == "lesson"
+class TestMemoryFile:
+    def test_creates_file_on_read(self, memory_file: MemoryFile) -> None:
+        content = memory_file.read()
+        assert memory_file.file_path.exists()
+        assert "# Memories" in content
+        assert "## Pinned" in content
+        assert "## Learned" in content
 
-    def test_add_with_all_fields(self, memory_db: MemoryDB) -> None:
-        mid = memory_db.add(
-            category="mistake",
-            summary="Used sleep for polling",
-            details="Should have used async agent",
-            sentiment="negative",
-            tags="async,polling",
+    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
+        file_path = tmp_path / "sub" / "dir" / "memory.md"
+        mem = MemoryFile(file_path=file_path)
+        mem.read()
+        assert file_path.exists()
+
+    def test_write_and_read(self, memory_file: MemoryFile) -> None:
+        memory_file.write("custom content")
+        assert memory_file.read() == "custom content"
+
+    def test_template_structure(self) -> None:
+        assert "## Pinned" in _TEMPLATE
+        assert "## Learned" in _TEMPLATE
+
+
+class TestAddPinned:
+    def test_add_pinned(self, memory_file: MemoryFile) -> None:
+        memory_file.add_pinned("lesson", "Always use uv run")
+        content = memory_file.read()
+        assert "- [lesson] Always use uv run" in content
+
+    def test_pinned_appears_in_pinned_section(self, memory_file: MemoryFile) -> None:
+        memory_file.add_pinned("preference", "Never merge without asking")
+        content = memory_file.read()
+        lines = content.split("\n")
+        pinned_idx = next(i for i, line in enumerate(lines) if "## Pinned" in line)
+        learned_idx = next(i for i, line in enumerate(lines) if "## Learned" in line)
+        entry_idx = next(i for i, line in enumerate(lines) if "Never merge without asking" in line)
+        assert pinned_idx < entry_idx < learned_idx
+
+    def test_add_multiple_pinned(self, memory_file: MemoryFile) -> None:
+        memory_file.add_pinned("lesson", "First lesson")
+        memory_file.add_pinned("preference", "Second preference")
+        content = memory_file.read()
+        assert "- [lesson] First lesson" in content
+        assert "- [preference] Second preference" in content
+
+
+class TestAddLearned:
+    def test_add_learned(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("mistake", "Used sleep for polling")
+        content = memory_file.read()
+        assert "- [mistake] Used sleep for polling" in content
+
+    def test_learned_appears_in_learned_section(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("lesson", "Cache mounts need uid")
+        content = memory_file.read()
+        lines = content.split("\n")
+        learned_idx = next(i for i, line in enumerate(lines) if "## Learned" in line)
+        entry_idx = next(i for i, line in enumerate(lines) if "Cache mounts need uid" in line)
+        assert entry_idx > learned_idx
+
+    def test_add_multiple_learned(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("lesson", "First")
+        memory_file.add_learned("mistake", "Second")
+        content = memory_file.read()
+        assert "- [lesson] First" in content
+        assert "- [mistake] Second" in content
+
+
+class TestMixedSections:
+    def test_pinned_and_learned_separate(self, memory_file: MemoryFile) -> None:
+        memory_file.add_pinned("preference", "Pinned entry")
+        memory_file.add_learned("lesson", "Learned entry")
+        content = memory_file.read()
+        lines = content.split("\n")
+        pinned_idx = next(i for i, line in enumerate(lines) if "## Pinned" in line)
+        learned_idx = next(i for i, line in enumerate(lines) if "## Learned" in line)
+        pinned_entry = next(i for i, line in enumerate(lines) if "Pinned entry" in line)
+        learned_entry = next(i for i, line in enumerate(lines) if "Learned entry" in line)
+        assert pinned_idx < pinned_entry < learned_idx < learned_entry
+
+
+class TestMigration:
+    def _create_test_db(self, db_path: Path) -> None:
+        """Create a test SQLite memory DB."""
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE memories ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "date TEXT NOT NULL,"
+            "category TEXT NOT NULL,"
+            "summary TEXT NOT NULL,"
+            "sentiment TEXT DEFAULT 'neutral',"
+            "details TEXT,"
+            "tags TEXT,"
+            "recall_count INTEGER DEFAULT 0,"
+            "last_recalled TEXT"
+            ")"
         )
-        assert mid is not None
-        results = memory_db.list_memories()
-        assert len(results) == 1
-        assert results[0]["sentiment"] == "negative"
-        assert results[0]["tags"] == "async,polling"
-        assert results[0]["details"] == "Should have used async agent"
-
-    def test_invalid_category(self, memory_db: MemoryDB) -> None:
-        with pytest.raises(ValueError, match="Invalid category"):
-            memory_db.add(category="invalid", summary="test")
-
-    def test_invalid_sentiment(self, memory_db: MemoryDB) -> None:
-        with pytest.raises(ValueError, match="Invalid sentiment"):
-            memory_db.add(category="lesson", summary="test", sentiment="angry")
-
-    def test_search(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="buildah chown bug", tags="docker,buildah")
-        memory_db.add(category="done", summary="Added security auditor")
-        results = memory_db.search("buildah")
-        assert len(results) == 1
-        assert "buildah" in results[0]["summary"]
-
-    def test_search_by_tags(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Some lesson", tags="docker,buildah")
-        results = memory_db.search("docker")
-        assert len(results) == 1
-
-    def test_search_with_category_filter(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Docker lesson", tags="docker")
-        memory_db.add(category="done", summary="Docker task done", tags="docker")
-        results = memory_db.search("docker", category="lesson")
-        assert len(results) == 1
-        assert results[0]["category"] == "lesson"
-
-    def test_list_by_category(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Lesson 1")
-        memory_db.add(category="done", summary="Done 1")
-        memory_db.add(category="lesson", summary="Lesson 2")
-        results = memory_db.list_memories(category="lesson")
-        assert len(results) == 2
-        assert all(r["category"] == "lesson" for r in results)
-
-    def test_list_limit(self, memory_db: MemoryDB) -> None:
-        for i in range(10):
-            memory_db.add(category="done", summary=f"Task {i}")
-        results = memory_db.list_memories(limit=5)
-        assert len(results) == 5
-
-    def test_delete(self, memory_db: MemoryDB) -> None:
-        mid = memory_db.add(category="lesson", summary="To delete")
-        assert memory_db.delete(mid) is True
-        results = memory_db.list_memories()
-        assert len(results) == 0
-
-    def test_delete_nonexistent(self, memory_db: MemoryDB) -> None:
-        assert memory_db.delete(999) is False
-
-    def test_empty_search(self, memory_db: MemoryDB) -> None:
-        results = memory_db.search("nonexistent")
-        assert results == []
-
-    def test_db_created_on_init(self, tmp_path: Path) -> None:
-        db_path = tmp_path / "subdir" / "memories.db"
-        MemoryDB(db_path=db_path)
-        assert db_path.exists()
-
-    def test_order_by_date_desc(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="done", summary="First")
-        memory_db.add(category="done", summary="Second")
-        results = memory_db.list_memories()
-        # Most recent first
-        assert results[0]["summary"] == "Second"
-        assert results[1]["summary"] == "First"
-
-
-class TestRecallTracking:
-    def test_search_increments_recall_count(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
-        memory_db.search("buildah")
-        results = memory_db.list_memories()
-        assert results[0]["recall_count"] == 1
-
-    def test_search_increments_multiple_times(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
-        memory_db.search("buildah")
-        memory_db.search("buildah")
-        memory_db.search("buildah")
-        results = memory_db.list_memories()
-        assert results[0]["recall_count"] == 3
-
-    def test_search_sets_last_recalled(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
-        memory_db.search("buildah")
-        results = memory_db.list_memories()
-        assert results[0]["last_recalled"] is not None
-
-    def test_search_no_match_no_recall(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
-        memory_db.search("nonexistent")
-        results = memory_db.list_memories()
-        assert results[0]["recall_count"] == 0
-
-    def test_new_memory_has_zero_recall(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="test")
-        results = memory_db.list_memories()
-        assert results[0]["recall_count"] == 0
-        assert results[0]["last_recalled"] is None
-
-
-class TestScoring:
-    def test_score_empty_db(self, memory_db: MemoryDB) -> None:
-        assert memory_db.score_memories() == []
-
-    def test_score_returns_scores(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Test lesson")
-        results = memory_db.score_memories()
-        assert len(results) == 1
-        assert "score" in results[0]
-        assert isinstance(results[0]["score"], float)
-
-    def test_recalled_memory_scores_higher(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="recalled lesson", tags="test")
-        memory_db.add(category="lesson", summary="forgotten lesson", tags="other")
-        # Recall the first one several times
-        for _ in range(5):
-            memory_db.search("recalled")
-        results = memory_db.score_memories()
-        recalled = next(m for m in results if "recalled" in m["summary"])
-        forgotten = next(m for m in results if "forgotten" in m["summary"])
-        assert recalled["score"] > forgotten["score"]
-
-    def test_score_respects_limit(self, memory_db: MemoryDB) -> None:
-        for i in range(10):
-            memory_db.add(category="done", summary=f"Task {i}")
-        results = memory_db.score_memories(limit=3)
-        assert len(results) == 3
-
-
-class TestPruning:
-    def test_prune_empty_db(self, memory_db: MemoryDB) -> None:
-        assert memory_db.prune() == []
-
-    def test_prune_dry_run_doesnt_delete(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="done", summary="Old task")
-        # Force old date
-        conn = memory_db._connect(readonly=False)
-        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
+        conn.execute(
+            "INSERT INTO memories (date, category, summary) VALUES ('2026-01-01 00:00:00', 'lesson', 'Test lesson one')"
+        )
+        conn.execute(
+            "INSERT INTO memories (date, category, summary) VALUES "
+            "('2026-01-02 00:00:00', 'preference', 'Test preference')"
+        )
+        conn.execute(
+            "INSERT INTO memories (date, category, summary) VALUES ('2026-01-03 00:00:00', 'mistake', 'Test mistake')"
+        )
         conn.commit()
         conn.close()
-        pruned = memory_db.prune(dry_run=True)
-        assert len(pruned) > 0
-        # Still exists
-        assert len(memory_db.list_memories()) == 1
 
-    def test_prune_apply_deletes(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="done", summary="Old task")
-        conn = memory_db._connect(readonly=False)
-        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
+    def test_migrate_from_db(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memories.db"
+        self._create_test_db(db_path)
+        mem = MemoryFile(file_path=tmp_path / "memory.md")
+        count = mem.migrate_from_db()
+        assert count == 3
+        content = mem.read()
+        assert "- [lesson] Test lesson one" in content
+        assert "- [preference] Test preference" in content
+        assert "- [mistake] Test mistake" in content
+
+    def test_migrate_deletes_db(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memories.db"
+        self._create_test_db(db_path)
+        # Also create dreams files
+        (tmp_path / "dreams.md").write_text("old dreams")
+        (tmp_path / "dreams.lock").write_text("")
+        mem = MemoryFile(file_path=tmp_path / "memory.md")
+        mem.migrate_from_db()
+        assert not db_path.exists()
+        assert not (tmp_path / "dreams.md").exists()
+        assert not (tmp_path / "dreams.lock").exists()
+
+    def test_migrate_no_db(self, tmp_path: Path) -> None:
+        mem = MemoryFile(file_path=tmp_path / "memory.md")
+        count = mem.migrate_from_db()
+        assert count == 0
+
+    def test_migrate_empty_db(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memories.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE memories (id INTEGER PRIMARY KEY, date TEXT, category TEXT, summary TEXT)")
         conn.commit()
         conn.close()
-        pruned = memory_db.prune(dry_run=False)
-        assert len(pruned) > 0
-        assert len(memory_db.list_memories()) == 0
+        mem = MemoryFile(file_path=tmp_path / "memory.md")
+        count = mem.migrate_from_db()
+        assert count == 0
+        assert not db_path.exists()
 
-    def test_prune_keeps_recalled_memories(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Important lesson", tags="test")
-        # Make it old
-        conn = memory_db._connect(readonly=False)
-        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
-        conn.commit()
-        conn.close()
-        # But recall it frequently
-        for _ in range(10):
-            memory_db.search("Important")
-        pruned = memory_db.prune(dry_run=True)
-        # Should not be pruned because it's frequently recalled
-        assert all("Important" not in p["summary"] for p in pruned)
-
-
-class TestStats:
-    def test_stats_empty(self, memory_db: MemoryDB) -> None:
-        result = memory_db.stats()
-        assert result["total"] == 0
-
-    def test_stats_with_data(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="L1")
-        memory_db.add(category="lesson", summary="L2")
-        memory_db.add(category="done", summary="D1")
-        result = memory_db.stats()
-        assert result["total"] == 3
-        assert result["categories"]["lesson"] == 2
-        assert result["categories"]["done"] == 1
-
-    def test_stats_recall_tracking(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="buildah bug", tags="docker")
-        memory_db.add(category="lesson", summary="not searched")
-        memory_db.search("buildah")
-        result = memory_db.stats()
-        assert result["recalled"] == 1
-        assert result["never_recalled"] == 1
-
-
-class TestDream:
-    def test_dream_empty_db(self, memory_db: MemoryDB) -> None:
-        report = memory_db.dream()
-        assert "Dream Report" in report
-        assert "Total memories: 0" in report
-
-    def test_dream_with_data(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Test lesson")
-        report = memory_db.dream()
-        assert "Dream Report" in report
-        assert "Total memories: 1" in report
-
-    def test_dream_prunes_low_value_memories(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="done", summary="Old task")
-        # Make it old so it becomes a prune candidate
-        conn = memory_db._connect(readonly=False)
-        conn.execute("UPDATE memories SET date = '2020-01-01 00:00:00'")
-        conn.commit()
-        conn.close()
-        report = memory_db.dream()
-        assert "Pruned" in report
-        # Verify it was actually deleted
-        assert len(memory_db.list_memories()) == 0
-
-    def test_dream_returns_string(self, memory_db: MemoryDB) -> None:
-        report = memory_db.dream()
-        assert isinstance(report, str)
-
-    def test_dream_no_duplicates(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Unique lesson")
-        report = memory_db.dream()
-        assert "## Duplicates merged" in report
-        assert "No duplicates found." in report
-
-    def test_dream_merges_exact_duplicates(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Same lesson")
-        memory_db.add(category="lesson", summary="Same lesson")
-        report = memory_db.dream()
-        assert "## Duplicates merged (1)" in report
-        assert "removed #" in report
-        # Should have deleted the duplicate
-        assert len(memory_db.list_memories()) == 1
-
-
-class TestFindDuplicates:
-    def test_no_duplicates(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="First unique lesson")
-        memory_db.add(category="lesson", summary="Completely different topic")
-        pairs = memory_db._find_duplicates()
-        assert pairs == []
-
-    def test_empty_db(self, memory_db: MemoryDB) -> None:
-        pairs = memory_db._find_duplicates()
-        assert pairs == []
-
-    def test_single_memory(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Only one")
-        pairs = memory_db._find_duplicates()
-        assert pairs == []
-
-    def test_exact_match(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Use uv run for Python")
-        memory_db.add(category="lesson", summary="Use uv run for Python")
-        pairs = memory_db._find_duplicates()
-        assert len(pairs) == 1
-        keep, remove = pairs[0]
-        # Same recall_count (0), so keep newer (higher id)
-        assert keep["id"] > remove["id"]
-
-    def test_exact_match_case_insensitive(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Use UV Run")
-        memory_db.add(category="lesson", summary="use uv run")
-        pairs = memory_db._find_duplicates()
-        assert len(pairs) == 1
-
-    def test_exact_match_whitespace_stripped(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="  spaced out  ")
-        memory_db.add(category="lesson", summary="spaced out")
-        pairs = memory_db._find_duplicates()
-        assert len(pairs) == 1
-
-    def test_fuzzy_match_high_similarity(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="use uv run for python scripts")
-        memory_db.add(category="lesson", summary="use uv run for python scripts always")
-        # 5/6 words overlap = Jaccard ~0.83
-        pairs = memory_db._find_duplicates()
-        assert len(pairs) == 1
-
-    def test_fuzzy_match_below_threshold(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="use uv run for python")
-        memory_db.add(category="lesson", summary="docker build container image deploy")
-        pairs = memory_db._find_duplicates()
-        assert pairs == []
-
-    def test_keeps_higher_recall_count(self, memory_db: MemoryDB) -> None:
-        _id1 = memory_db.add(category="lesson", summary="duplicate lesson", tags="dup")
-        memory_db.add(category="lesson", summary="duplicate lesson", tags="dup")
-        # Recall id1 several times to boost its recall count
-        for _ in range(5):
-            memory_db.search("duplicate")
-        pairs = memory_db._find_duplicates()
-        assert len(pairs) == 1
-        keep, remove = pairs[0]
-        # id1 was recalled more (both get recalled on search, but id1 has more total)
-        assert keep.get("recall_count", 0) >= remove.get("recall_count", 0)
-
-    def test_keeps_newer_on_equal_recall(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="same thing")
-        id2 = memory_db.add(category="lesson", summary="same thing")
-        pairs = memory_db._find_duplicates()
-        assert len(pairs) == 1
-        keep, _remove = pairs[0]
-        assert keep["id"] == id2  # newer (higher id) kept
-
-    def test_each_memory_appears_once(self, memory_db: MemoryDB) -> None:
-        # Add 3 identical memories — only 1 pair should be formed
-        # (the third is already matched in a pair)
-        memory_db.add(category="lesson", summary="triple dup")
-        memory_db.add(category="lesson", summary="triple dup")
-        memory_db.add(category="lesson", summary="triple dup")
-        pairs = memory_db._find_duplicates()
-        # Each memory appears in at most one pair
-        seen_ids: set[int] = set()
-        for keep, remove in pairs:
-            assert keep["id"] not in seen_ids
-            assert remove["id"] not in seen_ids
-            seen_ids.add(keep["id"])
-            seen_ids.add(remove["id"])
-
-    def test_punctuation_handling(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="don't use pip! ever.")
-        memory_db.add(category="lesson", summary="don't use pip ever")
-        pairs = memory_db._find_duplicates()
-        assert len(pairs) == 1
-
-
-class TestMergeDuplicates:
-    def test_dry_run_no_delete(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="dup entry")
-        memory_db.add(category="lesson", summary="dup entry")
-        pairs = memory_db.merge_duplicates(dry_run=True)
-        assert len(pairs) == 1
-        # Both still exist
-        assert len(memory_db.list_memories()) == 2
-
-    def test_merge_deletes_duplicates(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="dup entry")
-        memory_db.add(category="lesson", summary="dup entry")
-        pairs = memory_db.merge_duplicates(dry_run=False)
-        assert len(pairs) == 1
-        remaining = memory_db.list_memories()
-        assert len(remaining) == 1
-        # The kept one should still be there
-        keep, _remove = pairs[0]
-        assert remaining[0]["id"] == keep["id"]
-
-    def test_merge_no_duplicates(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="Unique A")
-        memory_db.add(category="lesson", summary="Unique B")
-        pairs = memory_db.merge_duplicates(dry_run=False)
-        assert pairs == []
-        assert len(memory_db.list_memories()) == 2
-
-    def test_merge_multiple_pairs(self, memory_db: MemoryDB) -> None:
-        memory_db.add(category="lesson", summary="alpha duplicate")
-        memory_db.add(category="lesson", summary="alpha duplicate")
-        memory_db.add(category="mistake", summary="beta duplicate")
-        memory_db.add(category="mistake", summary="beta duplicate")
-        memory_db.add(category="done", summary="unique entry")
-        pairs = memory_db.merge_duplicates(dry_run=False)
-        assert len(pairs) == 2
-        remaining = memory_db.list_memories()
-        assert len(remaining) == 3  # 2 kept + 1 unique
+    def test_migrate_idempotent(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "memories.db"
+        self._create_test_db(db_path)
+        mem = MemoryFile(file_path=tmp_path / "memory.md")
+        mem.migrate_from_db()
+        # Second call — no DB, returns 0
+        count = mem.migrate_from_db()
+        assert count == 0


### PR DESCRIPTION
## Summary

Replaces the entire SQLite-based memory system with a plain `memory.md` file. The DB was overengineered — scoring algorithms, Jaccard similarity, recall tracking — when the LLM doing the dreaming is infinitely better at understanding what's useful, duplicate, or stale.

**Net result: -879 lines of code.**

## memory.md format

```markdown
# Memories

## Pinned (user requested — never auto-remove)
- [preference] Always use uv run, never python directly
- [lesson] Never merge PRs without asking first

## Learned (auto-extracted — dream may reorganize/remove)
- [lesson] buildah chown -R breaks cache mounts — use --mount=type=cache with correct uid
- [mistake] Closed issue with incomplete deliverables — check Done section before closing
```

- **Pinned** — user explicitly said "remember this" via `/remember`. Dream NEVER removes these.
- **Learned** — auto-extracted by dreaming from session context. Dream can reorganize, deduplicate, remove.

## Changes

### Python (`myk_pi_tools/memory/`)
- `store.py` — `MemoryFile` replaces `MemoryDB`. Simple read/write/add_pinned/add_learned + DB migration
- `commands.py` — simplified: `add`, `show`, `migrate`, `path` (removed: search, list, score, prune, dream, stats, delete)
- `__init__.py` — exports `MemoryFile`

### Extension (`extensions/orchestrator/`)
- `rules.ts` — reads `memory.md` directly (no subprocess, instant). Auto-triggers migration on first run if `memories.db` exists
- `dreaming.ts` — worker reads session + memory.md, rewrites the file (add, dedup, remove stale, NEVER touch Pinned)

### Rules & Prompts
- `rules/35-memory.md` — full rewrite for memory.md system
- `rules/40-critical-rules.md` — added Task Focus rule (never lose workflow on interruptions)
- `prompts/dream.md` — updated for LLM-native dreaming
- `prompts/remember.md` — writes to Pinned section with `--pinned` flag

### Migration
On first session start, if `memories.db` exists:
1. Reads all memories from DB → writes to memory.md Learned section
2. Deletes `memories.db`, `dreams.md`, `dreams.lock`
3. One-time — once DB is gone, never runs again

### What was removed
- SQLite schema, migrations, recall tracking
- Scoring algorithms, Jaccard similarity, fuzzy matching
- Pruning logic, merge logic, stats
- fcntl locking, dreams.md rotation
- 52 SQLite-based tests → replaced with 16 focused tests

## Tests
16 tests pass (MemoryFile CRUD + migration)

Fixes #155