### PR TITLE
feat(container): map host user HOME so mounted config paths resolve correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,10 +78,8 @@ RUN mkdir -p /home/node/.npm-global && npm config set prefix /home/node/.npm-glo
 ENV PATH="/home/node/.npm-global/bin:/home/node/.pi/agent/bin:/home/node/.local/bin:$PATH"
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
 
-# Cursor auth: symlink from default location to mount-safe path
-# (mounting dirs under ~/.config/ breaks Chrome, so cursor auth mounts to ~/.cursor/)
-RUN mkdir -p /home/node/.config/cursor /home/node/.cursor && \
-  ln -sf /home/node/.cursor/auth.json /home/node/.config/cursor/auth.json
+# Cursor auth: create config dir (auth.json mounted or symlinked at runtime)
+RUN mkdir -p /home/node/.config/cursor
 
 # agent-browser: use Playwright's Chromium with container-safe flags
 ENV AGENT_BROWSER_ARGS="--no-sandbox,--disable-dev-shm-usage"
@@ -110,13 +108,21 @@ RUN /bin/bash -o pipefail -c "curl -fsSL https://claude.ai/install.sh | bash"
 
 COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
 
-# Workaround for buildah bug #6747: RUN --mount=type=cache resets
-# ownership of parent directories. Re-chown /home/node after all
-# mount-cached RUN instructions have completed.
+# Workaround: re-chown /home/node after cache mounts (buildah bug #6747).
 USER root
+# sudo for init-entrypoint (node needs root to chown/symlink host HOME)
+RUN apt-get update && apt-get install -y --no-install-recommends sudo && rm -rf /var/lib/apt/lists/* && \
+    echo 'node ALL=(ALL) NOPASSWD:SETENV: /usr/local/bin/init-entrypoint.sh' >> /etc/sudoers.d/pi-init && \
+    chmod 0440 /etc/sudoers.d/pi-init
+
 RUN chown node:node /home/node
+
+COPY --chmod=755 init-entrypoint.sh /usr/local/bin/init-entrypoint.sh
+
+# USER node so docker exec enters as node.
+# Entrypoint uses sudo for root operations then runs as node.
 USER node
 
 WORKDIR /workspace
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["init-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -244,11 +244,11 @@ docker run --rm -it \
   --network host \
   --env-file /path/to/.env \
   -v "$PWD":"$PWD":rw \
-  -v "$HOME/.pi":/home/node/.pi:rw \
-  -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
-  -v "$HOME/.gitignore-global":/home/node/.gitignore-global:ro \
-  -v "$HOME/.ssh":/home/node/.ssh:ro \
-  -v "$HOME/.config/gh":/home/node/.gh-config:ro \
+  -v "$HOME/.pi":"$HOME/.pi":rw \
+  -v "$HOME/.gitconfig":"$HOME/.gitconfig":ro \
+  -v "$HOME/.gitignore-global":"$HOME/.gitignore-global":ro \
+  -v "$HOME/.ssh":"$HOME/.ssh":ro \
+  -v "$HOME/.config/gh":"$HOME/.config/gh":ro \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest
 ```
@@ -261,10 +261,13 @@ Create a `.env` file with container-specific variables:
 # Timezone (host timezone for correct timestamps)
 TZ=Asia/Jerusalem
 
+# Host username (creates /home/<user> -> container home symlink so host paths resolve)
+PI_HOST_USER=myakove
+
 # Google Cloud / Vertex AI
 GOOGLE_CLOUD_PROJECT=your-project-id
 GOOGLE_CLOUD_LOCATION=us-east5
-GOOGLE_APPLICATION_CREDENTIALS=/home/node/.gcloud-adc.json
+GOOGLE_APPLICATION_CREDENTIALS=/home/myakove/.config/gcloud/application_default_credentials.json
 VERTEX_PROJECT_ID=your-project-id
 VERTEX_REGION=us-east5
 VERTEX_CLAUDE_1M=true
@@ -272,7 +275,7 @@ VERTEX_CLAUDE_1M=true
 # GitHub
 GITHUB_TOKEN=ghp_xxx
 GITHUB_API_TOKEN=ghp_xxx
-GH_CONFIG_DIR=/home/node/.gh-config
+GH_CONFIG_DIR=/home/myakove/.config/gh
 
 # Gemini (optional)
 GEMINI_API_KEY=xxx
@@ -281,7 +284,8 @@ GEMINI_API_KEY=xxx
 # ACPX_AGENTS=cursor
 
 # mcpl (MCP Launchpad) config path inside the container (must match mount target)
-MCPL_CONFIG_FILES=/home/node/.mcpl/mcp.json
+# Use your actual home path — it resolves inside the container via the PI_HOST_USER symlink
+MCPL_CONFIG_FILES=/home/myakove/.config/mcpl/mcp.json
 ```
 
 Pass via `--env-file /path/to/.env` in the docker run command.
@@ -366,12 +370,12 @@ npm install && npm run build
 
 | Mount | Purpose |
 |---|---|
-| `-v "<PATH_TO_MCPL_CONFIG>":/home/node/.mcpl/mcp.json:ro` | MCP server config for `mcpl` |
-| `-v "$HOME/.agents":/home/node/.agents:rw` | User-level skills (install/uninstall from container) |
-| `-v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro` | Google Cloud ADC (for Claude via Vertex AI) |
-| `-v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro` | Cursor CLI auth (for acpx cursor models) |
-| `-v "$HOME/.config/glab-cli":/home/node/.config/glab-cli:ro` | GitLab CLI config (auth tokens, host settings) |
-| `-v "$HOME/screenshots":/home/node/screenshots` | Share screenshots/images with the agent |
+| `-v "<PATH_TO_MCPL_CONFIG>":"$HOME/.config/mcpl/mcp.json":ro` | MCP server config for `mcpl` |
+| `-v "$HOME/.agents":"$HOME/.agents":rw` | User-level skills (install/uninstall from container) |
+| `-v "$HOME/.config/gcloud/application_default_credentials.json":"$HOME/.config/gcloud/application_default_credentials.json":ro` | Google Cloud ADC (for Claude via Vertex AI) |
+| `-v "$HOME/.config/cursor/auth.json":"$HOME/.config/cursor/auth.json":ro` | Cursor CLI auth (for acpx cursor models) |
+| `-v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro` | GitLab CLI config (auth tokens, host settings) |
+| `-v "$HOME/screenshots":"$HOME/screenshots"` | Share screenshots/images with the agent |
 | `-v /var/run/docker.sock:/var/run/docker.sock:ro` + `--group-add $(stat -c '%g' /var/run/docker.sock)` | Docker container inspection via `docker-safe` |
 | `-v /var/run/podman/podman.sock:/var/run/podman/podman.sock:ro` | Podman container inspection via `docker-safe` |
 
@@ -428,17 +432,17 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   --network host \
   --env-file "$HOME/.pi/.env" \
   -v "$PWD":"$PWD":rw \
-  -v "$HOME/.pi":/home/node/.pi:rw \
-  -v "$HOME/.gitconfig":/home/node/.gitconfig:ro \
-  -v "$HOME/.gitignore-global":/home/node/.gitignore-global:ro \
-  -v "$HOME/.ssh":/home/node/.ssh:ro \
-  -v "$HOME/.config/gh":/home/node/.gh-config:ro \
-  -v "$HOME/.config/mcpl/mcp.json":/home/node/.mcpl/mcp.json:ro \ # adjust host path to your mcpl config location
-  -v "$HOME/.agents":/home/node/.agents:rw \
-  -v "$HOME/.config/gcloud/application_default_credentials.json":/home/node/.gcloud-adc.json:ro \
-  -v "$HOME/.config/cursor/auth.json":/home/node/.cursor/auth.json:ro \
-  -v "$HOME/.config/glab-cli":/home/node/.config/glab-cli:ro \
-  -v "$HOME/screenshots":/home/node/screenshots \
+  -v "$HOME/.pi":"$HOME/.pi":rw \
+  -v "$HOME/.gitconfig":"$HOME/.gitconfig":ro \
+  -v "$HOME/.gitignore-global":"$HOME/.gitignore-global":ro \
+  -v "$HOME/.ssh":"$HOME/.ssh":ro \
+  -v "$HOME/.config/gh":"$HOME/.config/gh":ro \
+  -v "$HOME/.config/mcpl/mcp.json":"$HOME/.config/mcpl/mcp.json":ro \ # adjust host path to your mcpl config location
+  -v "$HOME/.agents":"$HOME/.agents":rw \
+  -v "$HOME/.config/gcloud/application_default_credentials.json":"$HOME/.config/gcloud/application_default_credentials.json":ro \
+  -v "$HOME/.config/cursor/auth.json":"$HOME/.config/cursor/auth.json":ro \
+  -v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro \
+  -v "$HOME/screenshots":"$HOME/screenshots":ro \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --group-add $(stat -c '%g' /var/run/docker.sock) \
   -w "$PWD" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Main entrypoint — runs as node user (dropped from root by init-entrypoint.sh).
+# HOME is set to /home/$PI_HOST_USER if configured, otherwise /home/node.
 set -e
 
 # Always install/update pi to get the latest version on every container start
@@ -36,10 +38,10 @@ fi
 
 
 # Fix host-specific paths in mounted .gitconfig (read-only mount, can't write in-place)
-cp /home/node/.gitconfig /home/node/.gitconfig-local 2>/dev/null || true
-if [ -f /home/node/.gitconfig-local ]; then
-    export GIT_CONFIG_GLOBAL=/home/node/.gitconfig-local
-    git config --global core.excludesFile /home/node/.gitignore-global
+cp "$HOME/.gitconfig" "$HOME/.gitconfig-local" 2>/dev/null || true
+if [ -f "$HOME/.gitconfig-local" ]; then
+    export GIT_CONFIG_GLOBAL="$HOME/.gitconfig-local"
+    git config --global core.excludesFile "$HOME/.gitignore-global"
 fi
 
 # SSH timeout — detect dead connections during git fetch/push/pull

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Init wrapper — handles HOME mapping for PI_HOST_USER.
+# When called as node (by docker), re-execs as root via sudo for chown/symlink,
+# then execs entrypoint.sh as node. No root access remains after setup.
+set -e
+
+# If running as node, re-exec as root for the setup phase
+if [ "$(id -u)" != "0" ]; then
+    if [ -n "$PI_HOST_USER" ] && [ "$PI_HOST_USER" != "node" ]; then
+        exec sudo --preserve-env "$0" "$@"
+    fi
+    # No PI_HOST_USER — skip root setup, run entrypoint directly as node
+    exec entrypoint.sh "$@"
+fi
+
+# Running as root — do the HOME setup
+NEW_HOME="/home/$PI_HOST_USER"
+if [ -d "$NEW_HOME" ]; then
+    chown node:node "$NEW_HOME"
+    [ -d "$NEW_HOME/.config" ] && chown node:node "$NEW_HOME/.config"
+
+    # Symlink container-internal tool dirs/files into the new HOME
+    for item in .npm-global .npm .npmrc .cache .local .claude .claude.json \
+                .cursor .acpx .agent-browser .bashrc .bash_logout .profile; do
+        if [ -e "/home/node/$item" ] && [ ! -e "$NEW_HOME/$item" ]; then
+            ln -sf "/home/node/$item" "$NEW_HOME/$item"
+        fi
+    done
+
+    # Reverse symlinks: point /home/node/.config items to mounted ones
+    # so tools using the original home path still find config files
+    for item in cursor gh glab-cli mcpl docsfy jji rootcoz gcloud; do
+        if [ -e "$NEW_HOME/.config/$item" ] && [ ! -L "/home/node/.config/$item" ]; then
+            rm -rf "/home/node/.config/$item"
+            ln -sf "$NEW_HOME/.config/$item" "/home/node/.config/$item"
+        fi
+    done
+
+    export HOME="$NEW_HOME"
+    # Ensure PATH includes new HOME-based paths
+    export PATH="$NEW_HOME/.npm-global/bin:$NEW_HOME/.pi/agent/bin:$NEW_HOME/.local/bin:$PATH"
+fi
+
+# Drop to node permanently — runuser replaces the process
+exec runuser -m -u node -- entrypoint.sh "$@"


### PR DESCRIPTION
## Problem

Config files like mcpl's `mcp.json` contain hardcoded host paths (e.g., `/home/myakove/.cache/...`) that don't resolve inside the container where HOME is `/home/node`. Also, `docker exec` entered as root, and cursor auth didn't work with `$HOME` mounts.

## Solution

New `PI_HOST_USER` env var (set in `.env` file) triggers HOME remapping:

### `init-entrypoint.sh` (new)
- Runs as node, escalates to root via `sudo` for setup
- Creates `/home/$PI_HOST_USER` writable by node
- Symlinks container-internal tool dirs (`.npm-global`, `.cache`, `.cursor`, etc.) into the new HOME
- Reverse-symlinks mounted `.config/*` dirs back into `/home/node/.config/` for tools using the original path
- Sets `HOME=/home/$PI_HOST_USER` and updates PATH
- Drops back to node via `runuser`

### `Dockerfile`
- Installs `sudo` with passwordless `NOPASSWD:SETENV` for init-entrypoint only
- `USER node` — so `docker exec` enters as node (not root)
- Removed stale cursor auth symlink (handled at runtime now)

### `entrypoint.sh`
- Cleaned up — runs as node only, HOME already set by init-entrypoint

### `README.md`
- All mount examples use `$HOME:$HOME` (no more `/home/node`)
- Env var examples use `/home/myakove/...` matching `PI_HOST_USER=myakove`
- Added `PI_HOST_USER` to `.env` example

## Usage

Add to `~/.pi/.env`:
```
PI_HOST_USER=myakove
```

All mounts now use `$HOME:$HOME` pattern — same path host and container.