### PR TITLE
feat: add glab (GitLab CLI) to container image and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,12 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   apt-get update && apt-get install -y --no-install-recommends gh && \
   rm -rf /var/lib/apt/lists/*
 
+# Install GitLab CLI (latest release .deb from GitLab API)
+RUN GLAB_VERSION=$(curl -fsSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases" | grep -o '"tag_name":"v[^"]*"' | head -1 | cut -d'"' -f4 | sed 's/^v//') && \
+  curl -fsSL -o /tmp/glab.deb "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.deb" && \
+  dpkg -i /tmp/glab.deb && \
+  rm -f /tmp/glab.deb
+
 # Install Chromium via Playwright (--with-deps installs all system libs)
 RUN mkdir -p /home/node/.cache/ms-playwright && \
   PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright \

--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ npm install && npm run build
 | `-v "$HOME/.agents":/home/node/.agents:rw` | User-level skills (install/uninstall from container) |
 | `-v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro` | Google Cloud ADC (for Claude via Vertex AI) |
 | `-v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro` | Cursor CLI auth (for acpx cursor models) |
+| `-v "$HOME/.config/glab-cli":/home/node/.config/glab-cli:ro` | GitLab CLI config (auth tokens, host settings) |
 | `-v "$HOME/screenshots":/home/node/screenshots` | Share screenshots/images with the agent |
 | `-v /var/run/docker.sock:/var/run/docker.sock:ro` + `--group-add $(stat -c '%g' /var/run/docker.sock)` | Docker container inspection via `docker-safe` |
 | `-v /var/run/podman/podman.sock:/var/run/podman/podman.sock:ro` | Podman container inspection via `docker-safe` |
@@ -369,6 +370,7 @@ npm install && npm run build
 | `pi` | Coding agent |
 | `git` | Version control |
 | `gh` | GitHub CLI (PRs, issues) |
+| `glab` | GitLab CLI (MRs, issues, pipelines) — install [gitlab-cli-skills](https://github.com/vince-winkintel/gitlab-cli-skills) for full agent support |
 | `uv` / `uvx` | Python execution (enforced by orchestrator) |
 | `go` | Go development and code review |
 | `mcpl` | MCP server access (search, Jenkins, etc.) |
@@ -423,6 +425,7 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.agents":/home/node/.agents:rw \
   -v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro \
   -v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro \
+  -v "$HOME/.config/glab-cli":/home/node/.config/glab-cli:ro \
   -v "$HOME/screenshots":/home/node/screenshots \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --group-add $(stat -c '%g' /var/run/docker.sock) \


### PR DESCRIPTION
- Install latest glab via GitLab API .deb in Dockerfile
- Add glab to tools table in README
- Add glab-cli config mount to optional mounts and shell alias