### PR TITLE
fix(orchestrator): status bar order and always show async/cron counts

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -107,7 +107,7 @@ export function registerAsyncAgents(
     lastWidgetKey = widgetKey;
     if (running.length > 0) {
       // Always re-set status for running agents (other status updates may have triggered a re-render)
-      ctx.ui.setStatus("async-agents", ctx.ui.theme.fg("warning", `⏳ ${running.length} async agent${running.length > 1 ? "s" : ""}`));
+      ctx.ui.setStatus("1-async", ctx.ui.theme.fg("warning", `⏳ ${running.length} async agent${running.length > 1 ? "s" : ""}`));
       if (changed) {
         pi.events.emit("pidash:async-status", {
           count: running.length,
@@ -123,7 +123,7 @@ export function registerAsyncAgents(
         });
       }
     } else if (changed) {
-      ctx.ui.setStatus("async-agents", ctx.ui.theme.fg("muted", `⏳ 0 async agents`));
+      ctx.ui.setStatus("1-async", ctx.ui.theme.fg("muted", `⏳ 0 async agents`));
       pi.events.emit("pidash:async-status", { count: 0, agents: "", jobs: [] });
     }
   }
@@ -394,8 +394,8 @@ export function registerAsyncAgents(
     } catch {}
     if (asyncState.jobs.size > 0 || hasResultFiles) {
       ensureAsyncPoller();
-      updateAsyncWidget();
     }
+    updateAsyncWidget(); // Always set status (shows "0 async agents" when idle)
 
     startResultWatcher();
   });

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -111,9 +111,9 @@ export function registerCron(
     const count = tasks.size;
     if (lastCtx?.hasUI) {
       if (count > 0) {
-        lastCtx.ui.setStatus("crons", lastCtx.ui.theme.fg("muted", `⏰ ${count} cron${count > 1 ? "s" : ""}`));
+        lastCtx.ui.setStatus("2-crons", lastCtx.ui.theme.fg("muted", `⏰ ${count} cron${count > 1 ? "s" : ""}`));
       } else {
-        lastCtx.ui.setStatus("crons", lastCtx.ui.theme.fg("muted", `⏰ 0 crons`));
+        lastCtx.ui.setStatus("2-crons", lastCtx.ui.theme.fg("muted", `⏰ 0 crons`));
       }
     }
     pi.events.emit("pidash:cron-status", {

--- a/extensions/orchestrator/diff-viewer.ts
+++ b/extensions/orchestrator/diff-viewer.ts
@@ -104,12 +104,12 @@ export function registerDifit(pi: ExtensionAPI): void {
 
   function setDifitStatus(ctx: any, port: number): void {
     const statusText = ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${port}`);
-    ctx.ui.setStatus("diff-viewer", statusText);
+    ctx.ui.setStatus("4-diff", statusText);
     pi.events?.emit("diff-viewer:port", port);
   }
 
   function clearDifitStatus(ctx: any): void {
-    ctx.ui.setStatus("diff-viewer", undefined);
+    ctx.ui.setStatus("4-diff", undefined);
   }
 
   /** Start a new difit process. Returns port on success, null on failure. */

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -68,6 +68,7 @@ export default function (pi: ExtensionAPI) {
   registerSubagentTool(pi, spawnAsyncAgent, killAsyncAgent);
   registerEnforcement(pi, IN_CONTAINER);
   registerRules(pi);
+
   registerStatusLine(pi, IN_CONTAINER, terminalNotify);
   registerBtw(pi);
   registerDifit(pi);

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -370,7 +370,7 @@ export function registerPidash(
 
         // Show status
         if (ctx.hasUI) {
-          ctx.ui.setStatus("pidash", ctx.ui.theme.fg("accent", `🌐 http://localhost:${PIDASH_PORT}`));
+          ctx.ui.setStatus("5-pidash", ctx.ui.theme.fg("accent", `🌐 http://localhost:${PIDASH_PORT}`));
         }
       });
 
@@ -805,7 +805,7 @@ export function registerPidash(
           ex("pkill -f pidash-server", { stdio: "ignore" });
         } catch {}
         if (ctx.hasUI) {
-          ctx.ui.setStatus("pidash", undefined);
+          ctx.ui.setStatus("5-pidash", undefined);
           ctx.ui.notify("pidash server stopped", "info");
         }
         return;

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -23,7 +23,7 @@ export function registerStatusLine(
     const text = parts.join(ctx.ui.theme.fg("dim", ICON_SEP));
     if (text === lastStatusText) return; // Skip redundant re-renders
     lastStatusText = text;
-    ctx.ui.setStatus("combined", text);
+    ctx.ui.setStatus("3-git", text);
     // Clear individual statuses to avoid duplicates
     ctx.ui.setStatus("container", undefined);
     ctx.ui.setStatus("git", undefined);


### PR DESCRIPTION
- Number-prefix status keys: `1-async` → `2-crons` → `3-git` → `4-diff` → `5-pidash`
- Pi sorts status keys alphabetically — prefixes guarantee the desired order
- Always show `⏳ 0 async agents` and `⏰ 0 crons` even when idle
- Fix syntax error in cron.ts (extra paren)