### PR TITLE
fix(difit): keep stdout/stderr open to prevent EPIPE crash on browser refresh

### DIFF
--- a/extensions/orchestrator/diff-viewer.ts
+++ b/extensions/orchestrator/diff-viewer.ts
@@ -139,9 +139,10 @@ export function registerDifit(pi: ExtensionAPI): void {
       return null;
     }
 
-    // Detach — let difit survive beyond this session if others need it
-    proc.stdout?.destroy();
-    proc.stderr?.destroy();
+    // Detach — let difit survive beyond this session if others need it.
+    // Keep consuming stdout/stderr silently to avoid EPIPE killing difit.
+    proc.stdout?.resume();
+    proc.stderr?.resume();
     proc.unref();
 
     trackedPid = proc.pid ?? null;


### PR DESCRIPTION
Destroying stdout/stderr after capturing the port caused difit to crash with EPIPE when it tried to log on browser refresh. Use `resume()` to drain silently instead.