### PR TITLE
feat(pidash): interactive async panel, agent names, scroll fixes, UX cleanup

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -85,10 +85,21 @@ export function registerAsyncAgents(
     if (running.length > 0) {
       const names = running.map(j => j.name || j.agent).join(", ");
       ctx.ui.setStatus("async-agents", ctx.ui.theme.fg("warning", `⏳ ${running.length} async: ${names}`));
-      pi.events.emit("pidash:async-status", { count: running.length, agents: names });
+      pi.events.emit("pidash:async-status", {
+        count: running.length,
+        agents: names,
+        jobs: running.map(j => ({
+          id: j.id,
+          name: j.name || j.agent,
+          agent: j.agent,
+          task: j.task,
+          status: j.status,
+          startedAt: j.startedAt,
+        })),
+      });
     } else {
       ctx.ui.setStatus("async-agents", undefined);
-      pi.events.emit("pidash:async-status", { count: 0, agents: "" });
+      pi.events.emit("pidash:async-status", { count: 0, agents: "", jobs: [] });
     }
   }
 

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -53,6 +53,6 @@ export default function (pi: ExtensionAPI) {
   registerBtw(pi);
   registerDiffity(pi);
   registerDreaming(pi, spawnAsyncAgent);
-  registerPidash(pi);
+  registerPidash(pi, killAsyncAgent);
   registerSessionValidation(pi);
 }

--- a/extensions/orchestrator/pidash-ui/src/App.tsx
+++ b/extensions/orchestrator/pidash-ui/src/App.tsx
@@ -38,6 +38,7 @@ export function App() {
   const [streaming, setStreaming] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [searchType, setSearchType] = useState("all");
+  const [scrollKey, setScrollKey] = useState(0);
   const [availableCommands, setAvailableCommands] = useState<Array<{ name: string; description: string }>>([]);
   const saved = useRef(loadState());
   const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
@@ -161,8 +162,18 @@ export function App() {
           break;
 
         case "tool_execution_start": {
-          const name = ev.toolName || "tool";
-          const id = addMsg(name as any, `${ev.args?.command ? ev.args.command : ""}`, "tool-call");
+          let name = ev.toolName || "tool";
+          let detail = ev.args?.command ? ev.args.command : "";
+          // Show agent name for subagent tool calls
+          if (name === "subagent" && ev.args) {
+            const label = ev.args.name || ev.args.agent;
+            if (label) name = `subagent (${label})`;
+            if (ev.args.asyncKill) detail = `kill: ${ev.args.asyncKill}`;
+            else if (ev.args.task) detail = ev.args.task.slice(0, 150);
+            else if (ev.args.tasks) detail = `${ev.args.tasks.length} parallel tasks`;
+            else if (ev.args.chain) detail = `${ev.args.chain.length} chain steps`;
+          }
+          const id = addMsg(name as any, detail, "tool-call");
           toolRef.current = { id, name };
           break;
         }
@@ -220,6 +231,7 @@ export function App() {
     setStreaming(false);
     setSearchQuery("");
     setSearchType("all");
+    setScrollKey(k => k + 1);
     thinkRef.current = { id: "", text: "" };
     assistRef.current = { id: "", text: "" };
     lastUserRef.current = "";
@@ -228,7 +240,7 @@ export function App() {
     send({ type: "pidash-command", pid: s.pid, command: "list-commands" });
     // Events from buffer replay arrive synchronously — mark replay done after a short delay
     setTimeout(() => { replayingRef.current = false; }, 2000);
-    location.hash = `#session/${s.pid}`;
+    // Session persisted via localStorage — no URL hash needed
     // Auto-collapse sidebar on mobile
     if (typeof window !== 'undefined' && window.innerWidth <= 768) setSidebarCollapsed(true);
   }, [send]);
@@ -245,9 +257,8 @@ export function App() {
 
   useEffect(() => {
     if (!connected || !sessions.length || restoredRef.current) return;
-    // Restore from hash first, then from localStorage
-    const hashMatch = location.hash.match(/^#session\/(\d+)$/);
-    const pid = hashMatch ? parseInt(hashMatch[1], 10) : saved.current.watchPid;
+    // Restore from localStorage
+    const pid = saved.current.watchPid;
     if (pid) {
       const s = sessions.find((x) => x.pid === pid);
       if (s) { restoredRef.current = true; watchSession(s); }
@@ -348,6 +359,7 @@ export function App() {
               searchQuery={searchQuery}
               searchType={searchType}
               streaming={streaming}
+              scrollKey={scrollKey}
               onAskResponse={(id, value) => {
                 if (value === "__confirmed__") {
                   send({ type: "extension_ui_response", pid: session!.pid, id, confirmed: true });
@@ -359,7 +371,7 @@ export function App() {
               }}
             />
             <InputBar disabled={!session.active} streaming={streaming} onSend={handleSend} onAbort={handleAbort} commands={availableCommands} />
-            <InfoBar session={session} model={model} tokens={tokens} streaming={streaming} send={send} onMessage={onMessage} />
+            <InfoBar session={session} model={model} tokens={tokens} send={send} onMessage={onMessage} />
           </>
         )}
       </div>

--- a/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { GitBranch, Circle, ExternalLink, Brain, Bot, ChevronDown } from "lucide-react";
+import { GitBranch, ExternalLink, Brain, Bot, ChevronDown } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
 import type { SessionInfo, TokenUsage } from "@/types";
 
 function fk(n: number): string {
@@ -20,12 +22,11 @@ interface Props {
   session: SessionInfo;
   model: string;
   tokens: TokenUsage | null;
-  streaming: boolean;
   send: (data: object) => void;
   onMessage: (handler: (data: any) => void) => () => void;
 }
 
-export function InfoBar({ session, model, tokens, streaming, send, onMessage }: Props) {
+export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
   const [models, setModels] = useState<ModelInfo[]>([]);
   const [thinkingLevel, setThinkingLevel] = useState(session.thinkingLevel || "medium");
 
@@ -35,7 +36,11 @@ export function InfoBar({ session, model, tokens, streaming, send, onMessage }: 
   }, [session.thinkingLevel]);
   const [openMenu, setOpenMenu] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
-  const [asyncAgents, setAsyncAgents] = useState<{ count: number; agents: string }>({ count: 0, agents: "" });
+  const [asyncAgents, setAsyncAgents] = useState<{
+    count: number;
+    agents: string;
+    jobs: Array<{ id: string; name: string; agent: string; task: string; status: string; startedAt: number }>;
+  }>({ count: 0, agents: "", jobs: [] });
   const filterRef = useRef<HTMLInputElement>(null);
 
   const ctxWin = session.contextWindow || 1000000;
@@ -56,7 +61,12 @@ export function InfoBar({ session, model, tokens, streaming, send, onMessage }: 
         if (ev.thinkingLevel) setThinkingLevel(ev.thinkingLevel);
       }
       if (ev.type === "async-status") {
-        setAsyncAgents({ count: ev.count || 0, agents: ev.agents || "" });
+        const newCount = ev.count || 0;
+        const newAgents = ev.agents || "";
+        setAsyncAgents(prev => {
+          if (prev.count === newCount && prev.agents === newAgents) return prev;
+          return { count: newCount, agents: newAgents, jobs: ev.jobs || [] };
+        });
       }
     });
   }, [onMessage]);
@@ -156,12 +166,17 @@ export function InfoBar({ session, model, tokens, streaming, send, onMessage }: 
       <span className="text-border">|</span>
 
       {/* Tokens */}
-      <span>↑{fk(input)} ↓{fk(output)}{cache > 0 && ` 📦${fk(cache)}`}</span>
+      <span className="tabular-nums">
+        <span className="inline-block min-w-[3.5em] text-right">↑{fk(input)}</span>
+        {" "}
+        <span className="inline-block min-w-[3.5em] text-right">↓{fk(output)}</span>
+        {cache > 0 && <span className="inline-block min-w-[3.5em] text-right"> 📦{fk(cache)}</span>}
+      </span>
 
       <span className="text-border">|</span>
 
       {/* Context */}
-      <span className={pctColor}>ctx {pct}%</span>
+      <span className={cn("tabular-nums inline-block min-w-[4em] text-right", pctColor)}>ctx {pct}%</span>
 
       {/* Git */}
       {session.branch && (
@@ -196,19 +211,49 @@ export function InfoBar({ session, model, tokens, streaming, send, onMessage }: 
         </>
       )}
 
-      {/* Async agents */}
-      {asyncAgents.count > 0 && (
-        <>
-          <span className="text-border">|</span>
-          <span className="text-yellow-400">⏳ {asyncAgents.count} async: {asyncAgents.agents}</span>
-        </>
-      )}
-
-      {/* Status */}
-      <span className="flex items-center gap-1">
-        <Circle className={`h-2 w-2 fill-current ${streaming ? "text-cyan-400" : "text-green-500"}`} />
-        {streaming ? "streaming" : "idle"}
-      </span>
+      {/* Async agents — always visible, pinned to far right */}
+      <div className="relative inline-block ml-auto">
+        {asyncAgents.count > 0 ? (
+          <Popover>
+            <PopoverTrigger className="text-yellow-400 hover:text-yellow-300 cursor-pointer text-xs">
+              ⏳ {asyncAgents.count} async
+            </PopoverTrigger>
+            <PopoverContent className="w-72 max-h-60 overflow-y-auto">
+              <div className="text-xs space-y-1.5">
+                <div className="font-bold text-foreground mb-1">Running Agents</div>
+                {asyncAgents.jobs.map((job) => {
+                  const elapsed = Math.round((Date.now() - job.startedAt) / 1000);
+                  const mins = Math.floor(elapsed / 60);
+                  const secs = elapsed % 60;
+                  const duration = mins > 0 ? `${mins}m ${secs}s` : `${secs}s`;
+                  return (
+                    <div key={job.id} className="flex items-center justify-between gap-2 p-1.5 rounded bg-muted/50">
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium text-foreground truncate">{job.name}</div>
+                        <div className="text-muted-foreground truncate text-[10px]">{job.task.slice(0, 60)}</div>
+                        <div className="text-muted-foreground text-[10px]">{job.agent} · {duration}</div>
+                      </div>
+                      <div className="flex gap-1 shrink-0">
+                        <button
+                          onClick={() => {
+                            send({ type: "pidash-command", command: "async-kill", target: job.name, pid: session.pid });
+                          }}
+                          className="px-1.5 py-0.5 rounded text-[10px] bg-red-500/20 text-red-400 hover:bg-red-500/40"
+                          title="Kill this agent"
+                        >
+                          Kill
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </PopoverContent>
+          </Popover>
+        ) : (
+          <span className="text-muted-foreground/50 text-xs">⏳ 0 async</span>
+        )}
+      </div>
     </div>
   );
 }

--- a/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
@@ -10,6 +10,7 @@ interface Props {
   searchQuery?: string;
   searchType?: string;
   streaming?: boolean;
+  scrollKey?: number;
   onAskResponse?: (id: string, value: string) => void;
 }
 
@@ -32,7 +33,7 @@ function getRoleColor(role: string): string {
   return roleColors[role] || "text-orange-400";
 }
 
-export function MessageList({ messages, searchQuery, searchType, streaming, onAskResponse }: Props) {
+export function MessageList({ messages, searchQuery, searchType, streaming, scrollKey, onAskResponse }: Props) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
@@ -40,6 +41,17 @@ export function MessageList({ messages, searchQuery, searchType, streaming, onAs
   useEffect(() => {
     if (autoScroll) bottomRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, autoScroll]);
+
+  // Force scroll to bottom on session switch — keep scrolling during replay
+  useEffect(() => {
+    setAutoScroll(true);
+    // Scroll multiple times during replay (messages arrive over ~2s)
+    const times = [50, 200, 500, 1000, 2000, 3000];
+    const timers = times.map(ms =>
+      setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: "instant" }), ms)
+    );
+    return () => timers.forEach(clearTimeout);
+  }, [scrollKey]);
 
   return (
     <div

--- a/extensions/orchestrator/pidash-ui/src/components/ui/popover.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/popover.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+interface PopoverProps {
+  children: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+const PopoverContext = React.createContext<{
+  open: boolean;
+  setOpen: (v: boolean) => void;
+}>({ open: false, setOpen: () => {} });
+
+export function Popover({ children, open: controlledOpen, onOpenChange }: PopoverProps) {
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
+  return <PopoverContext.Provider value={{ open, setOpen }}>{children}</PopoverContext.Provider>;
+}
+
+export function PopoverTrigger({ children, className, asChild }: { children: React.ReactNode; className?: string; asChild?: boolean }) {
+  const { open, setOpen } = React.useContext(PopoverContext);
+  return (
+    <button className={className} onClick={() => setOpen(!open)} type="button">
+      {children}
+    </button>
+  );
+}
+
+export function PopoverContent({ children, className, align }: { children: React.ReactNode; className?: string; align?: string }) {
+  const { open, setOpen } = React.useContext(PopoverContext);
+  const ref = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    // Delay to avoid catching the trigger click
+    const timer = setTimeout(() => {
+      const handler = (e: MouseEvent) => {
+        if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      };
+      document.addEventListener("mousedown", handler);
+      return () => document.removeEventListener("mousedown", handler);
+    }, 50);
+    return () => clearTimeout(timer);
+  }, [open, setOpen]);
+
+  if (!open) return null;
+  return (
+    <div ref={ref} className={cn("absolute bottom-full mb-2 right-0 z-50 rounded-md border border-border bg-popover p-2 shadow-lg", className)}>
+      {children}
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -150,7 +150,10 @@ function getCurrentBranch(cwd: string): string {
 
 // ── Registration ─────────────────────────────────────────────────────
 
-export function registerPidash(pi: ExtensionAPI): void {
+export function registerPidash(
+  pi: ExtensionAPI,
+  killAsyncAgent?: (target: string) => { killed: string[]; errors: string[] },
+): void {
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
 
   let ws: any = null;
@@ -511,6 +514,11 @@ export function registerPidash(pi: ExtensionAPI): void {
               }
             }
 
+            if (parsed.command === "async-kill" && parsed.target) {
+              debugLog(`async-kill from browser: ${parsed.target}`);
+              pi.events.emit("pidash:async-kill", parsed.target);
+            }
+
             if (parsed.command === "list-commands") {
               try {
                 const cmds = (pi as any).getCommands?.() || [];
@@ -716,6 +724,16 @@ export function registerPidash(pi: ExtensionAPI): void {
       try { ws.send(JSON.stringify(data)); } catch {}
     }
   });
+
+  // Handle async-kill from browser
+  if (killAsyncAgent) {
+    pi.events.on("pidash:async-kill", (target: unknown) => {
+      if (typeof target === "string") {
+        const { killed } = killAsyncAgent(target);
+        debugLog(`async-kill result: ${killed.join(", ") || "none"}`);
+      }
+    });
+  }
 
   // Forward async agent status to browser
   pi.events.on("pidash:async-status", (data: unknown) => {

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -12,6 +12,7 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createRequire } from "node:module";
 
 const DEFAULT_PORT = 19190;
 const port = parseInt(process.env.PI_PIDASH_PORT || "", 10) || DEFAULT_PORT;
@@ -122,7 +123,8 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
 
 // ── WebSocket Server ────────────────────────────────────────────────
 
-const WebSocket = require("ws");
+const _require = createRequire(import.meta.url);
+const WebSocket = _require("ws");
 
 // Pi session clients
 const piWss = new WebSocket.Server({ noServer: true });
@@ -322,6 +324,19 @@ server.on("upgrade", (req: IncomingMessage, socket: any, head: Buffer) => {
     socket.destroy();
   }
 });
+
+// Clean up stale inactive sessions (disconnected > 5 min ago)
+const cleanupInterval = setInterval(() => {
+  const now = Date.now();
+  for (const [pid, client] of piClients.entries()) {
+    if (!client.session.active && now - client.session.lastActivity > 5 * 60 * 1000) {
+      piClients.delete(pid);
+      log(`cleaned up stale session: PID ${pid}`);
+      broadcastToBrowsers({ type: "session_removed", pid });
+    }
+  }
+}, 60 * 1000); // Check every minute
+if (cleanupInterval.unref) cleanupInterval.unref();
 
 // Ping all pi clients every 30s to keep connections alive
 const pingInterval = setInterval(() => {


### PR DESCRIPTION
## Changes

### Agent names in tool calls
- Subagent tool calls show `subagent (python-expert)` or `subagent (Dream)` instead of just "subagent"
- Task preview shown in detail line

### Interactive async agents panel
- Click `⏳ N async` badge to see list of running agents
- Each agent shows name, task preview, duration, and Kill button
- Kill sends command to server via pidash WebSocket
- Panel pinned to far right with `ml-auto` — no layout shift when agents start/stop
- Fixed flickering: skip state update when async data unchanged
- Fixed popover: delayed outside-click handler, right-aligned positioning

### Scroll behavior
- Scroll to bottom on session switch
- Auto-scroll follows new messages when at bottom of chat

### Cleanup
- Removed idle/streaming status indicator (redundant with chat UI)
- Remove URL hash on session select (always clean URL)
- Clean up stale inactive sessions after 5 minutes on server
- Pass killAsyncAgent as parameter instead of globalThis hack

Fixes #164