### PR TITLE
fix(reviews): poll skips cycles where all comments are auto-skipped

### DIFF
--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -25,6 +25,38 @@ _RATE_LIMIT_BUFFER_SECONDS = 30
 _POLL_SLEEP_SECONDS = 300  # 5 minutes between cycles when no rate limit
 
 
+def _has_actionable_comments(pr_number: str) -> bool:
+    """Check if the fetched reviews JSON has any actionable (non-auto-skipped) comments.
+
+    Reads the JSON file written by fetch_run and checks if any comments
+    have status 'pending' and are NOT auto-skipped.
+    """
+    import json
+    import os
+    import tempfile
+    from pathlib import Path
+
+    tmp_base = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
+    json_path = tmp_base / "pi-work" / f"pr-{pr_number}-reviews.json"
+
+    if not json_path.exists():
+        # Can't determine — assume actionable to be safe
+        return True
+
+    try:
+        with open(json_path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return True
+
+    for source in ("human", "qodo", "coderabbit"):
+        for comment in data.get(source, []):
+            if not comment.get("is_auto_skipped"):
+                return True
+
+    return False
+
+
 def run(review_url: str = "") -> int:
     """Poll for reviews in a loop until approval or new comments.
 
@@ -108,15 +140,16 @@ def run(review_url: str = "") -> int:
         print_stderr("[poll] Fetching reviews...")
         fetch_result = fetch_run(review_url)
 
-        # If fetch succeeded, check if there are new comments
-        # fetch_run prints JSON to stdout -- we can't easily re-parse it here
-        # But if it returned 0, there might be new comments
-        # The caller (review-handler) will check the JSON output
         if fetch_result == 0:
-            return 0
-
-        # Fetch failed -- log and retry
-        print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
+            # Check if there are actionable (non-auto-skipped) comments
+            # fetch_run saves JSON to a predictable path
+            has_actionable = _has_actionable_comments(pr_number)
+            if has_actionable:
+                return 0
+            print_stderr("[poll] All fetched comments are auto-skipped (previously addressed). No new comments.")
+        else:
+            # Fetch failed -- log and retry
+            print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
 
         # Step 7: No actionable result -- sleep and loop
         print_stderr(f"[poll] No new comments. Sleeping {_POLL_SLEEP_SECONDS}s before next cycle...")

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -90,7 +90,16 @@ Read the **Raw Arguments** section above. Parse as follows:
 - cleaned arguments = `https://github.com/org/repo/pull/123#pullrequestreview-456`
 - CLI call = `myk-pi-tools reviews fetch https://github.com/...`
 
+### Autorabbit Fast Path (MANDATORY)
+
+**If autorabbit mode is ON (set in Phase 0), skip Phases 1-8 entirely
+and jump directly to Phase 9 (Autorabbit Polling Loop).** The polling
+loop handles fetching, processing, and posting internally. There is no
+initial fetch/review cycle — the first fetch happens inside the poll.
+
 ### Phase 1: Fetch Reviews
+
+**Skip this phase if autorabbit mode is ON — see Autorabbit Fast Path above.**
 
 The `reviews fetch` command auto-detects the PR from the current branch.
 


### PR DESCRIPTION
When fetch returns only previously-addressed body-embedded comments (outside-diff, nitpick), poll now checks the JSON for actionable comments before returning. If all are auto-skipped, it keeps polling instead of returning stale results that cause the review-handler to re-process the same comments every cycle.