### PR TITLE
fix: add TZ env var to container .env example for correct timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ docker run --rm -it \
 Create a `.env` file with container-specific variables:
 
 ```env
+# Timezone (host timezone for correct timestamps)
+TZ=Asia/Jerusalem
+
 # Google Cloud / Vertex AI
 GOOGLE_CLOUD_PROJECT=your-project-id
 GOOGLE_CLOUD_LOCATION=us-east5


### PR DESCRIPTION
Container defaults to UTC — timestamps in TUI and pidash show wrong time. Add `TZ=Asia/Jerusalem` to the .env example so users set their timezone.