### PR TITLE
fix(async): programmatic async-kill via subagent tool and command args

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -67,7 +67,10 @@ export function formatDuration(ms: number): string {
 export function registerAsyncAgents(
   pi: ExtensionAPI,
   terminalNotify: (title: string, body: string) => void,
-): { spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string } } {
+): {
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string };
+  killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
+} {
   const asyncState: AsyncState = {
     jobs: new Map(),
     poller: null,
@@ -330,10 +333,76 @@ export function registerAsyncAgents(
     },
   });
 
-  // /async-kill command — interactive selection
+  // Kill an async agent by name, id prefix, or "all"
+  function killAsyncAgent(target: string): { killed: string[]; errors: string[] } {
+    const killed: string[] = [];
+    const errors: string[] = [];
+    const running = Array.from(asyncState.jobs.values()).filter(
+      (j) => j.status === "running" || j.status === "queued",
+    );
+
+    if (running.length === 0) {
+      errors.push("No running async agents.");
+      return { killed, errors };
+    }
+
+    const targets = target.toLowerCase() === "all"
+      ? running
+      : running.filter(j =>
+          (j.name && j.name.toLowerCase() === target.toLowerCase()) ||
+          j.id.startsWith(target) ||
+          j.agent.toLowerCase() === target.toLowerCase()
+        );
+
+    if (targets.length === 0) {
+      errors.push(`No matching async agent for: ${target}`);
+      return { killed, errors };
+    }
+
+    for (const job of targets) {
+      const status = readAsyncStatus(job.asyncDir);
+      if (status?.pid) {
+        try {
+          const tree = execFileSync("pstree", ["-p", String(status.pid)], { encoding: "utf-8", timeout: 3000 });
+          const matches = tree.match(/\((\d+)\)/g);
+          const allPids = matches ? [...new Set(matches.map((m: string) => parseInt(m.slice(1, -1), 10)))] : [status.pid];
+          for (const pid of allPids) {
+            try { process.kill(pid, "SIGKILL"); } catch {}
+          }
+        } catch {
+          try { process.kill(status.pid, "SIGKILL"); } catch {}
+          if (status.childPid) try { process.kill(status.childPid, "SIGKILL"); } catch {}
+        }
+      }
+      const label = job.name || job.agent;
+      killed.push(label);
+      job.status = "failed";
+      job.updatedAt = Date.now();
+      setTimeout(() => { asyncState.jobs.delete(job.id); updateAsyncWidget(); }, 5000);
+    }
+
+    updateAsyncWidget();
+    return { killed, errors };
+  }
+
+  // /async-kill command — accepts name/id/"all" or interactive selection
   pi.registerCommand("async-kill", {
-    description: "Kill a running async agent",
+    description: "Kill async agent(s) — /async-kill <name|id|all>",
     handler: async (_args, ctx) => {
+      const arg = (_args || "").trim();
+
+      // If arg provided, kill directly without interactive selection
+      if (arg) {
+        const { killed, errors } = killAsyncAgent(arg);
+        if (killed.length > 0) {
+          ctx.ui.notify(`Killed: ${killed.join(", ")}`, "info");
+        }
+        if (errors.length > 0) {
+          ctx.ui.notify(errors.join("\n"), "warning");
+        }
+        return;
+      }
+
       const running = Array.from(asyncState.jobs.values()).filter(
         (j) => j.status === "running" || j.status === "queued",
       );
@@ -393,5 +462,5 @@ export function registerAsyncAgents(
     },
   });
 
-  return { spawnAsyncAgent };
+  return { spawnAsyncAgent, killAsyncAgent };
 }

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -45,8 +45,8 @@ export default function (pi: ExtensionAPI) {
   };
 
   registerAskUser(pi, terminalNotify);
-  const { spawnAsyncAgent } = registerAsyncAgents(pi, terminalNotify);
-  registerSubagentTool(pi, spawnAsyncAgent);
+  const { spawnAsyncAgent, killAsyncAgent } = registerAsyncAgents(pi, terminalNotify);
+  registerSubagentTool(pi, spawnAsyncAgent, killAsyncAgent);
   registerEnforcement(pi, IN_CONTAINER);
   registerRules(pi);
   registerStatusLine(pi, IN_CONTAINER, terminalNotify);

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -88,6 +88,9 @@ const SubagentParams = Type.Object({
   name: Type.Optional(
     Type.String({ description: "Display name for async agents in status line and notifications (e.g., 'Dream', 'Code Review'). Defaults to agent name." }),
   ),
+  asyncKill: Type.Optional(
+    Type.String({ description: "Kill async agent(s) by name, id prefix, or 'all'. Returns which agents were killed." }),
+  ),
 });
 
 // ── Interfaces ───────────────────────────────────────────────────────────
@@ -470,6 +473,7 @@ export async function runSingleAgent(
 export function registerSubagentTool(
   pi: ExtensionAPI,
   spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string },
+  killAsyncAgent: (target: string) => { killed: string[]; errors: string[] },
 ): void {
   // Only the orchestrator (top-level pi) can spawn subagents.
   // Child processes set PI_SUBAGENT_CHILD=1 to prevent infinite recursion.
@@ -515,6 +519,19 @@ export function registerSubagentTool(
           projectAgentsDir: discovery.projectAgentsDir,
           results,
         });
+
+      // Kill async agents — early return before mode validation
+      if (params.asyncKill) {
+        const { killed, errors } = killAsyncAgent(params.asyncKill);
+        const lines: string[] = [];
+        if (killed.length > 0) lines.push(`Killed: ${killed.join(", ")}`);
+        if (errors.length > 0) lines.push(errors.join("\n"));
+        return {
+          content: [{ type: "text", text: lines.join("\n") || "No action taken." }],
+          details: mkd("single")([]),
+          isError: errors.length > 0 && killed.length === 0,
+        };
+      }
 
       if (modes !== 1) {
         const avail =


### PR DESCRIPTION
## Problem

The orchestrator couldn't kill async agents — `/async-kill` required interactive UI selection, so the AI resorted to `pkill -9` which doesn't work (runtime keeps respawning).

## Fix

**Code enforcement, not rules.** Three ways to kill async agents now:

### 1. Subagent tool (for orchestrator)
```json
{ "asyncKill": "Dream" }
{ "asyncKill": "all" }
```

### 2. Command with args (for prompts/commands)
```
/async-kill Dream
/async-kill all
/async-kill worker-1776666550604-lrbnpw
```

### 3. Interactive selection (existing, unchanged)
```
/async-kill
```
(shows select dialog when no args provided)

## Matching

Kills by (in order): display name, id prefix, or agent type. Case-insensitive for names.

## Changes

- `async-agents.ts` — extracted `killAsyncAgent(target)` function, updated `/async-kill` to accept args, export `killAsyncAgent`
- `subagent-tool.ts` — added `asyncKill` parameter
- `index.ts` — wire `killAsyncAgent` through to subagent tool

Fixes #162