### PR TITLE
fix(release): improve changelog quality — filter noise and enforce formatting

### DIFF
--- a/myk_pi_tools/release/info.py
+++ b/myk_pi_tools/release/info.py
@@ -197,6 +197,26 @@ _VALID_BRANCH_RE = re.compile(r"^(?!.*\.\.)[A-Za-z0-9._/][A-Za-z0-9._/-]*$")
 _ERR_INVALID_TARGET = "Invalid target branch: {!r}. Must not start with '-' or contain revision syntax."
 _ERR_INVALID_TAG_MATCH = "Invalid tag-match pattern: {!r}. Only alphanumeric, '.', '*', '-', '_' allowed."
 
+# Commit subjects that should be excluded from release changelogs
+_CHANGELOG_NOISE_PATTERNS = [
+    re.compile(r"address.*review", re.IGNORECASE),
+    re.compile(r"coderabbit", re.IGNORECASE),
+    re.compile(r"^chore:.*checkpoint", re.IGNORECASE),
+    re.compile(r"^chore:.*bump version", re.IGNORECASE),
+    re.compile(r"regenerate docs", re.IGNORECASE),
+    re.compile(r"pre-commit autoupdate", re.IGNORECASE),
+    re.compile(r"^Merge pull request"),
+    re.compile(r"^Merge branch"),
+]
+
+
+def _is_changelog_noise(commit: Commit) -> bool:
+    """Check if a commit should be excluded from release changelogs."""
+    for pattern in _CHANGELOG_NOISE_PATTERNS:
+        if pattern.search(commit.subject):
+            return True
+    return False
+
 
 def _detect_version_branch(current_branch: str) -> tuple[str | None, str | None]:
     """Auto-detect version branch and infer tag match pattern.
@@ -327,7 +347,8 @@ def _get_commits(last_tag: str | None, limit: int = 100) -> tuple[list[Commit], 
             )
         )
 
-    return commits, is_first_release
+    filtered = [c for c in commits if not _is_changelog_noise(c)]
+    return filtered, is_first_release
 
 
 def get_release_info(repo: str | None = None, target: str | None = None, tag_match: str | None = None) -> ReleaseInfo:

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -88,11 +88,39 @@ Store the detect-versions JSON output for use in Phase 4. The key fields are:
 
 Parse commits from Phase 1 output and categorize by conventional commit type:
 
-- Breaking Changes (MAJOR)
-- Features (MINOR)
-- Bug Fixes, Docs, Maintenance (PATCH)
+- Breaking Changes → MAJOR
+- Features (`feat:`) → MINOR
+- Bug Fixes (`fix:`), Docs (`docs:`), Maintenance (`chore:`, `refactor:`, `test:`, `ci:`) → PATCH
 
-Generate changelog from the categorized commits.
+**Changelog formatting rules (MANDATORY):**
+
+1. **Use standardized emoji section headers:**
+   - `### ⚠️ Breaking Changes`
+   - `### ✨ Features`
+   - `### 🐛 Bug Fixes`
+   - `### 🏗️ Architecture`
+   - `### 📚 Documentation`
+   - `### 🔧 Maintenance`
+
+2. **Always use PR/issue references, never commit hashes:**
+   - ✅ `- **Feature name** — description (#42)`
+   - ❌ `- Feature name (c958777)`
+   - Extract PR number from merge commit messages or commit body
+   - Only fall back to commit hash if absolutely no PR/issue reference exists
+
+3. **Each entry needs a bold title + description:**
+   - ✅ `- **Date range filter** — Filter dashboard by date range with URL persistence (#141)`
+   - ❌ `- add date range filter to dashboard (#141)`
+
+4. **Semver enforcement:** If ANY `feat:` commit is present, version bump MUST be MINOR minimum, never PATCH.
+
+5. **Always append a compare link at the bottom:**
+
+   ```text
+   **Full Changelog**: https://github.com/{owner}/{repo}/compare/{last_tag}...{new_tag}
+   ```
+
+Generate changelog from the categorized commits following these rules.
 
 **Version determination:**
 


### PR DESCRIPTION
## Changes

Closes #230

### Commit filtering (`info.py`)
Pre-filters noise commits before the LLM sees them:
- CodeRabbit review iterations (`address.*review`, `coderabbit`)
- Checkpoint commits (`chore:.*checkpoint`)
- Version bump commits (`chore:.*bump version`)
- Docs regeneration (`regenerate docs`)
- Pre-commit autoupdates (`pre-commit autoupdate`)
- Merge commits (`Merge pull request`, `Merge branch`)

### Changelog formatting rules (`release.md`)
Added mandatory formatting rules to Phase 3:
- Standardized emoji section headers (`### ✨ Features`, `### 🐛 Bug Fixes`, etc.)
- PR/issue references required, never commit hashes
- Each entry needs bold title + description
- `feat:` commits enforce MINOR bump minimum
- Always append `Full Changelog` compare link