### PR TITLE
fix(docker): install myk-pi-tools at runtime instead of build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,12 +89,8 @@ RUN --mount=type=cache,target=/home/node/.cache/uv,sharing=locked,uid=1000,gid=1
     uv tool install prek && \
     uv tool install mcp-proxy
 
-# Copy and install myk-pi-tools from local source
-COPY --chown=node:node pyproject.toml README.md /tmp/myk-pi-tools/
-COPY --chown=node:node myk_pi_tools/ /tmp/myk-pi-tools/myk_pi_tools/
-RUN --mount=type=cache,target=/home/node/.cache/uv,sharing=locked,uid=1000,gid=1000 \
-    uv tool install myk-pi-tools --from /tmp/myk-pi-tools && \
-    rm -rf /tmp/myk-pi-tools
+# myk-pi-tools is installed at runtime by entrypoint.sh from the latest
+# pi-config source (pulled via pi update). No need to bake it into the image.
 
 # Install Cursor Agent CLI (after uv tools — cursor changes rarely)
 RUN /bin/bash -o pipefail -c "curl -fsSL https://cursor.com/install | bash"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,6 +13,9 @@ else
     pi update git:github.com/myk-org/pi-config
 fi
 
+# Update myk-pi-tools to latest from local pi-config source
+uv tool install --force myk-pi-tools --from "$PI_PKG_DIR/myk-org/pi-config" 2>/dev/null || true
+
 # TODO: Switch back to upstream once PR is merged: https://github.com/isaacraja/pi-vertex-claude/pull/3
 # if [ ! -d "$PI_PKG_DIR/isaacraja/pi-vertex-claude" ]; then
 #     pi install git:github.com/isaacraja/pi-vertex-claude


### PR DESCRIPTION
Move myk-pi-tools installation from Dockerfile to entrypoint.sh so containers always get the latest version on startup. The entrypoint runs after `pi update` pulls the latest pi-config source, then installs myk-pi-tools from that source via `uv tool install --force`.

Removes the COPY + build-time install from Dockerfile — no more stale baked-in version.