### PR TITLE
fix(async-agents): revert to flat /tmp/pi-async-agents dir

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -71,7 +71,7 @@ export function registerAsyncAgents(
   spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string };
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
 } {
-  let ASYNC_DIR = ASYNC_BASE_DIR;
+  const ASYNC_DIR = ASYNC_BASE_DIR;
   let ASYNC_RESULTS_DIR = path.join(ASYNC_BASE_DIR, `results-${process.pid}`);
 
   const asyncState: AsyncState = {
@@ -303,17 +303,15 @@ export function registerAsyncAgents(
   // Start result watcher on session start
   pi.on("session_start", (_event, ctx) => {
     asyncState.lastCtx = ctx;
-    const sanitizedCwd = ctx.cwd.replace(/^\//, "").replace(/\//g, "--");
-    ASYNC_DIR = path.join(ASYNC_BASE_DIR, sanitizedCwd);
-    ASYNC_RESULTS_DIR = path.join(ASYNC_DIR, `results-${process.pid}`);
+    ASYNC_RESULTS_DIR = path.join(ASYNC_BASE_DIR, `results-${process.pid}`);
 
     // Clean up orphaned results directories from crashed sessions
     try {
-      for (const entry of fs.readdirSync(ASYNC_DIR)) {
+      for (const entry of fs.readdirSync(ASYNC_BASE_DIR)) {
         const m = entry.match(/^results-(\d+)$/);
         if (m) {
           try { process.kill(+m[1], 0); } catch {
-            try { fs.rmSync(path.join(ASYNC_DIR, entry), { recursive: true, force: true }); } catch {}
+            try { fs.rmSync(path.join(ASYNC_BASE_DIR, entry), { recursive: true, force: true }); } catch {}
           }
         }
       }


### PR DESCRIPTION
## Bug

Async agent results never surfaced in the conversation. Status line showed agents as "running" forever even though they had finished (agent_end in output.log).

## Root Cause

The cwd-scoped async directory introduced a mismatch between where results were written and where the watcher looked:

1. `session_start` set `ASYNC_DIR` to `/tmp/pi-async-agents/home--myakove--git--repo/`
2. Agents spawned with a **different cwd** (e.g. worktrees under `/tmp/pi-work/`) wrote results to that spawn-time path
3. But the watcher/poller kept looking at the session-cwd-scoped path
4. Result files existed on disk but were never found — no delivery, no status update

This broke multi-PR autorabbit workflows where 8 async agents were spawned with different worktree cwds.

## Fix

Revert `ASYNC_DIR` to the flat `/tmp/pi-async-agents` path. PID-scoped results directories (`results-{pid}`) still provide session isolation — the cwd scoping was unnecessary and harmful.