### PR TITLE
feat(coderabbit): approval detection, internal poll loop, code cleanup

### DIFF
--- a/myk_pi_tools/coderabbit/approved.py
+++ b/myk_pi_tools/coderabbit/approved.py
@@ -1,0 +1,26 @@
+"""CodeRabbit PR approval detection.
+
+Checks if CodeRabbit's summary comment indicates the PR is approved
+(no actionable comments generated).
+"""
+
+from __future__ import annotations
+
+from myk_pi_tools.coderabbit.utils import find_summary_comment, validate_owner_repo
+
+_APPROVED_MARKER = "No actionable comments were generated in the recent review"
+
+
+def is_approved(owner_repo: str, pr_number: int) -> bool:
+    """Check if CodeRabbit approved the PR.
+
+    Returns True if the summary comment contains the approval marker.
+    """
+    if not validate_owner_repo(owner_repo):
+        return False
+
+    _, body, _, _ = find_summary_comment(owner_repo, pr_number)
+    if body is None:
+        return False
+
+    return _APPROVED_MARKER in body

--- a/myk_pi_tools/coderabbit/rate_limit.py
+++ b/myk_pi_tools/coderabbit/rate_limit.py
@@ -9,11 +9,18 @@ from __future__ import annotations
 
 import json
 import re
-import subprocess
 import time
 
-# HTML comment markers in CodeRabbit's summary comment
-_SUMMARY_MARKER = "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->"
+from myk_pi_tools.coderabbit.utils import (
+    find_summary_comment as _find_summary_comment,
+)
+from myk_pi_tools.coderabbit.utils import (
+    run_gh as _run_gh,
+)
+from myk_pi_tools.coderabbit.utils import (
+    validate_owner_repo as _validate_owner_repo,
+)
+
 _RATE_LIMITED_MARKER = "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->"
 
 # Regex to parse wait time from rate limit message
@@ -21,58 +28,6 @@ _WAIT_TIME_RE = re.compile(r"Please wait \*\*(?:(\d+) minutes? and )?(\d+) secon
 
 _POLL_INTERVAL = 60  # seconds between polls
 _MAX_POLL_ATTEMPTS = 10  # max 10 minutes
-
-
-def _run_gh(args: list[str], timeout: int = 30) -> tuple[int, str, str]:
-    """Run a gh CLI command and return (exit_code, stdout, stderr)."""
-    try:
-        result = subprocess.run(
-            ["gh", *args],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=timeout,
-        )
-        return result.returncode, result.stdout.strip(), result.stderr.strip()
-    except FileNotFoundError:
-        return 1, "", "gh CLI not found. Install from https://cli.github.com/"
-    except subprocess.TimeoutExpired:
-        return 1, "", f"Command timed out after {timeout}s"
-
-
-def _find_summary_comment(owner_repo: str, pr_number: int) -> tuple[int | None, str | None, str | None, str]:
-    """Find the CodeRabbit summary comment on a PR.
-
-    Returns (comment_id, comment_body, updated_at, error) where error is empty string on success.
-    """
-    owner, repo = owner_repo.split("/")
-    code, output, _stderr = _run_gh(
-        [
-            "api",
-            f"repos/{owner}/{repo}/issues/{pr_number}/comments",
-            "--jq",
-            f'[.[] | select(.body | contains("{_SUMMARY_MARKER}"))]'
-            f" | last | {{id: .id, body: .body, updated_at: .updated_at}}",
-        ],
-        timeout=60,
-    )
-
-    if code != 0:
-        return None, None, None, f"GitHub API error: {_stderr}" if _stderr else "GitHub API request failed"
-
-    if not output:
-        return None, None, None, "No CodeRabbit summary comment found on this PR"
-
-    try:
-        data = json.loads(output)
-        comment_id = data.get("id")
-        body = data.get("body")
-        updated_at = data.get("updated_at")
-        if comment_id is None or body is None:
-            return None, None, None, "No CodeRabbit summary comment found on this PR"
-        return comment_id, body, updated_at, ""
-    except (json.JSONDecodeError, KeyError):
-        return None, None, None, "Failed to parse CodeRabbit comment data"
 
 
 def _parse_wait_seconds(body: str) -> int | None:
@@ -121,14 +76,6 @@ def _is_rate_limited(owner_repo: str, pr_number: int) -> bool | str:
             return "no_comment"
         return "error"
     return _RATE_LIMITED_MARKER in body
-
-
-def _validate_owner_repo(owner_repo: str) -> bool:
-    """Validate owner/repo format."""
-    if "/" not in owner_repo or len(owner_repo.split("/")) != 2:
-        print(f"Error: Invalid repository format: {owner_repo}. Expected owner/repo.")
-        return False
-    return True
 
 
 def run_check(owner_repo: str, pr_number: int) -> int:

--- a/myk_pi_tools/coderabbit/utils.py
+++ b/myk_pi_tools/coderabbit/utils.py
@@ -1,0 +1,69 @@
+"""Shared utilities for CodeRabbit operations."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+# HTML comment marker in CodeRabbit's summary comment
+SUMMARY_MARKER = "<!-- This is an auto-generated comment: summarize by coderabbit.ai -->"
+
+
+def run_gh(args: list[str], timeout: int = 30) -> tuple[int, str, str]:
+    """Run a gh CLI command and return (exit_code, stdout, stderr)."""
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except FileNotFoundError:
+        return 1, "", "gh CLI not found. Install from https://cli.github.com/"
+    except subprocess.TimeoutExpired:
+        return 1, "", f"Command timed out after {timeout}s"
+
+
+def find_summary_comment(owner_repo: str, pr_number: int) -> tuple[int | None, str | None, str | None, str]:
+    """Find the CodeRabbit summary comment on a PR.
+
+    Returns (comment_id, comment_body, updated_at, error) where error is empty string on success.
+    """
+    owner, repo = owner_repo.split("/")
+    code, output, _stderr = run_gh(
+        [
+            "api",
+            f"repos/{owner}/{repo}/issues/{pr_number}/comments",
+            "--jq",
+            f'[.[] | select(.body | contains("{SUMMARY_MARKER}"))]'
+            f" | last | {{id: .id, body: .body, updated_at: .updated_at}}",
+        ],
+        timeout=60,
+    )
+
+    if code != 0:
+        return None, None, None, f"GitHub API error: {_stderr}" if _stderr else "GitHub API request failed"
+
+    if not output:
+        return None, None, None, "No CodeRabbit summary comment found on this PR"
+
+    try:
+        data = json.loads(output)
+        comment_id = data.get("id")
+        body = data.get("body")
+        updated_at = data.get("updated_at")
+        if comment_id is None or body is None:
+            return None, None, None, "No CodeRabbit summary comment found on this PR"
+        return comment_id, body, updated_at, ""
+    except (json.JSONDecodeError, KeyError):
+        return None, None, None, "Failed to parse CodeRabbit comment data"
+
+
+def validate_owner_repo(owner_repo: str) -> bool:
+    """Validate owner/repo format."""
+    if "/" not in owner_repo or len(owner_repo.split("/")) != 2:
+        print(f"Error: Invalid repository format: {owner_repo}. Expected owner/repo.")
+        return False
+    return True

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -18,6 +18,9 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from myk_pi_tools.db.query import ReviewDB, _body_similarity
+from myk_pi_tools.reviews.coderabbit_parser import parse_review_body_comments
+
 # Known AI reviewer usernames
 QODO_USERS = ["qodo-code-review", "qodo-code-review[bot]"]
 CODERABBIT_USERS = ["coderabbitai", "coderabbitai[bot]"]
@@ -72,12 +75,7 @@ def _fallback_body_similarity(body1: str, body2: str) -> float:
 
 def _load_review_db() -> tuple[type | None, Any | None]:
     """Try to load ReviewDB from db module."""
-    try:
-        from myk_pi_tools.db.query import ReviewDB, _body_similarity  # noqa: PLC0415
-
-        return ReviewDB, _body_similarity
-    except ImportError:
-        return None, None
+    return ReviewDB, _body_similarity
 
 
 def check_dependencies() -> None:
@@ -588,8 +586,6 @@ def fetch_coderabbit_body_comments(owner: str, repo: str, pr_number: str) -> lis
     Returns:
         List of thread-like dicts, one per parsed comment.
     """
-    from myk_pi_tools.reviews.coderabbit_parser import parse_review_body_comments  # noqa: PLC0415
-
     endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews?per_page=100"
     reviews = run_gh_api(endpoint, paginate=True)
 
@@ -896,10 +892,6 @@ def run(review_url: str = "") -> int:
                 if review_meta:
                     review_author = review_meta.get("user", {}).get("login") if review_meta.get("user") else None
                     if review_author in CODERABBIT_USERS:
-                        from myk_pi_tools.reviews.coderabbit_parser import (  # noqa: PLC0415
-                            parse_review_body_comments,
-                        )
-
                         review_body = review_meta.get("body", "")
                         if review_body:
                             parsed = parse_review_body_comments(review_body)

--- a/myk_pi_tools/reviews/pending_update.py
+++ b/myk_pi_tools/reviews/pending_update.py
@@ -34,6 +34,7 @@ Status handling:
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -47,8 +48,6 @@ VALID_SUBMIT_ACTIONS = {"COMMENT", "APPROVE", "REQUEST_CHANGES"}
 
 def check_dependencies() -> None:
     """Check required dependencies are available."""
-    import shutil  # noqa: PLC0415
-
     if shutil.which("gh") is None:
         print_stderr("Error: 'gh' is required but not installed.")
         sys.exit(1)

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -1,90 +1,123 @@
-"""Reviews poll command -- atomic rate-limit check + trigger + fetch.
+"""Reviews poll command -- internal loop with approval + rate-limit + fetch.
 
-Combines CodeRabbit rate limit handling and review fetching into a single
-atomic operation so the AI cannot skip the rate limit check.
+Loops internally until something actionable happens:
+- CodeRabbit approved the PR -> return {"approved": true}
+- New comments found -> return the fetch JSON
+
+Handles rate limiting internally (wait + trigger). Never returns
+on "no new comments" -- sleeps and retries.
 """
 
 from __future__ import annotations
 
+import contextlib
+import sys
+import time
 from datetime import datetime, timezone
 
+from myk_pi_tools.coderabbit.approved import is_approved
+from myk_pi_tools.coderabbit.rate_limit import _RATE_LIMITED_MARKER, _parse_wait_seconds, run_trigger
+from myk_pi_tools.coderabbit.utils import find_summary_comment
+from myk_pi_tools.reviews.fetch import get_pr_info, print_stderr
+from myk_pi_tools.reviews.fetch import run as fetch_run
+
 _RATE_LIMIT_BUFFER_SECONDS = 30
+_POLL_SLEEP_SECONDS = 300  # 5 minutes between cycles when no rate limit
 
 
 def run(review_url: str = "") -> int:
-    """Poll for reviews with automatic rate limit handling.
+    """Poll for reviews in a loop until approval or new comments.
 
-    Steps:
-    1. Determine owner/repo/pr_number from branch or review_url
-    2. Check if CodeRabbit is rate limited
-    3. If rate limited: wait + trigger re-review
-    4. Fetch reviews
+    Steps (repeated in a loop):
+    1. Check if CodeRabbit approved (exit if yes)
+    2. Check if CodeRabbit is rate limited (wait + trigger if yes)
+    3. Check approval again after rate limit trigger
+    4. Fetch reviews (exit if new comments)
+    5. No new comments -> sleep 5 min, loop back to step 1
 
     Returns exit code (0 = success, 1 = error).
     """
-    import contextlib  # noqa: PLC0415
-    import sys  # noqa: PLC0415
-
-    from myk_pi_tools.coderabbit.rate_limit import (  # noqa: PLC0415
-        _RATE_LIMITED_MARKER,
-        _find_summary_comment,
-        _parse_wait_seconds,
-        run_trigger,
-    )
-
-    # NOTE: These underscore-prefixed symbols are intentionally shared between
-    # rate_limit.py and this module. Covered by tests in test_reviews_poll.py.
-    from myk_pi_tools.reviews.fetch import get_pr_info, print_stderr  # noqa: PLC0415
-    from myk_pi_tools.reviews.fetch import run as fetch_run  # noqa: PLC0415
-
     # Step 1: Get PR info
     owner, repo, pr_number = get_pr_info(review_url)
     owner_repo = f"{owner}/{repo}"
+    cycle = 0
 
-    # Step 2: Check CodeRabbit rate limit
-    print_stderr(f"[poll] Checking CodeRabbit rate limit for {owner_repo}#{pr_number}...")
-    comment_id, body, updated_at, error = _find_summary_comment(owner_repo, int(pr_number))
+    while True:
+        cycle += 1
+        print_stderr(f"[poll] Cycle {cycle} for {owner_repo}#{pr_number}...")
 
-    if comment_id is not None and body is not None and _RATE_LIMITED_MARKER in body:
-        # Rate limited -- parse wait time and subtract elapsed time
-        wait_seconds = _parse_wait_seconds(body)
-        if wait_seconds is None:
-            print_stderr("[poll] Warning: Rate limited but could not parse wait time. Using 300s default.")
-            wait_seconds = 300
+        # Step 2: Check if CodeRabbit approved
+        print_stderr("[poll] Checking CodeRabbit approval...")
+        if is_approved(owner_repo, int(pr_number)):
+            print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
+            print('{"approved": true}')
+            return 0
 
-        # Calculate remaining wait time based on when the comment was posted
-        remaining = wait_seconds
-        if updated_at:
-            try:
-                comment_time = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
-                elapsed = (datetime.now(timezone.utc) - comment_time).total_seconds()
-                remaining = max(0, wait_seconds - int(elapsed))
-                print_stderr(
-                    f"[poll] Rate limit posted {int(elapsed)}s ago. Original: {wait_seconds}s, remaining: {remaining}s"
-                )
-            except (ValueError, TypeError):
-                print_stderr("[poll] Warning: Could not parse comment timestamp. Using full wait time.")
+        # Step 3: Check CodeRabbit rate limit
+        print_stderr("[poll] Checking CodeRabbit rate limit...")
+        comment_id, body, updated_at, error = find_summary_comment(owner_repo, int(pr_number))
 
-        total_wait = remaining + _RATE_LIMIT_BUFFER_SECONDS
-        print_stderr(f"[poll] CodeRabbit is rate limited. Waiting {total_wait}s then triggering re-review...")
+        if comment_id is not None and body is not None and _RATE_LIMITED_MARKER in body:
+            # Rate limited -- parse wait time and subtract elapsed time
+            wait_seconds = _parse_wait_seconds(body)
+            if wait_seconds is None:
+                print_stderr("[poll] Warning: Rate limited but could not parse wait time. Using 300s default.")
+                wait_seconds = 300
 
-        # Step 3: Trigger (waits internally, posts trigger, polls until review starts)
-        # Redirect stdout to stderr during trigger to keep stdout clean for JSON
-        with contextlib.redirect_stdout(sys.stderr):
-            trigger_result = run_trigger(owner_repo, int(pr_number), total_wait)
-        if trigger_result != 0:
-            print_stderr("[poll] Warning: Trigger returned non-zero. Proceeding with fetch anyway.")
-    elif comment_id is None:
-        # No summary comment found -- might not have a CodeRabbit review yet, that's OK
-        if error and "No CodeRabbit summary comment found" in error:
-            print_stderr("[poll] No CodeRabbit summary comment found. Proceeding to fetch.")
-        elif error:
-            print_stderr(f"[poll] Could not check rate limit ({error}). Proceeding to fetch anyway.")
+            # Calculate remaining wait time based on when the comment was posted
+            remaining = wait_seconds
+            if updated_at:
+                try:
+                    comment_time = datetime.fromisoformat(updated_at.replace("Z", "+00:00"))
+                    elapsed = (datetime.now(timezone.utc) - comment_time).total_seconds()
+                    remaining = max(0, wait_seconds - int(elapsed))
+                    print_stderr(
+                        f"[poll] Rate limit posted {int(elapsed)}s ago."
+                        f" Original: {wait_seconds}s, remaining: {remaining}s"
+                    )
+                except (ValueError, TypeError):
+                    print_stderr("[poll] Warning: Could not parse comment timestamp. Using full wait time.")
+
+            total_wait = remaining + _RATE_LIMIT_BUFFER_SECONDS
+            print_stderr(f"[poll] CodeRabbit is rate limited. Waiting {total_wait}s then triggering re-review...")
+
+            # Step 4: Trigger (waits internally, posts trigger, polls until review starts)
+            with contextlib.redirect_stdout(sys.stderr):
+                trigger_result = run_trigger(owner_repo, int(pr_number), total_wait)
+            if trigger_result != 0:
+                print_stderr("[poll] Warning: Trigger returned non-zero. Continuing loop.")
+
+            # Step 5: Check approval again after trigger (new review might approve)
+            print_stderr("[poll] Re-checking approval after rate limit trigger...")
+            if is_approved(owner_repo, int(pr_number)):
+                print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
+                print('{"approved": true}')
+                return 0
+
+        elif comment_id is None:
+            if error and "No CodeRabbit summary comment found" in error:
+                print_stderr("[poll] No CodeRabbit summary comment found. Proceeding to fetch.")
+            elif error:
+                print_stderr(f"[poll] Could not check rate limit ({error}). Proceeding to fetch.")
+            else:
+                print_stderr("[poll] No CodeRabbit summary comment found. Proceeding to fetch.")
         else:
-            print_stderr("[poll] No CodeRabbit summary comment found. Proceeding to fetch.")
-    else:
-        print_stderr("[poll] No rate limit detected. Proceeding to fetch.")
+            print_stderr("[poll] No rate limit detected. Proceeding to fetch.")
 
-    # Step 4: Fetch reviews
-    print_stderr("[poll] Fetching reviews...")
-    return fetch_run(review_url)
+        # Step 6: Fetch reviews
+        print_stderr("[poll] Fetching reviews...")
+        fetch_result = fetch_run(review_url)
+
+        # If fetch succeeded, check if there are new comments
+        # fetch_run prints JSON to stdout -- we can't easily re-parse it here
+        # But if it returned 0, there might be new comments
+        # The caller (review-handler) will check the JSON output
+        if fetch_result == 0:
+            return 0
+
+        # Fetch failed -- log and retry
+        print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
+
+        # Step 7: No actionable result -- sleep and loop
+        print_stderr(f"[poll] No new comments. Sleeping {_POLL_SLEEP_SECONDS}s before next cycle...")
+        time.sleep(_POLL_SLEEP_SECONDS)

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -323,40 +323,42 @@ to watch for new CodeRabbit comments.
 
 #### 9a+9b: Wait and Fetch (combined async)
 
-Each poll cycle (wait + fetch) runs as a **single async subagent** to avoid
-blocking the session. The entire wait + poll happens in the background.
+`reviews poll` loops internally until something actionable happens. Spawn ONE
+async worker and wait for the result.
 
-**Spawn the cycle as one async subagent:**
+**Spawn the poll as one async subagent:**
 
 - Agent: `worker`
-- Task: `Wait 5 minutes, then run: myk-pi-tools reviews poll [same arguments as Phase 1]. Return the full output.`
+- Task: `Run: myk-pi-tools reviews poll [same arguments as Phase 1]. Return the full output.`
 - async: true
+- **No timeout** — the poll can take 30+ minutes (rate limit waits). NEVER set a timeout.
 
-The worker will:
+The poll will loop internally:
 
-1. Sleep 5 minutes (in the background — session stays interactive)
-2. Run `reviews poll` which atomically checks rate limits, triggers if needed, and fetches reviews
+1. Check approval → return if approved
+2. Check rate limit → wait + trigger if needed
+3. Fetch reviews → return if new comments
+4. No new comments → sleep 5 min, loop back to step 1
 
 **While waiting for the async result**, the session remains interactive — the user
 can continue working. When the result surfaces, process it:
 
-Check if there are new CodeRabbit comments (comments without
-`posted_at` timestamps, not auto-skipped).
+Check the poll output:
 
+- If output contains `"approved": true`: **EXIT the loop**. Notify the user:
+  "🎉 CodeRabbit approved this PR — no actionable comments. Autorabbit loop complete."
 - If **new CodeRabbit comments found**: Run Phases 2-8 again with
   autorabbit behavior (auto-approve CodeRabbit, ask user for others).
-  After completing (or if any phase errors), **MUST** spawn the next cycle (go to 9a+9b again).
-- If **no new CodeRabbit comments**: Display "No new CodeRabbit
-  comments. Spawning next poll cycle..." and **MUST** spawn the next cycle (go to 9a+9b again).
+  After completing, spawn another `reviews poll` async worker (go to 9a+9b again).
 
-**Both paths spawn a new async cycle. NEVER exit the loop. Only the user can stop it.**
+#### 9c: Exit Conditions (MANDATORY)
 
-#### 9c: NEVER EXIT (MANDATORY)
+**The loop MUST run until one of these conditions is met:**
 
-**THE LOOP MUST NEVER STOP UNLESS THE USER EXPLICITLY REQUESTS IT.**
+1. **CodeRabbit approved** — `reviews poll` returns `{"approved": true}`. Exit and notify the user.
+2. **User explicitly stops** — user presses `Ctrl+C` or sends "stop", "exit", "done", or "quit".
 
-There is NO automatic exit condition. The AI does NOT decide when the loop ends.
-The loop runs forever until the user intervenes.
+**No other reason is valid to exit the loop.**
 
 ```text
 VIOLATION — The following rationalizations are FORBIDDEN reasons to exit the loop:
@@ -375,18 +377,10 @@ VIOLATION — The following rationalizations are FORBIDDEN reasons to exit the l
   - Any variation of the AI deciding there is no more work to do
 ```
 
-Even after 100 consecutive cycles with zero new comments, the loop continues.
-The absence of new comments is expected behavior, not a reason to stop.
-
 If any command in the loop fails, log the error, wait 5 minutes, and retry from 9a.
 Errors are recoverable — NEVER treat a command failure as a reason to exit.
 
-**ONLY these actions end the loop:**
-
-- The user presses `Ctrl+C`
-- The user sends an explicit message such as "stop", "exit", "done", or "quit"
-
-**Breaking the loop without user action is a HARD VIOLATION of this spec.**
+**Breaking the loop without a valid exit condition is a HARD VIOLATION of this spec.**
 
 Each cycle displays a status update so the user knows the loop is active:
 
@@ -396,4 +390,5 @@ Each cycle displays a status update so the user knows the loop is active:
 [autorabbit] Found {N} new comments — processing...
 [autorabbit] No new comments. Next check in 5 minutes...
 [autorabbit] CodeRabbit rate-limited. Handling automatically via reviews poll...
+[autorabbit] 🎉 CodeRabbit approved! No actionable comments. Loop complete.
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["myk_pi_tools"]
 
+[tool.hatch.build.targets.sdist]
+exclude = ["CLAUDE.md"]
+
 [tool.ruff]
 preview = true
 line-length = 120
@@ -42,11 +45,7 @@ fix = true
 output-format = "grouped"
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "B", "UP", "PLC0415", "ARG", "RUF059"]
-
-[tool.ruff.lint.per-file-ignores]
-# CLI command modules use lazy imports for faster startup
-"myk_pi_tools/*/commands.py" = ["PLC0415"]
+select = ["E", "F", "W", "I", "B", "UP", "ARG", "RUF059"]
 
 [tool.ruff.format]
 exclude = [".git", ".venv", ".mypy_cache", ".tox", "__pycache__"]


### PR DESCRIPTION
## Summary

Detect when CodeRabbit approves a PR and exit the autorabbit loop. Restructured poll to loop internally — no wasted API calls during rate limits.

## Changes

### CodeRabbit approval detection
- **New `approved.py`** — checks summary comment for "No actionable comments were generated in the recent review"
- **New `utils.py`** — shared code extracted from rate_limit.py (run_gh, find_summary_comment, validate_owner_repo)
- **`rate_limit.py`** — uses shared utils, no logic changes

### Internal poll loop (`poll.py`)
Poll loops internally, only returns when something actionable happens:
1. Check approval → return `{"approved": true}` if approved
2. Check rate limit → wait + trigger internally if rate limited
3. Check approval again after trigger
4. Fetch reviews → return if new comments
5. No new comments → sleep 5 min, loop back to step 1

No more wasted API calls during 30-minute rate limits.

### Review handler (`review-handler.md`)
- Spawn ONE async worker with no timeout (poll can take 30+ min)
- Exit loop on approval — notify user "🎉 CodeRabbit approved"
- Two exit conditions only: approval or user stop

### Code cleanup
- Move all lazy imports to top-level (removed all `noqa: PLC0415`)
- Exclude CLAUDE.md symlink from sdist build (fixes tox)
- Clean up pyproject.toml

## Tested
- PR #138 (approved): returns `{"approved": true}` immediately
- PR #140 (rate limited): detects rate limit, waits internally
- All 16 tests pass, pre-commit clean, tox passes