### PR TITLE
fix: move last-activity timestamp to first position in TUI status bar

### DIFF
--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -109,7 +109,7 @@ export function registerStatusLine(
   const updateTimestamp = (ctx: any) => {
     if (!lastActivityTime) return;
     const text = ctx.ui.theme.fg("dim", `⏱ ${clockHHMM(lastActivityTime)} (${ago(lastActivityTime)})`);
-    ctx.ui.setStatus("4-time", text);
+    ctx.ui.setStatus("0-time", text);
   };
 
   const touchActivity = (_event: any, ctx: any) => {


### PR DESCRIPTION
Change status key from `4-time` to `0-time` so the timestamp appears first in the footer, before async agents, crons, and git status.