### PR TITLE
fix(reviews): fetch comments before waiting on rate limit in poll loop

### DIFF
--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -62,9 +62,9 @@ def run(review_url: str = "") -> int:
 
     Steps (repeated in a loop):
     1. Check if CodeRabbit approved (exit if yes)
-    2. Check if CodeRabbit is rate limited (wait + trigger if yes)
-    3. Check approval again after rate limit trigger
-    4. Fetch reviews (exit if new comments)
+    2. Fetch reviews (exit if actionable comments — fix them now, don't wait)
+    3. Check if CodeRabbit is rate limited (wait + trigger if yes)
+    4. Check approval again after rate limit trigger
     5. No new comments -> sleep 5 min, loop back to step 1
 
     Returns exit code (0 = success, 1 = error).
@@ -85,7 +85,22 @@ def run(review_url: str = "") -> int:
             print('{"approved": true}')
             return 0
 
-        # Step 3: Check CodeRabbit rate limit
+        # Step 3: Fetch reviews — get actionable comments before waiting on rate limit
+        print_stderr("[poll] Fetching reviews...")
+        fetch_result = fetch_run(review_url)
+
+        if fetch_result == 0:
+            # Check if there are actionable (non-auto-skipped) comments
+            # fetch_run saves JSON to a predictable path
+            has_actionable = _has_actionable_comments(pr_number)
+            if has_actionable:
+                return 0
+            print_stderr("[poll] All fetched comments are auto-skipped (previously addressed). No new comments.")
+        else:
+            # Fetch failed -- log and retry
+            print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
+
+        # Step 4: Check CodeRabbit rate limit
         print_stderr("[poll] Checking CodeRabbit rate limit...")
         comment_id, body, updated_at, error = find_summary_comment(owner_repo, int(pr_number))
 
@@ -113,7 +128,7 @@ def run(review_url: str = "") -> int:
             total_wait = remaining + _RATE_LIMIT_BUFFER_SECONDS
             print_stderr(f"[poll] CodeRabbit is rate limited. Waiting {total_wait}s then triggering re-review...")
 
-            # Step 4: Trigger (waits internally, posts trigger, polls until review starts)
+            # Trigger (waits internally, posts trigger, polls until review starts)
             with contextlib.redirect_stdout(sys.stderr):
                 trigger_result = run_trigger(owner_repo, int(pr_number), total_wait)
             if trigger_result != 0:
@@ -128,29 +143,14 @@ def run(review_url: str = "") -> int:
 
         elif comment_id is None:
             if error and "No CodeRabbit summary comment found" in error:
-                print_stderr("[poll] No CodeRabbit summary comment found. Proceeding to fetch.")
+                print_stderr("[poll] No CodeRabbit summary comment found.")
             elif error:
-                print_stderr(f"[poll] Could not check rate limit ({error}). Proceeding to fetch.")
+                print_stderr(f"[poll] Could not check rate limit ({error}).")
             else:
-                print_stderr("[poll] No CodeRabbit summary comment found. Proceeding to fetch.")
+                print_stderr("[poll] No CodeRabbit summary comment found.")
         else:
-            print_stderr("[poll] No rate limit detected. Proceeding to fetch.")
+            print_stderr("[poll] No rate limit detected.")
 
-        # Step 6: Fetch reviews
-        print_stderr("[poll] Fetching reviews...")
-        fetch_result = fetch_run(review_url)
-
-        if fetch_result == 0:
-            # Check if there are actionable (non-auto-skipped) comments
-            # fetch_run saves JSON to a predictable path
-            has_actionable = _has_actionable_comments(pr_number)
-            if has_actionable:
-                return 0
-            print_stderr("[poll] All fetched comments are auto-skipped (previously addressed). No new comments.")
-        else:
-            # Fetch failed -- log and retry
-            print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
-
-        # Step 7: No actionable result -- sleep and loop
+        # Step 6: No actionable result -- sleep and loop
         print_stderr(f"[poll] No new comments. Sleeping {_POLL_SLEEP_SECONDS}s before next cycle...")
         time.sleep(_POLL_SLEEP_SECONDS)


### PR DESCRIPTION
## Summary

Reorder the poll loop so actionable comments are fetched immediately instead of waiting for CodeRabbit rate limit to expire first.

## Before
```
1. Check approval → exit if approved
2. Check rate limit → wait + trigger (can take 30+ min)
3. Re-check approval
4. Fetch comments → exit if actionable
5. Sleep 5min → loop
```

## After
```
1. Check approval → exit if approved
2. Fetch comments → exit if actionable (fix them now!)
3. Check rate limit → wait + trigger
4. Re-check approval
5. Sleep 5min → loop
```

## Why

When a PR has pending CodeRabbit comments AND is rate-limited, the old flow would wait for the rate limit to expire before fetching the comments that were already sitting there. Now we grab them immediately and start fixing.

## Testing
- ✅ 16/16 pytest tests pass
- ✅ All 3 code reviewers approved (quality, guidelines, security)