### PR TITLE
feat(orchestrator): neovim integration — /nvim-changed-files and /nvim-ai-reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ pi-config/
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
 │   │   ├── rules.ts                 # Rule + memory injection (before_agent_start)
 │   │   ├── session-validation.ts    # Session start tool checks + upgrade changelog notification
+│   │   ├── nvim.ts                  # Neovim integration (quickfix, /nvim-changed-files)
 │   │   ├── status.ts                # /status command — unified session status snapshot
 │   │   ├── status-line.ts           # Git status, notifications, container indicator
 │   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Single extension that provides:
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
 | **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains memory.md |
 | **Upgrade changelog** | Shows release notes on session start after pi-config version upgrade |
+| **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |
 | **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status`, `/status`, `/dream`, `/remember` — with autocomplete argument hints |
 | **GitHub autocomplete** | Type `#` in the editor to get issue/PR suggestions from the current repo — lazy-loaded, 5min cache |
 | **Command arg completions** | Tab-complete arguments for slash commands — agent names for `/acpx-prompt`, branches for `/review-local`, PR numbers for `/pr-review`, and more |
@@ -62,6 +63,7 @@ Single extension that provides:
 | `/dream-auto` | Toggle automatic memory dreaming (every 3h + session end) |
 | `/cron add\|list\|remove` | Schedule recurring tasks within the pi session (e.g., `/cron add every 2h check for new issues`, `/cron add at 12:00 /review-handler`). Tasks run while pi is active, survive `/reload`, and stop on exit |
 | `/status` | Unified session snapshot — async agents, cron tasks, git branch, context usage |
+| `/nvim-changed-files` | Send git changed files to nvim's quickfix list (only inside nvim) |
 
 ## Installation
 

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -30,6 +30,7 @@ import { registerGithubAutocomplete } from "./github-autocomplete.js";
 import { registerExtendedAutocomplete } from "./extended-autocomplete.js";
 import { registerCron } from "./cron.js";
 import { registerStatus } from "./status.js";
+import { registerNvim } from "./nvim.js";
 import { ensureGitSshTimeout, isRunningInContainer, terminalNotify } from "./utils.js";
 
 const IN_CONTAINER = isRunningInContainer();
@@ -79,4 +80,5 @@ export default function (pi: ExtensionAPI) {
   registerSessionValidation(pi);
   registerGithubAutocomplete(pi);
   registerStatus(pi, IN_CONTAINER, getAsyncJobs, getCronTasks);
+  registerNvim(pi);
 }

--- a/extensions/orchestrator/nvim.ts
+++ b/extensions/orchestrator/nvim.ts
@@ -1,0 +1,168 @@
+/**
+ * Neovim integration — communicate with the parent nvim instance via RPC.
+ * Only registers when running inside nvim (NVIM env var is set).
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { runGit } from "./git-helpers.js";
+
+const NVIM_SOCKET = process.env.NVIM;
+
+/**
+ * Check if we're running inside a neovim terminal.
+ */
+export function isInsideNvim(): boolean {
+  return !!NVIM_SOCKET;
+}
+
+/**
+ * Execute a lua file in the parent nvim instance via --remote-expr.
+ * Returns the JSON-parsed result, or null on failure.
+ */
+function nvimExecLua(luaCode: string): any | null {
+  if (!NVIM_SOCKET) return null;
+
+  const tmpFile = path.join(os.tmpdir(), `pi-nvim-${process.pid}-${Date.now()}.lua`);
+  try {
+    fs.writeFileSync(tmpFile, luaCode, "utf-8");
+    const result = execFileSync(
+      "nvim",
+      ["--server", NVIM_SOCKET, "--remote-expr", `luaeval("dofile('${tmpFile.replace(/'/g, "\\'")}')")` ],
+      { timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
+    ).toString().trim();
+
+    if (!result) return null;
+    return JSON.parse(result);
+  } catch {
+    return null;
+  } finally {
+    try { fs.unlinkSync(tmpFile); } catch {}
+  }
+}
+
+/**
+ * Send a quickfix list to nvim and open the quickfix window.
+ * Each entry: { filename, lnum?, col?, text }
+ */
+function nvimSetQuickfix(entries: Array<{ filename: string; lnum?: number; col?: number; text?: string }>, title?: string): boolean {
+  if (!NVIM_SOCKET || entries.length === 0) return false;
+
+  const dataFile = path.join(os.tmpdir(), `pi-nvim-qf-${process.pid}-${Date.now()}.json`);
+  try {
+    fs.writeFileSync(dataFile, JSON.stringify(entries), "utf-8");
+
+    const titleLine = title ? `vim.fn.setqflist({}, "a", {title = "${title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"})` : "";
+    const safeDataFile = dataFile.replace(/"/g, '\\"');
+    const lua = `
+local f = io.open("${safeDataFile}", "r")
+if not f then return vim.fn.json_encode({status = "error", message = "no data file"}) end
+local raw = f:read("*a")
+f:close()
+os.remove("${safeDataFile}")
+local entries = vim.fn.json_decode(raw)
+local items = {}
+for _, e in ipairs(entries) do
+  table.insert(items, {
+    filename = e.filename,
+    lnum = e.lnum or 1,
+    col = e.col or 1,
+    text = e.text or "",
+  })
+end
+vim.fn.setqflist(items)
+${titleLine}
+vim.cmd("copen")
+return vim.fn.json_encode({status = "ok", count = #items})
+`;
+
+    const result = nvimExecLua(lua);
+    // Clean up data file if lua didn't remove it (nvim unreachable)
+    if (result?.status !== "ok") {
+      try { fs.unlinkSync(dataFile); } catch {}
+    }
+    return result?.status === "ok";
+  } catch {
+    try { fs.unlinkSync(dataFile); } catch {}
+    return false;
+  }
+}
+
+/**
+ * Get git changed files relative to origin/main (or HEAD if on main).
+ */
+function getChangedFiles(cwd: string): Array<{ filename: string; status: string }> {
+  const branchResult = runGit(["rev-parse", "--abbrev-ref", "HEAD"], cwd);
+  if (branchResult.code !== 0) return [];
+  const branch = branchResult.stdout?.trim() || "";
+
+  const seen = new Set<string>();
+  const files: Array<{ filename: string; status: string }> = [];
+
+  const parseDiffOutput = (output: string) => {
+    for (const line of output.trim().split("\n")) {
+      const parts = line.split("\t");
+      if (parts.length >= 2) {
+        const statusCode = parts[0].charAt(0);
+        const filename = parts[parts.length - 1];
+        if (seen.has(filename)) continue;
+        seen.add(filename);
+        const statusMap: Record<string, string> = {
+          M: "modified", A: "added", D: "deleted", R: "renamed", C: "copied",
+        };
+        files.push({ filename, status: statusMap[statusCode] || statusCode });
+      }
+    }
+  };
+
+  if (branch === "main" || branch === "master") {
+    const result = runGit(["diff", "--name-status", "HEAD"], cwd);
+    if (result.code === 0 && result.stdout?.trim()) parseDiffOutput(result.stdout);
+  } else {
+    // Committed changes vs default branch
+    const hasMain = runGit(["rev-parse", "--verify", "origin/main"], cwd).code === 0;
+    const base = hasMain ? "origin/main" : "origin/master";
+    const committed = runGit(["diff", "--name-status", `${base}...HEAD`], cwd);
+    if (committed.code === 0 && committed.stdout?.trim()) parseDiffOutput(committed.stdout);
+    // Uncommitted changes (working tree + staged)
+    const uncommitted = runGit(["diff", "--name-status", "HEAD"], cwd);
+    if (uncommitted.code === 0 && uncommitted.stdout?.trim()) parseDiffOutput(uncommitted.stdout);
+  }
+
+  return files;
+}
+
+export function registerNvim(pi: ExtensionAPI): void {
+  if (!isInsideNvim()) return;
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
+  pi.registerCommand("nvim-changed-files", {
+    description: "Open git changed files in nvim's quickfix list",
+    handler: async (_args, ctx) => {
+      if (!ctx.hasUI) return;
+
+      const files = getChangedFiles(ctx.cwd);
+      if (files.length === 0) {
+        ctx.ui.notify("No changed files found.", "info");
+        return;
+      }
+
+      const entries = files.map(f => ({
+        filename: path.resolve(ctx.cwd, f.filename),
+        lnum: 1,
+        text: f.status,
+      }));
+
+      const ok = nvimSetQuickfix(entries, "pi: changed files");
+      if (ok) {
+        ctx.ui.notify(`Sent ${entries.length} changed file(s) to nvim quickfix.`, "info");
+      } else {
+        ctx.ui.notify("Failed to send quickfix to nvim.", "warning");
+      }
+    },
+  });
+
+}


### PR DESCRIPTION
## Summary

Neovim integration via RPC — only active when running inside nvim (`$NVIM` env var set).

## Infrastructure (`nvim.ts`)

- `isInsideNvim()` — check if running inside a neovim terminal
- `nvimExecLua()` — execute lua in parent nvim via `--remote-expr` + temp file pattern
- `nvimSetQuickfix()` — send entries to nvim's quickfix list via JSON data file + lua script
- Path escaping for lua string interpolation (single quotes, double quotes, backslashes)
- Temp file cleanup on all failure paths

## Command

### `/nvim-changed-files`
Sends git changed files to nvim's quickfix list. Navigate with `]q` / `[q`.
- On main/master: shows uncommitted + staged changes
- On feature branches: shows committed changes vs origin/main AND uncommitted changes
- Auto-detects default branch (origin/main vs origin/master)
- Deduplicates files across both diff passes