### PR TITLE
feat(async): parallel async agents, display names, and worktree safety

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -25,6 +25,7 @@ const ASYNC_POLL_INTERVAL_MS = 3000;
 interface AsyncJob {
   id: string;
   agent: string;
+  name?: string;
   task: string;
   status: "queued" | "running" | "complete" | "failed";
   asyncDir: string;
@@ -66,7 +67,7 @@ export function formatDuration(ms: number): string {
 export function registerAsyncAgents(
   pi: ExtensionAPI,
   terminalNotify: (title: string, body: string) => void,
-): { spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean }) => { id: string; error?: string } } {
+): { spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string } } {
   const asyncState: AsyncState = {
     jobs: new Map(),
     poller: null,
@@ -79,7 +80,7 @@ export function registerAsyncAgents(
     const ctx = asyncState.lastCtx;
     const running = Array.from(asyncState.jobs.values()).filter(j => j.status === "running" || j.status === "queued");
     if (running.length > 0) {
-      const names = running.map(j => j.agent).join(", ");
+      const names = running.map(j => j.name || j.agent).join(", ");
       ctx.ui.setStatus("async-agents", ctx.ui.theme.fg("warning", `⏳ ${running.length} async: ${names}`));
       pi.events.emit("pidash:async-status", { count: running.length, agents: names });
     } else {
@@ -142,7 +143,8 @@ export function registerAsyncAgents(
       if (job.delivered) return; // Already delivered to user
 
       // Notify user
-      terminalNotify("pi", `Async agent ${data.agent} ${data.success ? "completed" : "failed"} (${formatDuration(data.durationMs)})`);
+      const displayName = job.name || data.agent;
+      terminalNotify("pi", `Async agent ${displayName} ${data.success ? "completed" : "failed"} (${formatDuration(data.durationMs)})`);
 
       // Surface result in conversation (skip for fire-and-forget jobs)
       if (asyncState.lastCtx && !job.fireAndForget) {
@@ -150,7 +152,7 @@ export function registerAsyncAgents(
         const output = (data.output || "").slice(0, 3000);
         pi.sendMessage({
           customType: "async-agent-result",
-          content: `## Async Agent Result: ${data.agent} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}`,
+          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}`,
           display: true,
         }, { triggerTurn: true, deliverAs: "followUp" });
       }
@@ -190,7 +192,7 @@ export function registerAsyncAgents(
     task: string,
     cwd: string,
     agents: AgentConfig[],
-    options?: { fireAndForget?: boolean },
+    options?: { fireAndForget?: boolean; name?: string },
   ): { id: string; error?: string } {
     const agent = agents.find(a => a.name === agentName);
     if (!agent) return { id: "", error: `Unknown agent: "${agentName}"` };
@@ -257,6 +259,7 @@ export function registerAsyncAgents(
     const job: AsyncJob = {
       id,
       agent: agentName,
+      name: options?.name,
       task: task.slice(0, 200),
       status: "queued",
       asyncDir,
@@ -310,15 +313,15 @@ export function registerAsyncAgents(
       }
 
       const lines: string[] = ["## Async Agents\n"];
-      lines.push("| Agent | Status | Duration | Task |");
-      lines.push("|-------|--------|----------|------|");
+      lines.push("| Name | Agent | Status | Duration | Task |");
+      lines.push("|------|-------|--------|----------|------|");
       for (const job of jobs) {
         const duration = job.durationMs
           ? formatDuration(job.durationMs)
           : formatDuration(Date.now() - job.startedAt);
         const statusIcon = job.status === "complete" ? "✅" : job.status === "failed" ? "❌" : job.status === "running" ? "⏳" : "⏸️";
         const taskPreview = job.task.length > 50 ? job.task.slice(0, 50) + "..." : job.task;
-        lines.push(`| ${job.agent} | ${statusIcon} ${job.status} | ${duration} | ${taskPreview} |`);
+        lines.push(`| ${job.name || "-"} | ${job.agent} | ${statusIcon} ${job.status} | ${duration} | ${taskPreview} |`);
       }
 
       if (ctx.hasUI) {

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -21,7 +21,7 @@ const DREAM_INTERVAL_MS = DREAM_INTERVAL_HOURS * 60 * 60 * 1000;
 
 export function registerDreaming(
   pi: ExtensionAPI,
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: any[], options?: { fireAndForget?: boolean }) => { id: string; error?: string },
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: any[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string },
 ): void {
   // Only the orchestrator (top-level pi) runs dreaming — skip in subagent children
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
@@ -65,7 +65,7 @@ export function registerDreaming(
       `5. Memory rules: one line per entry, max ~100 chars, specific and actionable, no fluff.`,
       cwd,
       agents,
-      { fireAndForget: true },
+      { fireAndForget: true, name: "Dream" },
     );
     // Reset flag after reasonable timeout (dream should complete in <5 min)
     if (id) setTimeout(() => { dreamInFlight = false; }, 5 * 60 * 1000);

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -571,6 +571,15 @@ export function registerSubagentTool(
 
         // Parallel async — spawn each task as a separate async agent
         if (params.tasks && params.tasks.length > 0) {
+          // Validate all tasks have names
+          const unnamed = params.tasks.filter(t => !(t as any).name);
+          if (unnamed.length > 0) {
+            return {
+              content: [{ type: "text", text: `Async agents require a name for display in status line. Missing name for: ${unnamed.map(t => t.agent).join(", ")}` }],
+              details: mkd("single")([]),
+              isError: true,
+            };
+          }
           const results: string[] = [];
           const errors: string[] = [];
           for (const t of params.tasks) {
@@ -607,6 +616,13 @@ export function registerSubagentTool(
         if (!params.cwd) {
           return {
             content: [{ type: "text", text: MISSING_CWD_ERROR }],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
+        if (!params.name) {
+          return {
+            content: [{ type: "text", text: "Async agents require a name for display in status line (e.g., 'Dream', 'Code Review', 'PR #42')." }],
             details: mkd("single")([]),
             isError: true,
           };

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -42,6 +42,7 @@ const TaskItem = Type.Object({
   agent: Type.String({ description: "Agent name" }),
   task: Type.String({ description: "Task to delegate" }),
   cwd: Type.String({ description: "Working directory" }),
+  name: Type.Optional(Type.String({ description: "Display name for async status" })),
 });
 const ChainItem = Type.Object({
   agent: Type.String({ description: "Agent name" }),
@@ -83,6 +84,9 @@ const SubagentParams = Type.Object({
   ),
   fireAndForget: Type.Optional(
     Type.Boolean({ description: "When true with async, skip result delivery to conversation. Agent runs silently — only terminal notification on completion. Use for maintenance tasks like memory dreaming.", default: false }),
+  ),
+  name: Type.Optional(
+    Type.String({ description: "Display name for async agents in status line and notifications (e.g., 'Dream', 'Code Review'). Defaults to agent name." }),
   ),
 });
 
@@ -465,7 +469,7 @@ export async function runSingleAgent(
 
 export function registerSubagentTool(
   pi: ExtensionAPI,
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean }) => { id: string; error?: string },
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string },
 ): void {
   // Only the orchestrator (top-level pi) can spawn subagents.
   // Child processes set PI_SUBAGENT_CHILD=1 to prevent infinite recursion.
@@ -557,16 +561,45 @@ export function registerSubagentTool(
 
       // Async mode — spawn in background and return immediately
       if (params.async === true) {
-        if (params.chain || params.tasks) {
+        if (params.chain) {
           return {
-            content: [{ type: "text", text: "Async mode currently supports single agent only. Use agent + task without chain/tasks." }],
+            content: [{ type: "text", text: "Async mode does not support chain. Use agent + task or tasks array." }],
             details: mkd("single")([]),
             isError: true,
           };
         }
+
+        // Parallel async — spawn each task as a separate async agent
+        if (params.tasks && params.tasks.length > 0) {
+          const results: string[] = [];
+          const errors: string[] = [];
+          for (const t of params.tasks) {
+            const r = spawnAsyncAgent(t.agent, t.task, t.cwd, agents, {
+              fireAndForget: params.fireAndForget,
+              name: (t as any).name,
+            });
+            if (r.error) {
+              errors.push(`${t.agent}: ${r.error}`);
+            } else {
+              const label = (t as any).name || t.agent;
+              results.push(`${label} [${r.id}]`);
+            }
+          }
+          const lines: string[] = [];
+          if (results.length > 0) lines.push(`Spawned ${results.length} async agents:\n${results.map(r => `- ${r}`).join("\n")}`);
+          if (errors.length > 0) lines.push(`Failed:\n${errors.map(e => `- ${e}`).join("\n")}`);
+          lines.push("\nUse /async-status to check progress.");
+          return {
+            content: [{ type: "text", text: lines.join("\n") }],
+            details: mkd("single")([]),
+            isError: errors.length > 0 && results.length === 0,
+          };
+        }
+
+        // Single async
         if (!params.agent || !params.task) {
           return {
-            content: [{ type: "text", text: "Async mode requires agent and task." }],
+            content: [{ type: "text", text: "Async mode requires agent and task (or tasks array)." }],
             details: mkd("single")([]),
             isError: true,
           };
@@ -578,7 +611,7 @@ export function registerSubagentTool(
             isError: true,
           };
         }
-        const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents, { fireAndForget: params.fireAndForget });
+        const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents, { fireAndForget: params.fireAndForget, name: params.name });
         if (result.error) {
           return {
             content: [{ type: "text", text: result.error }],
@@ -586,8 +619,9 @@ export function registerSubagentTool(
             isError: true,
           };
         }
+        const label = params.name || params.agent;
         return {
-          content: [{ type: "text", text: `Async agent spawned: ${params.agent} [${result.id}]\nUse /async-status to check progress. Results will appear when complete.` }],
+          content: [{ type: "text", text: `Async agent spawned: ${label} [${result.id}]\nUse /async-status to check progress. Results will appear when complete.` }],
           details: mkd("single")([]),
         };
       }

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -20,6 +20,24 @@ $ARGUMENTS
 
 Unified handler that processes ALL review sources from the current branch's GitHub PR.
 
+## Multi-PR Handling (MANDATORY)
+
+When asked to handle reviews for **multiple PRs**, NEVER switch branches in the main worktree.
+Use `git worktree` to create isolated directories for each PR:
+
+```bash
+# Create a worktree per PR
+git worktree add /tmp/pi-work/pr-42 origin/fix/issue-42
+git worktree add /tmp/pi-work/pr-43 origin/feat/issue-43
+
+# Run review-handler in each worktree directory
+# When done, clean up
+git worktree remove /tmp/pi-work/pr-42
+```
+
+Branch switching corrupts parallel agent work — other agents running in the
+main worktree will see the wrong branch.
+
 ## Prerequisites Check (MANDATORY)
 
 ### Step 0: Check uv

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -53,6 +53,30 @@ Only use sync (default) when the **very next step** depends on this agent's outp
 
 ---
 
+## Multi-PR / Multi-Branch Work (MANDATORY)
+
+**When working on multiple PRs or branches simultaneously:**
+
+- ❌ **NEVER** switch branches in the main worktree — other agents may be running there
+- ✅ **ALWAYS** use `git worktree` for each PR/branch when handling more than one
+
+```bash
+# Create a worktree for each PR
+git worktree add /tmp/pi-work/pr-42 origin/fix/issue-42
+git worktree add /tmp/pi-work/pr-43 origin/feat/issue-43
+
+# Work in each directory independently
+# When done, clean up
+git worktree remove /tmp/pi-work/pr-42
+```
+
+**Why:** Branch switching in the main worktree corrupts parallel agent work.
+Agent A switches to branch X, Agent B thinks it's still on branch Y —
+wrong diffs, wrong commits, wrong everything.
+Worktrees give each branch its own directory, fully isolated.
+
+---
+
 ## User Interaction (MANDATORY)
 
 **When you need user input** (approvals, selections, confirmations):


### PR DESCRIPTION
## Summary

Three improvements to async agents and multi-branch safety.

## Changes

### 1. Parallel async support (`subagent-tool.ts`)
`tasks` array + `async: true` now spawns each task as a separate background agent. Previously blocked with "single agent only" error.

### 2. Custom display names (`async-agents.ts`, `subagent-tool.ts`, `dreaming.ts`)
New `name` field on subagent tool and TaskItem schema. Used as display label in:
- TUI status line: `⏳ 2 async: Dream, Code Review` (instead of `worker, worker`)
- `/async-status` table (new Name column)
- pidash async status events
- Terminal notifications on completion

Dream agent now shows as "Dream" in status line.

### 3. Worktree safety rules
- `rules/40-critical-rules.md` — MANDATORY rule: never switch branches when multiple agents may be running, use `git worktree` instead
- `prompts/review-handler.md` — multi-PR handling must use worktrees, not branch switching

Fixes #159