### PR TITLE
fix(prompts): use worktrees/ subdir for multi-PR worktree paths

### DIFF
--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -26,15 +26,17 @@ When asked to handle reviews for **multiple PRs**, NEVER switch branches in the 
 Use `git worktree` to create isolated directories for each PR:
 
 ```bash
-# Create a worktree per PR (under /tmp/pi-work/<repo-name>/)
-git worktree add /tmp/pi-work/<repo-name>/pr-42 origin/fix/issue-42
-git worktree add /tmp/pi-work/<repo-name>/pr-43 origin/feat/issue-43
+# Create a worktree per PR (under /tmp/pi-work/<repo-name>/worktrees/)
+git worktree add /tmp/pi-work/<repo-name>/worktrees/pr-42 origin/fix/issue-42
+git worktree add /tmp/pi-work/<repo-name>/worktrees/pr-43 origin/feat/issue-43
 
 # Run review-handler in each worktree directory
-# When done, clean up
-git worktree remove /tmp/pi-work/<repo-name>/pr-42
+# When done, clean up all worktrees at once
+rm -rf /tmp/pi-work/<repo-name>/worktrees
 ```
 
+All worktrees live under a single `worktrees/` directory — easy to clean up
+in one shot, and easy to remove leftover worktrees from previous sessions.
 Branch switching corrupts parallel agent work — other agents running in the
 main worktree will see the wrong branch.
 


### PR DESCRIPTION
## Summary

Move worktree locations in review-handler.md from /tmp/pi-work/<repo-name>/pr-N to /tmp/pi-work/<repo-name>/worktrees/pr-N.

## Why

- All worktrees under a single worktrees/ directory makes cleanup trivial (single directory removal)
- Easy to remove leftover worktrees from previous sessions without affecting other temp files
- Consistent directory structure for multi-PR workflows

## Changes

- prompts/review-handler.md: Updated worktree paths and cleanup command in Multi-PR Handling section