### PR TITLE
fix(pidash): session identity, branch leak, tool headers

### DIFF
--- a/extensions/orchestrator/pidash-ui/src/App.tsx
+++ b/extensions/orchestrator/pidash-ui/src/App.tsx
@@ -10,15 +10,15 @@ import type { ChatMessage, PiEvent, SessionInfo, TokenUsage } from "@/types";
 
 const STORAGE_KEY = "pidash-state";
 
-function loadState(): { sidebarWidth: number; sidebarCollapsed: boolean; watchPid: number | null } {
+function loadState(): { sidebarWidth: number; sidebarCollapsed: boolean; watchPid: number | null; watchSessionId: string | null } {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) return JSON.parse(raw);
   } catch {}
-  return { sidebarWidth: 280, sidebarCollapsed: false, watchPid: null };
+  return { sidebarWidth: 280, sidebarCollapsed: false, watchPid: null, watchSessionId: null };
 }
 
-function saveState(state: { sidebarWidth: number; sidebarCollapsed: boolean; watchPid: number | null }) {
+function saveState(state: { sidebarWidth: number; sidebarCollapsed: boolean; watchPid: number | null; watchSessionId: string | null }) {
   try { localStorage.setItem(STORAGE_KEY, JSON.stringify(state)); } catch {}
 }
 
@@ -64,7 +64,7 @@ export function App() {
   const thinkRef = useRef({ id: "", text: "" });
   const assistRef = useRef({ id: "", text: "" });
   const lastUserRef = useRef("");
-  const toolRef = useRef({ id: "", name: "" });
+  const toolRef = useRef({ id: "", name: "", startTs: 0, callId: "" });
   const restoredRef = useRef(false);
   const replayingRef = useRef(false);
 
@@ -88,7 +88,7 @@ export function App() {
           if (ev.type === "session_updated" && ev.session) {
             // Update active session if it's the one we're watching
             setSession((prev) => {
-              if (prev?.pid === ev.session.pid) {
+              if (prev?.sessionId === ev.session.sessionId) {
                 if (ev.session.model !== undefined) setModel(ev.session.model);
                 return { ...prev, ...ev.session };
               }
@@ -173,8 +173,10 @@ export function App() {
             else if (ev.args.tasks) detail = `${ev.args.tasks.length} parallel tasks`;
             else if (ev.args.chain) detail = `${ev.args.chain.length} chain steps`;
           }
-          const id = addMsg(name as any, detail, "tool-call");
-          toolRef.current = { id, name };
+          const cid = ev.toolCallId || nextId();
+          const id = nextId();
+          setMessages((p) => [...p, { id, role: name as any, text: detail, className: "tool-call", meta: { callId: cid } }]);
+          toolRef.current = { id, name, startTs: ev.timestamp || Date.now(), callId: cid };
           break;
         }
 
@@ -186,10 +188,39 @@ export function App() {
 
         case "tool_execution_end": {
           const toolName = toolRef.current.name || ev.toolName || "tool";
-          toolRef.current = { id: "", name: "" };
+          const startTs = toolRef.current.startTs;
+          const callId = toolRef.current.callId;
+          toolRef.current = { id: "", name: "", startTs: 0, callId: "" };
           if (ev.result?.content?.[0]?.text) {
             const t = ev.result.content[0].text;
-            addMsg(toolName as any, `${ev.isError ? "✗ " : "✓ "}${t}`, "tool-result");
+            const endTs = ev.timestamp || Date.now();
+            let meta: ChatMessage["meta"] = startTs ? { startTs, endTs, callId } : { callId };
+            const results = ev.result?.details?.results;
+            if (results?.length) {
+              let totalInput = 0, totalOutput = 0, totalTurns = 0, totalCache = 0, totalCtx = 0, totalCost = 0;
+              for (const res of results) {
+                if (res.usage) {
+                  totalInput += res.usage.input || 0;
+                  totalOutput += res.usage.output || 0;
+                  totalTurns += res.usage.turns || 0;
+                  totalCache += res.usage.cacheRead || 0;
+                  totalCtx += res.usage.contextTokens || 0;
+                  totalCost += res.usage.cost || 0;
+                }
+              }
+              meta = {
+                ...meta,
+                turns: totalTurns,
+                input: totalInput,
+                output: totalOutput,
+                cacheRead: totalCache,
+                contextTokens: totalCtx,
+                cost: totalCost,
+                model: results[0]?.model,
+              };
+            }
+            const id = nextId();
+            setMessages((p) => [...p, { id, role: toolName as any, text: `${ev.isError ? "✗ " : "✓ "}${t}`, className: "tool-result", meta }]);
           }
           break;
         }
@@ -236,8 +267,8 @@ export function App() {
     assistRef.current = { id: "", text: "" };
     lastUserRef.current = "";
     replayingRef.current = true;
-    send({ type: "watch", pid: s.pid });
-    send({ type: "pidash-command", pid: s.pid, command: "list-commands" });
+    send({ type: "watch", sessionId: s.sessionId });
+    send({ type: "pidash-command", sessionId: s.sessionId, command: "list-commands" });
     // Events from buffer replay arrive synchronously — mark replay done after a short delay
     setTimeout(() => { replayingRef.current = false; }, 2000);
     // Session persisted via localStorage — no URL hash needed
@@ -252,24 +283,24 @@ export function App() {
       sidebarWidth,
       sidebarCollapsed: mobile ? true : sidebarCollapsed,
       watchPid: session?.pid ?? null,
+      watchSessionId: session?.sessionId ?? null,
     });
   }, [sidebarWidth, sidebarCollapsed, session]);
 
   useEffect(() => {
     if (!connected || !sessions.length || restoredRef.current) return;
     // Restore from localStorage
+    const sid = saved.current.watchSessionId;
     const pid = saved.current.watchPid;
-    if (pid) {
-      const s = sessions.find((x) => x.pid === pid);
-      if (s) { restoredRef.current = true; watchSession(s); }
-    }
+    const s = sid ? sessions.find((x) => x.sessionId === sid) : pid ? sessions.find((x) => x.pid === pid) : null;
+    if (s) { restoredRef.current = true; watchSession(s); }
   }, [connected, sessions, watchSession]);
 
 
 
 
   const handleAbort = useCallback(() => {
-    if (session) send({ type: "pidash-command", pid: session.pid, command: "abort" });
+    if (session) send({ type: "pidash-command", sessionId: session.sessionId, command: "abort" });
   }, [session, send]);
 
   useEffect(() => {
@@ -284,7 +315,7 @@ export function App() {
     if (!session) return;
     lastUserRef.current = text;
     addMsg("user", text);
-    send({ type: "prompt", pid: session.pid, text });
+    send({ type: "prompt", sessionId: session.sessionId, text });
   }, [session, send, addMsg]);
 
   return (
@@ -303,7 +334,7 @@ export function App() {
           >
             <SessionSidebar
             sessions={sessions}
-            activePid={session?.pid ?? null}
+            activeSessionId={session?.sessionId ?? null}
             connected={connected}
             onSelect={watchSession}
             collapsed={false}
@@ -362,11 +393,11 @@ export function App() {
               scrollKey={scrollKey}
               onAskResponse={(id, value) => {
                 if (value === "__confirmed__") {
-                  send({ type: "extension_ui_response", pid: session!.pid, id, confirmed: true });
+                  send({ type: "extension_ui_response", sessionId: session!.sessionId, id, confirmed: true });
                 } else if (value === "__denied__") {
-                  send({ type: "extension_ui_response", pid: session!.pid, id, confirmed: false });
+                  send({ type: "extension_ui_response", sessionId: session!.sessionId, id, confirmed: false });
                 } else {
-                  send({ type: "extension_ui_response", pid: session!.pid, id, value });
+                  send({ type: "extension_ui_response", sessionId: session!.sessionId, id, value });
                 }
               }}
             />

--- a/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx
@@ -55,7 +55,7 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
   // Reset async agents when session changes
   useEffect(() => {
     setAsyncAgents({ count: 0, agents: "", jobs: [] });
-  }, [session.pid]);
+  }, [session.sessionId]);
 
   useEffect(() => {
     return onMessage((ev: any) => {
@@ -91,8 +91,8 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
     e.stopPropagation();
     if (openMenu === name) { setOpenMenu(null); return; }
     setOpenMenu(name);
-    if (name === "models") send({ type: "pidash-command", command: "list-models", pid: session.pid });
-  }, [openMenu, send, session.pid]);
+    if (name === "models") send({ type: "pidash-command", command: "list-models", sessionId: session.sessionId });
+  }, [openMenu, send, session.sessionId]);
 
   return (
     <div className={cn("flex items-center gap-3 px-4 py-2 border-t border-border text-sm text-muted-foreground relative max-md:flex-wrap max-md:gap-2 max-md:text-xs md:whitespace-nowrap md:scrollbar-none", inactive && "opacity-50 pointer-events-none")}>
@@ -127,7 +127,7 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
                 key={m.id}
                 className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent transition-colors flex justify-between ${(m.name === displayModel || m.id === displayModel) ? "bg-accent/50" : ""}`}
                 onClick={() => {
-                  send({ type: "pidash-command", pid: session.pid, command: "set-model", modelId: m.id });
+                  send({ type: "pidash-command", sessionId: session.sessionId, command: "set-model", modelId: m.id });
                   setOpenMenu(null);
                 }}
               >
@@ -158,7 +158,7 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
                 className={`w-full text-left px-3 py-1.5 text-sm hover:bg-accent transition-colors ${lvl === thinkingLevel ? "bg-accent/50" : ""}`}
                 onClick={() => {
                   setThinkingLevel(lvl);
-                  send({ type: "pidash-command", pid: session.pid, command: "set-thinking", level: lvl });
+                  send({ type: "pidash-command", sessionId: session.sessionId, command: "set-thinking", level: lvl });
                   setOpenMenu(null);
                 }}
               >
@@ -234,7 +234,7 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
                   {asyncAgents.count > 1 && (
                     <button
                       onClick={() => {
-                        send({ type: "pidash-command", command: "async-kill", target: "all", pid: session.pid });
+                        send({ type: "pidash-command", command: "async-kill", target: "all", sessionId: session.sessionId });
                       }}
                       className="px-1.5 py-0.5 rounded text-[10px] bg-red-500/20 text-red-400 hover:bg-red-500/40"
                     >
@@ -267,7 +267,7 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
                       <div className="flex gap-1 shrink-0">
                         <button
                           onClick={() => {
-                            send({ type: "pidash-command", command: "async-kill", target: job.name, pid: session.pid });
+                            send({ type: "pidash-command", command: "async-kill", target: job.name, sessionId: session.sessionId });
                           }}
                           className="px-1.5 py-0.5 rounded text-[10px] bg-red-500/20 text-red-400 hover:bg-red-500/40"
                           title="Kill this agent"

--- a/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
@@ -33,6 +33,20 @@ function getRoleColor(role: string): string {
   return roleColors[role] || "text-orange-400";
 }
 
+function fk(n: number): string {
+  if (n >= 1e6) return (n / 1e6).toFixed(1) + "M";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + "k";
+  return String(n);
+}
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return rem > 0 ? `${m}m${rem}s` : `${m}m`;
+}
+
 export function MessageList({ messages, searchQuery, searchType, streaming, scrollKey, onAskResponse }: Props) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -63,17 +77,44 @@ export function MessageList({ messages, searchQuery, searchType, streaming, scro
       }}
     >
       <div className="p-4 space-y-2">
-        {messages
-          .filter((msg) => {
-            // Type filter
+        {(() => {
+          const filtered = messages.filter((msg) => {
             if (searchType && searchType !== "all" && msg.role !== searchType) return false;
-            // Text filter
             if (searchQuery && !msg.text.toLowerCase().includes(searchQuery.toLowerCase())) return false;
             return true;
-          })
-          .map((msg) => (
-            <MessageItem key={msg.id} msg={msg} searchQuery={searchQuery} onAskResponse={onAskResponse} />
-          ))}
+          });
+
+          // Group tool-call + tool-result by correlation ID (callId in meta)
+          const resultByCallId = new Map<string, ChatMessage>();
+          for (const msg of filtered) {
+            if (msg.className === "tool-result" && msg.meta?.callId) {
+              resultByCallId.set(msg.meta.callId, msg);
+            }
+          }
+          const usedResults = new Set<string>();
+          const grouped: Array<{ call?: ChatMessage; result?: ChatMessage } | ChatMessage> = [];
+          for (const msg of filtered) {
+            if (msg.className === "tool-call" && msg.meta?.callId) {
+              const result = resultByCallId.get(msg.meta.callId);
+              if (result) {
+                grouped.push({ call: msg, result });
+                usedResults.add(result.id);
+                continue;
+              }
+            }
+            // Skip results that were already grouped with their call
+            if (msg.className === "tool-result" && msg.meta?.callId && usedResults.has(msg.id)) continue;
+            grouped.push(msg);
+          }
+
+          return grouped.map((item, idx) => {
+            if ('call' in item) {
+              return <ToolGroup key={item.call!.id} call={item.call!} result={item.result!} searchQuery={searchQuery} />;
+            }
+            const msg = item as ChatMessage;
+            return <MessageItem key={msg.id} msg={msg} searchQuery={searchQuery} onAskResponse={onAskResponse} />;
+          });
+        })()}
         {streaming && (
           <div className="flex items-center gap-2 py-2 text-muted-foreground text-xs">
             <div className="flex gap-1">
@@ -194,6 +235,75 @@ function MessageItem({ msg, searchQuery, onAskResponse }: { msg: ChatMessage; se
   );
 }
 
+function ToolGroup({ call, result, searchQuery }: { call: ChatMessage; result: ChatMessage; searchQuery?: string }) {
+  const [open, setOpen] = useState(false);
+  const matchesSearch = searchQuery && (
+    call.text.toLowerCase().includes(searchQuery.toLowerCase()) ||
+    result.text.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+  const color = getRoleColor(call.role);
+  const isError = result.text.startsWith("✗");
+  const borderColor = isError ? "border-red-500" : "border-green-600";
+
+  const meta = result.meta;
+  const statusIcon = isError ? "✗" : "✓";
+  const statusColor = isError ? "text-red-500" : "text-green-500";
+  const callSummary = call.text.split("\n")[0].slice(0, 120);
+
+  // Build stats string from meta
+  let statsStr = "";
+  if (meta) {
+    const parts: string[] = [];
+    if (meta.turns) parts.push(`${meta.turns} turn${meta.turns > 1 ? "s" : ""}`);
+    if (meta.input) parts.push(`↑${fk(meta.input)}`);
+    if (meta.output) parts.push(`↓${fk(meta.output)}`);
+    if (meta.cacheRead) parts.push(`R${fk(meta.cacheRead)}`);
+    if (meta.contextTokens) parts.push(`ctx:${fk(meta.contextTokens)}`);
+    if (meta.cost) parts.push(`$${meta.cost.toFixed(4)}`);
+    if (meta.model) parts.push(meta.model);
+    if (meta.startTs && meta.endTs) parts.push(formatDuration(meta.endTs - meta.startTs));
+    statsStr = parts.join(" ");
+  }
+
+  return (
+    <Collapsible open={open || !!matchesSearch} onOpenChange={setOpen}>
+      <CollapsibleTrigger className={cn(
+        "flex items-center gap-1 text-[10px] font-bold uppercase tracking-wider cursor-pointer select-none hover:opacity-80 w-full text-left",
+        color,
+      )}>
+        {open ? <ChevronDown className="h-3 w-3 flex-shrink-0" /> : <ChevronRight className="h-3 w-3 flex-shrink-0" />}
+        <span className="flex-shrink-0">{call.role}</span>
+        <span className={cn("flex-shrink-0", statusColor)}>{statusIcon}</span>
+        {!open && statsStr && (
+          <span className="font-normal normal-case tracking-normal text-muted-foreground ml-1 text-[10px] truncate">
+            {statsStr}
+          </span>
+        )}
+        {!open && !statsStr && (
+          <span className="font-normal normal-case tracking-normal text-muted-foreground ml-1 truncate">{callSummary}</span>
+        )}
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className={cn(
+          "mt-1 rounded-md bg-card p-2.5 text-[11px] whitespace-pre-wrap break-words border-l-2 relative group",
+          "border-orange-500",
+        )}>
+          <div className="text-[9px] font-bold uppercase text-muted-foreground mb-1">call</div>
+          <HighlightText text={call.text} query={searchQuery} />
+        </div>
+        <div className={cn(
+          "mt-1 rounded-md bg-card p-2.5 text-[11px] whitespace-pre-wrap break-words border-l-2 relative group",
+          borderColor,
+        )}>
+          <div className="text-[9px] font-bold uppercase text-muted-foreground mb-1">result</div>
+          <HighlightText text={result.text} query={searchQuery} />
+          <CopyBtn text={result.text} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
 function CollapsibleMessage({ msg, searchQuery }: { msg: ChatMessage; searchQuery?: string }) {
   const [open, setOpen] = useState(false);
   const matchesSearch = searchQuery && msg.text.toLowerCase().includes(searchQuery.toLowerCase());
@@ -201,6 +311,7 @@ function CollapsibleMessage({ msg, searchQuery }: { msg: ChatMessage; searchQuer
   const isResult = msg.className === "tool-result";
   const isError = isResult && msg.text.startsWith("✗");
   const borderColor = msg.role === "thinking" ? "border-purple-500" : isResult ? (isError ? "border-red-500" : "border-green-600") : "border-orange-500";
+
   const summary = msg.text.split("\n")[0].slice(0, 100);
 
   return (

--- a/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
@@ -16,14 +16,14 @@ function ago(iso: string): string {
 
 interface Props {
   sessions: SessionInfo[];
-  activePid: number | null;
+  activeSessionId: string | null;
   connected: boolean;
   onSelect: (s: SessionInfo) => void;
   collapsed: boolean;
   onToggle: () => void;
 }
 
-export function SessionSidebar({ sessions, activePid, connected, onSelect, collapsed, onToggle }: Props) {
+export function SessionSidebar({ sessions, activeSessionId, connected, onSelect, collapsed, onToggle }: Props) {
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
   const [initialized, setInitialized] = useState(false);
 
@@ -68,7 +68,7 @@ export function SessionSidebar({ sessions, activePid, connected, onSelect, colla
   };
 
   // Auto-expand groups that contain the active session
-  const activeGroup = sessions.find(s => s.pid === activePid);
+  const activeGroup = sessions.find(s => s.sessionId === activeSessionId);
   const activeGroupName = activeGroup ? (activeGroup.cwd.split("/").pop() || activeGroup.cwd) : null;
 
   return (
@@ -110,10 +110,10 @@ export function SessionSidebar({ sessions, activePid, connected, onSelect, colla
 
               {/* Sessions in this group */}
               {isExpanded && group.sessions.map((s) => {
-                const isActive = s.pid === activePid;
+                const isActive = s.sessionId === activeSessionId;
                 return (
                   <div
-                    key={s.pid}
+                    key={s.sessionId}
                     className={cn(
                       "pl-7 pr-3 py-2 cursor-pointer transition-colors border-b border-border/50",
                       isActive && "bg-accent border-l-3 border-l-primary",
@@ -133,7 +133,7 @@ export function SessionSidebar({ sessions, activePid, connected, onSelect, colla
                           <span className={s.gitDirty ? "text-red-500" : "text-green-500"}>
                             {s.gitDirty ? "●" : "✓"}
                           </span>
-                          <span className="truncate max-w-[80px]">{s.branch}</span>
+                          <span className="truncate">{s.branch}</span>
                         </span>
                       )}
                       <span>{ago(s.startedAt)}</span>

--- a/extensions/orchestrator/pidash-ui/src/hooks/useSessions.ts
+++ b/extensions/orchestrator/pidash-ui/src/hooks/useSessions.ts
@@ -14,7 +14,7 @@ export function useSessions(wsConnected: boolean, onMessage: (h: (d: any) => voi
 
   useEffect(() => {
     return onMessage((ev) => {
-      if (["session_added", "session_removed", "session_updated"].includes(ev.type)) load();
+      if (ev.type === "session_added" || ev.type === "session_removed") load();
     });
   }, [onMessage, load]);
 

--- a/extensions/orchestrator/pidash-ui/src/types.ts
+++ b/extensions/orchestrator/pidash-ui/src/types.ts
@@ -1,4 +1,5 @@
 export interface SessionInfo {
+  sessionId: string;
   pid: number;
   cwd: string;
   branch: string;
@@ -31,9 +32,21 @@ export interface PiEvent {
     delta?: string;
     partial?: { model?: string; usage?: TokenUsage };
   };
+  toolCallId?: string;
   toolName?: string;
   args?: { command?: string };
-  result?: { content?: Array<{ type: string; text: string }> };
+  result?: {
+    content?: Array<{ type: string; text: string }>;
+    details?: {
+      mode?: string;
+      results?: Array<{
+        agent?: string;
+        usage?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number; cost?: number; contextTokens?: number; turns?: number };
+        model?: string;
+        exitCode?: number;
+      }>;
+    };
+  };
   isError?: boolean;
 }
 
@@ -52,4 +65,16 @@ export interface ChatMessage {
   role: MessageRole;
   text: string;
   className?: string;
+  meta?: {
+    turns?: number;
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    contextTokens?: number;
+    model?: string;
+    startTs?: number;
+    endTs?: number;
+    cost?: number;
+    callId?: string;
+  };
 }

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -163,6 +163,7 @@ export function registerPidash(
   let spawning = false;
   const MAX_EVENT_BUFFER = 5000;
   let lastCtx: any = null;
+  const sessionId = `${process.pid}:${process.cwd()}`;
   const eventBuffer: string[] = []; // Buffer events for replay on daemon reconnect
 
   async function connect(ctx: any) {
@@ -221,6 +222,7 @@ export function registerPidash(
         const reg = JSON.stringify({
           type: "register",
           pid: process.pid,
+          sessionId,
           cwd: ctx.cwd,
           branch: git.branch,
           gitDirty: git.dirty,
@@ -783,8 +785,10 @@ export function registerPidash(
       connect(ctx);
     } else if (ws) {
       // Already connected — session switched (e.g., /resume, /new)
+      eventBuffer.length = 0; // Clear stale events to prevent cross-session replay on reconnect
       ws.send(JSON.stringify({
         type: "session_switch",
+        sessionId,
         cwd: ctx.cwd,
         branch: getCurrentBranch(ctx.cwd),
         sessionFile: ctx.sessionFile || "",
@@ -797,6 +801,12 @@ export function registerPidash(
   pi.on("tool_result", (_event, ctx) => {
     if (!connected && !shuttingDown) connect(ctx);
   });
+
+  // Periodic reconnect — ensures sessions that started before the daemon still connect
+  const reconnectPoller = setInterval(() => {
+    if (!connected && !connecting && !shuttingDown && lastCtx) connect(lastCtx);
+  }, 15000);
+  if (reconnectPoller.unref) reconnectPoller.unref();
 
   // ── Command execution from browser ────────────────────────────────
   //
@@ -911,6 +921,7 @@ export function registerPidash(
 
   pi.on("session_shutdown", () => {
     shuttingDown = true;
+    clearInterval(reconnectPoller);
     if (ws) { try { ws.close(); } catch {} ws = null; }
     connected = false;
   });

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -27,6 +27,7 @@ function log(msg: string) {
 // ── Session state ───────────────────────────────────────────────────
 
 interface SessionInfo {
+  sessionId: string;
   pid: number;
   cwd: string;
   branch: string;
@@ -49,9 +50,9 @@ interface PiClient {
   eventBuffer: string[];
 }
 
-const piClients = new Map<number, PiClient>();
+const piClients = new Map<string, PiClient>();
 const browserClients = new Set<any>();
-const browserWatchMap = new WeakMap<any, number | null>();
+const browserWatchMap = new WeakMap<any, string | null>();
 
 // ── HTTP Server ─────────────────────────────────────────────────────
 
@@ -143,7 +144,9 @@ piWss.on("connection", (ws: any) => {
       const parsed = JSON.parse(data.toString());
 
       if (parsed.type === "register") {
+        const sessionId = parsed.sessionId || `${parsed.pid}:${parsed.cwd}`;
         const session: SessionInfo = {
+          sessionId,
           pid: parsed.pid,
           cwd: parsed.cwd || "",
           branch: parsed.branch || "",
@@ -160,7 +163,7 @@ piWss.on("connection", (ws: any) => {
           thinkingLevel: parsed.thinkingLevel || "medium",
         };
         // Re-registration: update existing inactive session (keep event buffer)
-        const existing = piClients.get(parsed.pid);
+        const existing = piClients.get(sessionId);
         if (existing) {
           existing.ws = ws;
           existing.session = session;
@@ -169,8 +172,8 @@ piWss.on("connection", (ws: any) => {
         } else {
           piClient = { ws, session, eventBuffer: [] };
         }
-        piClients.set(parsed.pid, piClient);
-        log(`session registered: PID ${parsed.pid}, cwd: ${parsed.cwd}`);
+        piClients.set(sessionId, piClient);
+        log(`session registered: ${sessionId}, cwd: ${parsed.cwd}`);
         broadcastToBrowsers({ type: "session_added", session });
         return;
       }
@@ -184,7 +187,7 @@ piWss.on("connection", (ws: any) => {
         if (parsed.diffPort !== undefined) piClient.session.diffPort = parsed.diffPort;
         if (parsed.thinkingLevel !== undefined) piClient.session.thinkingLevel = parsed.thinkingLevel;
         piClient.session.lastActivity = Date.now();
-        broadcastToBrowsers({ type: "session_updated", session: piClient.session });
+        sendToWatchers(piClient.session.sessionId, { type: "session_updated", session: piClient.session });
         return;
       }
 
@@ -194,15 +197,16 @@ piWss.on("connection", (ws: any) => {
         if (parsed.branch) piClient.session.branch = parsed.branch;
         if (parsed.sessionFile) piClient.session.sessionFile = parsed.sessionFile;
         piClient.session.lastActivity = Date.now();
-        broadcastToBrowsers({ type: "session_updated", session: piClient.session });
-        log(`session switched: PID ${piClient.session.pid}, cwd: ${parsed.cwd}`);
+        piClient.eventBuffer.length = 0; // Clear buffer to prevent cross-session replay
+        sendToWatchers(piClient.session.sessionId, { type: "session_updated", session: piClient.session });
+        log(`session switched: ${piClient.session.sessionId}, cwd: ${parsed.cwd}`);
         return;
       }
 
       // Forward pi event to browsers watching this session + buffer
       if (piClient) {
         piClient.session.lastActivity = Date.now();
-        const pid = piClient.session.pid;
+        const sid = piClient.session.sessionId;
         const raw = data.toString();
 
         // Buffer the event for replay on browser connect
@@ -213,7 +217,7 @@ piWss.on("connection", (ws: any) => {
         }
 
         for (const browser of browserClients) {
-          if (browserWatchMap.get(browser) === pid) {
+          if (browserWatchMap.get(browser) === sid) {
             try { browser.send(raw); } catch {}
           }
         }
@@ -225,11 +229,10 @@ piWss.on("connection", (ws: any) => {
 
   ws.on("close", () => {
     if (piClient) {
-      const pid = piClient.session.pid;
       piClient.session.active = false;
       piClient.ws = null;
-      log(`session disconnected: PID ${pid} (kept as inactive)`);
-      broadcastToBrowsers({ type: "session_updated", session: piClient.session });
+      log(`session disconnected: ${piClient.session.sessionId} (kept as inactive)`);
+      sendToWatchers(piClient.session.sessionId, { type: "session_updated", session: piClient.session });
     }
   });
 
@@ -254,50 +257,53 @@ browserWss.on("connection", (ws: any) => {
       const parsed = JSON.parse(data.toString());
 
       if (parsed.type === "watch") {
-        browserWatchMap.set(ws, parsed.pid ?? null);
-        log(`browser watching PID: ${parsed.pid}`);
+        const watchId = parsed.sessionId ?? null;
+        browserWatchMap.set(ws, watchId);
+        log(`browser watching: ${watchId}`);
         // Replay buffered events
-        if (parsed.pid) {
-          const client = piClients.get(parsed.pid);
+        if (watchId) {
+          const client = piClients.get(watchId);
           if (client) {
             for (const event of client.eventBuffer) {
               try { ws.send(event); } catch {}
             }
-            log(`replayed ${client.eventBuffer.length} events for PID ${parsed.pid}`);
+            log(`replayed ${client.eventBuffer.length} events for ${watchId}`);
           }
         }
         return;
       }
 
-      if (parsed.type === "prompt" && parsed.pid && parsed.text) {
-        const piClient = piClients.get(parsed.pid);
-        if (piClient) {
+      if (parsed.type === "prompt" && parsed.text && parsed.sessionId) {
+        const piClient = piClients.get(parsed.sessionId);
+        if (piClient && piClient.ws) {
           piClient.ws.send(JSON.stringify({ type: "prompt", text: parsed.text }));
-          log(`prompt forwarded to PID ${parsed.pid}: ${parsed.text.slice(0, 50)}`);
+          log(`prompt forwarded to ${parsed.sessionId}: ${parsed.text.slice(0, 50)}`);
         }
         return;
       }
 
       // Forward extension UI responses (ask_user answers) to pi session
-      if (parsed.type === "extension_ui_response" && parsed.pid && parsed.id) {
-        const piClient = piClients.get(parsed.pid);
+      if (parsed.type === "extension_ui_response" && parsed.id) {
+        if (!parsed.sessionId) return;
+        const piClient = piClients.get(parsed.sessionId);
         if (piClient && piClient.ws) {
           const response: any = { type: "extension_ui_response", id: parsed.id };
           if (parsed.value !== undefined) response.value = parsed.value;
           if (parsed.confirmed !== undefined) response.confirmed = parsed.confirmed;
           if (parsed.cancelled) response.cancelled = true;
           piClient.ws.send(JSON.stringify(response));
-          log(`UI response forwarded to PID ${parsed.pid}: ${JSON.stringify(response).slice(0, 100)}`);
+          log(`UI response forwarded to ${parsed.sessionId}: ${JSON.stringify(response).slice(0, 100)}`);
         }
         return;
       }
 
       // Forward pidash commands to pi session
-      if (parsed.type === "pidash-command" && parsed.pid) {
-        const piClient = piClients.get(parsed.pid);
+      if (parsed.type === "pidash-command") {
+        if (!parsed.sessionId) return;
+        const piClient = piClients.get(parsed.sessionId);
         if (piClient && piClient.ws) {
           piClient.ws.send(JSON.stringify(parsed));
-          log(`command forwarded to PID ${parsed.pid}: ${parsed.command}`);
+          log(`command forwarded to ${parsed.sessionId}: ${parsed.command}`);
         }
         return;
       }
@@ -319,6 +325,15 @@ function broadcastToBrowsers(event: object) {
   }
 }
 
+function sendToWatchers(sessionId: string, event: object) {
+  const data = JSON.stringify(event);
+  for (const browser of browserClients) {
+    if (browserWatchMap.get(browser) === sessionId) {
+      try { browser.send(data); } catch {}
+    }
+  }
+}
+
 // Route upgrade requests to the correct WS server
 server.on("upgrade", (req: IncomingMessage, socket: any, head: Buffer) => {
   const url = new URL(req.url || "/", `http://localhost:${port}`);
@@ -335,11 +350,11 @@ server.on("upgrade", (req: IncomingMessage, socket: any, head: Buffer) => {
 // Clean up stale inactive sessions (disconnected > 5 min ago)
 const cleanupInterval = setInterval(() => {
   const now = Date.now();
-  for (const [pid, client] of piClients.entries()) {
+  for (const [sessionId, client] of piClients.entries()) {
     if (!client.session.active && now - client.session.lastActivity > 5 * 60 * 1000) {
-      piClients.delete(pid);
-      log(`cleaned up stale session: PID ${pid}`);
-      broadcastToBrowsers({ type: "session_removed", pid });
+      piClients.delete(sessionId);
+      log(`cleaned up stale session: ${sessionId}`);
+      broadcastToBrowsers({ type: "session_removed", sessionId });
     }
   }
 }, 60 * 1000); // Check every minute
@@ -347,7 +362,7 @@ if (cleanupInterval.unref) cleanupInterval.unref();
 
 // Ping all pi clients every 30s to keep connections alive
 const pingInterval = setInterval(() => {
-  for (const [pid, client] of piClients) {
+  for (const [, client] of piClients) {
     if (client.ws) {
       try { client.ws.ping(); } catch {}
     }


### PR DESCRIPTION
## Problem

Multiple pidash bugs affecting the web UI:

1. **Branch leak** — `session_updated` events were broadcast to ALL browsers, causing the status bar to show branches from other sessions
2. **PID 1 collision** — All container sessions registered as PID 1, overwriting each other in the server's session map. Only the last-registered session was visible in the sidebar
3. **Missing sessions** — Sessions starting before the pidash daemon had no retry mechanism to connect later
4. **No tool stats** — Tool call sections in the chat had no usage information (turns, tokens, model, duration)
5. **Branch truncation** — Branch names in the sidebar had a fixed `max-w-[80px]` that didn't react to sidebar resize
6. **Cross-session replay** — Session switch (`/new`, `/resume`) didn't clear event buffers, causing stale events to replay into new sessions
7. **Undefined `sid`** — Log statements referenced a removed variable, causing silent ReferenceErrors

## Changes

- Use `sessionId` (`pid:cwd`) instead of PID as session key everywhere (server, extension, UI)
- Add `sendToWatchers()` to scope `session_updated` to watching browsers only
- Add 15s reconnect poller for late-starting sessions
- Clear both extension-side and server-side event buffers on session switch
- Group tool-call/result pairs into single collapsible with usage stats in header
- Remove fixed max-width on sidebar branch names
- Stop sidebar refetching all sessions on every `session_updated`
- Fix undefined `sid` in server log statements
- Add `details` type to `PiEvent.result` for proper TypeScript typing
- Use `callId` correlation for deterministic tool-call/result grouping

## Files Changed

- `scripts/pidash-server.ts` — sessionId-based routing, sendToWatchers, buffer clear
- `extensions/orchestrator/pidash.ts` — sessionId generation, reconnect poller, buffer clear
- `extensions/orchestrator/pidash-ui/src/App.tsx` — sessionId-based session matching, tool meta extraction
- `extensions/orchestrator/pidash-ui/src/types.ts` — sessionId, meta, details types
- `extensions/orchestrator/pidash-ui/src/components/MessageList.tsx` — ToolGroup component, callId grouping
- `extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx` — activeSessionId prop
- `extensions/orchestrator/pidash-ui/src/components/InfoBar.tsx` — sessionId in commands
- `extensions/orchestrator/pidash-ui/src/hooks/useSessions.ts` — removed session_updated refetch

## Review

- Reviewed by 3 internal reviewers (quality, guidelines, security)
- Peer reviewed by Cursor via acpx (2 rounds)
- Tested with 4 live sessions (3 containers + 1 native)