### PR TITLE
fix(rules): file preview server survives shell cleanup

### DIFF
--- a/rules/45-file-preview.md
+++ b/rules/45-file-preview.md
@@ -1,15 +1,27 @@
-# File Preview (Container)
+# File Preview
 
-When generating or modifying HTML, frontend, or any browser-viewable files inside a container:
+When generating or modifying HTML, frontend, or any browser-viewable files:
 
 1. Save the file under the project directory (`$PWD`) or `/tmp/pi-work/`
-2. Serve it using:
+2. Serve it using a Python script that ignores SIGHUP (survives shell cleanup):
 
    ```bash
-   uv run python -m http.server <port> --directory <dir>
+   uv run python3 -c "
+   import signal, http.server, socketserver
+   signal.signal(signal.SIGHUP, signal.SIG_IGN)
+   socketserver.TCPServer.allow_reuse_address = True
+   with socketserver.TCPServer(('', PORT), http.server.SimpleHTTPRequestHandler) as s:
+       s.serve_forever()
+   " &
    ```
 
-   Use port `8080` by default. If the port is in use, try `8081`, `8082`, etc.
+   To find a free port, ask the OS:
+
+   ```bash
+   uv run python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"
+   ```
+
+   Use the printed port number as `PORT`.
 
 3. Tell the user:
 
@@ -17,4 +29,9 @@ When generating or modifying HTML, frontend, or any browser-viewable files insid
 
 4. Keep the server running until the user confirms they're done previewing.
 
-This works because the container uses `--network host`, so the host can reach services on any port.
+**Why not `python -m http.server`?** The `uv run` wrapper creates a parent
+process chain. When bash background job cleanup runs, the parent `uv` process
+gets killed, taking the Python child with it. The `signal.SIGHUP` ignore
+prevents this.
+
+This works in containers (`--network host`) and native installs.


### PR DESCRIPTION
The old `uv run python -m http.server &` approach dies because uv creates a wrapper process — when bash cleans up background jobs, the parent uv process gets killed, taking the Python child with it.

**Fix:**
- Ignore SIGHUP in Python so the server survives shell cleanup
- Use `allow_reuse_address` to handle stale ports from dead servers
- Start from port 9080 (avoid common ports like 8080, 3000, 5000)
- Works in containers and native installs