### PR TITLE
fix(extensions): prevent diff-viewer from keeping async agents alive (#204)

### DIFF
--- a/extensions/orchestrator/diff-viewer.ts
+++ b/extensions/orchestrator/diff-viewer.ts
@@ -92,6 +92,9 @@ function countOtherPiSessions(cwd: string): number {
 }
 
 export function registerDifit(pi: ExtensionAPI): void {
+  // Skip in async subagent child processes — difit's stdout/stderr streams
+  // keep the event loop alive and prevent the process from ever exiting.
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
   if (!hasDifit()) return;
 
   let trackedPid: number | null = null;
@@ -141,8 +144,11 @@ export function registerDifit(pi: ExtensionAPI): void {
 
     // Detach — let difit survive beyond this session if others need it.
     // Keep consuming stdout/stderr silently to avoid EPIPE killing difit.
+    // Unref streams so they don't keep the event loop alive.
     proc.stdout?.resume();
     proc.stderr?.resume();
+    if (proc.stdout?.unref) proc.stdout.unref();
+    if (proc.stderr?.unref) proc.stderr.unref();
     proc.unref();
 
     trackedPid = proc.pid ?? null;


### PR DESCRIPTION
Fixes #204

## Root Cause

`diff-viewer.ts` loads in ALL pi processes, including headless child processes spawned by `async-runner.ts`. It spawns `difit --no-open --keep-alive` and the `proc.stdout?.resume()` / `proc.stderr?.resume()` calls create active readable stream handles that prevent pi from ever exiting — even after the agent work completes.

This is why async agent results never surfaced — the processes hung forever.

## Fix

1. **Primary:** Guard `registerDifit()` with `PI_SUBAGENT_CHILD` check — difit is not needed in headless async agents
2. **Secondary:** Unref stdout/stderr streams so they don't keep the event loop alive even in the main session