### PR TITLE
fix(docker): add .worktrees/ to global gitignore in entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -53,6 +53,9 @@ GITIGNORE_FILE="$(git config --global core.excludesFile 2>/dev/null || echo "$HO
 if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.pi/memory/' "$GITIGNORE_FILE" 2>/dev/null; then
     echo '.pi/memory/' >> "$GITIGNORE_FILE"
 fi
+if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.worktrees/' "$GITIGNORE_FILE" 2>/dev/null; then
+    echo '.worktrees/' >> "$GITIGNORE_FILE"
+fi
 
 
 exec pi "$@"

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -36,8 +36,8 @@ git worktree remove .worktrees/pr-42
 git worktree remove .worktrees/pr-43
 ```
 
-All worktrees live under `.worktrees/` in the repo — git tracks them
-automatically via `.git/worktrees/`, no `.gitignore` entry needed.
+All worktrees live under `.worktrees/` in the repo.
+`.worktrees/` is in the global gitignore (added by entrypoint.sh).
 Branch switching corrupts parallel agent work — other agents running in the
 main worktree will see the wrong branch.
 


### PR DESCRIPTION
## Summary

`.worktrees/` directories show up as untracked files. Git only auto-ignores its internal `.git/worktrees/` metadata, not the actual working directory.

## Changes

- `entrypoint.sh`: Add `.worktrees/` to global gitignore (same pattern as `.pi/memory/`)
- `prompts/review-handler.md`: Fix incorrect claim that no gitignore entry is needed