### PR TITLE
chore: migrate npm packages from @mariozechner to @earendil-works scope

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ set -e
 mkdir -p "/tmp/pi-work/$(basename "$PWD")"
 
 # Always install/update pi to get the latest version on every container start
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent
 
 # Install or update packages
 PI_PKG_DIR="$HOME/.pi/agent/git/github.com"

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -25,9 +25,9 @@ import type {
 	Context,
 	Model,
 	SimpleStreamOptions,
-} from "@mariozechner/pi-ai";
-import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { spawn, execSync } from "child_process";
 
 // =============================================================================

--- a/extensions/orchestrator/agents.ts
+++ b/extensions/orchestrator/agents.ts
@@ -9,7 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getAgentDir, parseFrontmatter } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, parseFrontmatter } from "@earendil-works/pi-coding-agent";
 
 export type AgentScope = "user" | "project" | "both";
 

--- a/extensions/orchestrator/ask-user.ts
+++ b/extensions/orchestrator/ask-user.ts
@@ -2,7 +2,7 @@
  * ask_user tool — presents questions to the user with selectable options.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   Container,
   Input,
@@ -10,8 +10,8 @@ import {
   SelectList,
   Spacer,
   Text,
-} from "@mariozechner/pi-tui";
-import { DynamicBorder } from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-tui";
+import { DynamicBorder } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 
 export function registerAskUser(

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -10,8 +10,8 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentConfig } from "./agents.js";
 import { getPiInvocation } from "./utils.js";
 
@@ -287,8 +287,8 @@ export function registerAsyncAgents(
     // Find jiti for TypeScript execution
     let jitiCliPath: string | undefined;
     try {
-      const piPkgDir = path.dirname(require.resolve("@mariozechner/pi-coding-agent/package.json"));
-      const candidate = path.join(piPkgDir, "node_modules/@mariozechner/jiti/lib/jiti-cli.mjs");
+      const piPkgDir = path.dirname(require.resolve("@earendil-works/pi-coding-agent/package.json"));
+      const candidate = path.join(piPkgDir, "node_modules/jiti/lib/jiti-cli.mjs");
       if (fs.existsSync(candidate)) jitiCliPath = candidate;
     } catch {}
 

--- a/extensions/orchestrator/btw.ts
+++ b/extensions/orchestrator/btw.ts
@@ -2,19 +2,19 @@
  * /btw command — quick side questions without polluting conversation history.
  */
 
-import { complete, type UserMessage } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { complete, type UserMessage } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   BorderedLoader,
   convertToLlm,
   serializeConversation,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   Key,
   matchesKey,
   visibleWidth,
   wrapTextWithAnsi,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 
 export function registerBtw(pi: ExtensionAPI): void {
   pi.registerCommand("btw", {

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -15,7 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Type } from "typebox";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { discoverAgents } from "./agents.js";
 
 // ── Types ────────────────────────────────────────────────────────────

--- a/extensions/orchestrator/daemon-manager.ts
+++ b/extensions/orchestrator/daemon-manager.ts
@@ -72,7 +72,7 @@ export function findJitiPath(): string | undefined {
   try {
     let dir = path.dirname(new URL(import.meta.url).pathname);
     for (let i = 0; i < 10; i++) {
-      const candidate = path.join(dir, "node_modules", "@mariozechner", "jiti", "lib", "jiti-cli.mjs");
+      const candidate = path.join(dir, "node_modules", "jiti", "lib", "jiti-cli.mjs");
       if (fs.existsSync(candidate)) { jitiPath = candidate; break; }
       const parent = path.dirname(dir);
       if (parent === dir) break;
@@ -81,8 +81,8 @@ export function findJitiPath(): string | undefined {
     if (!jitiPath) {
       const globalCandidate = path.join(
         path.dirname(process.execPath), "..", "lib", "node_modules",
-        "@mariozechner", "pi-coding-agent", "node_modules",
-        "@mariozechner", "jiti", "lib", "jiti-cli.mjs",
+        "@earendil-works", "pi-coding-agent", "node_modules",
+        "jiti", "lib", "jiti-cli.mjs",
       );
       if (fs.existsSync(globalCandidate)) jitiPath = globalCandidate;
     }

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -12,7 +12,7 @@
 
 import { spawn } from "node:child_process";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { discoverAgents } from "./agents.js";
 
 // Default: 3 hours. Override with PI_DREAM_INTERVAL_HOURS env var (0.5–24).

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -3,8 +3,8 @@
  * remote script execution, memory writes, dangerous).
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { isToolCallEventType } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import {
   DANGEROUS,
   getCurrentBranch,

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -18,9 +18,9 @@
  *   /pidash <Tab>                → start, stop, restart, status
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from "@mariozechner/pi-tui";
-import { fuzzyFilter } from "@mariozechner/pi-tui";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from "@earendil-works/pi-tui";
+import { fuzzyFilter } from "@earendil-works/pi-tui";
 
 // ── Cache infrastructure ────────────────────────────────────────────
 

--- a/extensions/orchestrator/github-autocomplete.ts
+++ b/extensions/orchestrator/github-autocomplete.ts
@@ -5,13 +5,13 @@
  * Lazy-loads on first # keystroke, caches for 5 minutes, includes both issues and PRs.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   type AutocompleteItem,
   type AutocompleteProvider,
   type AutocompleteSuggestions,
   fuzzyFilter,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 
 type GitHubItem = {
   number: number;

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -14,7 +14,7 @@
  * - Pidash web UI (live session viewer)
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { registerAskUser } from "./ask-user.js";
 import { registerAsyncAgents } from "./async-agents.js";
 import { registerBtw } from "./btw.js";

--- a/extensions/orchestrator/nvim.ts
+++ b/extensions/orchestrator/nvim.ts
@@ -7,7 +7,7 @@ import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { runGit } from "./git-helpers.js";
 
 const NVIM_SOCKET = process.env.NVIM;

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -13,8 +13,8 @@ import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { SessionManager } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { commandHandlerRegistry, latestCommandCtx } from "./index.js";
 import { checkHealth, ensureUiBuilt, spawnDaemon as spawnDaemonGeneric, killDaemon, waitForDaemon, createLogger } from "./daemon-manager.js";
 

--- a/extensions/orchestrator/pidiff.ts
+++ b/extensions/orchestrator/pidiff.ts
@@ -10,7 +10,7 @@ import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   createLogger,
   checkHealth,

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -6,7 +6,7 @@
 import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { formatDuration } from "./async-agents.js";
 
 export function registerRules(

--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -6,7 +6,7 @@ import { execSync, execFileSync } from "node:child_process";
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 export function registerSessionValidation(pi: ExtensionAPI): void {
   // ── /repair command ─────────────────────────────────────────────────

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -2,7 +2,7 @@
  * Git status line, container indicator, desktop notifications, git poller.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getCurrentBranch, runGit } from "./git-helpers.js";
 import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
 import { clockHHMM } from "./utils.js";

--- a/extensions/orchestrator/status.ts
+++ b/extensions/orchestrator/status.ts
@@ -3,7 +3,7 @@
  * Direct handler (no AI roundtrip).
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AsyncJob } from "./async-agents.js";
 import type { CronTask } from "./cron.js";
 import { getCurrentBranch, runGit } from "./git-helpers.js";

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -11,20 +11,20 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
-import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import type { Message } from "@mariozechner/pi-ai";
-import { StringEnum } from "@mariozechner/pi-ai";
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import type { Message } from "@earendil-works/pi-ai";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   getMarkdownTheme,
   withFileMutationQueue,
-} from "@mariozechner/pi-coding-agent";
+} from "@earendil-works/pi-coding-agent";
 import {
   Container,
   Markdown,
   Spacer,
   Text,
-} from "@mariozechner/pi-tui";
+} from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
 import { clockHHMM, getPiInvocation } from "./utils.js";


### PR DESCRIPTION
## Summary

The pi coding agent npm packages have moved from `@mariozechner` to `@earendil-works` after Mario Zechner joined Earendil. The old packages are deprecated.

## Changes

- **entrypoint.sh**: Updated global install command to `@earendil-works/pi-coding-agent`
- **20 TypeScript files**: Migrated all imports from `@mariozechner/pi-*` to `@earendil-works/pi-*`
- **daemon-manager.ts**: Updated jiti discovery paths from `@mariozechner/jiti` fork to upstream `jiti` 2.7
- **async-agents.ts**: Updated runtime `require.resolve` path and jiti candidate path

## Scope

| Old | New |
|-----|-----|
| `@mariozechner/pi-coding-agent` | `@earendil-works/pi-coding-agent` |
| `@mariozechner/pi-ai` | `@earendil-works/pi-ai` |
| `@mariozechner/pi-tui` | `@earendil-works/pi-tui` |
| `@mariozechner/pi-agent-core` | `@earendil-works/pi-agent-core` |
| `@mariozechner/jiti` (fork) | `jiti` (upstream 2.7) |

Closes #290