### PR TITLE
fix(async-agents): skip redundant status bar updates to prevent TUI flickering

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -81,12 +81,16 @@ export function registerAsyncAgents(
     lastCtx: null,
   };
 
+  let lastWidgetKey = "";
   function updateAsyncWidget() {
     if (!asyncState.lastCtx?.hasUI) return;
     const ctx = asyncState.lastCtx;
     const running = Array.from(asyncState.jobs.values()).filter(j => j.status === "running" || j.status === "queued");
+    const names = running.map(j => j.name || j.agent).join(", ");
+    const widgetKey = `${running.length}:${names}`;
+    if (widgetKey === lastWidgetKey) return; // Nothing changed, skip re-render
+    lastWidgetKey = widgetKey;
     if (running.length > 0) {
-      const names = running.map(j => j.name || j.agent).join(", ");
       ctx.ui.setStatus("async-agents", ctx.ui.theme.fg("warning", `⏳ ${running.length} async: ${names}`));
       pi.events.emit("pidash:async-status", {
         count: running.length,


### PR DESCRIPTION
## Problem

The async agent status bar flickers continuously while an async agent is running. The poller calls `updateAsyncWidget()` every 3 seconds, which calls `setStatus()` unconditionally — triggering a TUI re-render each time even when nothing changed.

## Fix

Added a `lastWidgetKey` check that compares `count:names` before calling `setStatus`. If nothing changed since the last update, the function returns early without touching the TUI.