### PR TITLE
fix(pidash): popover overflow clip, scroll-to-bottom, async reset, cache headers

### DIFF
--- a/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
@@ -51,6 +51,11 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
   const pctColor = pct > 80 ? "text-red-500" : pct > 50 ? "text-orange-400" : "";
   const displayModel = model || session.model || "—";
 
+  // Reset async agents when session changes
+  useEffect(() => {
+    setAsyncAgents({ count: 0, agents: "", jobs: [] });
+  }, [session.pid]);
+
   useEffect(() => {
     return onMessage((ev: any) => {
       if (ev.type === "models-list" && ev.models) {
@@ -89,7 +94,7 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
   }, [openMenu, send, session.pid]);
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2 border-t border-border text-sm text-muted-foreground relative max-md:flex-wrap max-md:gap-2 max-md:text-xs md:overflow-x-auto md:whitespace-nowrap md:scrollbar-none">
+    <div className="flex items-center gap-3 px-4 py-2 border-t border-border text-sm text-muted-foreground relative max-md:flex-wrap max-md:gap-2 max-md:text-xs md:whitespace-nowrap md:scrollbar-none">
       {/* Model */}
       <div className="relative">
         <button
@@ -213,11 +218,14 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
 
       {/* Async agents — always visible, pinned to far right */}
       <div className="relative inline-block ml-auto">
-        {asyncAgents.count > 0 ? (
-          <Popover>
-            <PopoverTrigger className="text-yellow-400 hover:text-yellow-300 cursor-pointer text-xs">
-              ⏳ {asyncAgents.count} async
-            </PopoverTrigger>
+        <Popover>
+          <PopoverTrigger className={cn(
+            "cursor-pointer text-xs",
+            asyncAgents.count > 0 ? "text-yellow-400 hover:text-yellow-300" : "text-muted-foreground/50"
+          )}>
+            ⏳ {asyncAgents.count} async
+          </PopoverTrigger>
+          {asyncAgents.count > 0 && (
             <PopoverContent className="w-72 max-h-60 overflow-y-auto">
               <div className="text-xs space-y-1.5">
                 <div className="font-bold text-foreground mb-1">Running Agents</div>
@@ -249,10 +257,8 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
                 })}
               </div>
             </PopoverContent>
-          </Popover>
-        ) : (
-          <span className="text-muted-foreground/50 text-xs">⏳ 0 async</span>
-        )}
+          )}
+        </Popover>
       </div>
     </div>
   );

--- a/extensions/orchestrator/pidash-ui/src/components/ui/popover.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/popover.tsx
@@ -10,40 +10,51 @@ interface PopoverProps {
 const PopoverContext = React.createContext<{
   open: boolean;
   setOpen: (v: boolean) => void;
-}>({ open: false, setOpen: () => {} });
+  triggerRef: React.RefObject<HTMLButtonElement | null>;
+}>({ open: false, setOpen: () => {}, triggerRef: { current: null } });
 
 export function Popover({ children, open: controlledOpen, onOpenChange }: PopoverProps) {
   const [internalOpen, setInternalOpen] = React.useState(false);
+  const triggerRef = React.useRef<HTMLButtonElement | null>(null);
   const open = controlledOpen ?? internalOpen;
   const setOpen = onOpenChange ?? setInternalOpen;
-  return <PopoverContext.Provider value={{ open, setOpen }}>{children}</PopoverContext.Provider>;
+  return <PopoverContext.Provider value={{ open, setOpen, triggerRef }}>{children}</PopoverContext.Provider>;
 }
 
-export function PopoverTrigger({ children, className, asChild }: { children: React.ReactNode; className?: string; asChild?: boolean }) {
-  const { open, setOpen } = React.useContext(PopoverContext);
+export function PopoverTrigger({ children, className }: { children: React.ReactNode; className?: string; asChild?: boolean }) {
+  const { open, setOpen, triggerRef } = React.useContext(PopoverContext);
   return (
-    <button className={className} onClick={() => setOpen(!open)} type="button">
+    <button ref={triggerRef} className={className} onClick={(e) => { e.stopPropagation(); setOpen(!open); }} type="button">
       {children}
     </button>
   );
 }
 
-export function PopoverContent({ children, className, align }: { children: React.ReactNode; className?: string; align?: string }) {
-  const { open, setOpen } = React.useContext(PopoverContext);
+export function PopoverContent({ children, className }: { children: React.ReactNode; className?: string; align?: string }) {
+  const { open, setOpen, triggerRef } = React.useContext(PopoverContext);
   const ref = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
     if (!open) return;
-    // Delay to avoid catching the trigger click
+
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      // Don't close if clicking inside popover or on trigger
+      if (ref.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+
+    // Delay adding listener to avoid catching the click that opened it
     const timer = setTimeout(() => {
-      const handler = (e: MouseEvent) => {
-        if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-      };
       document.addEventListener("mousedown", handler);
-      return () => document.removeEventListener("mousedown", handler);
-    }, 50);
-    return () => clearTimeout(timer);
-  }, [open, setOpen]);
+    }, 10);
+
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("mousedown", handler);
+    };
+  }, [open, setOpen, triggerRef]);
 
   if (!open) return null;
   return (

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -106,7 +106,14 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
   try {
     const data = fs.readFileSync(absPath);
     const ext = path.extname(absPath).toLowerCase();
-    res.writeHead(200, { "Content-Type": MIME[ext] || "application/octet-stream" });
+    const headers: Record<string, string> = { "Content-Type": MIME[ext] || "application/octet-stream" };
+    // No cache for HTML, long cache for hashed assets
+    if (ext === ".html") {
+      headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+    } else if (filePath.includes("/assets/")) {
+      headers["Cache-Control"] = "public, max-age=31536000, immutable";
+    }
+    res.writeHead(200, headers);
     res.end(data);
   } catch {
     // SPA fallback — serve index.html for unknown routes


### PR DESCRIPTION
## Fixes

- **Popover invisible on click**: InfoBar had `overflow-x-auto` which clipped the upward-opening popover. Removed the overflow constraint.
- **Popover remounting**: Popover component is now always mounted — never torn down on re-renders from async-status updates
- **Popover cleanup**: proper useEffect cleanup, trigger ref shared via context to exclude from outside-click
- **Scroll-to-bottom**: fires at multiple intervals (50ms–3s) during session replay to catch messages as they load
- **Async count stale**: resets to 0 on session switch
- **Token width dancing**: tabular-nums with fixed min-width
- **Removed idle/streaming indicator**: redundant with chat UI
- **Cache headers**: no-cache for HTML, immutable for hashed assets
- **pidash-server ws**: createRequire fix (same as pidash.ts)

Fixes #164