### PR TITLE
feat: add PI_PIDASH_ENABLE and PI_PIDIFF_ENABLE env vars to disable daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,9 @@ http://<your-ip>:19190
 
 # Custom port:
 PI_PIDASH_PORT=9999 pi
+
+# Disable pidash entirely:
+PI_PIDASH_ENABLE=false pi
 ```
 
 **Management:**
@@ -396,6 +399,9 @@ http://localhost:19290
 
 # Custom port:
 PI_PIDIFF_PORT=9999 pi
+
+# Disable pidiff entirely:
+PI_PIDIFF_ENABLE=false pi
 ```
 
 **Management:**

--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -81,6 +81,17 @@ export function registerPidash(
 ): void {
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
 
+  const pidashDisabled = ["false", "0", "no", "off"].includes(process.env.PI_PIDASH_ENABLE?.toLowerCase() ?? "");
+  if (pidashDisabled) {
+    pi.registerCommand("pidash", {
+      description: "Manage pidash server — /pidash start|stop|restart|status",
+      handler: async (_args, ctx) => {
+        if (ctx.hasUI) ctx.ui.notify("pidash is disabled (PI_PIDASH_ENABLE=false). Set PI_PIDASH_ENABLE=true or unset it to enable.", "info");
+      },
+    });
+    return;
+  }
+
   let ws: any = null;
   let connected = false;
   let connecting = false;

--- a/extensions/orchestrator/pidiff.ts
+++ b/extensions/orchestrator/pidiff.ts
@@ -45,6 +45,17 @@ function getBranch(cwd: string): string {
 export function registerPidiff(pi: ExtensionAPI): void {
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
 
+  const pidiffDisabled = ["false", "0", "no", "off"].includes(process.env.PI_PIDIFF_ENABLE?.toLowerCase() ?? "");
+  if (pidiffDisabled) {
+    pi.registerCommand("pidiff", {
+      description: "Manage pidiff server — /pidiff start|stop|restart|status",
+      handler: async (_args, ctx) => {
+        if (ctx.hasUI) ctx.ui.notify("pidiff is disabled (PI_PIDIFF_ENABLE=false). Set PI_PIDIFF_ENABLE=true or unset it to enable.", "info");
+      },
+    });
+    return;
+  }
+
   let ws: any = null;
   let connected = false;
   let connecting = false;


### PR DESCRIPTION
## Summary

Users can now disable pidash and pidiff daemons via environment variables. Default is enabled — set to `false` to disable.

## Usage

```bash
PI_PIDASH_ENABLE=false pi   # Disable pidash
PI_PIDIFF_ENABLE=false pi   # Disable pidiff
```

Accepted falsy values: `false`, `0`, `no`, `off` (case-insensitive).

## Changes

- **pidash.ts**: Check `PI_PIDASH_ENABLE` early — skip all daemon/WebSocket setup when disabled, register stub `/pidash` command with helpful message
- **pidiff.ts**: Same pattern with `PI_PIDIFF_ENABLE`
- **README.md**: Document both env vars in pidash and pidiff sections

Closes #293