### PR TITLE
fix(ask-user): show only options in tool UI, question stays in main chat

### DIFF
--- a/extensions/orchestrator/ask-user.ts
+++ b/extensions/orchestrator/ask-user.ts
@@ -159,22 +159,15 @@ export function registerAskUser(
           const topBorder = new DynamicBorder((s: string) =>
             theme.fg("accent", s),
           );
-          const question = new Text(
-            theme.fg("accent", theme.bold(params.question)),
-            1,
-            0,
-          );
-          const spacer = new Spacer(1);
           const bottomBorder = new DynamicBorder((s: string) =>
             theme.fg("accent", s),
           );
 
-          // Build container for each mode without recreating components
+          // Build container — question is already in the main chat,
+          // overlay shows only the selectable options / input
           const buildContainer = () => {
             const c = new Container();
             c.addChild(topBorder);
-            c.addChild(question);
-            c.addChild(spacer);
             if (mode === "select" && selectList) {
               c.addChild(selectList);
               c.addChild(selectHelp);
@@ -216,7 +209,7 @@ export function registerAskUser(
             },
           };
         },
-        { overlay: true },
+
       );
 
       unsubscribe();


### PR DESCRIPTION
## Problem

When the AI asks a long question via `ask_user`, the overlay renders both the question text AND the options. Long questions push the options off-screen, making them impossible to see or interact with.

## Fix

- Removed the question text from the ask_user tool UI — the question is already visible in the main chat as a normal assistant message
- Removed overlay mode — renders inline instead of floating on top, so it doesn't cover the question text
- The tool now shows only the selectable options (or free-text input), keeping it compact and always usable regardless of question length