### PR TITLE
feat(docker): add Gemini CLI to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,9 @@ RUN DOCKER_VERSION=$(curl -fsSL https://download.docker.com/linux/static/stable/
 # Copy docker-safe wrapper
 COPY --chmod=755 scripts/docker-safe /usr/local/bin/docker-safe
 
-# Install acpx, agent-browser, pi-web-access, difit (pi itself is installed at runtime in entrypoint.sh)
+# Install acpx, agent-browser, pi-web-access, difit, gemini-cli (pi itself is installed at runtime in entrypoint.sh)
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-    npm install -g acpx agent-browser pi-web-access difit
+    npm install -g acpx agent-browser pi-web-access difit @google/gemini-cli
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
 RUN chown -R node:node /home/node


### PR DESCRIPTION
## Summary

Add `@google/gemini-cli` to the container image for use with acpx.

## Changes

- Added `@google/gemini-cli` to the global npm install in Dockerfile alongside acpx, agent-browser, pi-web-access, and difit