### PR TITLE
fix(pidash): survive laptop suspend/resume

### DIFF
--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -345,12 +345,26 @@ export function registerPidash(
         });
 
         // Send heartbeat every 30s to prevent idle disconnects
+        // Also detect dead connections after suspend/resume
+        let pongReceived = true;
+        wsClient.on("pong", () => { pongReceived = true; });
         const heartbeat = setInterval(() => {
-          if (wsClient.readyState === 1) { // WebSocket.OPEN
-            try { wsClient.ping(); } catch {}
-          } else {
+          if (wsClient.readyState !== 1) { // Not OPEN
             clearInterval(heartbeat);
+            return;
           }
+          if (!pongReceived) {
+            // No pong since last ping — connection is dead
+            debugLog("heartbeat: no pong received — connection dead, forcing reconnect");
+            clearInterval(heartbeat);
+            try { wsClient.terminate(); } catch {}
+            connected = false;
+            ws = null;
+            if (!shuttingDown && lastCtx) setTimeout(() => connect(lastCtx), 1000);
+            return;
+          }
+          pongReceived = false;
+          try { wsClient.ping(); } catch {}
         }, 30000);
         if ((heartbeat as any).unref) (heartbeat as any).unref();
 

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -1127,5 +1127,7 @@ server.on("error", (err: any) => {
   process.exit(1);
 });
 
+// Ignore SIGHUP — survives terminal close and laptop suspend/resume
+process.on("SIGHUP", () => { log("SIGHUP received — ignoring (survive suspend/resume)"); });
 process.on("SIGTERM", () => { log("SIGTERM received"); server.close(); process.exit(0); });
 process.on("SIGINT", () => { log("SIGINT received"); server.close(); process.exit(0); });


### PR DESCRIPTION
Closes #245

**Server:** Ignore SIGHUP — no longer exits on terminal close or suspend/resume.

**Extension:** Ping/pong heartbeat detects dead WebSocket connections after suspend. If no pong received within 30s, terminates the dead connection and forces reconnect (which respawns the server if needed).