### PR TITLE
fix(repair): reload session after repair via switchSession to force tree rebuild

### DIFF
--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -164,9 +164,12 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
       fs.writeFileSync(sessionFile, repairedLines.join("\n") + "\n");
 
       ctx.ui.notify(
-        `\ud83d\udd27 Repaired ${totalFixed} orphaned tool call${totalFixed > 1 ? "s" : ""}:\n${fixedDetails.join("\n")}`,
+        `\ud83d\udd27 Repaired ${totalFixed} orphaned tool call${totalFixed > 1 ? "s" : ""}:\n${fixedDetails.join("\n")}\nReloading session...`,
         "info",
       );
+
+      // Force session re-read — switchSession to the same file rebuilds the tree
+      await ctx.switchSession(sessionFile);
     },
   });
 


### PR DESCRIPTION
## Problem

After `/repair` fixes orphaned tool calls, the user still gets the same API error. The in-memory session tree isn't rebuilt — pi keeps the old cached state. Users had to do `/new` then `/resume` manually to get the fix to take effect.

## Fix

After writing the repaired session file, call `ctx.switchSession(sessionFile)` to force pi to re-read and rebuild the session tree from the repaired file. No manual `/new` + `/resume` needed.