### PR TITLE
fix(docs): update README for memory.md system, enforce docs updates in reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,12 +39,12 @@ pi-config/
 │   │   ├── index.ts                 # Main entry — imports and wires all modules
 │   │   ├── agents.ts                # Agent discovery
 │   │   ├── ask-user.ts              # ask_user tool
-│   │   ├── async-agents.ts          # Async background agent infrastructure
+│   │   ├── async-agents.ts          # Async background agent infrastructure (fireAndForget support)
 │   │   ├── async-runner.ts          # Standalone async runner (spawned detached)
 │   │   ├── btw.ts                   # /btw command
 │   │   ├── diffity.ts               # Auto-start diffity diff viewer
 │   │   ├── dreaming.ts              # Background memory consolidation (inspired by OpenClaw)
-│   │   ├── pidash.ts                # Live web dashboard extension (connects to pidash daemon)
+│   │   ├── pidash.ts                # Live web dashboard extension (connects to pidash daemon, forwards provider response info)
 │   │   ├── pidash-ui/               # React + shadcn/ui web dashboard
 │   │   │   ├── src/                 # React source (components, hooks, types)
 │   │   │   └── dist/               # Built output (generated, gitignored)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Single extension that provides:
 | **Desktop notifications** | Notifies via `notify-send` on task completion, waiting for input, and action required |
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
-| **Dreaming** | Background memory consolidation — scores, prunes, and generates dream reports |
-| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status`, `/dream`, `/remember` |
+| **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains memory.md |
+| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status`, `/dream`, `/remember` — with autocomplete argument hints |
 
 ### Agents (24)
 
@@ -53,8 +53,9 @@ Single extension that provides:
 | `/coderabbit-rate-limit [number\|url]` | Handle CodeRabbit rate limiting on PRs |
 | `/query-db <command>` | Query the review comments database |
 | `/acpx-prompt <agent> [--fix\|--peer] <prompt>` | Run prompts via external AI agents (cursor, codex, gemini, etc.) |
-| `/dream` | Run memory consolidation — score, prune, generate dream report |
+| `/dream` | Run memory consolidation — extract, deduplicate, maintain memory.md |
 | `/remember <what>` | Save a memory for future sessions |
+| `/dream-auto` | Toggle automatic memory dreaming (every 3h + session end) |
 
 ## Installation
 
@@ -256,8 +257,12 @@ Pass via `--env-file /path/to/.env` in the docker run command.
 
 ### Project memory
 
-The memory system stores per-repo lessons and patterns in `.pi/memory/memories.db`.
-This file is auto-added to the global gitignore in the container.
+The memory system stores per-repo lessons and patterns in `.pi/memory/memory.md` — a plain markdown file with two sections:
+
+- **Pinned** — user-requested memories (via `/remember`), never auto-removed
+- **Learned** — auto-extracted by dreaming, can be reorganized/removed
+
+The file is auto-added to the global gitignore in the container.
 
 For **native** (non-container) usage, add it to your global gitignore:
 
@@ -265,6 +270,8 @@ For **native** (non-container) usage, add it to your global gitignore:
 echo '.pi/memory/' >> ~/.gitignore-global
 git config --global core.excludesFile ~/.gitignore-global
 ```
+
+**Migration:** If you have an existing `memories.db`, it's automatically migrated to `memory.md` on the next session start.
 
 ### Pidash — live web dashboard
 

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -15,6 +15,8 @@ You are a code review specialist focused on **project guidelines and style adher
 ## Review Focus
 
 - AGENTS.md compliance (read the project's AGENTS.md first!)
+- **Documentation updates (MANDATORY)** — if code was added/changed/removed, check that AGENTS.md and README.md are updated.
+  Flag missing docs as `[CRITICAL]`. See the Documentation Updates table in AGENTS.md.
 - Project-specific coding standards
 - Naming conventions matching existing codebase
 - File/folder structure consistency
@@ -27,8 +29,9 @@ You are a code review specialist focused on **project guidelines and style adher
 
 1. First read AGENTS.md to understand project rules
 2. Review the changed files against those rules
-3. Check consistency with existing codebase patterns
-4. Report deviations
+3. **Check if AGENTS.md or README.md need updating** based on the changes — missing doc updates are `[CRITICAL]`
+4. Check consistency with existing codebase patterns
+5. Report deviations
 
 ## Output Format
 


### PR DESCRIPTION
## Problem

Multiple PRs merged without documentation updates despite rule 25-documentation-updates.md. The code-reviewer-guidelines agent wasn't checking for this.

## Changes

### README.md
- Memory section: `memories.db` → `memory.md` with Pinned/Learned sections
- Dreaming description: reflects LLM-native consolidation
- Added migration note for existing DB users

### agents/code-reviewer-guidelines.md
- Documentation updates are now a **CRITICAL** blocking finding
- Added explicit check step: "Check if AGENTS.md or README.md need updating"
- Missing docs = `[CRITICAL]` severity, not a suggestion

Fixes #157