### PR TITLE
fix(status-line): skip redundant setStatus calls to prevent TUI flickering

### DIFF
--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -13,13 +13,17 @@ export function registerStatusLine(
 ): void {
   // ── Combined status line builder ───────────────────────────────────────
 
+  let lastStatusText = "";
   const buildStatus = (ctx: any, gitPart: string) => {
     const parts: string[] = [];
 
     if (IN_CONTAINER) parts.push(ICON_CONTAINER);
     parts.push(gitPart);
 
-    ctx.ui.setStatus("combined", parts.join(ctx.ui.theme.fg("dim", ICON_SEP)));
+    const text = parts.join(ctx.ui.theme.fg("dim", ICON_SEP));
+    if (text === lastStatusText) return; // Skip redundant re-renders
+    lastStatusText = text;
+    ctx.ui.setStatus("combined", text);
     // Clear individual statuses to avoid duplicates
     ctx.ui.setStatus("container", undefined);
     ctx.ui.setStatus("git", undefined);


### PR DESCRIPTION
## Problem

The TUI status bar flickers when async agents are running. Root cause: `buildStatus` in `status-line.ts` calls `setStatus` 3 times on every `tool_result`, `tool_execution_end`, `agent_end`, and `turn_end` event — even when the git status hasn't changed. This triggers 3 TUI re-renders per event, causing visible flickering.

## Fix

Added `lastStatusText` check — `buildStatus` now compares the new status text against the previous value and returns early if identical. This eliminates redundant `setStatus` calls and the associated TUI re-renders.