### PR TITLE
feat(prompts): improve dream prompt — direct file writes, explicit extraction rules

### DIFF
--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -4,8 +4,9 @@
  * Inspired by OpenClaw's dreaming system (v2026.4.5).
  * See: https://docs.openclaw.ai/concepts/dreaming
  *
- * When enabled, runs "uv run myk-pi-tools memory dream" every 3 hours
- * as an async background agent, plus on session shutdown as a detached process.
+ * When enabled, spawns a worker agent every 3 hours (and on session quit)
+ * that reads the session file, extracts memories, and writes memory.md directly.
+ * No CLI calls — the worker reads/writes the file using read/write tools.
  * Users toggle with /dream-auto on|off.
  */
 

--- a/prompts/dream.md
+++ b/prompts/dream.md
@@ -2,10 +2,9 @@
 description: "Run memory consolidation — extract, deduplicate, reorganize memories — /dream"
 ---
 
-> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior,
-> or reproducible bug while executing this command — DO NOT work around it
-> silently. Ask the user: "Should I create a GitHub issue for this?"
-> Route to `myk-org/pi-config` for prompt/extension issues,
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to `myk-org/pi-config` for prompt/extension issues,
 > or to the relevant tool's repository for CLI issues.
 
 ## Memory Dreaming
@@ -14,22 +13,36 @@ Inspired by [OpenClaw's dreaming system](https://docs.openclaw.ai/concepts/dream
 
 Run memory consolidation as a **background async agent** — never block the session.
 
-Dreaming is a **self-contained action** — the LLM worker:
-
-1. Reads the session file and extracts things worth remembering
-2. Adds new entries to the Learned section of memory.md
-3. Reorganizes — deduplicates, removes stale entries from Learned
-4. NEVER removes Pinned entries
-
-Delegate to a `worker` agent with `async: true` and `fireAndForget: true` (no result injection into conversation):
+Delegate to a `worker` agent with `async: true` and `fireAndForget: true`:
 
 ```text
-Task:
-1. Read the current session file to find things worth remembering
-2. Read the memory file: uv run myk-pi-tools memory show
-3. Add new entries: uv run myk-pi-tools memory add -c <category> -s "<summary>"
-4. Reorganize the memory file — deduplicate and remove stale Learned entries
-5. NEVER remove or modify Pinned entries
+Task: Memory dreaming — analyze session and maintain memory.md.
+Memory file: <memPath from `uv run myk-pi-tools memory path`>
+Session file: <current session file if available>
+
+Steps:
+1. Read the memory file directly.
+2. If a session file is provided, read it and extract things worth remembering:
+   - User corrections → [lesson]
+   - User preferences → [preference]
+   - Mistakes or repeated fix attempts → [mistake]
+   - Completed features/PRs merged → [done]
+   - Patterns or conventions → [pattern]
+   Add new entries to the Learned section. Do NOT add duplicates.
+3. Reorganize the memory file:
+   - Remove duplicate or near-duplicate entries from Learned
+   - Remove stale/useless entries from Learned
+   - Keep under 50 entries
+   - NEVER remove or modify entries in the Pinned section
+4. Write the updated file using the write tool. Keep the exact format:
+
+   # Memories
+   ## Pinned (user requested — never auto-remove)
+   - [category] summary
+   ## Learned (auto-extracted — dream may reorganize/remove)
+   - [category] summary
+
+5. Memory rules: one line per entry, max ~100 chars, specific and actionable.
 ```
 
 Tell the user: "Running memory consolidation in background..."


### PR DESCRIPTION
Closes #212

- Rewrite `dream.md` to use direct file read/write instead of N CLI calls
- Explicit category rules (lesson, preference, mistake, done, pattern)
- Cap at 50 entries, preserve Pinned section
- Update `dreaming.ts` comment to reflect new approach