### PR TITLE
feat(extensions): leverage pi 0.69.0 features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ pi-config/
 │   │   │   ├── src/                 # React source (components, hooks, types)
 │   │   │   └── dist/               # Built output (generated, gitignored)
 │   │   ├── enforcement.ts           # Command enforcement (python/pip, git, security, dangerous)
+│   │   ├── github-autocomplete.ts   # GitHub issue # autocomplete provider
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
 │   │   ├── rules.ts                 # Rule + memory injection (before_agent_start)

--- a/extensions/orchestrator/ask-user.ts
+++ b/extensions/orchestrator/ask-user.ts
@@ -12,7 +12,7 @@ import {
   Text,
 } from "@mariozechner/pi-tui";
 import { DynamicBorder } from "@mariozechner/pi-coding-agent";
-import { Type } from "@sinclair/typebox";
+import { Type } from "typebox";
 
 export function registerAskUser(
   pi: ExtensionAPI,
@@ -222,7 +222,7 @@ export function registerAskUser(
       unsubscribe();
 
       if (result === null) {
-        return { content: [{ type: "text", text: "User cancelled" }] };
+        return { content: [{ type: "text", text: "User cancelled" }], terminate: true };
       }
       return { content: [{ type: "text", text: result }] };
     },

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -321,7 +321,7 @@ export function registerAsyncAgents(
   });
 
   // Clean up on shutdown
-  pi.on("session_shutdown", () => {
+  pi.on("session_shutdown", (_event) => {
     if (asyncState.poller) { clearInterval(asyncState.poller); asyncState.poller = null; }
     if (asyncState.watcher) { asyncState.watcher.close(); asyncState.watcher = null; }
     // Clean up PID-scoped results directory

--- a/extensions/orchestrator/diff-viewer.ts
+++ b/extensions/orchestrator/diff-viewer.ts
@@ -100,6 +100,7 @@ export function registerDifit(pi: ExtensionAPI): void {
   let trackedPid: number | null = null;
   let difitPort: number | null = null;
   let weStartedIt = false;
+  let shuttingDown = false;
 
   function setDifitStatus(ctx: any, port: number): void {
     const statusText = ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${port}`);
@@ -155,11 +156,12 @@ export function registerDifit(pi: ExtensionAPI): void {
     difitPort = port;
     weStartedIt = true;
 
-    // Monitor for unexpected exit
+    // Monitor for unexpected exit — skip UI updates if extension is shutting down
+    // (ctx.ui throws on stale extension instances after session replacement)
     proc.on("exit", () => {
       trackedPid = null;
       difitPort = null;
-      clearDifitStatus(ctx);
+      if (!shuttingDown) clearDifitStatus(ctx);
     });
 
     return port;
@@ -197,6 +199,7 @@ export function registerDifit(pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", (_event, ctx) => {
+    shuttingDown = true;
     // Only kill difit if no other pi sessions share this cwd
     if (trackedPid && countOtherPiSessions(ctx.cwd) === 0) {
       try { process.kill(trackedPid, "SIGTERM"); } catch {}

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -119,9 +119,13 @@ export function registerDreaming(
   // Fire-and-forget dream on session shutdown.
   // Uses detached spawn (not async agent) because the session is ending —
   // async agents need the pi process alive to deliver results.
-  pi.on("session_shutdown", () => {
+  pi.on("session_shutdown", (event) => {
     stopTimer();
     if (!enabled || !lastCwd || dreamInFlight) return;
+
+    // Only dream on quit — skip for fork/new/resume/reload since the
+    // session continues or transitions, not ending meaningfully.
+    if ((event as any).reason && (event as any).reason !== "quit") return;
 
     // On shutdown, run a lightweight dream via detached async runner
     // (can't use spawnAsyncAgent since the session is ending)

--- a/extensions/orchestrator/github-autocomplete.ts
+++ b/extensions/orchestrator/github-autocomplete.ts
@@ -1,0 +1,195 @@
+/**
+ * GitHub issue autocomplete — type # to get issue suggestions from the current repo.
+ *
+ * Leverages pi 0.69.0's ctx.ui.addAutocompleteProvider() API.
+ * Based on pi's github-issue-autocomplete.ts example extension.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import {
+  type AutocompleteItem,
+  type AutocompleteProvider,
+  type AutocompleteSuggestions,
+  fuzzyFilter,
+} from "@mariozechner/pi-tui";
+
+type GitHubIssue = {
+  number: number;
+  title: string;
+  state: string;
+};
+
+const MAX_ISSUES = 100;
+const MAX_SUGGESTIONS = 20;
+
+function extractIssueToken(textBeforeCursor: string): string | undefined {
+  const match = textBeforeCursor.match(/(?:^|[ \t])#([^\s#]*)$/);
+  return match?.[1];
+}
+
+function parseGitHubRepo(remoteUrl: string): string | undefined {
+  const sshMatch = remoteUrl.match(
+    /^git@github\.com:([^/]+\/[^/]+?)(?:\.git)?$/,
+  );
+  if (sshMatch) return sshMatch[1];
+
+  const httpsMatch = remoteUrl.match(
+    /^https?:\/\/github\.com\/([^/]+\/[^/]+?)(?:\.git)?$/,
+  );
+  if (httpsMatch) return httpsMatch[1];
+
+  return undefined;
+}
+
+function formatIssueItem(issue: GitHubIssue): AutocompleteItem {
+  return {
+    value: `#${issue.number}`,
+    label: `#${issue.number}`,
+    description: `[${issue.state.toLowerCase()}] ${issue.title}`,
+  };
+}
+
+function filterIssues(
+  issues: GitHubIssue[],
+  query: string,
+): AutocompleteItem[] {
+  if (!query.trim()) {
+    return issues.slice(0, MAX_SUGGESTIONS).map(formatIssueItem);
+  }
+
+  // Numeric prefix match first
+  if (/^\d+$/.test(query)) {
+    const numericMatches = issues
+      .filter((issue) => String(issue.number).startsWith(query))
+      .slice(0, MAX_SUGGESTIONS)
+      .map(formatIssueItem);
+    if (numericMatches.length > 0) return numericMatches;
+  }
+
+  // Fuzzy search on number + title
+  return fuzzyFilter(
+    issues,
+    query,
+    (issue) => `${issue.number} ${issue.title}`,
+  )
+    .slice(0, MAX_SUGGESTIONS)
+    .map(formatIssueItem);
+}
+
+function createIssueAutocompleteProvider(
+  current: AutocompleteProvider,
+  getIssues: () => Promise<GitHubIssue[] | undefined>,
+): AutocompleteProvider {
+  return {
+    async getSuggestions(
+      lines,
+      cursorLine,
+      cursorCol,
+      options,
+    ): Promise<AutocompleteSuggestions | null> {
+      const currentLine = lines[cursorLine] ?? "";
+      const textBeforeCursor = currentLine.slice(0, cursorCol);
+      const token = extractIssueToken(textBeforeCursor);
+
+      if (token === undefined) {
+        return current.getSuggestions(lines, cursorLine, cursorCol, options);
+      }
+
+      const issues = await getIssues();
+      if (options.signal.aborted || !issues || issues.length === 0) {
+        return current.getSuggestions(lines, cursorLine, cursorCol, options);
+      }
+
+      const suggestions = filterIssues(issues, token);
+      if (suggestions.length === 0) {
+        return current.getSuggestions(lines, cursorLine, cursorCol, options);
+      }
+
+      return { items: suggestions, prefix: `#${token}` };
+    },
+
+    applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+      return current.applyCompletion(
+        lines,
+        cursorLine,
+        cursorCol,
+        item,
+        prefix,
+      );
+    },
+
+    shouldTriggerFileCompletion(lines, cursorLine, cursorCol) {
+      return (
+        current.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ??
+        true
+      );
+    },
+  };
+}
+
+export function registerGithubAutocomplete(pi: ExtensionAPI): void {
+  // Skip in subagent children — they have no UI
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
+  pi.on("session_start", async (_event, ctx) => {
+    if (!ctx.hasUI) return;
+
+    // Resolve GitHub repo from git remote
+    const remoteResult = await pi.exec("git", ["remote", "-v"], {
+      cwd: ctx.cwd,
+      timeout: 5_000,
+    });
+    if (remoteResult.code !== 0) return; // Not a git repo
+
+    let repo: string | undefined;
+    for (const line of remoteResult.stdout.split("\n")) {
+      const columns = line.trim().split(/\s+/);
+      const remoteUrl = columns[1];
+      if (remoteUrl) {
+        repo = parseGitHubRepo(remoteUrl);
+        if (repo) break;
+      }
+    }
+    if (!repo) return; // Not a GitHub repo
+
+    // Lazy-load issues (first autocomplete trigger fetches them)
+    let issuesPromise: Promise<GitHubIssue[] | undefined> | undefined;
+
+    const getIssues = async (): Promise<GitHubIssue[] | undefined> => {
+      issuesPromise ||= (async () => {
+        const result = await pi.exec(
+          "gh",
+          [
+            "issue",
+            "list",
+            "--repo",
+            repo!,
+            "--state",
+            "open",
+            "--limit",
+            String(MAX_ISSUES),
+            "--json",
+            "number,title,state",
+          ],
+          { cwd: ctx.cwd, timeout: 10_000 },
+        );
+        if (result.code !== 0) return undefined;
+
+        try {
+          return JSON.parse(result.stdout) as GitHubIssue[];
+        } catch {
+          return undefined;
+        }
+      })();
+      return issuesPromise;
+    };
+
+    // Pre-fetch issues in background
+    void getIssues();
+
+    // Register autocomplete provider
+    ctx.ui.addAutocompleteProvider((current) =>
+      createIssueAutocompleteProvider(current, getIssues),
+    );
+  });
+}

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -26,6 +26,7 @@ import { registerRules } from "./rules.js";
 import { registerSessionValidation } from "./session-validation.js";
 import { registerStatusLine } from "./status-line.js";
 import { registerSubagentTool } from "./subagent-tool.js";
+import { registerGithubAutocomplete } from "./github-autocomplete.js";
 import { ensureGitSshTimeout, isRunningInContainer, terminalNotify } from "./utils.js";
 
 const IN_CONTAINER = isRunningInContainer();
@@ -55,4 +56,5 @@ export default function (pi: ExtensionAPI) {
   registerDreaming(pi, spawnAsyncAgent);
   registerPidash(pi, killAsyncAgent);
   registerSessionValidation(pi);
+  registerGithubAutocomplete(pi);
 }

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -476,14 +476,37 @@ export function registerPidash(
               } catch (e: any) { debugLog(`set-thinking error: ${e.message}`); }
             }
 
-            // TODO: switch-session and new-session require switchSession/newSession
-            // which are only on ExtensionCommandContext (not available from extensions).
-            // Waiting for pi to expose these on the extension runtime API.
-            if (parsed.command === "switch-session") {
-              debugLog("switch-session: not available — pi API limitation");
+            if (parsed.command === "switch-session" && parsed.sessionFile && execCtx) {
+              if (!execCtxIsCommand) {
+                debugLog("switch-session: skipped — no command context (run /pidash first)");
+              } else {
+                debugLog(`switch-session: ${parsed.sessionFile}`);
+                try {
+                  await (execCtx as any).switchSession(parsed.sessionFile, {
+                    withSession: async () => {
+                      debugLog("switch-session: completed via withSession");
+                    },
+                  });
+                } catch (e: any) {
+                  debugLog(`switch-session error: ${e.message}`);
+                }
+              }
             }
-            if (parsed.command === "new-session") {
-              debugLog("new-session: not available — pi API limitation");
+            if (parsed.command === "new-session" && execCtx) {
+              if (!execCtxIsCommand) {
+                debugLog("new-session: skipped — no command context (run /pidash first)");
+              } else {
+                debugLog("new-session: creating new session");
+                try {
+                  await (execCtx as any).newSession({
+                    withSession: async () => {
+                      debugLog("new-session: completed via withSession");
+                    },
+                  });
+                } catch (e: any) {
+                  debugLog(`new-session error: ${e.message}`);
+                }
+              }
             }
 
             if (parsed.command === "abort") {
@@ -749,13 +772,16 @@ export function registerPidash(
   }, 10000);
   if (statusInterval.unref) statusInterval.unref();
 
-  // Store command context from the first command invocation
+  // Store command context — only a real ExtensionCommandContext (from a command handler)
+  // has session control methods like switchSession()/newSession().
   let execCtx: any = null;
+  let execCtxIsCommand = false;
 
   pi.on("session_start", (_event, ctx) => {
     if (!execCtx) {
       execCtx = ctx;
-      debugLog("execCtx created from session_start");
+      execCtxIsCommand = false;
+      debugLog("execCtx created from session_start (not command context)");
     }
     if (!connected) {
       connect(ctx);
@@ -795,8 +821,9 @@ export function registerPidash(
   pi.registerCommand("pidash", {
     description: "Manage pidash server — /pidash start|stop|restart|status",
     handler: async (args, ctx) => {
-      // Capture command context (for future use when pi exposes switchSession/newSession)
+      // Capture real ExtensionCommandContext — has switchSession()/newSession()
       execCtx = ctx;
+      execCtxIsCommand = true;
 
       const cmd = (args || "").trim().toLowerCase();
 
@@ -895,7 +922,17 @@ export function registerPidash(
     }
   });
 
-  pi.on("session_shutdown", () => {
+  pi.on("session_shutdown", (event) => {
+    // Forward shutdown reason to pidash dashboard
+    if (ws && connected) {
+      try {
+        ws.send(JSON.stringify({
+          type: "session_shutdown",
+          reason: (event as any).reason,
+          targetSessionFile: (event as any).targetSessionFile,
+        }));
+      } catch {}
+    }
     shuttingDown = true;
     clearInterval(reconnectPoller);
     if (ws) { try { ws.close(); } catch {} ws = null; }

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -87,7 +87,7 @@ export function registerStatusLine(
     if (lastCtx) updateBranch(null, lastCtx);
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
-  pi.on("session_shutdown", () => {
+  pi.on("session_shutdown", (_event) => {
     clearInterval(gitPoller);
   });
 

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -25,7 +25,7 @@ import {
   Spacer,
   Text,
 } from "@mariozechner/pi-tui";
-import { Type } from "@sinclair/typebox";
+import { Type } from "typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
 import { getPiInvocation } from "./utils.js";
 


### PR DESCRIPTION
## Summary

Adopts new APIs from pi 0.69.0 to improve the orchestrator extension.

## Changes

### TypeBox 1.x Migration
- Migrated `ask-user.ts` and `subagent-tool.ts` from `@sinclair/typebox` 0.34.x to `typebox` 1.x
- Pi 0.69.0 removed the old package; legacy alias still works but will be removed

### GitHub Issue Autocomplete Provider (NEW)
- New `github-autocomplete.ts` module
- Type `#` in the editor to get matching open issues from the current GitHub repo
- Uses `ctx.ui.addAutocompleteProvider()` API (pi 0.69.0)
- Lazy-loads issues via `gh issue list`, fuzzy-filters locally
- Enhances the issue-first workflow

### `session_shutdown` Reason Handling
- **Dreaming**: only runs on `quit` reason — skips `fork`, `new`, `resume`, `reload` (no point dreaming when transitioning sessions)
- **Pidash**: forwards `reason` and `targetSessionFile` to dashboard via WebSocket
- **Status line / async agents**: accept event param for type-safety

### `terminate: true` for ask_user
- When user cancels an `ask_user` dialog, returns `terminate: true` to skip the unnecessary LLM follow-up turn

### Pidash Session Switching
- Replaced TODO stubs with working `switchSession()` / `newSession()` implementations using `withSession` callbacks (pi 0.69.0 API)

## Files Changed
- `extensions/orchestrator/ask-user.ts` — TypeBox + terminate
- `extensions/orchestrator/subagent-tool.ts` — TypeBox
- `extensions/orchestrator/github-autocomplete.ts` — NEW
- `extensions/orchestrator/index.ts` — wire up autocomplete
- `extensions/orchestrator/dreaming.ts` — shutdown reason
- `extensions/orchestrator/pidash.ts` — shutdown reason + session switching
- `extensions/orchestrator/status-line.ts` — event param
- `extensions/orchestrator/async-agents.ts` — event param
- `AGENTS.md` — file listing

Closes #206