### PR TITLE
feat: add timestamp visibility to TUI status bar and pidash messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ pi-config/
 │   │   ├── session-validation.ts    # Session start tool checks + upgrade changelog notification
 │   │   ├── nvim.ts                  # Neovim integration (quickfix, /nvim-changed-files)
 │   │   ├── status.ts                # /status command — unified session status snapshot
-│   │   ├── status-line.ts           # Git status, notifications, container indicator
+│   │   ├── status-line.ts           # Git status, notifications, container indicator, last-activity timestamp
 │   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent
 │   │   └── utils.ts                 # Shared utilities
 │   └── acpx-provider/              # ACPX provider extension

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Single extension that provides:
 | **Git protection** | Blocks commits/pushes to main/master, merged branches, `--no-verify`, `git add .` |
 | **Dangerous command gate** | Confirms `rm -rf`, `sudo`, `mkfs`, etc. |
 | **Rule injection** | Injects orchestrator routing rules into system prompt |
-| **Git status** | Live git status in status line with colored icons — updates after every tool call |
+| **Git status** | Live git status in status line with colored icons — updates after every tool call. Last-activity clock `⏱ HH:MM (Xm/Xh ago)` shows time since last response |
 | **Desktop notifications** | Notifies via `notify-send` on task completion, waiting for input, and action required |
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
@@ -326,6 +326,7 @@ Pidash is a web-based dashboard that runs alongside the TUI, accessible from any
 - Browser push notifications for background events (configurable per event type)
 - Async agent live streaming (real-time tool calls and output inline in chat)
 - Sidebar session working indicator (pulsing green dot when AI is active)
+- `[HH:MM]` timestamps on all messages
 
 **Access:**
 

--- a/extensions/orchestrator/pidash-ui/src/App.tsx
+++ b/extensions/orchestrator/pidash-ui/src/App.tsx
@@ -87,7 +87,7 @@ export function App() {
 
   const addMsg = useCallback((role: ChatMessage["role"], text: string, className?: string, meta?: ChatMessage["meta"]): string => {
     const id = nextId();
-    setMessages((p) => [...p, { id, role, text, className, meta }]);
+    setMessages((p) => [...p, { id, role, text, className, meta, timestamp: Date.now() }]);
     return id;
   }, []);
 
@@ -205,7 +205,7 @@ export function App() {
           }
           const cid = ev.toolCallId || nextId();
           const id = nextId();
-          setMessages((p) => [...p, { id, role: name as any, text: detail, className: "tool-call", meta: { callId: cid } }]);
+          setMessages((p) => [...p, { id, role: name as any, text: detail, className: "tool-call", meta: { callId: cid }, timestamp: Date.now() }]);
           toolRef.current = { id, name, startTs: ev.timestamp || Date.now(), callId: cid };
           break;
         }
@@ -250,7 +250,7 @@ export function App() {
               };
             }
             const id = nextId();
-            setMessages((p) => [...p, { id, role: toolName as any, text: `${ev.isError ? "✗ " : "✓ "}${t}`, className: "tool-result", meta }]);
+            setMessages((p) => [...p, { id, role: toolName as any, text: `${ev.isError ? "✗ " : "✓ "}${t}`, className: "tool-result", meta, timestamp: Date.now() }]);
           }
           break;
         }
@@ -424,7 +424,7 @@ export function App() {
 
   const watchSession = useCallback((s: SessionInfo) => {
     setSession(s);
-    setMessages([{ id: nextId(), role: "system", text: `Watching session — ${s.cwd}` }]);
+    setMessages([{ id: nextId(), role: "system", text: `Watching session — ${s.cwd}`, timestamp: Date.now() }]);
     setModel(s.model || "");
     setTokens(null);
     setStreaming(false);

--- a/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
+++ b/extensions/orchestrator/pidash-ui/src/components/MessageList.tsx
@@ -14,6 +14,12 @@ interface Props {
   onAskResponse?: (id: string, value: string) => void;
 }
 
+function formatClock(ts?: number): string {
+  if (ts == null) return "";
+  const d = new Date(ts);
+  return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+}
+
 const roleColors: Record<string, string> = {
   user: "text-green-500",
   assistant: "text-blue-400",
@@ -169,6 +175,7 @@ function MessageItem({ msg, searchQuery, onAskResponse }: { msg: ChatMessage; se
     return (
       <div>
         <div className={cn("text-[10px] font-bold uppercase tracking-wider mb-0.5", getRoleColor("ask_user"))}>
+          {msg.timestamp && <span className="text-muted-foreground font-normal normal-case tracking-normal mr-1.5">[{formatClock(msg.timestamp)}]</span>}
           action required
         </div>
         <div className="rounded-md bg-card p-3 text-[13px] whitespace-pre-wrap break-words border-l-2 border-cyan-400">
@@ -222,6 +229,7 @@ function MessageItem({ msg, searchQuery, onAskResponse }: { msg: ChatMessage; se
   return (
     <div>
       <div className={cn("text-[10px] font-bold uppercase tracking-wider mb-0.5", getRoleColor(msg.role))}>
+        {msg.timestamp && <span className="text-muted-foreground font-normal normal-case tracking-normal mr-1.5">[{formatClock(msg.timestamp)}]</span>}
         {msg.role}
       </div>
       <div className={cn(
@@ -272,6 +280,7 @@ function ToolGroup({ call, result, searchQuery }: { call: ChatMessage; result: C
         color,
       )}>
         {open ? <ChevronDown className="h-3 w-3 flex-shrink-0" /> : <ChevronRight className="h-3 w-3 flex-shrink-0" />}
+        {call.timestamp && <span className="font-normal normal-case tracking-normal text-muted-foreground flex-shrink-0">[{formatClock(call.timestamp)}]</span>}
         <span className="flex-shrink-0">{call.role}</span>
         <span className={cn("flex-shrink-0", statusColor)}>{statusIcon}</span>
         {!open && statsStr && (
@@ -321,6 +330,7 @@ function CollapsibleMessage({ msg, searchQuery }: { msg: ChatMessage; searchQuer
         color,
       )}>
         {open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}
+        {msg.timestamp && <span className="font-normal normal-case tracking-normal text-muted-foreground">[{formatClock(msg.timestamp)}]</span>}
         {msg.role}
         {!open && msg.meta?.startTs && msg.meta?.endTs && (
           <span className="font-normal normal-case tracking-normal text-muted-foreground ml-1 flex-shrink-0">

--- a/extensions/orchestrator/pidash-ui/src/types.ts
+++ b/extensions/orchestrator/pidash-ui/src/types.ts
@@ -82,6 +82,7 @@ export interface ChatMessage {
   role: MessageRole;
   text: string;
   className?: string;
+  timestamp?: number;
   meta?: {
     turns?: number;
     input?: number;

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -5,6 +5,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { getCurrentBranch, runGit } from "./git-helpers.js";
 import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
+import { clockHHMM } from "./utils.js";
 
 export function registerStatusLine(
   pi: ExtensionAPI,
@@ -87,8 +88,48 @@ export function registerStatusLine(
     if (lastCtx) updateBranch(null, lastCtx);
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
+
+  // ── Last-activity timestamp ────────────────────────────────────────────
+
+  let lastActivityTime: Date | null = null;
+
+
+
+  const ago = (since: Date): string => {
+    const diffMs = Date.now() - since.getTime();
+    if (diffMs < 0) return "now";
+    const mins = Math.floor(diffMs / 60_000);
+    if (mins < 1) return "now";
+    if (mins < 60) return `${mins}m`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h`;
+    return `${Math.floor(hours / 24)}d`;
+  };
+
+  const updateTimestamp = (ctx: any) => {
+    if (!lastActivityTime) return;
+    const text = ctx.ui.theme.fg("dim", `⏱ ${clockHHMM(lastActivityTime)} (${ago(lastActivityTime)})`);
+    ctx.ui.setStatus("4-time", text);
+  };
+
+  const touchActivity = (_event: any, ctx: any) => {
+    lastActivityTime = new Date();
+    updateTimestamp(ctx);
+  };
+
+  pi.on("session_start", touchActivity);
+  pi.on("turn_end", touchActivity);
+  pi.on("agent_end", touchActivity);
+  pi.on("tool_execution_end", touchActivity);
+
+  const timePoller = setInterval(() => {
+    if (lastCtx && lastActivityTime) updateTimestamp(lastCtx);
+  }, 30_000);
+  if (timePoller.unref) timePoller.unref();
+
   pi.on("session_shutdown", (_event) => {
     clearInterval(gitPoller);
+    clearInterval(timePoller);
   });
 
   // ── Desktop notifications — notify when user attention is needed ─────

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -27,7 +27,7 @@ import {
 } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
-import { getPiInvocation } from "./utils.js";
+import { clockHHMM, getPiInvocation } from "./utils.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -1016,13 +1016,16 @@ export function registerSubagentTool(
       };
     },
 
-    renderCall(args, theme) {
+    renderCall(args, theme, context) {
+      if (!context.state.startedAt) context.state.startedAt = clockHHMM();
+      const ts = theme.fg("dim", `[${context.state.startedAt}] `);
       const scope: AgentScope = args.agentScope ?? "user";
       if (args.chain?.length > 0) {
         const chainEst = args.chain.every((s: any) => s.estimatedSeconds != null)
           ? theme.fg("dim", ` ~${args.chain.reduce((sum: number, s: any) => sum + s.estimatedSeconds, 0)}s (sum)`)
           : "";
         let t =
+          ts +
           theme.fg("toolTitle", theme.bold("subagent ")) +
           theme.fg("accent", `chain (${args.chain.length} steps)`) +
           theme.fg("muted", ` [${scope}]`) + chainEst;
@@ -1040,6 +1043,7 @@ export function registerSubagentTool(
           ? theme.fg("dim", ` ~${Math.max(...args.tasks.map((tk: any) => tk.estimatedSeconds))}s (max)`)
           : "";
         let t =
+          ts +
           theme.fg("toolTitle", theme.bold("subagent ")) +
           theme.fg("accent", `parallel (${args.tasks.length} tasks)`) +
           theme.fg("muted", ` [${scope}]`) + parallelEst;
@@ -1052,6 +1056,7 @@ export function registerSubagentTool(
       const asyncLabel = args.async === true ? theme.fg("warning", " [async]") : "";
       const estLabel = args.estimatedSeconds != null && args.async !== true ? theme.fg("dim", ` ~${args.estimatedSeconds}s`) : "";
       let t =
+        ts +
         theme.fg("toolTitle", theme.bold("subagent ")) +
         theme.fg("accent", args.agent || "...") +
         theme.fg("muted", ` [${scope}]`) + asyncLabel + estLabel;
@@ -1059,11 +1064,13 @@ export function registerSubagentTool(
       return new Text(t, 0, 0);
     },
 
-    renderResult(result, { expanded }, theme) {
+    renderResult(result, { expanded }, theme, context) {
+      if (!context.state.completedAt) context.state.completedAt = clockHHMM();
+      const ts = theme.fg("dim", `[${context.state.completedAt}] `);
       const details = result.details as SubagentDetails | undefined;
       if (!details || details.results.length === 0) {
         const t = result.content[0];
-        return new Text(t?.type === "text" ? t.text : "(no output)", 0, 0);
+        return new Text(ts + (t?.type === "text" ? t.text : "(no output)"), 0, 0);
       }
       const mdTheme = getMarkdownTheme();
 
@@ -1118,7 +1125,7 @@ export function registerSubagentTool(
         const final = getFinalOutput(r.messages);
         if (expanded) {
           const c = new Container();
-          let h = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+          let h = `${ts}${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
           if (isErr && r.stopReason)
             h += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
           c.addChild(new Text(h, 0, 0));
@@ -1156,7 +1163,7 @@ export function registerSubagentTool(
           }
           return c;
         }
-        let t = `${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
+        let t = `${ts}${icon} ${theme.fg("toolTitle", theme.bold(r.agent))}${theme.fg("muted", ` (${r.agentSource})`)}`;
         if (isErr && r.stopReason)
           t += ` ${theme.fg("error", `[${r.stopReason}]`)}`;
         if (isErr && r.errorMessage)
@@ -1184,7 +1191,7 @@ export function registerSubagentTool(
           const c = new Container();
           c.addChild(
             new Text(
-              `${icon} ${theme.fg("toolTitle", theme.bold("chain "))}${theme.fg("accent", `${ok}/${details.results.length} steps`)}`,
+              `${ts}${icon} ${theme.fg("toolTitle", theme.bold("chain "))}${theme.fg("accent", `${ok}/${details.results.length} steps`)}`,
               0,
               0,
             ),
@@ -1234,7 +1241,7 @@ export function registerSubagentTool(
           }
           return c;
         }
-        let t = `${icon} ${theme.fg("toolTitle", theme.bold("chain "))}${theme.fg("accent", `${ok}/${details.results.length} steps`)}`;
+        let t = `${ts}${icon} ${theme.fg("toolTitle", theme.bold("chain "))}${theme.fg("accent", `${ok}/${details.results.length} steps`)}`;
         for (const r of details.results) {
           const ri =
             r.exitCode === 0
@@ -1271,7 +1278,7 @@ export function registerSubagentTool(
           const c = new Container();
           c.addChild(
             new Text(
-              `${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`,
+              `${ts}${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`,
               0,
               0,
             ),
@@ -1321,7 +1328,7 @@ export function registerSubagentTool(
           }
           return c;
         }
-        let t = `${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`;
+        let t = `${ts}${icon} ${theme.fg("toolTitle", theme.bold("parallel "))}${theme.fg("accent", status)}`;
         for (const r of details.results) {
           const ri =
             r.exitCode === -1

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -24,6 +24,10 @@ export function ensureGitSshTimeout(): void {
   }
 }
 
+/** Format a Date as HH:MM (24h clock). */
+export const clockHHMM = (d: Date = new Date()): string =>
+  `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+
 export function isRunningInContainer(): boolean {
   try {
     // Check for /.dockerenv (Docker) or /run/.containerenv (Podman)


### PR DESCRIPTION
## Summary

Adds clock timestamps across the TUI and pidash web dashboard so users can see when activity happened — especially useful when checking back on sessions after hours away.

## Changes

### TUI Status Bar — Last Activity Timestamp
- New `⏱ HH:MM (Xm/Xh)` indicator in the footer status bar
- Updates on `session_start`, `turn_end`, `agent_end`, `tool_execution_end`
- 30s polling keeps the "ago" text fresh during idle
- Handles negative clock drift gracefully

### TUI Subagent Timestamps
- `[HH:MM]` prepended to subagent `renderCall` (when fired) and `renderResult` (when completed)
- Timestamps captured once via `context.state` — stable across re-renders
- Only on top-level headers for chain/parallel, not per sub-result

### Pidash Web Dashboard
- `[HH:MM]` timestamp before every role label (user, assistant, tool calls, thinking, system)
- Timestamps set via `Date.now()` on all message creation paths (`addMsg` + direct `setMessages`)
- `formatClock` with proper null check (`ts == null` instead of `!ts`)

### Shared Utility
- Extracted `clockHHMM()` to `utils.ts` — shared between `status-line.ts` and `subagent-tool.ts`

### Documentation
- Updated `AGENTS.md` repository structure (status-line.ts description)
- Updated `README.md` feature table and pidash features list

## Files Changed (8)
- `extensions/orchestrator/utils.ts` — shared `clockHHMM()` helper
- `extensions/orchestrator/status-line.ts` — last-activity status bar indicator
- `extensions/orchestrator/subagent-tool.ts` — renderCall/renderResult timestamps
- `extensions/orchestrator/pidash-ui/src/types.ts` — `timestamp` field on ChatMessage
- `extensions/orchestrator/pidash-ui/src/App.tsx` — timestamp on all message creation
- `extensions/orchestrator/pidash-ui/src/components/MessageList.tsx` — `[HH:MM]` display
- `AGENTS.md` — docs update
- `README.md` — docs update