### PR TITLE
fix(pidash): always emit async-status to pidash for browser reconnect

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -107,26 +107,23 @@ export function registerAsyncAgents(
     const changed = widgetKey !== lastWidgetKey;
     lastWidgetKey = widgetKey;
     if (running.length > 0) {
-      // Always re-set status for running agents (other status updates may have triggered a re-render)
       ctx.ui.setStatus("1-async", ctx.ui.theme.fg("warning", `⏳ ${running.length} async agent${running.length > 1 ? "s" : ""}`));
-      if (changed) {
-        pi.events.emit("pidash:async-status", {
-          count: running.length,
-          agents: names,
-          jobs: running.map(j => ({
-            id: j.id,
-            name: j.name || j.agent,
-            agent: j.agent,
-            task: j.task,
-            status: j.status,
-            startedAt: j.startedAt,
-          })),
-        });
-      }
     } else if (changed) {
       ctx.ui.setStatus("1-async", ctx.ui.theme.fg("muted", `⏳ 0 async agents`));
-      pi.events.emit("pidash:async-status", { count: 0, agents: "", jobs: [] });
     }
+    // Always emit to pidash — browser may have reconnected and needs fresh state
+    pi.events.emit("pidash:async-status", {
+      count: running.length,
+      agents: names,
+      jobs: running.map(j => ({
+        id: j.id,
+        name: j.name || j.agent,
+        agent: j.agent,
+        task: j.task,
+        status: j.status,
+        startedAt: j.startedAt,
+      })),
+    });
   }
 
   function ensureAsyncPoller() {


### PR DESCRIPTION
## Problem

Pidash shows `0 async` agents after a pidash-server restart, even when sessions have running async agents. The browser never gets the current count because `async-status` was only emitted on **changes** — after server restart the event buffer is lost and no change occurs.

## Fix

- **Always emit `pidash:async-status`** on every `updateAsyncWidget()` call, not just when the widget key changes. TUI `setStatus` still guards the zero-count update to avoid flicker.
- `updateAsyncWidget()` is already called on `session_start` (re-register after reconnect), so the browser gets fresh state immediately.

## Note

Cron status was already correct — it always emits without a change guard and calls `updateCronStatus()` on `session_start`.