### PR TITLE
fix(prompts): forbid AskUserQuestion during autorabbit polling loop

### DIFF
--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -318,6 +318,15 @@ myk-pi-tools reviews store {json_path}
 
 **Skip this phase if `--autorabbit` was NOT passed.**
 
+🚨 **ABSOLUTE RULE: NO USER INTERACTION DURING THE POLLING LOOP.**
+
+**NEVER call AskUserQuestion during Phase 9. NEVER present options,
+dialogs, choices, or questions to the user. The polling loop is FULLY
+AUTOMATIC. If something is stuck, stale, or unclear — keep polling
+silently. Do NOT invent questions like "PRs are stuck, what do you
+want to do?" or "Should I keep polling?" or any variation. The loop
+runs silently until an exit condition is met. Period.**
+
 After the review flow completes (Phases 1-8), enter a polling loop
 to watch for new CodeRabbit comments.
 
@@ -377,6 +386,22 @@ VIOLATION — The following rationalizations are FORBIDDEN reasons to exit the l
   - "The API returned an error"
   - "An error prevents continuing"
   - Any variation of the AI deciding there is no more work to do
+```
+
+```text
+VIOLATION — The following user interactions are FORBIDDEN during Phase 9:
+
+  - Calling AskUserQuestion for ANY reason
+  - Presenting options like "keep polling / stop / skip"
+  - Asking "should I continue?"
+  - Asking "PRs are stuck, what do you want to do?"
+  - Asking for user input about stale comments
+  - Asking for user decisions about polling strategy
+  - ANY dialog, question, or prompt to the user
+  - Any variation of the AI asking the user what to do
+
+The ONLY way the user interacts with the loop is by explicitly
+sending "stop", "exit", "done", or "quit" — unprompted by the AI.
 ```
 
 If any command in the loop fails, log the error, wait 5 minutes, and retry from 9a.


### PR DESCRIPTION
## Problem

The autorabbit polling loop (Phase 9 of review-handler) was asking the user questions like "Both PRs are stuck waiting for CodeRabbit approval — what do you want to do?" This violates the loop's design — it should run fully automatically until either CodeRabbit approves or the user explicitly stops it.

## Root Cause

The prompt didn't explicitly forbid ALL user interaction during Phase 9. It only said "the user is NEVER asked about CodeRabbit items" in Phase 2, but the AI interpreted the polling loop as a place where it could invent new questions about stuck states.

## Fix

Added two explicit enforcement blocks to Phase 9:

1. **Absolute rule at the top of Phase 9** — "NO USER INTERACTION DURING THE POLLING LOOP" with examples of forbidden behaviors
2. **VIOLATION block for forbidden interactions** — Explicit list of banned dialog patterns (AskUserQuestion, options, "should I continue?", etc.)

The only way the user interacts with the loop is by unprompted sending "stop"/"exit"/"done"/"quit".