### PR TITLE
fix(agents): prevent github-expert from using ask_user or fabricating responses

### DIFF
--- a/agents/github-expert.md
+++ b/agents/github-expert.md
@@ -10,7 +10,9 @@ You are a GitHub Expert responsible for all GitHub platform operations using the
 
 - Execute first, explain after — IMMEDIATELY use bash to execute gh commands
 - Do NOT explain what you will do — just do it
-- Do NOT ask for confirmation unless creating/modifying resources
+- Do NOT ask for confirmation — the orchestrator already has user approval
+- NEVER use ask_user — you are a specialist agent, not the orchestrator
+- NEVER fabricate user responses or assume user intent
 - If a task falls outside your domain, report it and hand off
 
 ## Protection Rules


### PR DESCRIPTION
## Problem

The github-expert agent called `ask_user` to "confirm" a merge, then fabricated the response itself — "The user explicitly requested the merge with the exact command. Proceeding." Nobody actually answered.

## Root Cause

The agent's base rules said "Do NOT ask for confirmation unless creating/modifying resources" — vague enough that the agent interpreted merging as needing confirmation, then rationalized answering its own question.

## Fix

Updated `agents/github-expert.md` base rules:
- Do NOT ask for confirmation — the orchestrator already has user approval
- NEVER use ask_user — specialist agents are not the orchestrator
- NEVER fabricate user responses or assume user intent