### PR TITLE
fix: file preview server — use dedicated httpd.py script with nohup+disown (#268)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,7 @@ pi-config/
 │   └── reviews/
 ├── scripts/                         # Utility scripts
 │   ├── docker-safe                  # Restricted Docker/Podman CLI wrapper (container only)
+│   ├── httpd.py                     # HTTP file server for file preview (used by rules/45-file-preview.md)
 │   └── pidash-server.ts             # Pidash daemon (WebSocket hub for all pi sessions + Discord bot)
 ├── Dockerfile                       # Container image definition
 ├── entrypoint.sh                    # Container entrypoint

--- a/rules/45-file-preview.md
+++ b/rules/45-file-preview.md
@@ -3,25 +3,18 @@
 When generating or modifying HTML, frontend, or any browser-viewable files:
 
 1. Save the file under the project directory (`$PWD`) or `/tmp/pi-work/`
-2. Serve it using a Python script that ignores SIGHUP (survives shell cleanup):
+2. Find a free port and launch the server:
 
    ```bash
-   uv run python3 -c "
-   import signal, http.server, socketserver
-   signal.signal(signal.SIGHUP, signal.SIG_IGN)
-   socketserver.TCPServer.allow_reuse_address = True
-   with socketserver.TCPServer(('', PORT), http.server.SimpleHTTPRequestHandler) as s:
-       s.serve_forever()
-   " &
+   HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
+   PORT=$(uv run python3 $HTTPD --find-port)
+   nohup uv run python3 $HTTPD --port $PORT --dir /path/to/serve > /tmp/httpd-$PORT.log 2>&1 &
+   disown
+   sleep 0.5
+   if ! kill -0 $! 2>/dev/null; then echo "Server failed to start:"; cat /tmp/httpd-$PORT.log; fi
    ```
 
-   To find a free port, ask the OS:
-
-   ```bash
-   uv run python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()"
-   ```
-
-   Use the printed port number as `PORT`.
+   Replace `/path/to/serve` with the directory containing the files.
 
 3. Tell the user:
 
@@ -29,9 +22,8 @@ When generating or modifying HTML, frontend, or any browser-viewable files:
 
 4. Keep the server running until the user confirms they're done previewing.
 
-**Why not `python -m http.server`?** The `uv run` wrapper creates a parent
-process chain. When bash background job cleanup runs, the parent `uv` process
-gets killed, taking the Python child with it. The `signal.SIGHUP` ignore
-prevents this.
+**Why `nohup` + `disown`?** `uv run` creates a parent process chain. When bash
+cleans up background jobs, it kills the `uv` parent. `nohup` protects from
+SIGHUP, `disown` removes it from bash's job table.
 
 This works in containers (`--network host`) and native installs.

--- a/scripts/httpd.py
+++ b/scripts/httpd.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Simple HTTP file server for pi file preview."""
+
+import argparse
+import http.server
+import os
+import signal
+import socket
+import sys
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+def serve(port: int, directory: str, bind: str) -> None:
+    if not os.path.isdir(directory):
+        print(f"Error: {directory} is not a directory", file=sys.stderr)
+        sys.exit(1)
+    os.chdir(directory)
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
+
+    handler = http.server.SimpleHTTPRequestHandler
+    httpd = http.server.HTTPServer((bind, port), handler)
+
+    print(f"Serving {directory} on http://localhost:{port} (bind {bind})")
+    sys.stdout.flush()
+    httpd.serve_forever()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple HTTP file server for pi file preview.")
+    parser.add_argument("--port", type=int, help="Port to serve on")
+    parser.add_argument("--dir", type=str, help="Directory to serve")
+    parser.add_argument("--bind", type=str, default="127.0.0.1", help="Address to bind (default: 127.0.0.1)")
+    parser.add_argument("--find-port", action="store_true", help="Print a free port and exit")
+    args = parser.parse_args()
+
+    if args.find_port:
+        print(find_free_port())
+        return
+
+    if args.port is None or args.dir is None:
+        parser.error("--port and --dir are required unless --find-port is used")
+
+    serve(args.port, args.dir, args.bind)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #268

## Problem

The file preview server pattern in `rules/45-file-preview.md` used an inline Python one-liner with `signal.SIGHUP` ignore, which didn't work — the server died when bash exited because `uv run` creates a parent process chain that gets killed first.

## Fix

- **New `scripts/httpd.py`** — dedicated stdlib HTTP server script with `--port`, `--dir`, `--bind`, and `--find-port` flags
- **`nohup` + `disown`** — properly detaches the server from bash's job table
- **Startup verification** — logs to `/tmp/httpd-$PORT.log` and checks if server started
- **Security** — binds `127.0.0.1` by default (not `0.0.0.0`), validates `--dir` exists
- **Updated rule** — `rules/45-file-preview.md` now calls the script instead of inline code
- **Updated AGENTS.md** — added `httpd.py` to repository structure