### PR TITLE
docs: decouple mcpl config path from ~/.claude/

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ GEMINI_API_KEY=xxx
 
 # acpx agents (optional)
 # ACPX_AGENTS=cursor
+
+# mcpl (MCP Launchpad) config path inside the container (must match mount target)
+MCPL_CONFIG_FILES=/home/node/.mcpl/mcp.json
 ```
 
 Pass via `--env-file /path/to/.env` in the docker run command.
@@ -355,7 +358,7 @@ npm install && npm run build
 
 | Mount | Purpose |
 |---|---|
-| `-v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro` | MCP server config for `mcpl` |
+| `-v "<PATH_TO_MCPL_CONFIG>":/home/node/.mcpl/mcp.json:ro` | MCP server config for `mcpl` |
 | `-v "$HOME/.agents":/home/node/.agents:rw` | User-level skills (install/uninstall from container) |
 | `-v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro` | Google Cloud ADC (for Claude via Vertex AI) |
 | `-v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro` | Cursor CLI auth (for acpx cursor models) |
@@ -422,7 +425,7 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.gitignore-global":/home/node/.gitignore-global:ro \
   -v "$HOME/.ssh":/home/node/.ssh:ro \
   -v "$HOME/.config/gh":/home/node/.gh-config:ro \
-  -v "$HOME/.claude/mcp.json":/home/node/.claude/mcp.json:ro \
+  -v "$HOME/.config/mcpl/mcp.json":/home/node/.mcpl/mcp.json:ro \ # adjust host path to your mcpl config location
   -v "$HOME/.agents":/home/node/.agents:rw \
   -v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro \
   -v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro \


### PR DESCRIPTION
## Summary

Removes the hard dependency on `~/.claude/mcp.json` for mcpl config in the Docker setup. The mcpl config can live anywhere — it shouldn't be tied to Claude's directory.

## Changes

- **Optional mounts table**: Changed host path to `<PATH_TO_MCPL_CONFIG>` placeholder, container target to `/home/node/.mcpl/mcp.json`
- **Shell alias**: Updated to `$HOME/.config/mcpl/mcp.json` as default host path with a comment to adjust
- **.env example**: Added `MCPL_CONFIG_FILES=/home/node/.mcpl/mcp.json` so mcpl finds the config inside the container