### PR TITLE
feat: enforce temp files under /tmp/pi-work/<cwd>, mount for persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ docker run --rm -it \
   -v "$HOME/.gitignore-global":"$HOME/.gitignore-global":ro \
   -v "$HOME/.ssh":"$HOME/.ssh":ro \
   -v "$HOME/.config/gh":"$HOME/.config/gh":ro \
+  -v /tmp/pi-work:/tmp/pi-work:rw \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest
 ```
@@ -376,6 +377,7 @@ npm install && npm run build
 | `-v "$HOME/.config/cursor/auth.json":"$HOME/.config/cursor/auth.json":ro` | Cursor CLI auth (for acpx cursor models) |
 | `-v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro` | GitLab CLI config (auth tokens, host settings) |
 | `-v "$HOME/screenshots":"$HOME/screenshots"` | Share screenshots/images with the agent |
+| `-v /tmp/pi-work:/tmp/pi-work:rw` | Persistent temp files (survives container restarts) |
 | `-v /var/run/docker.sock:/var/run/docker.sock:ro` + `--group-add $(stat -c '%g' /var/run/docker.sock)` | Docker container inspection via `docker-safe` |
 | `-v /var/run/podman/podman.sock:/var/run/podman/podman.sock:ro` | Podman container inspection via `docker-safe` |
 
@@ -443,6 +445,7 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.config/cursor/auth.json":"$HOME/.config/cursor/auth.json":ro \
   -v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro \
   -v "$HOME/screenshots":"$HOME/screenshots":ro \
+  -v /tmp/pi-work:/tmp/pi-work:rw \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --group-add $(stat -c '%g' /var/run/docker.sock) \
   -w "$PWD" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,9 @@
 # HOME is set to /home/$PI_HOST_USER if configured, otherwise /home/node.
 set -e
 
+# Create temp dir for this project (persists across container restarts when mounted)
+mkdir -p "/tmp/pi-work/$(basename "$PWD")"
+
 # Always install/update pi to get the latest version on every container start
 npm install -g @mariozechner/pi-coding-agent
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -221,6 +221,15 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       }
     }
 
+    // Enforce temp files go to /tmp/pi-work/ — not bare /tmp/
+    // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
+    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-work/.test(command)) {
+      return {
+        block: true,
+        reason: `⛔ mktemp must use /tmp/pi-work/$(basename $PWD)/ prefix. Use: mktemp /tmp/pi-work/$(basename $PWD)/XXXXXX`,
+      };
+    }
+
     // Dangerous command confirmation
     if (DANGEROUS.some((p) => p.test(command))) {
       if (!ctx.hasUI)

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -153,13 +153,13 @@ Present findings to user grouped by severity (CRITICAL, WARNING, SUGGESTION). As
 If user selected findings, create temp directory and write JSON to temp file:
 
 ```bash
-mkdir -p /tmp/pi-work
+mkdir -p /tmp/pi-work/$(basename $PWD)
 ```
 
 Use the `owner`, `repo`, `pr_number`, and `head_sha` from Phase 0 or Phase 1a metadata:
 
 ```bash
-myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} /tmp/pi-work/pr-review-comments.json
+myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} /tmp/pi-work/$(basename $PWD)/pr-review-comments.json
 ```
 
 ### Phase 5: Summary

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -199,7 +199,7 @@ skipped and why before proceeding.
 Create a temp file with cleanup, write changelog to it, and create release:
 
 ```bash
-CHANGELOG_FILE=$(mktemp /tmp/pi-release-XXXXXX.md)
+CHANGELOG_FILE=$(mktemp /tmp/pi-work/$(basename $PWD)/release-XXXXXX.md)
 trap "rm -f $CHANGELOG_FILE" EXIT
 
 cat > "$CHANGELOG_FILE" << 'EOF'

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -149,7 +149,10 @@ Provide clear, concise options. Include a 'no' or 'cancel' option when appropria
 
 ## Temp Files
 
-**ALL temp files MUST go to `/tmp/pi-work/<repo-name>/`** (e.g., `/tmp/pi-work/pi-config/`).
+**ALL temp files MUST go to `/tmp/pi-work/<cwd-basename>/`** (e.g., `/tmp/pi-work/pi-config/`).
+
+- `<cwd-basename>` is the last segment of the current working directory (not repo name — not all dirs are repos)
+- This path persists across container restarts when `/tmp/pi-work` is mounted from the host
 
 NEVER create temp files in the project directory.
 

--- a/rules/45-file-preview.md
+++ b/rules/45-file-preview.md
@@ -8,10 +8,10 @@ When generating or modifying HTML, frontend, or any browser-viewable files:
    ```bash
    HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
    PORT=$(uv run python3 $HTTPD --find-port)
-   nohup uv run python3 $HTTPD --port $PORT --dir /path/to/serve > /tmp/httpd-$PORT.log 2>&1 &
+   nohup uv run python3 $HTTPD --port $PORT --dir /path/to/serve > /tmp/pi-work/$(basename $PWD)/httpd-$PORT.log 2>&1 &
    disown
    sleep 0.5
-   if ! kill -0 $! 2>/dev/null; then echo "Server failed to start:"; cat /tmp/httpd-$PORT.log; fi
+   if ! kill -0 $! 2>/dev/null; then echo "Server failed to start:"; cat /tmp/pi-work/$(basename $PWD)/httpd-$PORT.log; fi
    ```
 
    Replace `/path/to/serve` with the directory containing the files.


### PR DESCRIPTION
## Problem

Temp files created by the AI (review JSON, changelogs, etc.) are lost when the container restarts because they go to bare `/tmp/`. Sessions that resume after restart can't find their temp files.

## Fix

- **Rule** — Updated to `/tmp/pi-work/<cwd-basename>/` (uses cwd, not repo name — not all dirs are repos)
- **Enforcement** — `mktemp` calls not using `/tmp/pi-work/` are blocked
- **Entrypoint** — `mkdir -p /tmp/pi-work/$(basename $PWD)` at startup so the dir always exists
- **Docker mount** — Added `-v /tmp/pi-work:/tmp/pi-work:rw` to README examples
- **Prompts** — Updated `release.md`, `pr-review.md`, `45-file-preview.md` to use `$(basename $PWD)` subdir

Temp files now persist across container restarts when `/tmp/pi-work` is mounted from the host.