### PR TITLE
feat(orchestrator): upgrade changelog notification on session start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ pi-config/
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
 │   │   ├── rules.ts                 # Rule + memory injection (before_agent_start)
-│   │   ├── session-validation.ts    # Session start tool checks
+│   │   ├── session-validation.ts    # Session start tool checks + upgrade changelog notification
 │   │   ├── status.ts                # /status command — unified session status snapshot
 │   │   ├── status-line.ts           # Git status, notifications, container indicator
 │   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Single extension that provides:
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
 | **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains memory.md |
+| **Upgrade changelog** | Shows release notes on session start after pi-config version upgrade |
 | **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status`, `/status`, `/dream`, `/remember` — with autocomplete argument hints |
 | **GitHub autocomplete** | Type `#` in the editor to get issue/PR suggestions from the current repo — lazy-loaded, 5min cache |
 | **Command arg completions** | Tab-complete arguments for slash commands — agent names for `/acpx-prompt`, branches for `/review-local`, PR numbers for `/pr-review`, and more |

--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -2,7 +2,7 @@
  * Session start validation — checks for required/optional CLI tools.
  */
 
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
@@ -82,5 +82,75 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
         missing.length > 0 ? "warning" : "info",
       );
     }
+
+    // ── Upgrade changelog ──────────────────────────────────────────────
+    // Find pi-config package.json by walking up from this file's directory
+    try {
+      let searchDir = __dirname ?? path.dirname(new URL(import.meta.url).pathname);
+      let currentVersion: string | null = null;
+      for (let i = 0; i < 5; i++) {
+        const candidate = path.join(searchDir, "package.json");
+        if (fs.existsSync(candidate)) {
+          try {
+            const pkg = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+            if (pkg.name === "pi-orchestrator-config" && pkg.version) {
+              currentVersion = pkg.version;
+              break;
+            }
+          } catch {}
+        }
+        searchDir = path.dirname(searchDir);
+      }
+      if (currentVersion) {
+          const versionFile = path.join(
+            process.env.HOME || "",
+            ".pi",
+            "pi-config-last-version",
+          );
+          let lastVersion: string | null = null;
+          try {
+            lastVersion = fs.readFileSync(versionFile, "utf-8").trim();
+          } catch {}
+
+          if (!lastVersion) {
+            // First run — just record the version, no notification
+            try {
+              fs.mkdirSync(path.dirname(versionFile), { recursive: true });
+              fs.writeFileSync(versionFile, currentVersion, "utf-8");
+            } catch {}
+          } else if (lastVersion !== currentVersion && hasCmd("gh")) {
+            // Version changed — fetch release notes (5s timeout, no shell)
+            const tag = `v${currentVersion}`;
+            const releaseUrl = `https://github.com/myk-org/pi-config/releases/tag/${tag}`;
+            let notified = false;
+            try {
+              const body = execFileSync(
+                "gh",
+                ["release", "view", "--repo", "myk-org/pi-config", tag, "--json", "body", "--jq", ".body"],
+                { timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
+              ).toString().trim();
+              if (body) {
+                const maxLen = 1500;
+                const truncated = body.length > maxLen
+                  ? body.slice(0, maxLen) + `\n\n... [See full notes](${releaseUrl})`
+                  : body;
+                ctx.ui.notify(
+                  `🚀 pi-config updated: ${lastVersion} → ${currentVersion}\n\n${truncated}`,
+                  "info",
+                );
+                notified = true;
+              }
+            } catch {}
+            // Only update version file after successful notification
+            // so failed attempts retry on next session
+            if (notified) {
+              try {
+                fs.mkdirSync(path.dirname(versionFile), { recursive: true });
+                fs.writeFileSync(versionFile, currentVersion, "utf-8");
+              } catch {}
+            }
+          }
+      }
+    } catch {}
   });
 }


### PR DESCRIPTION
## Summary

Shows release notes when pi-config is upgraded between sessions. On `session_start`, compares the current `package.json` version against `~/.pi/pi-config-last-version` — if different, fetches the GitHub release notes and displays them.

## Behavior

- **First run**: Writes version file silently, no notification
- **Same version**: No-op
- **Upgraded/changed**: Shows `🚀 pi-config updated: 1.19.0 → 1.20.0` + release notes
- **Failed fetch**: Retries next session (version file only updated after successful notification)
- **No `gh` CLI**: Silently skipped

## Safety

- `execFileSync` with args array (no shell injection)
- Body truncated to 1500 chars with link to full release
- `hasCmd("gh")` guard before attempting fetch
- All failures silently caught — won't break startup
- Walks up directories to find `package.json` (works regardless of install path)

## Docs

- `AGENTS.md`: Updated session-validation.ts description
- `README.md`: Added "Upgrade changelog" to feature table