### PR TITLE
feat(pidash): keyboard shortcuts, session switcher, and keybinding settings

### DIFF
--- a/extensions/orchestrator/pidash-ui/src/App.tsx
+++ b/extensions/orchestrator/pidash-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PanelLeftOpen, Search } from "lucide-react";
 import { SessionSidebar } from "@/components/SessionSidebar";
 import { InfoBar } from "@/components/InfoBar";
@@ -7,6 +7,9 @@ import { InputBar } from "@/components/InputBar";
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { useSessions } from "@/hooks/useSessions";
 import { useNotifications } from "@/hooks/useNotifications";
+import { useKeybindings, matchesKeybinding } from "@/hooks/useKeybindings";
+import { SessionSwitcher } from "@/components/SessionSwitcher";
+import { KeybindingSettings } from "@/components/KeybindingSettings";
 import type { ChatMessage, PiEvent, SessionInfo, TokenUsage } from "@/types";
 
 const STORAGE_KEY = "pidash-state";
@@ -42,6 +45,10 @@ export function App() {
   const [searchType, setSearchType] = useState("all");
   const [scrollKey, setScrollKey] = useState(0);
   const [availableCommands, setAvailableCommands] = useState<Array<{ name: string; description: string }>>([]);
+  const keybindings = useKeybindings();
+  const [showSwitcher, setShowSwitcher] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+
   const asyncMsgRef = useRef<Map<string, { msgId: string; text: string }>>(new Map());
   const messagesRef = useRef(messages);
   const saved = useRef(loadState());
@@ -469,13 +476,78 @@ export function App() {
     if (session) send({ type: "pidash-command", sessionId: session.sessionId, command: "abort" });
   }, [session, send]);
 
+  // Flatten sessions matching sidebar order: active groups first, then alphabetical, active sessions first within groups
+  const flatSessions = useMemo(() => {
+    const groups = new Map<string, SessionInfo[]>();
+    for (const s of sessions) {
+      const name = (s.cwd || "").split("/").pop() || s.cwd;
+      if (!groups.has(name)) groups.set(name, []);
+      groups.get(name)!.push(s);
+    }
+    // Sort within groups: active first
+    for (const g of groups.values()) {
+      g.sort((a, b) => (b.active ? 1 : 0) - (a.active ? 1 : 0));
+    }
+    // Sort groups: active groups first, then alphabetical
+    const sorted = [...groups.entries()].sort((a, b) => {
+      const aActive = a[1].some(s => s.active);
+      const bActive = b[1].some(s => s.active);
+      if (aActive !== bActive) return bActive ? 1 : -1;
+      return a[0].localeCompare(b[0]);
+    });
+    return sorted.flatMap(([, sessions]) => sessions);
+  }, [sessions]);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && streaming && session) handleAbort();
+      // Don't intercept when typing in inputs (except Escape)
+      const tag = (e.target as HTMLElement)?.tagName;
+      const isInput = tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT";
+
+      if (matchesKeybinding(e, keybindings.getKey("abort"))) {
+        if (streaming && session) { e.preventDefault(); handleAbort(); }
+        if (showSwitcher) { e.preventDefault(); setShowSwitcher(false); }
+        if (showSettings) { e.preventDefault(); setShowSettings(false); }
+        return;
+      }
+
+      if (isInput) return;
+
+      if (matchesKeybinding(e, keybindings.getKey("session-switcher"))) {
+        e.preventDefault();
+        setShowSwitcher(prev => !prev);
+        return;
+      }
+
+      if (matchesKeybinding(e, keybindings.getKey("prev-session"))) {
+        e.preventDefault();
+        if (flatSessions.length < 2 || !session) return;
+        const idx = flatSessions.findIndex(s => s.sessionId === session.sessionId);
+        const prev = idx <= 0 ? flatSessions[flatSessions.length - 1] : flatSessions[idx - 1];
+        if (prev) watchSession(prev);
+        return;
+      }
+
+      if (matchesKeybinding(e, keybindings.getKey("next-session"))) {
+        e.preventDefault();
+        if (flatSessions.length < 2 || !session) return;
+        const idx = flatSessions.findIndex(s => s.sessionId === session.sessionId);
+        const next = idx >= flatSessions.length - 1 ? flatSessions[0] : flatSessions[idx + 1];
+        if (next) watchSession(next);
+        return;
+      }
+
+      for (let n = 1; n <= 9; n++) {
+        if (matchesKeybinding(e, keybindings.getKey(`session-${n}`))) {
+          e.preventDefault();
+          if (flatSessions[n - 1]) watchSession(flatSessions[n - 1]);
+          return;
+        }
+      }
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [streaming, session, handleAbort]);
+  }, [streaming, session, handleAbort, keybindings.getKey, flatSessions, watchSession, showSwitcher, showSettings]);
 
   const handleSend = useCallback((text: string, images?: Array<{ data: string; mimeType: string; filename: string }>) => {
     if (!session) return;
@@ -506,6 +578,7 @@ export function App() {
             collapsed={false}
             onToggle={() => setSidebarCollapsed(true)}
             notifications={notifications}
+            onSettings={() => setShowSettings(prev => !prev)}
           />
           <div
             className="absolute right-0 top-0 bottom-0 w-1 cursor-col-resize hover:bg-primary/30 z-10 max-md:hidden"
@@ -574,6 +647,23 @@ export function App() {
         )}
       </div>
 
+      {showSettings && (
+        <KeybindingSettings
+          bindings={keybindings.bindings}
+          onUpdate={keybindings.updateBinding}
+          onReset={keybindings.resetToDefaults}
+          onClose={() => setShowSettings(false)}
+        />
+      )}
+
+      {showSwitcher && (
+        <SessionSwitcher
+          sessions={flatSessions}
+          activeSessionId={session?.sessionId ?? null}
+          onSelect={watchSession}
+          onClose={() => setShowSwitcher(false)}
+        />
+      )}
     </div>
   );
 }

--- a/extensions/orchestrator/pidash-ui/src/components/KeybindingSettings.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/KeybindingSettings.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from "react";
+import type { Keybinding } from "@/hooks/useKeybindings";
+import { eventToKeyString } from "@/hooks/useKeybindings";
+
+interface Props {
+  bindings: Keybinding[];
+  onUpdate: (id: string, newKey: string) => void;
+  onReset: () => void;
+  onClose: () => void;
+}
+
+export function KeybindingSettings({ bindings, onUpdate, onReset, onClose }: Props) {
+  const [recording, setRecording] = useState<string | null>(null);
+
+  const handleKeyCapture = useCallback((e: KeyboardEvent) => {
+    if (!recording) return;
+    // Ignore lone modifier keys
+    if (["Control", "Alt", "Shift", "Meta"].includes(e.key)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    // Escape cancels recording instead of assigning
+    if (e.key === "Escape") { setRecording(null); return; }
+    const keyStr = eventToKeyString(e);
+    onUpdate(recording, keyStr);
+    setRecording(null);
+  }, [recording, onUpdate]);
+
+  useEffect(() => {
+    if (!recording) return;
+    document.addEventListener("keydown", handleKeyCapture, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyCapture, true);
+    };
+  }, [recording, handleKeyCapture]);
+
+  const formatKey = (key: string) => {
+    return key.split("+").map((part, i) => (
+      <span key={i}>
+        {i > 0 && <span className="text-muted-foreground mx-0.5">+</span>}
+        <kbd className="bg-accent border border-border px-1.5 py-0.5 rounded text-xs font-mono">{part}</kbd>
+      </span>
+    ));
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-start justify-center pt-[10vh] z-50" onClick={onClose} role="dialog" aria-modal="true" aria-label="Keyboard shortcuts settings">
+      <div className="w-[600px] max-h-[75vh] overflow-y-auto bg-card border border-border rounded-lg shadow-2xl p-8" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-lg font-semibold flex items-center gap-2">⚙️ Keyboard Shortcuts</h2>
+          <button onClick={onClose} className="text-muted-foreground hover:text-foreground text-sm px-2 py-1 rounded hover:bg-accent">✕ Close</button>
+        </div>
+        <p className="text-xs text-muted-foreground mb-6">Customize keyboard shortcuts. Changes are saved automatically.</p>
+
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-border">
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase py-2 px-3">Action</th>
+              <th className="text-left text-[11px] font-semibold text-muted-foreground uppercase py-2 px-3">Shortcut</th>
+              <th className="w-16"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {bindings.map(b => (
+              <tr key={b.id} className="border-b border-border/30 hover:bg-accent/30 transition-colors">
+                <td className="py-2.5 px-3 text-sm">{b.label}</td>
+                <td className="py-2.5 px-3">
+                  {recording === b.id ? (
+                    <div className="inline-flex items-center gap-2 px-2.5 py-1 border border-primary rounded text-xs text-primary animate-pulse">
+                      ⏺ Press new shortcut...
+                    </div>
+                  ) : (
+                    <span className="inline-flex items-center gap-0.5">{formatKey(b.key)}</span>
+                  )}
+                </td>
+                <td className="py-2.5 px-3">
+                  {recording !== b.id && (
+                    <button
+                      onClick={() => setRecording(b.id)}
+                      className="text-[11px] text-muted-foreground border border-border px-2 py-0.5 rounded hover:bg-accent hover:text-foreground transition-colors"
+                    >
+                      Edit
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <button
+          onClick={onReset}
+          className="mt-6 text-xs text-muted-foreground border border-border px-4 py-2 rounded hover:bg-accent hover:text-foreground transition-colors"
+        >
+          Reset to Defaults
+        </button>
+        <p className="mt-3 text-[11px] text-muted-foreground flex items-center gap-1.5">
+          <span className="text-green-500">✓</span> Settings saved automatically
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/SessionSidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { GitBranch, Circle, Pause, PanelLeftClose, ChevronRight, ChevronDown, Folder } from "lucide-react";
+import { GitBranch, Circle, Pause, PanelLeftClose, ChevronRight, ChevronDown, Folder, Settings } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -22,6 +22,7 @@ interface Props {
   onSelect: (s: SessionInfo) => void;
   collapsed: boolean;
   onToggle: () => void;
+  onSettings?: () => void;
   notifications?: {
     permission: NotificationPermission;
     supported: boolean;
@@ -47,7 +48,7 @@ function saveCollapsedProjects(projects: Set<string>): void {
   try { localStorage.setItem(COLLAPSED_STORAGE_KEY, JSON.stringify([...projects])); } catch {}
 }
 
-export function SessionSidebar({ sessions, activeSessionId, connected, onSelect, collapsed, onToggle, notifications }: Props) {
+export function SessionSidebar({ sessions, activeSessionId, connected, onSelect, collapsed, onToggle, onSettings, notifications }: Props) {
   const [collapsedProjects, setCollapsedProjectsRaw] = useState<Set<string>>(() => loadCollapsedProjects());
 
   // Wrap setter to persist to localStorage
@@ -108,6 +109,11 @@ export function SessionSidebar({ sessions, activeSessionId, connected, onSelect,
             setPreference={notifications.setPreference}
             requestPermission={notifications.requestPermission}
           />}
+          {onSettings && (
+            <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-muted-foreground" onClick={onSettings}>
+              <Settings className="h-3.5 w-3.5" />
+            </Button>
+          )}
           <Button variant="ghost" size="sm" className="h-6 w-6 p-0 text-muted-foreground" onClick={onToggle}>
             <PanelLeftClose className="h-3.5 w-3.5" />
           </Button>

--- a/extensions/orchestrator/pidash-ui/src/components/SessionSwitcher.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/SessionSwitcher.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useRef, useState } from "react";
+import type { SessionInfo } from "@/types";
+
+interface Props {
+  sessions: SessionInfo[];
+  activeSessionId: string | null;
+  onSelect: (session: SessionInfo) => void;
+  onClose: () => void;
+}
+
+export function SessionSwitcher({ sessions, activeSessionId, onSelect, onClose }: Props) {
+  const [query, setQuery] = useState("");
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = sessions.filter(s => {
+    if (!query) return true;
+    const q = query.toLowerCase();
+    const name = (s.cwd || "").split("/").pop() || "";
+    return name.toLowerCase().includes(q) || (s.model || "").toLowerCase().includes(q) || (s.branch || "").toLowerCase().includes(q);
+  });
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    setSelectedIdx(0);
+  }, [query, filtered.length]);
+
+  useEffect(() => {
+    const el = listRef.current?.children[selectedIdx] as HTMLElement;
+    if (el) el.scrollIntoView({ block: "nearest" });
+  }, [selectedIdx]);
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") { e.preventDefault(); onClose(); return; }
+    if (filtered.length === 0) return;
+    if (e.key === "ArrowDown") { e.preventDefault(); setSelectedIdx(i => Math.min(i + 1, filtered.length - 1)); return; }
+    if (e.key === "ArrowUp") { e.preventDefault(); setSelectedIdx(i => Math.max(i - 1, 0)); return; }
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (filtered[selectedIdx]) { onSelect(filtered[selectedIdx]); onClose(); }
+      return;
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-start justify-center pt-[15vh] z-50" onClick={onClose} role="dialog" aria-modal="true" aria-label="Session switcher">
+      <div className="w-[520px] bg-card border border-border rounded-lg shadow-2xl overflow-hidden" onClick={e => e.stopPropagation()} onKeyDown={handleKey}>
+        <div className="p-3 border-b border-border">
+          <input
+            ref={inputRef}
+            className="w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground font-mono"
+            placeholder="Switch session..."
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+        </div>
+        <div ref={listRef} className="max-h-[300px] overflow-y-auto">
+          {filtered.length === 0 && (
+            <div className="p-4 text-center text-muted-foreground text-sm">No matching sessions</div>
+          )}
+          {filtered.map((s, i) => {
+            const name = (s.cwd || "").split("/").pop() || s.cwd;
+            const isActive = s.sessionId === activeSessionId;
+            const isSelected = i === selectedIdx;
+            return (
+              <div
+                key={s.sessionId}
+                className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer border-l-[3px] transition-colors ${
+                  isSelected ? "bg-accent border-l-primary" : "border-l-transparent hover:bg-accent/50"
+                }`}
+                onClick={() => { onSelect(s); onClose(); }}
+                onMouseEnter={() => setSelectedIdx(i)}
+              >
+                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${s.active ? (s.working ? "bg-yellow-400 animate-pulse" : "bg-green-500") : "bg-orange-400"}`} />
+                <span className="text-sm font-medium flex-1 truncate">{name}</span>
+                <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+                  {s.model || "—"}{s.branch ? ` · ${s.branch}` : ""}
+                </span>
+                <span className={`text-[10px] px-1.5 py-0.5 rounded ${
+                  s.active ? (s.working ? "bg-yellow-500/15 text-yellow-400" : "bg-green-500/15 text-green-500") : "bg-orange-400/15 text-orange-400"
+                }`}>
+                  {s.active ? (s.working ? "active" : "idle") : "offline"}
+                </span>
+                {isActive && <span className="text-primary text-sm">✓</span>}
+              </div>
+            );
+          })}
+        </div>
+        <div className="px-4 py-2 border-t border-border text-[11px] text-muted-foreground flex gap-4">
+          <span><kbd className="bg-accent px-1 rounded text-[10px]">↑</kbd><kbd className="bg-accent px-1 rounded text-[10px] ml-0.5">↓</kbd> navigate</span>
+          <span><kbd className="bg-accent px-1 rounded text-[10px]">Enter</kbd> select</span>
+          <span><kbd className="bg-accent px-1 rounded text-[10px]">Esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/extensions/orchestrator/pidash-ui/src/hooks/useKeybindings.ts
+++ b/extensions/orchestrator/pidash-ui/src/hooks/useKeybindings.ts
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface Keybinding {
+  id: string;
+  label: string;
+  defaultKey: string;
+  key: string;
+}
+
+const STORAGE_KEY = "pidash-keybindings";
+
+const DEFAULT_KEYBINDINGS: Keybinding[] = [
+  { id: "session-switcher", label: "Open session switcher", defaultKey: "Ctrl+K", key: "Ctrl+K" },
+  { id: "prev-session", label: "Previous session", defaultKey: "Ctrl+ArrowUp", key: "Ctrl+ArrowUp" },
+  { id: "next-session", label: "Next session", defaultKey: "Ctrl+ArrowDown", key: "Ctrl+ArrowDown" },
+  { id: "session-1", label: "Jump to session 1", defaultKey: "Ctrl+1", key: "Ctrl+1" },
+  { id: "session-2", label: "Jump to session 2", defaultKey: "Ctrl+2", key: "Ctrl+2" },
+  { id: "session-3", label: "Jump to session 3", defaultKey: "Ctrl+3", key: "Ctrl+3" },
+  { id: "session-4", label: "Jump to session 4", defaultKey: "Ctrl+4", key: "Ctrl+4" },
+  { id: "session-5", label: "Jump to session 5", defaultKey: "Ctrl+5", key: "Ctrl+5" },
+  { id: "session-6", label: "Jump to session 6", defaultKey: "Ctrl+6", key: "Ctrl+6" },
+  { id: "session-7", label: "Jump to session 7", defaultKey: "Ctrl+7", key: "Ctrl+7" },
+  { id: "session-8", label: "Jump to session 8", defaultKey: "Ctrl+8", key: "Ctrl+8" },
+  { id: "session-9", label: "Jump to session 9", defaultKey: "Ctrl+9", key: "Ctrl+9" },
+  { id: "abort", label: "Abort / Stop", defaultKey: "Escape", key: "Escape" },
+];
+
+function loadKeybindings(): Keybinding[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_KEYBINDINGS.map(k => ({ ...k }));
+    const saved: Record<string, string> = JSON.parse(raw);
+    return DEFAULT_KEYBINDINGS.map(k => ({ ...k, key: saved[k.id] || k.defaultKey }));
+  } catch {
+    return DEFAULT_KEYBINDINGS.map(k => ({ ...k }));
+  }
+}
+
+function saveKeybindings(bindings: Keybinding[]) {
+  try {
+    const map: Record<string, string> = {};
+    for (const b of bindings) map[b.id] = b.key;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {}
+}
+
+export function eventToKeyString(e: KeyboardEvent): string {
+  const parts: string[] = [];
+  if (e.ctrlKey || e.metaKey) parts.push("Ctrl");
+  if (e.altKey) parts.push("Alt");
+  if (e.shiftKey) parts.push("Shift");
+  const key = e.key;
+  if (!["Control", "Alt", "Shift", "Meta"].includes(key)) {
+    parts.push(key.length === 1 ? key.toUpperCase() : key);
+  }
+  return parts.join("+");
+}
+
+export function matchesKeybinding(e: KeyboardEvent, keyStr: string): boolean {
+  const parts = keyStr.split("+");
+  const needCtrl = parts.includes("Ctrl");
+  const needAlt = parts.includes("Alt");
+  const needShift = parts.includes("Shift");
+  const keyPart = parts.filter(p => !["Ctrl", "Alt", "Shift"].includes(p))[0] || "";
+
+  if (needCtrl !== (e.ctrlKey || e.metaKey)) return false;
+  if (needAlt !== e.altKey) return false;
+  if (needShift !== e.shiftKey) return false;
+
+  const eventKey = e.key.length === 1 ? e.key.toUpperCase() : e.key;
+  return eventKey === keyPart;
+}
+
+export function useKeybindings() {
+  const [bindings, setBindings] = useState<Keybinding[]>(loadKeybindings);
+
+  const updateBinding = useCallback((id: string, newKey: string) => {
+    setBindings(prev => {
+      // Clear duplicate: if another binding uses this key, reset it to its default
+      const updated = prev.map(b => {
+        if (b.id === id) return { ...b, key: newKey };
+        if (b.key === newKey) return { ...b, key: b.defaultKey };
+        return b;
+      });
+      saveKeybindings(updated);
+      return updated;
+    });
+  }, []);
+
+  const resetToDefaults = useCallback(() => {
+    const defaults = DEFAULT_KEYBINDINGS.map(k => ({ ...k }));
+    saveKeybindings(defaults);
+    setBindings(defaults);
+  }, []);
+
+  const getKey = useCallback((id: string): string => {
+    return bindings.find(b => b.id === id)?.key || "";
+  }, [bindings]);
+
+  const api = useMemo(() => ({ bindings, updateBinding, resetToDefaults, getKey }), [bindings, updateBinding, resetToDefaults, getKey]);
+  return api;
+}


### PR DESCRIPTION
Closes #213

## Changes

### Session Switcher Popup (Ctrl+K)
- Fuzzy search by session name, model, or branch
- Arrow up/down navigation, Enter to select, Esc to close
- Currently watched session highlighted with checkmark
- ARIA dialog semantics for accessibility

### Quick Shortcuts
- **Ctrl+↑ / Ctrl+↓** — cycle through sessions (wraps around)
- **Ctrl+1 through Ctrl+9** — jump to session by position
- Session order matches sidebar (active groups first, then alphabetical)

### Keybinding Settings Page
- ⚙️ gear icon in sidebar header opens settings
- All shortcuts customizable — click Edit, press new key combo
- Escape cancels recording (doesn't assign Escape)
- Duplicate key detection — conflicting binding reset to default
- Persisted to localStorage — survives refresh/close/reopen
- Reset to Defaults button

### New files
- `hooks/useKeybindings.ts` — keybinding hook with localStorage persistence
- `components/SessionSwitcher.tsx` — Ctrl+K session switcher popup
- `components/KeybindingSettings.tsx` — settings page

### Peer reviewed
Cursor — 2 rounds, 8 findings addressed (Escape recording bug, useEffect re-subscribe, selectedIdx bounds, session order parity, duplicate detection, accessibility)