### PR TITLE
feat(discord): support file attachments from Discord DMs

### DIFF
--- a/extensions/orchestrator/pidash-ui/src/App.tsx
+++ b/extensions/orchestrator/pidash-ui/src/App.tsx
@@ -477,11 +477,11 @@ export function App() {
     return () => document.removeEventListener("keydown", onKey);
   }, [streaming, session, handleAbort]);
 
-  const handleSend = useCallback((text: string) => {
+  const handleSend = useCallback((text: string, images?: Array<{ data: string; mimeType: string; filename: string }>) => {
     if (!session) return;
     lastUserRef.current = text;
-    addMsg("user", text);
-    send({ type: "prompt", sessionId: session.sessionId, text });
+    addMsg("user", text + (images ? ` [+${images.length} file(s)]` : ""));
+    send({ type: "prompt", sessionId: session.sessionId, text, images: images || undefined });
   }, [session, send, addMsg]);
 
   return (

--- a/extensions/orchestrator/pidash-ui/src/components/InputBar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/InputBar.tsx
@@ -1,17 +1,19 @@
 import { useRef, useCallback, useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
-import { Send, Square } from "lucide-react";
+import { Send, Square, Paperclip } from "lucide-react";
 
 interface Props {
   disabled: boolean;
   streaming?: boolean;
-  onSend: (text: string) => void;
+  onSend: (text: string, images?: Array<{ data: string; mimeType: string; filename: string }>) => void;
   onAbort?: () => void;
   commands?: Array<{ name: string; description: string }>;
 }
 
 export function InputBar({ disabled, streaming, onSend, onAbort, commands = [] }: Props) {
   const ref = useRef<HTMLTextAreaElement>(null);
+  const [pendingFiles, setPendingFiles] = useState<Array<{ data: string; mimeType: string; filename: string; preview?: string }>>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [suggestions, setSuggestions] = useState<Array<{ name: string; description: string }>>([]);
   const [selectedIdx, setSelectedIdx] = useState(0);
@@ -21,16 +23,19 @@ export function InputBar({ disabled, streaming, onSend, onAbort, commands = [] }
 
   const handleSend = useCallback(() => {
     const text = ref.current?.value.trim();
-    if (!text) return;
-    setHistory((prev) => [text, ...prev.filter(h => h !== text)].slice(0, 50));
+    if (!text && pendingFiles.length === 0) return;
+    if (text) {
+      setHistory((prev) => [text, ...prev.filter(h => h !== text)].slice(0, 50));
+    }
     setHistoryIdx(-1);
-    onSend(text);
+    onSend(text || "", pendingFiles.length > 0 ? pendingFiles.map(({ data, mimeType, filename }) => ({ data, mimeType, filename })) : undefined);
+    setPendingFiles([]);
     if (ref.current) {
       ref.current.value = "";
       ref.current.style.height = "auto";
     }
     setShowSuggestions(false);
-  }, [onSend]);
+  }, [onSend, pendingFiles]);
 
   const autoResize = useCallback(() => {
     const el = ref.current;
@@ -38,6 +43,39 @@ export function InputBar({ disabled, streaming, onSend, onAbort, commands = [] }
     el.style.height = "auto";
     el.style.height = Math.min(el.scrollHeight, 200) + "px";
   }, []);
+
+  const handleFiles = useCallback((files: FileList | null) => {
+    if (!files) return;
+    Array.from(files).forEach(file => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result as string;
+        if (file.type.startsWith("image/")) {
+          // Image: extract base64 data
+          const base64 = result.split(",")[1];
+          setPendingFiles(prev => [...prev, {
+            data: base64,
+            mimeType: file.type,
+            filename: file.name,
+            preview: result, // data URL for preview
+          }]);
+        } else {
+          // Text file: read as text and add to textarea
+          const textReader = new FileReader();
+          textReader.onload = () => {
+            const text = textReader.result as string;
+            if (ref.current) {
+              const existing = ref.current.value;
+              ref.current.value = existing + (existing ? "\n\n" : "") + `--- ${file.name} ---\n${text}`;
+              autoResize();
+            }
+          };
+          textReader.readAsText(file);
+        }
+      };
+      reader.readAsDataURL(file);
+    });
+  }, [autoResize]);
 
   const updateSuggestions = useCallback(() => {
     const text = ref.current?.value || "";
@@ -71,6 +109,14 @@ export function InputBar({ disabled, streaming, onSend, onAbort, commands = [] }
 
   return (
     <div className="relative">
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept="image/*,.txt,.log,.md,.json,.yaml,.yml,.toml,.csv,.xml,.html,.css,.js,.ts,.py,.sh,.go,.java,.rs,.rb,.c,.cpp,.h,.hpp"
+        className="hidden"
+        onChange={(e) => { handleFiles(e.target.files); e.target.value = ""; }}
+      />
       {showSuggestions && suggestions.length > 0 && (
         <div ref={suggestionsRef} className="absolute bottom-full left-0 right-0 mx-3 mb-1 bg-card border border-border rounded-lg shadow-xl py-1 max-h-48 overflow-y-auto z-50">
           {suggestions.map((cmd, i) => (
@@ -85,7 +131,27 @@ export function InputBar({ disabled, streaming, onSend, onAbort, commands = [] }
           ))}
         </div>
       )}
+      {pendingFiles.length > 0 && (
+        <div className="flex gap-2 px-3 pt-2 flex-wrap border-t border-border">
+          {pendingFiles.map((f, i) => (
+            <div key={i} className="relative group">
+              {f.preview ? (
+                <img src={f.preview} alt={f.filename} className="h-16 w-16 object-cover rounded border border-border" />
+              ) : (
+                <div className="h-16 w-16 flex items-center justify-center rounded border border-border bg-muted text-xs text-muted-foreground">{f.filename.split('.').pop()}</div>
+              )}
+              <button
+                className="absolute -top-1 -right-1 bg-destructive text-destructive-foreground rounded-full w-4 h-4 text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                onClick={() => setPendingFiles(prev => prev.filter((_, j) => j !== i))}
+              >×</button>
+            </div>
+          ))}
+        </div>
+      )}
       <div className="flex items-end gap-2 p-3 border-t border-border">
+        <Button size="sm" variant="ghost" onClick={() => fileInputRef.current?.click()} disabled={disabled} className="mb-0.5" title="Attach file">
+          <Paperclip className="h-4 w-4" />
+        </Button>
         <textarea
           ref={ref}
           rows={1}
@@ -130,6 +196,8 @@ export function InputBar({ disabled, streaming, onSend, onAbort, commands = [] }
             }
           }}
           onInput={() => { autoResize(); updateSuggestions(); }}
+          onDrop={(e) => { e.preventDefault(); handleFiles(e.dataTransfer.files); }}
+          onDragOver={(e) => e.preventDefault()}
           onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
         />
         {streaming ? (

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -363,9 +363,21 @@ export function registerPidash(
       wsClient.on("message", async (data: Buffer) => {
         try {
           const parsed = JSON.parse(data.toString());
-          if (parsed.type === "prompt" && parsed.text) {
-            debugLog(`received prompt from browser: ${parsed.text.slice(0, 100)}`);
-            pi.sendUserMessage(parsed.text, { deliverAs: "followUp" });
+          if (parsed.type === "prompt" && (parsed.text || parsed.images)) {
+            debugLog(`received prompt from browser: ${(parsed.text || "").slice(0, 100)}${parsed.images ? ` [+${parsed.images.length} images]` : ""}`);
+            if (parsed.images && parsed.images.length > 0) {
+              // Build content array with text + images
+              const content: Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }> = [];
+              if (parsed.text) {
+                content.push({ type: "text", text: parsed.text });
+              }
+              for (const img of parsed.images) {
+                content.push({ type: "image", data: img.data, mimeType: img.mimeType });
+              }
+              pi.sendUserMessage(content, { deliverAs: "followUp" });
+            } else {
+              pi.sendUserMessage(parsed.text, { deliverAs: "followUp" });
+            }
           }
           if (parsed.type === "extension_ui_response" && parsed.id) {
             debugLog(`received UI response from browser: ${JSON.stringify(parsed).slice(0, 100)}`);

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -371,11 +371,13 @@ browserWss.on("connection", (ws: any) => {
         return;
       }
 
-      if (parsed.type === "prompt" && parsed.text && parsed.sessionId) {
+      if (parsed.type === "prompt" && (parsed.text || parsed.images) && parsed.sessionId) {
         const piClient = piClients.get(parsed.sessionId);
         if (piClient && piClient.ws) {
-          piClient.ws.send(JSON.stringify({ type: "prompt", text: parsed.text }));
-          log(`prompt forwarded to ${parsed.sessionId}: ${parsed.text.slice(0, 50)}`);
+          const fwd: any = { type: "prompt", text: parsed.text || "" };
+          if (parsed.images && parsed.images.length > 0) fwd.images = parsed.images;
+          piClient.ws.send(JSON.stringify(fwd));
+          log(`prompt forwarded to ${parsed.sessionId}: ${(parsed.text || "").slice(0, 50)}${parsed.images ? ` [+${parsed.images.length} images]` : ""}`);
         }
         return;
       }
@@ -955,6 +957,20 @@ if (process.env.DISCORD_BOT_TOKEN) {
       }
     });
 
+    // Download Discord attachment and convert to base64
+    async function downloadAttachment(url: string): Promise<{ data: string; mimeType: string } | null> {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) return null;
+        const buffer = Buffer.from(await response.arrayBuffer());
+        const contentType = response.headers.get("content-type") || "application/octet-stream";
+        return { data: buffer.toString("base64"), mimeType: contentType };
+      } catch (e: any) {
+        log(`[discord] attachment download error: ${e.message}`);
+        return null;
+      }
+    }
+
     // Handle DM messages (prompts + ask_user responses)
     discord.on("raw", async (event: any) => {
       if (event.t !== "MESSAGE_CREATE") return;
@@ -964,7 +980,7 @@ if (process.env.DISCORD_BOT_TOKEN) {
       if (d.guild_id) return; // Only DMs
 
       const text = (d.content || "").trim();
-      if (!text) return;
+      if (!text && (!d.attachments || d.attachments.length === 0)) return;
 
       const userId = d.author.id;
       const channelId = d.channel_id;
@@ -1017,9 +1033,53 @@ if (process.env.DISCORD_BOT_TOKEN) {
         return;
       }
 
-      discordOriginatedPrompts.add(text);
-      setTimeout(() => discordOriginatedPrompts.delete(text), 30000);
-      client.ws.send(JSON.stringify({ type: "prompt", text }));
+      // Process attachments (images, text files)
+      const attachments = d.attachments || [];
+      const images: Array<{ data: string; mimeType: string; filename: string }> = [];
+      const fileContents: string[] = [];
+
+      if (attachments.length > 0) {
+        for (const att of attachments) {
+          const isImage = att.content_type?.startsWith("image/");
+          const isText = att.content_type?.startsWith("text/") ||
+            /\.(txt|log|md|json|yaml|yml|toml|csv|xml|html|css|js|ts|py|sh|go|java|rs|rb|c|cpp|h|hpp)$/i.test(att.filename || "");
+
+          if (isImage) {
+            const downloaded = await downloadAttachment(att.url);
+            if (downloaded) {
+              images.push({ ...downloaded, filename: att.filename || "image" });
+            }
+          } else if (isText && att.size < 100000) { // <100KB text files
+            try {
+              const response = await fetch(att.url);
+              if (response.ok) {
+                const content = await response.text();
+                fileContents.push(`--- ${att.filename} ---\n${content}`);
+              }
+            } catch (e: any) {
+              log(`[discord] text file download error: ${e.message}`);
+            }
+          } else {
+            // Binary or large file — just mention it
+            fileContents.push(`[Attached file: ${att.filename} (${att.content_type}, ${(att.size / 1024).toFixed(1)}KB) — binary file not included]`);
+          }
+        }
+      }
+
+      // Build the prompt with any text file contents appended
+      const fullText = fileContents.length > 0
+        ? (text ? text + "\n\n" : "") + fileContents.join("\n\n")
+        : text;
+
+      if (!fullText && images.length === 0) return; // Nothing to send
+
+      discordOriginatedPrompts.add(fullText || text);
+      setTimeout(() => discordOriginatedPrompts.delete(fullText || text), 30000);
+      client.ws.send(JSON.stringify({
+        type: "prompt",
+        text: fullText || "",
+        images: images.length > 0 ? images : undefined,
+      }));
     });
 
     discord.once("ready", async (c: any) => {


### PR DESCRIPTION
## Changes

Closes #226 (Discord part — Web UI file upload is a separate follow-up)

### Discord file attachments
When users attach files in Discord DMs, they are now processed and forwarded to the pi session:

- **Images** (png, jpg, gif, webp): Downloaded, converted to base64, sent as `ImageContent` to `sendUserMessage` — the agent can see and analyze them
- **Text/code files** (txt, log, md, json, yaml, py, ts, sh, go, etc.): Content is inlined into the prompt text (up to 100KB)
- **Binary/large files**: Mentioned with filename, type, and size but not included

### Extension changes
- `pidash.ts` now handles `images` array in prompt messages, building a multimodal `(TextContent | ImageContent)[]` array for `pi.sendUserMessage`

### What's NOT in this PR
- Web UI file upload support (future PR)