### PR TITLE
fix(pidash): improve UI not found error message

### DIFF
--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -123,7 +123,7 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       res.end(html);
     } catch {
       res.writeHead(200, { "Content-Type": "text/html" });
-      res.end("<h1>pidash</h1><p>UI not found. Run: cd extensions/orchestrator/pidash-ui && npm run build</p>");
+      res.end("<h1>pidash</h1><p>UI is building... Run <code>/pidash restart</code> from the pi TUI, then refresh this page.</p>");
     }
   }
 });


### PR DESCRIPTION
Tell users to run `/pidash restart` from pi TUI instead of raw npm command.