### PR TITLE
fix(pidash): sidebar groups expanded by default, persist user preference

### DIFF
--- a/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
@@ -31,17 +31,33 @@ interface Props {
   };
 }
 
-export function SessionSidebar({ sessions, activeSessionId, connected, onSelect, collapsed, onToggle, notifications }: Props) {
-  const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
-  const [initialized, setInitialized] = useState(false);
+// Track which groups the user explicitly collapsed.
+// Everything NOT in this set is expanded by default.
+const COLLAPSED_STORAGE_KEY = "pidash-collapsed-projects";
 
-  // Auto-expand all groups when sessions first load
-  if (!initialized && sessions.length > 0) {
-    setInitialized(true);
-    const all = new Set<string>();
-    for (const s of sessions) all.add(s.cwd.split("/").pop() || s.cwd);
-    setExpandedProjects(all);
-  }
+function loadCollapsedProjects(): Set<string> {
+  try {
+    const raw = localStorage.getItem(COLLAPSED_STORAGE_KEY);
+    if (raw) return new Set(JSON.parse(raw));
+  } catch {}
+  return new Set();
+}
+
+function saveCollapsedProjects(projects: Set<string>): void {
+  try { localStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify([...projects])); } catch {}
+}
+
+export function SessionSidebar({ sessions, activeSessionId, connected, onSelect, collapsed, onToggle, notifications }: Props) {
+  const [collapsedProjects, setCollapsedProjectsRaw] = useState<Set<string>>(() => loadCollapsedProjects());
+
+  // Wrap setter to persist to localStorage
+  const setCollapsedProjects = (update: Set<string> | ((prev: Set<string>) => Set<string>)) => {
+    setCollapsedProjectsRaw((prev) => {
+      const next = typeof update === "function" ? update(prev) : update;
+      saveCollapsedProjects(next);
+      return next;
+    });
+  };
 
   if (collapsed) return null;
 
@@ -67,10 +83,10 @@ export function SessionSidebar({ sessions, activeSessionId, connected, onSelect,
   });
 
   const toggleProject = (name: string) => {
-    setExpandedProjects(prev => {
+    setCollapsedProjects(prev => {
       const next = new Set(prev);
-      if (next.has(name)) next.delete(name);
-      else next.add(name);
+      if (next.has(name)) next.delete(name); // was collapsed → expand
+      else next.add(name); // was expanded → collapse
       return next;
     });
   };
@@ -102,7 +118,7 @@ export function SessionSidebar({ sessions, activeSessionId, connected, onSelect,
           <p className="p-4 text-center text-xs text-muted-foreground">No sessions</p>
         )}
         {sortedGroups.map(([name, group]) => {
-          const isExpanded = expandedProjects.has(name);
+          const isExpanded = !collapsedProjects.has(name);
           const hasActive = group.sessions.some(s => s.active);
           const count = group.sessions.length;
 


### PR DESCRIPTION
## Summary

Sidebar project groups were collapsed by default for new sessions. Now all groups are expanded by default, and user collapse/expand choices persist across page refreshes.

## Problem

The previous approach tracked which groups were **expanded** (starting from an empty set). New groups added after initial load were collapsed because they weren't in the expanded set.

## Fix

Inverted the logic — now tracks which groups the user has **collapsed**. Everything NOT in the collapsed set is expanded by default. This means:
- All groups expanded on first load ✅
- New sessions/groups auto-expand ✅
- User collapse choices persist in localStorage (`pidash-collapsed-projects`) ✅
- Survives page refresh ✅

## Testing
- ✅ All groups expanded by default
- ✅ Collapse persists across refresh
- ✅ New groups appear expanded