### PR TITLE
feat(pidash): add browser push notifications for session events

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Single extension that provides:
 | **Subagent tool** | Delegate tasks to specialist agents (single, parallel, chain, async modes) |
 | **Async background agents** | Spawn agents in background with `async: true` — results surface automatically when complete |
 | **`/btw` command** | Quick side questions without polluting conversation history — ephemeral overlay |
-| **`/async-status` command** | Show status of running/completed background agents |
+| **`/async-status` command** | Show status of background agents — select one for live output streaming |
 | **`ask_user` tool** | Structured user input with options and free-text — used by workflows |
 | **Python/pip enforcement** | Blocks `python`/`pip` — requires `uv`/`uvx` |
 | **Git protection** | Blocks commits/pushes to main/master, merged branches, `--no-verify`, `git add .` |
@@ -312,6 +312,9 @@ Pidash is a web-based dashboard that runs alongside the TUI, accessible from any
 - ask_user tool bridging (answer from browser or TUI)
 - Mobile responsive
 - Event buffering for message replay on refresh
+- Browser push notifications for background events (configurable per event type)
+- Async agent live streaming (real-time tool calls and output inline in chat)
+- Sidebar session working indicator (pulsing green dot when AI is active)
 
 **Access:**
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -11,13 +11,13 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { AgentConfig } from "./agents.js";
 import { getPiInvocation } from "./utils.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
-const ASYNC_DIR = path.join(os.tmpdir(), "pi-async-agents");
-const ASYNC_RESULTS_DIR = path.join(ASYNC_DIR, `results-${process.pid}`);
+const ASYNC_BASE_DIR = path.join(os.tmpdir(), "pi-async-agents");
 const ASYNC_POLL_INTERVAL_MS = 3000;
 
 // ── Interfaces ───────────────────────────────────────────────────────────
@@ -71,6 +71,9 @@ export function registerAsyncAgents(
   spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string };
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
 } {
+  let ASYNC_DIR = ASYNC_BASE_DIR;
+  let ASYNC_RESULTS_DIR = path.join(ASYNC_BASE_DIR, `results-${process.pid}`);
+
   const asyncState: AsyncState = {
     jobs: new Map(),
     poller: null,
@@ -243,6 +246,7 @@ export function registerAsyncAgents(
       model: agent.model,
       resultPath,
       asyncDir,
+      sessionId: `${process.pid}:${process.cwd()}`,
       piCommand: inv.command,
       piArgs: inv.args,
     }), { mode: 0o600 });
@@ -292,6 +296,9 @@ export function registerAsyncAgents(
   // Start result watcher on session start
   pi.on("session_start", (_event, ctx) => {
     asyncState.lastCtx = ctx;
+    const sanitizedCwd = ctx.cwd.replace(/^\//, "").replace(/\//g, "--");
+    ASYNC_DIR = path.join(ASYNC_BASE_DIR, sanitizedCwd);
+    ASYNC_RESULTS_DIR = path.join(ASYNC_DIR, `results-${process.pid}`);
 
     // Clean up orphaned results directories from crashed sessions
     try {
@@ -318,7 +325,7 @@ export function registerAsyncAgents(
 
   // /async-status command
   pi.registerCommand("async-status", {
-    description: "Show status of background async agents",
+    description: "Show status of background async agents — select one to view live output",
     handler: async (_args, ctx) => {
       const jobs = Array.from(asyncState.jobs.values());
       if (jobs.length === 0) {
@@ -326,21 +333,195 @@ export function registerAsyncAgents(
         return;
       }
 
-      const lines: string[] = ["## Async Agents\n"];
-      lines.push("| Name | Agent | Status | Duration | Task |");
-      lines.push("|------|-------|--------|----------|------|");
-      for (const job of jobs) {
-        const duration = job.durationMs
-          ? formatDuration(job.durationMs)
-          : formatDuration(Date.now() - job.startedAt);
-        const statusIcon = job.status === "complete" ? "✅" : job.status === "failed" ? "❌" : job.status === "running" ? "⏳" : "⏸️";
-        const taskPreview = job.task.length > 50 ? job.task.slice(0, 50) + "..." : job.task;
-        lines.push(`| ${job.name || "-"} | ${job.agent} | ${statusIcon} ${job.status} | ${duration} | ${taskPreview} |`);
+      // If only completed agents, show static summary
+      const running = jobs.filter(j => j.status === "running" || j.status === "queued");
+      if (running.length === 0) {
+        const lines: string[] = ["All agents completed:\n"];
+        for (const job of jobs) {
+          const dur = job.durationMs ? formatDuration(job.durationMs) : formatDuration(Date.now() - job.startedAt);
+          const icon = job.status === "complete" ? "✅" : "❌";
+          lines.push(`${icon} ${job.name || job.agent} (${dur}) — ${job.task.slice(0, 60)}`);
+        }
+        ctx.ui.notify(lines.join("\n"), "info");
+        return;
       }
 
-      if (ctx.hasUI) {
-        ctx.ui.notify(lines.join("\n"), "info");
-      }
+      // Build selection list
+      const options = running.map((j) => {
+        const duration = formatDuration(Date.now() - j.startedAt);
+        const taskPreview = j.task.length > 60 ? j.task.slice(0, 60) + "..." : j.task;
+        return `${j.name || j.agent} (${duration}) — ${taskPreview}`;
+      });
+
+      const selected = await ctx.ui.select("View async agent output:", options);
+      if (!selected) return;
+
+      const idx = options.indexOf(selected);
+      if (idx < 0) return;
+
+      const job = running[idx];
+      const outputPath = path.join(job.asyncDir, "output.log");
+
+      // Create a live output viewer as an overlay
+      await ctx.ui.custom<void>((tui, _theme, _kb, done) => {
+        const lines: string[] = [];
+        let scrollOffset = 0;
+        let maxScroll = 0;
+        let following = true; // auto-scroll to bottom
+        let closed = false;
+        let cachedWidth: number | undefined;
+        let cachedLines: string[] | undefined;
+
+        // Parse a JSON line from the output log into a display string
+        function parseLine(raw: string): string | null {
+          try {
+            const ev = JSON.parse(raw);
+            if (ev.type === "message_update" && ev.assistantMessageEvent) {
+              const ae = ev.assistantMessageEvent;
+              if (ae.type === "text_delta" && ae.delta) return ae.delta;
+              if (ae.type === "thinking_delta" && ae.delta) return null;
+              if (ae.type === "toolcall_delta" && ae.content) return null;
+              return null;
+            }
+            if (ev.type === "tool_execution_start") {
+              const name = ev.toolName || "tool";
+              const cmd = ev.args?.command ? ` ${ev.args.command.slice(0, 80)}` : "";
+              return `\n🔧 ${name}${cmd}`;
+            }
+            if (ev.type === "tool_execution_end") {
+              const text = ev.result?.content?.[0]?.text || "";
+              const prefix = ev.isError ? "✗" : "✓";
+              return `\n${prefix} ${text.slice(0, 200)}`;
+            }
+            if (ev.type === "agent_end") return "\n--- Agent finished ---";
+            return null;
+          } catch {
+            return null;
+          }
+        }
+
+        // Read existing output and watch for new content
+        let filePos = 0;
+        let textBuffer = "";
+
+        function readNewContent() {
+          if (closed) return;
+          try {
+            const content = fs.readFileSync(outputPath, "utf-8");
+            if (content.length > filePos) {
+              const newContent = content.slice(filePos);
+              filePos = content.length;
+              textBuffer += newContent;
+
+              // Process complete lines
+              const parts = textBuffer.split("\n");
+              textBuffer = parts.pop() || "";
+              for (const part of parts) {
+                if (!part.trim()) continue;
+                const parsed = parseLine(part);
+                if (parsed !== null) {
+                  for (const l of parsed.split("\n")) {
+                    if (l) lines.push(l);
+                    else lines.push("");
+                  }
+                }
+              }
+              cachedWidth = undefined;
+              cachedLines = undefined;
+              tui.requestRender();
+            }
+          } catch {}
+        }
+
+        // Poll for new content every 500ms
+        const poller = setInterval(readNewContent, 500);
+        readNewContent();
+
+        return {
+          handleInput(data: string) {
+            if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+              closed = true;
+              clearInterval(poller);
+              done(undefined);
+              return;
+            }
+            if (matchesKey(data, Key.up)) {
+              if (scrollOffset > 0) { scrollOffset--; following = false; cachedWidth = undefined; tui.requestRender(); }
+              return;
+            }
+            if (matchesKey(data, Key.down)) {
+              if (scrollOffset < maxScroll) { scrollOffset++; cachedWidth = undefined; tui.requestRender(); }
+              if (scrollOffset >= maxScroll) following = true;
+              return;
+            }
+            if (matchesKey(data, Key.pageUp)) {
+              scrollOffset = Math.max(0, scrollOffset - 10); following = false; cachedWidth = undefined; tui.requestRender();
+              return;
+            }
+            if (matchesKey(data, Key.pageDown)) {
+              scrollOffset = Math.min(maxScroll, scrollOffset + 10);
+              if (scrollOffset >= maxScroll) following = true;
+              cachedWidth = undefined; tui.requestRender();
+              return;
+            }
+            if (matchesKey(data, Key.home)) {
+              scrollOffset = 0; following = false; cachedWidth = undefined; tui.requestRender();
+              return;
+            }
+            if (matchesKey(data, Key.end)) {
+              scrollOffset = maxScroll; following = true; cachedWidth = undefined; tui.requestRender();
+              return;
+            }
+          },
+
+          invalidate() { cachedWidth = undefined; cachedLines = undefined; },
+
+          render(width: number): string[] {
+            if (cachedLines && cachedWidth === width) return cachedLines;
+
+            const headerWidth = width - 2;
+            const dur = formatDuration(Date.now() - job.startedAt);
+            const status = readAsyncStatus(job.asyncDir);
+            const state = status?.state || job.status;
+            const stateIcon = state === "complete" ? "✅" : state === "failed" ? "❌" : "⏳";
+            const header = truncateToWidth(`${stateIcon} ${job.name || job.agent} — ${dur} — ${job.task.slice(0, 40)}`, headerWidth);
+            const footer = truncateToWidth("↑↓ scroll  PgUp/PgDn  Home/End  Esc close", headerWidth);
+            const sep = "─".repeat(Math.min(width, headerWidth));
+
+            // Wrap all lines to fit width
+            const wrapped: string[] = [];
+            for (const line of lines) {
+              const w = wrapTextWithAnsi(line, width - 2);
+              for (const wl of w) {
+                wrapped.push(truncateToWidth(wl, width - 2));
+              }
+            }
+
+            // Calculate visible area
+            const viewHeight = Math.max(5, Math.min(30, ((tui as any).height ?? 24) - 8));
+            maxScroll = Math.max(0, wrapped.length - viewHeight);
+
+            // Auto-scroll to bottom
+            if (following) {
+              scrollOffset = maxScroll;
+            }
+
+            const visible = wrapped.slice(scrollOffset, scrollOffset + viewHeight);
+
+            // Pad to viewHeight
+            while (visible.length < viewHeight) visible.push("");
+
+            cachedLines = [header, sep, ...visible, sep, footer];
+            cachedWidth = width;
+            return cachedLines;
+          },
+
+          dispose() {
+            closed = true;
+            clearInterval(poller);
+          },
+        };
+      });
     },
   });
 

--- a/extensions/orchestrator/async-runner.ts
+++ b/extensions/orchestrator/async-runner.ts
@@ -7,6 +7,7 @@
 import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { createRequire } from "node:module";
 
 interface RunConfig {
   id: string;
@@ -69,6 +70,34 @@ async function run(config: RunConfig): Promise<void> {
   writeJson(statusPath, status);
 
   const outputStream = fs.createWriteStream(outputPath, { flags: "w" });
+
+  // Connect to pidash server to stream events
+  const pidashPort = parseInt(process.env.PI_PIDASH_PORT || "", 10) || 19190;
+  let pidashWs: any = null;
+  const pidashLog = path.join(config.asyncDir, "pidash-ws.log");
+  fs.writeFileSync(pidashLog, `START port=${pidashPort} id=${config.id}\n`);
+  try {
+    const _require = createRequire(import.meta.url);
+    fs.appendFileSync(pidashLog, `require ok, importing ws\n`);
+    const WebSocket = _require("ws");
+    fs.appendFileSync(pidashLog, `ws loaded, connecting...\n`);
+    pidashWs = new WebSocket(`ws://127.0.0.1:${pidashPort}/ws/async`);
+    pidashWs.on("open", () => {
+      fs.appendFileSync(pidashLog, `connected!\n`);
+      pidashWs.send(JSON.stringify({
+        type: "async_register",
+        id: config.id,
+        agent: config.agent,
+        task: config.task.slice(0, 200),
+        cwd: config.cwd,
+        sessionId: config.sessionId,
+      }));
+    });
+    pidashWs.on("error", (e: any) => { fs.appendFileSync(pidashLog, `error: ${e.message}\n`); });
+  } catch (e: any) {
+    fs.appendFileSync(pidashLog, `CATCH: ${e.message}\n${e.stack}\n`);
+  }
+
   let stdout = "";
   let lineCount = 0;
 
@@ -89,6 +118,17 @@ async function run(config: RunConfig): Promise<void> {
       stdout += text;
       outputStream.write(text);
       lineCount += text.split("\n").length - 1;
+
+      // Forward events to pidash
+      if (pidashWs?.readyState === 1) {
+        for (const line of text.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            const ev = JSON.parse(line);
+            pidashWs.send(JSON.stringify({ type: "async_event", id: config.id, event: ev }));
+          } catch {}
+        }
+      }
 
       // Update status periodically (every ~10 lines)
       if (lineCount % 10 === 0) {
@@ -137,6 +177,12 @@ async function run(config: RunConfig): Promise<void> {
   status.exitCode = exitCode;
   status.outputLines = lineCount;
   writeJson(statusPath, status);
+
+  // Notify pidash of completion and close
+  if (pidashWs?.readyState === 1) {
+    pidashWs.send(JSON.stringify({ type: "async_complete", id: config.id, success: exitCode === 0 }));
+    pidashWs.close();
+  }
 
   // Write result for the watcher to pick up
   writeJson(config.resultPath, {

--- a/extensions/orchestrator/pidash-ui/src/App.tsx
+++ b/extensions/orchestrator/pidash-ui/src/App.tsx
@@ -6,6 +6,7 @@ import { MessageList } from "@/components/MessageList";
 import { InputBar } from "@/components/InputBar";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { useSessions } from "@/hooks/useSessions";
+import { useNotifications } from "@/hooks/useNotifications";
 import type { ChatMessage, PiEvent, SessionInfo, TokenUsage } from "@/types";
 
 const STORAGE_KEY = "pidash-state";
@@ -30,6 +31,7 @@ const textFrom = (msg: any): string =>
 export function App() {
   const { connected, send, onMessage } = useWebSocket("/ws/browser");
   const sessions = useSessions(connected, onMessage);
+  const notifications = useNotifications();
 
   const [session, setSession] = useState<SessionInfo | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
@@ -40,6 +42,8 @@ export function App() {
   const [searchType, setSearchType] = useState("all");
   const [scrollKey, setScrollKey] = useState(0);
   const [availableCommands, setAvailableCommands] = useState<Array<{ name: string; description: string }>>([]);
+  const asyncMsgRef = useRef<Map<string, { msgId: string; text: string }>>(new Map());
+  const messagesRef = useRef(messages);
   const saved = useRef(loadState());
   const isMobile = typeof window !== 'undefined' && window.innerWidth <= 768;
   const [sidebarCollapsed, setSidebarCollapsed] = useState(isMobile ? true : saved.current.sidebarCollapsed);
@@ -67,6 +71,12 @@ export function App() {
   const toolRef = useRef({ id: "", name: "", startTs: 0, callId: "" });
   const restoredRef = useRef(false);
   const replayingRef = useRef(false);
+  const notificationsRef = useRef(notifications);
+  const sessionRef = useRef(session);
+
+  useEffect(() => { notificationsRef.current = notifications; }, [notifications]);
+  useEffect(() => { sessionRef.current = session; }, [session]);
+  useEffect(() => { messagesRef.current = messages; }, [messages]);
 
   const addMsg = useCallback((role: ChatMessage["role"], text: string, className?: string): string => {
     const id = nextId();
@@ -225,6 +235,144 @@ export function App() {
           break;
         }
 
+        case "session_input_needed": {
+          const n = notificationsRef.current;
+          if (!n.preferences.inputNeeded) break;
+          const isWatched = ev.sessionId === sessionRef.current?.sessionId;
+          const tabFocused = document.hasFocus();
+          if (tabFocused && isWatched) break;
+          const repo = ev.cwd?.split("/").pop() || "session";
+          n.notify(`Input needed — ${repo}`, { body: ev.title || "Waiting for your response" });
+          break;
+        }
+
+        case "session_turn_complete": {
+          const n = notificationsRef.current;
+          if (!n.preferences.turnComplete) break;
+          const isWatched = ev.sessionId === sessionRef.current?.sessionId;
+          const tabFocused = document.hasFocus();
+          if (tabFocused && isWatched) break;
+          const repo = ev.cwd?.split("/").pop() || "session";
+          n.notify(`AI done — ${repo}`, { body: "Ready for input" });
+          break;
+        }
+
+        case "session_notification": {
+          const n = notificationsRef.current;
+          const isWatched = ev.sessionId === sessionRef.current?.sessionId;
+          const tabFocused = document.hasFocus();
+
+          // Tab not focused → notify for ALL sessions
+          // Tab focused → notify only for non-watched sessions
+          if (tabFocused && isWatched) break;
+
+          const repo = ev.cwd?.split("/").pop() || "session";
+
+          const txt = (ev.resultText || "").toLowerCase();
+              const tl = (ev.toolName || "").toLowerCase();
+              const isTestEvent = tl.includes("test") || txt.includes("pytest") || txt.includes("test_");
+
+              if (ev.isError && n.preferences.sessionError) {
+                n.notify(`Error — ${repo}`, { body: "Tool execution failed" });
+              } else if (ev.isSubagent && n.preferences.agentComplete) {
+                const agentLabel = ev.agentName || "agent";
+                n.notify(`Agent finished — ${repo}`, { body: agentLabel });
+              } else if (isTestEvent && n.preferences.testResults) {
+                const passed = !ev.isError && !txt.includes("fail") && !txt.includes("error");
+                n.notify(passed ? `Tests: ✓ Passed — ${repo}` : `Tests: ✗ Failed — ${repo}`);
+              } else if (n.preferences.toolComplete && !ev.isError && !ev.isSubagent) {
+                n.notify(`Tool: ${ev.toolName || "tool"} — ${repo}`);
+              }
+          break;
+        }
+
+        case "async_agent_start": {
+          const asyncId = ev.id as string;
+          if (!asyncId) break;
+          // Only show async agents from the watched session
+          if ((ev as any).sessionId && (ev as any).sessionId !== sessionRef.current?.sessionId) break;
+          // Find the subagent tool-result message that spawned this async agent
+          let targetMsgId = "";
+          const currentMsgs = messagesRef.current;
+          for (let i = currentMsgs.length - 1; i >= 0; i--) {
+            if (currentMsgs[i].className === "tool-result" && currentMsgs[i].text.includes(asyncId)) {
+              targetMsgId = currentMsgs[i].id;
+              break;
+            }
+          }
+          if (!targetMsgId) {
+            // Fallback: create inline message
+            const agent = (ev as any).agent || "agent";
+            const repo = ((ev as any).cwd || "").split("/").pop() || "";
+            targetMsgId = addMsg("system" as any, `⏳ ${agent} — ${repo}`, "async-agent-running");
+          }
+          asyncMsgRef.current.set(asyncId, { msgId: targetMsgId, text: "" });
+          break;
+        }
+
+        case "async_agent_event": {
+          const asyncId = ev.id as string;
+          const inner = (ev as any).event;
+          if (!asyncId || !inner) break;
+          if ((ev as any).sessionId && (ev as any).sessionId !== sessionRef.current?.sessionId) break;
+          const tracked = asyncMsgRef.current.get(asyncId);
+          if (!tracked) break;
+
+          let changed = false;
+
+          if (inner.type === "message_update" && inner.assistantMessageEvent) {
+            const ae = inner.assistantMessageEvent;
+            if (ae.type === "text_delta" && ae.delta) {
+              tracked.text += ae.delta;
+              changed = true;
+            }
+          }
+
+          if (inner.type === "tool_execution_start") {
+            const name = inner.toolName || "tool";
+            const detail = inner.args?.command ? ` ${inner.args.command.slice(0, 100)}` : "";
+            tracked.text += `\n🔧 ${name}${detail}`;
+            changed = true;
+          }
+
+          if (inner.type === "tool_execution_end" && inner.result?.content?.[0]?.text) {
+            const result = inner.result.content[0].text.slice(0, 200);
+            tracked.text += `\n${inner.isError ? "✗" : "✓"} ${result}`;
+            changed = true;
+          }
+
+          if (changed) {
+            setMessages(prev => prev.map(m => {
+              if (m.id !== tracked.msgId) return m;
+              const header = m.text.split("\n")[0];
+              return { ...m, text: header + "\n" + tracked.text.trim() };
+            }));
+          }
+          break;
+        }
+
+        case "async_agent_complete": {
+          const asyncId = ev.id as string;
+          if (!asyncId) break;
+          if ((ev as any).sessionId && (ev as any).sessionId !== sessionRef.current?.sessionId) break;
+          const tracked = asyncMsgRef.current.get(asyncId);
+          if (!tracked) break;
+          setMessages(prev => prev.map(m => {
+            if (m.id !== tracked.msgId) return m;
+            if (m.className === "async-agent-running") {
+              // Fallback system message — update icon
+              const header = m.text.split("\n")[0].replace("⏳", (ev as any).success === false ? "❌" : "✅");
+              return { ...m, text: header + "\n" + tracked.text.trim(), className: "async-agent-done" };
+            }
+            // Tool-result message — just mark as complete by appending status
+            const status = (ev as any).success === false ? "\n❌ Agent failed" : "\n✅ Agent complete";
+            const header = m.text.split("\n")[0];
+            return { ...m, text: header + "\n" + tracked.text.trim() + status };
+          }));
+          asyncMsgRef.current.delete(asyncId);
+          break;
+        }
+
         case "extension_ui_request":
           // Skip stale UI requests from replay (older than 10 seconds)
           if (ev.timestamp && Date.now() - ev.timestamp > 10000) break;
@@ -287,6 +435,11 @@ export function App() {
     });
   }, [sidebarWidth, sidebarCollapsed, session]);
 
+  // Reset restore state on disconnect so we re-watch after server restart
+  useEffect(() => {
+    if (!connected) restoredRef.current = false;
+  }, [connected]);
+
   useEffect(() => {
     if (!connected || !sessions.length || restoredRef.current) return;
     // Restore from localStorage
@@ -339,6 +492,7 @@ export function App() {
             onSelect={watchSession}
             collapsed={false}
             onToggle={() => setSidebarCollapsed(true)}
+            notifications={notifications}
           />
           <div
             className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/30 z-10 max-md:hidden"

--- a/extensions/orchestrator/pidash-ui/src/components/NotificationSettings.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/NotificationSettings.tsx
@@ -1,0 +1,76 @@
+import { Bell, BellOff } from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { NotificationPreferences } from "@/types";
+
+interface Props {
+  permission: NotificationPermission;
+  supported: boolean;
+  preferences: NotificationPreferences;
+  setPreference: <K extends keyof NotificationPreferences>(key: K, value: boolean) => void;
+  requestPermission: () => void;
+}
+
+const PREF_LABELS: Record<keyof NotificationPreferences, string> = {
+  turnComplete: "AI turn complete",
+  agentComplete: "Agent complete",
+  testResults: "Test results",
+  sessionError: "Session errors",
+  toolComplete: "Tool execution (noisy)",
+  inputNeeded: "Input needed (ask_user)",
+};
+
+export function NotificationSettings({ permission, supported, preferences, setPreference, requestPermission }: Props) {
+  if (!supported) return null;
+
+  const active = permission === "granted";
+
+  return (
+    <div className="relative inline-block">
+      <Popover>
+        <PopoverTrigger className={cn(
+          "cursor-pointer flex items-center gap-1 text-xs transition-colors",
+          active ? "text-primary hover:text-primary/80" : "text-muted-foreground/50 hover:text-muted-foreground"
+        )}>
+          {active ? <Bell className="h-3.5 w-3.5" /> : <BellOff className="h-3.5 w-3.5" />}
+        </PopoverTrigger>
+        <PopoverContent className="w-56" side="bottom">
+          <div className="text-xs space-y-2">
+            <div className="font-bold text-foreground">Notifications</div>
+
+            {permission === "default" && (
+              <button
+                onClick={requestPermission}
+                className="w-full px-2 py-1.5 rounded text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+              >
+                Enable Notifications
+              </button>
+            )}
+
+            {permission === "denied" && (
+              <div className="text-muted-foreground py-1">
+                Notifications blocked. Enable in browser settings.
+              </div>
+            )}
+
+            {permission === "granted" && (
+              <div className="space-y-1.5">
+                {(Object.keys(PREF_LABELS) as Array<keyof NotificationPreferences>).map((key) => (
+                  <label key={key} className="flex items-center gap-2 cursor-pointer hover:text-foreground transition-colors">
+                    <input
+                      type="checkbox"
+                      checked={preferences[key]}
+                      onChange={(e) => setPreference(key, e.target.checked)}
+                      className="rounded border-border accent-primary"
+                    />
+                    <span>{PREF_LABELS[key]}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
@@ -3,8 +3,9 @@ import { GitBranch, Circle, Pause, PanelLeftClose, ChevronRight, ChevronDown, Fo
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { NotificationSettings } from "@/components/NotificationSettings";
 import { cn } from "@/lib/utils";
-import type { SessionInfo } from "@/types";
+import type { SessionInfo, NotificationPreferences } from "@/types";
 
 function ago(iso: string): string {
   const m = Math.floor((Date.now() - new Date(iso).getTime()) / 60000);
@@ -21,9 +22,16 @@ interface Props {
   onSelect: (s: SessionInfo) => void;
   collapsed: boolean;
   onToggle: () => void;
+  notifications?: {
+    permission: NotificationPermission;
+    supported: boolean;
+    preferences: NotificationPreferences;
+    setPreference: <K extends keyof NotificationPreferences>(key: K, value: boolean) => void;
+    requestPermission: () => void;
+  };
 }
 
-export function SessionSidebar({ sessions, activeSessionId, connected, onSelect, collapsed, onToggle }: Props) {
+export function SessionSidebar({ sessions, activeSessionId, connected, onSelect, collapsed, onToggle, notifications }: Props) {
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
   const [initialized, setInitialized] = useState(false);
 
@@ -77,6 +85,13 @@ export function SessionSidebar({ sessions, activeSessionId, connected, onSelect,
         <span className="text-sm font-bold text-primary">pidash</span>
         <span className="flex items-center gap-2">
           <Circle className={cn("h-2 w-2 fill-current", connected ? "text-green-500" : "text-red-500")} />
+          {notifications && <NotificationSettings
+            permission={notifications.permission}
+            supported={notifications.supported}
+            preferences={notifications.preferences}
+            setPreference={notifications.setPreference}
+            requestPermission={notifications.requestPermission}
+          />}
           <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-muted-foreground" onClick={onToggle}>
             <PanelLeftClose className="h-3.5 w-3.5" />
           </Button>
@@ -124,6 +139,12 @@ export function SessionSidebar({ sessions, activeSessionId, connected, onSelect,
                   >
                     <div className={cn("text-xs font-medium truncate flex items-center gap-1.5", s.active ? "text-primary" : "text-muted-foreground")}>
                       {!s.active && <Pause className="h-3 w-3 flex-shrink-0 text-muted-foreground" />}
+                      {s.active && s.working && (
+                        <span className="relative flex h-2 w-2 flex-shrink-0">
+                          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                          <span className="relative inline-flex rounded-full h-2 w-2 bg-green-400" />
+                        </span>
+                      )}
                       <span className="truncate">{s.model || "—"}</span>
                     </div>
                     <div className="flex items-center gap-1.5 mt-0.5 text-[10px] text-muted-foreground">

--- a/extensions/orchestrator/pidash-ui/src/components/ui/popover.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/ui/popover.tsx
@@ -30,7 +30,7 @@ export function PopoverTrigger({ children, className }: { children: React.ReactN
   );
 }
 
-export function PopoverContent({ children, className }: { children: React.ReactNode; className?: string; align?: string }) {
+export function PopoverContent({ children, className, side = "top" }: { children: React.ReactNode; className?: string; align?: string; side?: "top" | "bottom" }) {
   const { open, setOpen, triggerRef } = React.useContext(PopoverContext);
   const ref = React.useRef<HTMLDivElement>(null);
 
@@ -58,7 +58,7 @@ export function PopoverContent({ children, className }: { children: React.ReactN
 
   if (!open) return null;
   return (
-    <div ref={ref} className={cn("absolute bottom-full mb-2 right-0 z-50 rounded-md border border-border bg-popover p-2 shadow-lg", className)}>
+    <div ref={ref} className={cn("absolute right-0 z-50 rounded-md border border-border bg-popover p-2 shadow-lg", side === "top" ? "bottom-full mb-2" : "top-full mt-2", className)}>
       {children}
     </div>
   );

--- a/extensions/orchestrator/pidash-ui/src/hooks/useNotifications.ts
+++ b/extensions/orchestrator/pidash-ui/src/hooks/useNotifications.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useState } from "react";
+import type { NotificationPreferences } from "@/types";
+
+const STORAGE_KEY = "pidash-notifications";
+
+const DEFAULT_PREFS: NotificationPreferences = {
+  turnComplete: true,
+  agentComplete: true,
+  testResults: true,
+  sessionError: true,
+  toolComplete: false,
+  inputNeeded: true,
+};
+
+function loadPrefs(): NotificationPreferences {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return { ...DEFAULT_PREFS, ...JSON.parse(raw) };
+  } catch {}
+  return { ...DEFAULT_PREFS };
+}
+
+function savePrefs(prefs: NotificationPreferences) {
+  try { localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs)); } catch {}
+}
+
+export function useNotifications() {
+  const supported = typeof window !== "undefined" && "Notification" in window;
+  const [permission, setPermission] = useState<NotificationPermission>(
+    supported ? Notification.permission : "denied"
+  );
+  const [preferences, setPreferences] = useState<NotificationPreferences>(loadPrefs);
+
+  // Sync permission state (e.g. user changes in browser settings)
+  useEffect(() => {
+    if (!supported) return;
+    setPermission(Notification.permission);
+  }, [supported]);
+
+  const requestPermission = useCallback(async () => {
+    if (!supported) return;
+    const result = await Notification.requestPermission();
+    setPermission(result);
+  }, [supported]);
+
+  const setPreference = useCallback(<K extends keyof NotificationPreferences>(key: K, value: boolean) => {
+    setPreferences((prev) => {
+      const next = { ...prev, [key]: value };
+      savePrefs(next);
+      return next;
+    });
+  }, []);
+
+  const notify = useCallback((title: string, options?: NotificationOptions) => {
+    if (!supported || permission !== "granted") return;
+    try {
+      const n = new Notification(title, options);
+      n.onclick = () => { window.focus(); n.close(); };
+      setTimeout(() => n.close(), 5000);
+    } catch {}
+  }, [supported, permission]);
+
+  return { permission, supported, preferences, setPreference, requestPermission, notify };
+}

--- a/extensions/orchestrator/pidash-ui/src/hooks/useSessions.ts
+++ b/extensions/orchestrator/pidash-ui/src/hooks/useSessions.ts
@@ -15,6 +15,11 @@ export function useSessions(wsConnected: boolean, onMessage: (h: (d: any) => voi
   useEffect(() => {
     return onMessage((ev) => {
       if (ev.type === "session_added" || ev.type === "session_removed") load();
+      if (ev.type === "session_updated" && ev.session) {
+        setSessions((prev) => prev.map((s) =>
+          s.sessionId === ev.session.sessionId ? { ...s, ...ev.session } : s
+        ));
+      }
     });
   }, [onMessage, load]);
 

--- a/extensions/orchestrator/pidash-ui/src/types.ts
+++ b/extensions/orchestrator/pidash-ui/src/types.ts
@@ -14,6 +14,7 @@ export interface SessionInfo {
   diffPort?: number | null;
   contextWindow?: number;
   thinkingLevel?: string;
+  working?: boolean;
 }
 
 export interface PiEvent {
@@ -34,7 +35,7 @@ export interface PiEvent {
   };
   toolCallId?: string;
   toolName?: string;
-  args?: { command?: string };
+  args?: { command?: string; agent?: string; name?: string; task?: string; tasks?: any[]; chain?: any[]; asyncKill?: string; async?: boolean };
   result?: {
     content?: Array<{ type: string; text: string }>;
     details?: {
@@ -48,6 +49,13 @@ export interface PiEvent {
     };
   };
   isError?: boolean;
+  // session_notification fields
+  sessionId?: string;
+  cwd?: string;
+  isSubagent?: boolean;
+  agentName?: string;
+  resultText?: string;
+  partialResult?: { content?: Array<{ type: string; text: string }> };
 }
 
 export interface TokenUsage {
@@ -56,6 +64,15 @@ export interface TokenUsage {
   cacheRead?: number;
   cacheWrite?: number;
   totalTokens?: number;
+}
+
+export interface NotificationPreferences {
+  turnComplete: boolean;
+  agentComplete: boolean;
+  testResults: boolean;
+  sessionError: boolean;
+  toolComplete: boolean;
+  inputNeeded: boolean;
 }
 
 export type MessageRole = "user" | "assistant" | "tool" | "thinking" | "system";

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -161,7 +161,6 @@ export function registerPidash(
   let connecting = false;
   let shuttingDown = false;
   let spawning = false;
-  const MAX_EVENT_BUFFER = 5000;
   let lastCtx: any = null;
   const sessionId = `${process.pid}:${process.cwd()}`;
   const eventBuffer: string[] = []; // Buffer events for replay on daemon reconnect
@@ -238,28 +237,14 @@ export function registerPidash(
         debugLog(`sending register: ${reg}`);
         wsClient.send(reg);
 
-        // Replay buffered events to restore history on daemon reconnect
-        // Send in batches with yields to prevent WebSocket overload
-        if (eventBuffer.length > 0) {
-          debugLog(`replaying ${eventBuffer.length} buffered events`);
-          const BATCH_SIZE = 50;
-          let i = 0;
-          const replayBatch = () => {
-            const end = Math.min(i + BATCH_SIZE, eventBuffer.length);
-            for (; i < end; i++) {
-              try { wsClient.send(eventBuffer[i]); } catch {}
-            }
-            if (i < eventBuffer.length) {
-              setTimeout(replayBatch, 10);
-            } else {
-              debugLog(`replay complete: ${eventBuffer.length} events`);
-            }
-          };
-          replayBatch();
-        }
-
-        // Load existing session history (for --continue / resumed sessions)
-        if (eventBuffer.length === 0) {
+        // Always load history from session file (source of truth)
+        eventBuffer.length = 0;
+        const pushBuffered = (ev: string) => {
+          wsClient.send(ev);
+          eventBuffer.push(ev);
+          while (eventBuffer.length > 10000) eventBuffer.shift();
+        };
+        {
           try {
             const entries = ctx.sessionManager?.getEntries?.() || [];
             let historyCount = 0;
@@ -270,9 +255,7 @@ export function registerPidash(
               const ts = e.timestamp ? new Date(e.timestamp).getTime() : Date.now();
 
               if (msg.role === "user") {
-                const ev = JSON.stringify({ type: "message_start", message: msg, timestamp: ts });
-                wsClient.send(ev);
-                eventBuffer.push(ev);
+                pushBuffered(JSON.stringify({ type: "message_start", message: msg, timestamp: ts }));
               }
 
               if (msg.role === "assistant" && msg.content) {
@@ -284,8 +267,7 @@ export function registerPidash(
                       assistantMessageEvent: { type: "thinking_delta", delta: part.thinking, partial: { model: msg.model, usage: msg.usage } },
                       timestamp: ts,
                     });
-                    wsClient.send(thinkEv);
-                    eventBuffer.push(thinkEv);
+                    pushBuffered(thinkEv);
                   }
                 }
 
@@ -297,8 +279,7 @@ export function registerPidash(
                       assistantMessageEvent: { type: "text_delta", delta: part.text, partial: { model: msg.model, usage: msg.usage } },
                       timestamp: ts,
                     });
-                    wsClient.send(textEv);
-                    eventBuffer.push(textEv);
+                    pushBuffered(textEv);
                   }
                 }
 
@@ -311,15 +292,12 @@ export function registerPidash(
                       args: part.arguments,
                       timestamp: ts,
                     });
-                    wsClient.send(toolEv);
-                    eventBuffer.push(toolEv);
+                    pushBuffered(toolEv);
                   }
                 }
 
                 // Send message_end
-                const endEv = JSON.stringify({ type: "message_end", message: msg, timestamp: ts });
-                wsClient.send(endEv);
-                eventBuffer.push(endEv);
+                pushBuffered(JSON.stringify({ type: "message_end", message: msg, timestamp: ts }));
               }
 
               // Tool results
@@ -331,27 +309,22 @@ export function registerPidash(
                   isError: msg.isError || false,
                   timestamp: ts,
                 });
-                wsClient.send(resultEv);
-                eventBuffer.push(resultEv);
+                pushBuffered(resultEv);
               }
 
               // Custom messages (async agent results, etc.)
               if (msg.role === "custom" && msg.display) {
                 const content = typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content || "");
-                const ev = JSON.stringify({
+                pushBuffered(JSON.stringify({
                   type: "message_start",
                   message: { role: "custom", display: true, content, customType: msg.customType },
                   timestamp: ts,
-                });
-                wsClient.send(ev);
-                eventBuffer.push(ev);
+                }));
               }
 
               // Catch-all: any other message role — forward as-is
               if (!["user", "assistant", "toolResult", "custom"].includes(msg.role)) {
-                const ev = JSON.stringify({ type: "message_start", message: msg, timestamp: ts });
-                wsClient.send(ev);
-                eventBuffer.push(ev);
+                pushBuffered(JSON.stringify({ type: "message_start", message: msg, timestamp: ts }));
               }
 
               historyCount++;
@@ -361,6 +334,9 @@ export function registerPidash(
             debugLog(`session history load error: ${e.message}`);
           }
         }
+
+        // Signal replay is complete so the server can stop suppressing notifications
+        try { wsClient.send(JSON.stringify({ type: "replay_complete" })); } catch {}
 
         // Respond to pings (keepalive)
         wsClient.on("ping", () => {
@@ -601,8 +577,8 @@ export function registerPidash(
       const msg = JSON.stringify(payload);
       if (type !== "extension_ui_request") {
         eventBuffer.push(msg);
-        // Prevent unbounded growth — drop oldest events
-        while (eventBuffer.length > MAX_EVENT_BUFFER) eventBuffer.shift();
+        // Cap incremental buffer — session file is the source of truth for full history
+        while (eventBuffer.length > 10000) eventBuffer.shift();
       }
       if (ws && connected) {
         try { ws.send(msg); } catch (e: any) { debugLog(`forward ${type} error: ${e.message}`); }

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -42,12 +42,14 @@ interface SessionInfo {
   diffPort?: number | null;
   contextWindow?: number;
   thinkingLevel?: string;
+  working?: boolean;
 }
 
 interface PiClient {
   ws: any;
   session: SessionInfo;
   eventBuffer: string[];
+  replaying: boolean;
 }
 
 const piClients = new Map<string, PiClient>();
@@ -168,13 +170,15 @@ piWss.on("connection", (ws: any) => {
           existing.ws = ws;
           existing.session = session;
           existing.eventBuffer = []; // Clear stale buffer — extension will replay current events
+          existing.replaying = true;
           piClient = existing;
         } else {
-          piClient = { ws, session, eventBuffer: [] };
+          piClient = { ws, session, eventBuffer: [], replaying: true };
         }
         piClients.set(sessionId, piClient);
         log(`session registered: ${sessionId}, cwd: ${parsed.cwd}`);
         broadcastToBrowsers({ type: "session_added", session });
+        // replaying flag cleared when extension sends replay_complete
         return;
       }
 
@@ -203,9 +207,26 @@ piWss.on("connection", (ws: any) => {
         return;
       }
 
+      if (parsed.type === "replay_complete" && piClient) {
+        piClient.replaying = false;
+        log(`replay complete for ${piClient.session.sessionId}`);
+        return;
+      }
+
       // Forward pi event to browsers watching this session + buffer
       if (piClient) {
         piClient.session.lastActivity = Date.now();
+
+        // Track AI working state and broadcast to all browsers
+        if (parsed.type === "agent_start") {
+          piClient.session.working = true;
+          broadcastToBrowsers({ type: "session_updated", session: piClient.session });
+        }
+        if (parsed.type === "agent_end") {
+          piClient.session.working = false;
+          broadcastToBrowsers({ type: "session_updated", session: piClient.session });
+        }
+
         const sid = piClient.session.sessionId;
         const raw = data.toString();
 
@@ -213,12 +234,60 @@ piWss.on("connection", (ws: any) => {
         // Skip extension_ui_request — these are one-time interactions
         if (parsed.type !== "extension_ui_request") {
           piClient.eventBuffer.push(raw);
-          if (piClient.eventBuffer.length > 5000) piClient.eventBuffer.shift();
+          while (piClient.eventBuffer.length > 10000) piClient.eventBuffer.shift();
         }
 
         for (const browser of browserClients) {
           if (browserWatchMap.get(browser) === sid) {
             try { browser.send(raw); } catch {}
+          }
+        }
+
+        // Broadcast notification-worthy events to ALL browsers (skip during replay)
+        if (parsed.type === "tool_execution_end" && !piClient.replaying) {
+          const toolName = parsed.toolName || "";
+          const isSubagent = toolName === "subagent" || !!(parsed.args?.agent);
+          const isError = parsed.isError === true;
+          const resultText = parsed.result?.content?.[0]?.text || "";
+
+          const notifEvent = JSON.stringify({
+            type: "session_notification",
+            sessionId: sid,
+            cwd: piClient.session.cwd,
+            toolName,
+            isError,
+            isSubagent,
+            agentName: parsed.args?.name || parsed.args?.agent || "",
+            resultText: resultText.slice(0, 200),
+          });
+          for (const browser of browserClients) {
+            try { browser.send(notifEvent); } catch {}
+          }
+        }
+
+        // Broadcast AI turn complete to ALL browsers (skip during replay)
+        if (parsed.type === "agent_end" && !piClient.replaying) {
+          const notifEvent = JSON.stringify({
+            type: "session_turn_complete",
+            sessionId: sid,
+            cwd: piClient.session.cwd,
+          });
+          for (const browser of browserClients) {
+            try { browser.send(notifEvent); } catch {}
+          }
+        }
+
+        // Broadcast input-needed events to ALL browsers (skip during replay)
+        if (!piClient.replaying && parsed.type === "extension_ui_request" && parsed.id && (parsed.method === "select" || parsed.method === "confirm" || parsed.method === "input")) {
+          const notifEvent = JSON.stringify({
+            type: "session_input_needed",
+            sessionId: sid,
+            cwd: piClient.session.cwd,
+            title: parsed.title || "Input needed",
+            method: parsed.method,
+          });
+          for (const browser of browserClients) {
+            try { browser.send(notifEvent); } catch {}
           }
         }
       }
@@ -334,6 +403,73 @@ function sendToWatchers(sessionId: string, event: object) {
   }
 }
 
+// Async agent clients
+const asyncWss = new WebSocket.Server({ noServer: true });
+const asyncAgents = new Map<string, { id: string; agent: string; task: string; cwd: string; sessionId?: string }>();
+
+asyncWss.on("connection", (ws: any) => {
+  log("async agent WebSocket connected");
+  let agentId: string | null = null;
+
+  ws.on("message", (data: Buffer) => {
+    try {
+      const parsed = JSON.parse(data.toString());
+
+      if (parsed.type === "async_register") {
+        log(`async agent registered: ${parsed.id} (${parsed.agent})`);
+        agentId = parsed.id;
+        asyncAgents.set(agentId, {
+          id: parsed.id,
+          agent: parsed.agent,
+          task: parsed.task,
+          cwd: parsed.cwd,
+          sessionId: parsed.sessionId,
+        });
+        // Broadcast to all browsers
+        broadcastToBrowsers({
+          type: "async_agent_start",
+          id: parsed.id,
+          agent: parsed.agent,
+          task: parsed.task,
+          cwd: parsed.cwd,
+          sessionId: parsed.sessionId,
+        });
+        return;
+      }
+
+      if (parsed.type === "async_event" && parsed.id) {
+        log(`async event from ${parsed.id}: ${parsed.event?.type}`);
+        broadcastToBrowsers({
+          type: "async_agent_event",
+          id: parsed.id,
+          event: parsed.event,
+          sessionId: asyncAgents.get(parsed.id)?.sessionId,
+        });
+        return;
+      }
+
+      if (parsed.type === "async_complete" && parsed.id) {
+        broadcastToBrowsers({
+          type: "async_agent_complete",
+          id: parsed.id,
+          success: parsed.success,
+          sessionId: asyncAgents.get(parsed.id)?.sessionId,
+        });
+        asyncAgents.delete(parsed.id);
+        return;
+      }
+    } catch {}
+  });
+
+  ws.on("close", () => {
+    if (agentId) asyncAgents.delete(agentId);
+  });
+
+  ws.on("error", () => {
+    if (agentId) asyncAgents.delete(agentId);
+  });
+});
+
 // Route upgrade requests to the correct WS server
 server.on("upgrade", (req: IncomingMessage, socket: any, head: Buffer) => {
   const url = new URL(req.url || "/", `http://localhost:${port}`);
@@ -342,6 +478,8 @@ server.on("upgrade", (req: IncomingMessage, socket: any, head: Buffer) => {
     piWss.handleUpgrade(req, socket, head, (ws: any) => piWss.emit("connection", ws, req));
   } else if (url.pathname === "/ws/browser") {
     browserWss.handleUpgrade(req, socket, head, (ws: any) => browserWss.emit("connection", ws, req));
+  } else if (url.pathname === "/ws/async") {
+    asyncWss.handleUpgrade(req, socket, head, (ws: any) => asyncWss.emit("connection", ws, req));
   } else {
     socket.destroy();
   }


### PR DESCRIPTION
## Summary

Adds browser push notifications, async agent live streaming, sidebar working indicators, and TUI live output viewer to the pidash dashboard.

## Features

### Browser Push Notifications (issue #189)
- **useNotifications hook** with configurable event categories (AI turn complete, agent finished, test results, session errors, tool completion, input needed)
- **NotificationSettings** bell icon in sidebar header with toggleable preferences
- Tab not focused → notify for ALL sessions
- Tab focused → notify only for non-watched sessions
- Preferences persisted to localStorage

### Async Agent Streaming (issue #190)
- Async runner connects to pidash server via `/ws/async` WebSocket
- Server broadcasts events to all browsers, scoped by sessionId
- Browser shows streaming content inline in the subagent tool-result block
- Real-time tool calls, text output, and completion status

### Sidebar Working Indicator
- Pulsing green dot when AI is actively working per session
- Real-time via `session_updated` broadcasts and `useSessions` hook

### TUI `/async-status` Live Viewer
- Interactive agent selector (like `/async-kill`)
- Overlay popup with real-time output streaming from `output.log`
- Scrollable with auto-follow, ↑↓/PgUp/PgDn/Home/End, closes with Escape

### Additional Improvements
- Session history always loads from session file (source of truth)
- Explicit `replay_complete` handshake (replaces 5s timer for notification suppression)
- Bounded event buffers (10000 cap via `pushBuffered` helper)
- Repo-scoped async agent temp dirs (`/tmp/pi-async-agents/<sanitized-full-path>/`)
- `PopoverContent` supports `side="top"|"bottom"` positioning

## Changed Files

| File | Change |
|------|--------|
| `src/hooks/useNotifications.ts` | NEW — Notification API hook |
| `src/components/NotificationSettings.tsx` | NEW — Bell icon popover |
| `src/App.tsx` | Notification triggers, async agent event handlers |
| `src/components/InfoBar.tsx` | Removed notifications (moved to sidebar) |
| `src/components/SessionSidebar.tsx` | Added notifications + working indicator |
| `src/components/ui/popover.tsx` | Added `side` prop |
| `src/hooks/useSessions.ts` | Added `session_updated` real-time handling |
| `src/types.ts` | NotificationPreferences, working, PiEvent fields |
| `extensions/orchestrator/pidash.ts` | Session file history, pushBuffered, replay_complete |
| `extensions/orchestrator/async-agents.ts` | /async-status live viewer, repo-scoped dirs, sessionId |
| `extensions/orchestrator/async-runner.ts` | WebSocket connection to pidash server |
| `scripts/pidash-server.ts` | /ws/async endpoint, working state, replay_complete, notifications |
| `README.md` | Updated features list and /async-status description |

## Peer Review

4-round peer review with Cursor CLI. All 6 findings addressed:
- Async events session-scoped (sessionId through full chain)
- Repo temp dir collision fixed (sanitized full path)
- Notification preference logic fixed (testResults no longer blocks toolComplete)
- Event buffers bounded (pushBuffered helper, 10000 cap)
- Replay suppression replaced with explicit handshake
- Preload peak memory bounded

Closes #189, closes #190