### PR TITLE
feat: inject async agents status into orchestrator context at every turn

### DIFF
--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -69,7 +69,7 @@ export default function (pi: ExtensionAPI) {
   const { spawnAsyncAgent, killAsyncAgent, getAsyncJobs } = registerAsyncAgents(pi, terminalNotify);
   registerSubagentTool(pi, spawnAsyncAgent, killAsyncAgent);
   registerEnforcement(pi, IN_CONTAINER);
-  registerRules(pi);
+  registerRules(pi, getAsyncJobs);
 
   registerStatusLine(pi, IN_CONTAINER, terminalNotify);
   registerBtw(pi);

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -7,8 +7,12 @@ import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { formatDuration } from "./async-agents.js";
 
-export function registerRules(pi: ExtensionAPI): void {
+export function registerRules(
+  pi: ExtensionAPI,
+  getAsyncJobs?: () => Array<{ id: string; agent: string; name?: string; task: string; status: string; startedAt: number }>,
+): void {
   const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
   let migrationChecked = false;
 
@@ -31,6 +35,21 @@ export function registerRules(pi: ExtensionAPI): void {
       } catch {
         extra +=
           "\n\n[ORCHESTRATOR RULES] You are a MANAGER. Delegate work to subagents.\n";
+      }
+    }
+
+    // Async agent status — always show so the AI knows what's running
+    if (!isSubagent && getAsyncJobs) {
+      const jobs = getAsyncJobs();
+      if (jobs.length === 0) {
+        extra += "\n\n# Async Agents Status\n\nNo async agents running.\n";
+      } else {
+        let status = `\n\n# Async Agents Status\n\n${jobs.length} async agent(s) running — kill any that are no longer needed:\n`;
+        for (const j of jobs) {
+          const elapsed = formatDuration(Date.now() - j.startedAt);
+          status += `- ${j.name || j.agent} (${j.agent}) — ${elapsed}\n`;
+        }
+        extra += status;
       }
     }
 


### PR DESCRIPTION
## Problem

The AI often leaves async agents running when they're no longer needed. It has no visibility into what's currently running unless it manually checks `/async-status`.

## Fix

Inject the async agents status into the orchestrator's system prompt context at `before_agent_start`. The AI always sees:

```
# Async Agents Status

No async agents running.
```

or when agents are active:

```
# Async Agents Status

3 async agent(s) running — kill any that are no longer needed:
- code-review (worker) — 45m0s
- monitor-build (worker) — 2h3m
- pr-merge (worker) — 5m12s
```

- Always shown (even when 0) so the AI knows when agents finished
- Minimal format: name, agent type, runtime — no task text to save context tokens
- Only injected for the orchestrator, not subagents