### PR TITLE
fix(pidash): auto-rebuild dist when missing instead of showing dead-end message

### DIFF
--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -13,6 +13,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
+import { execSync } from "node:child_process";
 
 const DEFAULT_PORT = 19190;
 const port = parseInt(process.env.PI_PIDASH_PORT || "", 10) || DEFAULT_PORT;
@@ -128,8 +129,27 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
       res.writeHead(200, { "Content-Type": "text/html" });
       res.end(html);
     } catch {
+      // dist/ missing — try to build it
+      const uiSrcDir = path.join(UI_DIR, "..");
+      if (fs.existsSync(path.join(uiSrcDir, "package.json"))) {
+        try {
+          log("dist/ missing, building pidash-ui...");
+          execSync("npm install --production=false && npm run build", {
+            cwd: uiSrcDir,
+            stdio: "ignore",
+            timeout: 60000,
+          });
+          log("pidash-ui build complete");
+          const html = fs.readFileSync(path.join(UI_DIR, "index.html"));
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(html);
+          return;
+        } catch (buildErr: any) {
+          log(`pidash-ui build failed: ${buildErr.message}`);
+        }
+      }
       res.writeHead(200, { "Content-Type": "text/html" });
-      res.end("<h1>pidash</h1><p>UI is building... Run <code>/pidash restart</code> from the pi TUI, then refresh this page.</p>");
+      res.end("<h1>pidash</h1><p>UI build failed. Run <code>/pidash restart</code> from the pi TUI, then refresh this page.</p>");
     }
   }
 });


### PR DESCRIPTION
## Problem

After laptop lid close or pi update/re-clone, the pidash `dist/` directory gets deleted (it's gitignored). The running server shows a dead-end "UI is building..." message and the user has to manually `/pidash restart`.

## Fix

The server now auto-builds `dist/` when a request comes in and `index.html` is missing:
- Runs `npm install && npm run build` in the pidash-ui source directory
- Serves the freshly built UI on success
- Shows "UI build failed" only if the build actually fails

Tested: deleted dist/ while server was running → next request got HTTP 200 with rebuilt UI.