### PR TITLE
fix: pidiff auto-build, shared serve-ui, major UI rewrite with @pierre/diffs best practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,8 @@ pi-config/
 │   ├── docker-safe                  # Restricted Docker/Podman CLI wrapper (container only)
 │   ├── httpd.py                     # HTTP file server for file preview (used by rules/45-file-preview.md)
 │   ├── pidash-server.ts             # Pidash daemon (WebSocket hub for all pi sessions + Discord bot)
-│   └── pidiff-server.ts             # Pidiff daemon (multi-session diff hub with review comments)
+│   ├── pidiff-server.ts             # Pidiff daemon (multi-session diff hub with review comments)
+│   └── serve-ui.ts                  # Shared static UI serving + auto-build for daemon servers
 ├── Dockerfile                       # Container image definition
 ├── entrypoint.sh                    # Container entrypoint
 ├── README.md                        # Project README

--- a/extensions/orchestrator/pidiff-ui/package.json
+++ b/extensions/orchestrator/pidiff-ui/package.json
@@ -13,6 +13,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@pierre/diffs": "^1.1.20",
     "@pierre/trees": "^1.0.0-beta.3",
+    "@radix-ui/react-switch": "^1.2.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/extensions/orchestrator/pidiff-ui/src/App.tsx
+++ b/extensions/orchestrator/pidiff-ui/src/App.tsx
@@ -1,44 +1,29 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { PatchDiff } from "@pierre/diffs/react";
-import { useFileTree, FileTree } from "@pierre/trees/react";
-import { GitBranch, X, Send, MessageSquarePlus, Pencil } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { MultiFileDiff, WorkerPoolContextProvider } from "@pierre/diffs/react";
+import type { FileContents, WorkerPoolOptions, WorkerInitializationRenderOptions } from "@pierre/diffs/react";
+import { useFileTree, FileTree, useFileTreeSelection } from "@pierre/trees/react";
+import { GitBranch, X, Send, Pencil } from "lucide-react";
 import { themeToTreeStyles } from "@pierre/trees";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import { Switch } from "@/components/ui/switch";
 import { useWebSocket } from "@/hooks/useWebSocket";
-import type { DiffMode, DiffData, FileChange, GitCommit, ReviewComment, PiSession } from "@/types";
+import type { DiffMode, DiffData, FileDiffData, GitCommit, ReviewComment, PiSession } from "@/types";
+
+// ── WorkerPool (offloads diff computation to web workers) ───────────
+const WORKER_POOL_OPTIONS: WorkerPoolOptions = {
+  poolSize: Math.min(Math.max(1, (navigator?.hardwareConcurrency ?? 1) - 1), 3),
+  workerFactory() {
+    return new Worker(new URL("@pierre/diffs/worker/worker.js", import.meta.url));
+  },
+};
+
+const HIGHLIGHTER_OPTIONS: WorkerInitializationRenderOptions = {
+  theme: { dark: "pierre-dark", light: "pierre-light" },
+  langs: ["typescript", "tsx", "javascript", "jsx", "css", "json", "markdown", "python", "sh", "yaml", "html"],
+};
 import type { GitStatusEntry } from "@pierre/trees";
-
-// ── Helpers ─────────────────────────────────────────────────────────
-
-function parseFilesFromPatch(patch: string, area: FileChange["area"]): FileChange[] {
-  const files: FileChange[] = [];
-  const diffRegex = /^diff --git a\/(.*?) b\/(.*)$/gm;
-  let match: RegExpExecArray | null;
-  while ((match = diffRegex.exec(patch)) !== null) {
-    const oldPath = match[1];
-    const newPath = match[2];
-    const after = patch.slice(match.index + match[0].length, match.index + match[0].length + 200);
-    let status: FileChange["status"] = "modified";
-    if (after.includes("new file mode")) status = "added";
-    else if (after.includes("deleted file mode")) status = "deleted";
-    else if (oldPath !== newPath || after.includes("rename from")) status = "renamed";
-    files.push({ path: newPath, status, area });
-  }
-  return files;
-}
-
-function splitPatchByFile(patch: string): Array<{ path: string; patch: string }> {
-  const chunks: Array<{ path: string; patch: string }> = [];
-  for (const part of patch.split(/(?=^diff --git )/m)) {
-    const t = part.trim();
-    if (!t) continue;
-    const m = t.match(/^diff --git a\/(.*?) b\/(.*)/m);
-    if (m) chunks.push({ path: m[2], patch: t });
-  }
-  return chunks;
-}
 
 // ── Tree theme (github-dark) ────────────────────────────────────────
 
@@ -73,10 +58,12 @@ export function App() {
 
   // Sessions
   const [sessions, setSessions] = useState<PiSession[]>([]);
-  const [activeSession, setActiveSession] = useState<PiSession | null>(null);
+  const [activeSession, setActiveSession] = useState<PiSession | null>(() => {
+    try { const s = localStorage.getItem("pidiff-session"); return s ? JSON.parse(s) : null; } catch { return null; }
+  });
 
   const [diffData, setDiffData] = useState<DiffData>({
-    mode: "branch", staged: "", unstaged: "", committed: "", branch: "", files: [],
+    mode: "branch", files: [], branch: "",
   });
   const [mode, setMode] = useState<DiffMode>("branch");
   const [loading, setLoading] = useState(false);
@@ -86,6 +73,14 @@ export function App() {
   const [commitTo, setCommitTo] = useState("");
 
   const [diffStyle, setDiffStyle] = useState<"unified" | "split">("split");
+  const [diffIndicators, setDiffIndicators] = useState<"bars" | "classic" | "none">("bars");
+  const [lineDiffType, setLineDiffType] = useState<"word-alt" | "word" | "char" | "none">("word-alt");
+  const [disableBackground, setDisableBackground] = useState(false);
+  const [overflow, setOverflow] = useState<"scroll" | "wrap">("scroll");
+  const [disableLineNumbers, setDisableLineNumbers] = useState(false);
+  const [hunkSeparators, setHunkSeparators] = useState<"line-info" | "line-info-basic" | "metadata" | "simple">("line-info");
+  const [fontSize, setFontSize] = useState(13);
+  const [theme, setTheme] = useState<string>("pierre-dark");
   const [stale, setStale] = useState(false);
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
 
@@ -93,18 +88,28 @@ export function App() {
   const [comments, setComments] = useState<ReviewComment[]>(() => {
     try { const s = localStorage.getItem("pidiff-comments"); return s ? JSON.parse(s) : []; } catch { return []; }
   });
-  const [commentDraft, setCommentDraft] = useState<{ file: string; line: number; editIndex?: number } | null>(null);
-  const [commentText, setCommentText] = useState("");
+  const [openForms, setOpenForms] = useState<Array<{ file: string; side: "deletions" | "additions"; lineNumber: number }>>([]);
+  const hasOpenForm = openForms.length > 0;
 
   useEffect(() => {
     try { localStorage.setItem("pidiff-comments", JSON.stringify(comments)); } catch {}
   }, [comments]);
+
+  useEffect(() => {
+    try {
+      if (activeSession) localStorage.setItem("pidiff-session", JSON.stringify(activeSession));
+      else localStorage.removeItem("pidiff-session");
+    } catch {}
+  }, [activeSession]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
   const commitsRequested = useRef(false);
   const activeSessionRef = useRef<PiSession | null>(null);
   const loadingTimeout = useRef<ReturnType<typeof setTimeout>>();
   const modeRef = useRef(mode);
+  const scrollLock = useRef(0); // timestamp until which scroll-sync is paused
+  const selectedFileRef = useRef<string | null>(null);
+  const explorer = useExplorerWidth(280, 180, 600);
   useEffect(() => { modeRef.current = mode; }, [mode]);
 
   // ── WebSocket ─────────────────────────────────────────────────────
@@ -112,21 +117,16 @@ export function App() {
   useEffect(() => {
     return onMessage((ev: any) => {
       if (ev.type === "diff_update" && (ev.mode === modeRef.current || !ev.mode)) {
-        const staged = ev.staged || "";
-        const unstaged = ev.unstaged || "";
-        const committed = ev.committed || "";
-
-        const allFiles: FileChange[] = [];
+        const committed: FileDiffData[] = (ev.committed || []).map((f: any) => ({ ...f, area: "committed" as const }));
+        const staged: FileDiffData[] = (ev.staged || []).map((f: any) => ({ ...f, area: "staged" as const }));
+        const unstaged: FileDiffData[] = (ev.unstaged || []).map((f: any) => ({ ...f, area: "unstaged" as const }));
+        // Deduplicate: unstaged > staged > committed
         const seen = new Set<string>();
-        for (const f of parseFilesFromPatch(committed, "committed")) { seen.add(f.path); allFiles.push(f); }
-        for (const f of parseFilesFromPatch(staged, "staged")) { if (!seen.has(f.path)) { seen.add(f.path); allFiles.push(f); } }
-        for (const f of parseFilesFromPatch(unstaged, "unstaged")) { if (!seen.has(f.path)) allFiles.push(f); }
-
-        setDiffData({
-          mode: ev.mode || "branch", staged, unstaged, committed,
-          branch: ev.branch || "", files: allFiles,
-          fromRef: ev.fromRef, toRef: ev.toRef,
-        });
+        const allFiles: FileDiffData[] = [];
+        for (const f of unstaged) { seen.add(f.name); allFiles.push(f); }
+        for (const f of staged) { if (!seen.has(f.name)) { seen.add(f.name); allFiles.push(f); } }
+        for (const f of committed) { if (!seen.has(f.name)) allFiles.push(f); }
+        setDiffData({ mode: ev.mode || "branch", files: allFiles, branch: ev.branch || "", fromRef: ev.fromRef, toRef: ev.toRef });
         setLoading(false);
         setStale(false);
         if (loadingTimeout.current) clearTimeout(loadingTimeout.current);
@@ -139,12 +139,14 @@ export function App() {
       }
       if (ev.type === "sessions-list" && ev.sessions) {
         setSessions(ev.sessions);
-        // Auto-select first session if none selected
+        // Restore saved session or auto-select first
         if (!activeSessionRef.current && ev.sessions.length > 0) {
-          const first = ev.sessions[0];
-          setActiveSession(first);
-          activeSessionRef.current = first;
-          send({ type: "watch", sessionId: first.sessionId });
+          let saved: PiSession | null = null;
+          try { const s = localStorage.getItem("pidiff-session"); if (s) saved = JSON.parse(s); } catch {}
+          const target = saved ? ev.sessions.find(s => s.sessionId === saved!.sessionId) || ev.sessions[0] : ev.sessions[0];
+          setActiveSession(target);
+          activeSessionRef.current = target;
+          send({ type: "watch", sessionId: target.sessionId });
           setLoading(true);
         }
       }
@@ -167,7 +169,7 @@ export function App() {
         if (activeSessionRef.current?.sessionId === ev.sessionId) {
           setActiveSession(null);
           activeSessionRef.current = null;
-          setDiffData({ mode: "branch", staged: "", unstaged: "", committed: "", branch: "", files: [] });
+          setDiffData({ mode: "branch", files: [], branch: "" });
         }
       }
       if (ev.type === "session_updated" && ev.session) {
@@ -193,7 +195,7 @@ export function App() {
     activeSessionRef.current = s;
     setMode("branch");
     modeRef.current = "branch";
-    setDiffData({ mode: "branch", staged: "", unstaged: "", committed: "", branch: s.branch, files: [] });
+    setDiffData({ mode: "branch", files: [], branch: s.branch });
     setCommits(null);
     commitsRequested.current = false;
     setStale(false);
@@ -205,7 +207,7 @@ export function App() {
     setMode(m);
     modeRef.current = m;
     if (m === "commits") {
-      setDiffData(d => ({ ...d, committed: "", staged: "", unstaged: "", files: [] }));
+      setDiffData(d => ({ ...d, files: [] }));
       if (!commitsRequested.current) {
         commitsRequested.current = true;
         send({ type: "request-commits" });
@@ -224,9 +226,9 @@ export function App() {
 
   // ── File tree ─────────────────────────────────────────────────────
 
-  const paths = useMemo(() => diffData.files.map(f => f.path), [diffData.files]);
+  const paths = useMemo(() => [...new Set(diffData.files.map(f => f.name))], [diffData.files]);
   const gitStatus: GitStatusEntry[] = useMemo(
-    () => diffData.files.map(f => ({ path: f.path, status: f.status === "untracked" ? "added" as const : f.status })),
+    () => diffData.files.map(f => ({ path: f.name, status: f.status })),
     [diffData.files],
   );
 
@@ -238,39 +240,63 @@ export function App() {
     initialExpansion: "open",
     gitStatus,
     search: true,
-    onSelectionChange: useCallback((sel: readonly string[]) => { if (sel.length) setSelectedFile(sel[0]); }, []),
   });
 
   useEffect(() => { model.resetPaths(paths); }, [model, paths]);
   useEffect(() => { model.setGitStatus(gitStatus); }, [model, gitStatus]);
 
+  // ── Tree ↔ Diff scroll sync ───────────────────────────────────────
+  //
+  // Two directions:
+  //  A) User clicks file in tree → scroll diff to that file
+  //  B) User scrolls diff → highlight file in tree
+  //
+  // To prevent loops: clicking sets a scrollLock timestamp.
+  // Scroll handler skips tree updates while locked.
+
+  // (A) Tree click → scroll diff
+  const selectedPaths = useFileTreeSelection(model);
+  const prevSelectedRef = useRef<readonly string[]>([]);
+
   useEffect(() => {
-    if (!selectedFile || !scrollRef.current) return;
-    const el = scrollRef.current.querySelector(`[data-diff-file="${CSS.escape(selectedFile)}"]`);
+    // Only act on NEW selections (compare by reference — useFileTreeSelection returns new array)
+    if (selectedPaths === prevSelectedRef.current) return;
+    const prev = new Set(prevSelectedRef.current);
+    prevSelectedRef.current = selectedPaths;
+
+    if (!selectedPaths.length || !scrollRef.current) return;
+
+    // Find the newly selected path (one the user just clicked)
+    let newPath: string | null = null;
+    for (let i = selectedPaths.length - 1; i >= 0; i--) {
+      if (!prev.has(selectedPaths[i])) { newPath = selectedPaths[i]; break; }
+    }
+    if (!newPath) return;
+
+    // Lock scroll-sync for 1 second to prevent the scroll handler from fighting
+    scrollLock.current = Date.now() + 1000;
+    setSelectedFile(newPath);
+    const el = scrollRef.current.querySelector(`[data-diff-file="${CSS.escape(newPath)}"]`);
     if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
-  }, [selectedFile]);
+  }, [selectedPaths]);
 
-  // ── Patches ───────────────────────────────────────────────────────
+  // (B) Scroll diff → highlight tree — DISABLED (causes lag)
+  // TODO: Re-enable scroll-sync. The working approach uses:
+  //   - Debounced scroll listener on the diff container (scrollRef)
+  //   - Find topmost visible [data-diff-file] element via getBoundingClientRect
+  //   - Update tree selection via model.getItem(path)?.select() + deselect others
+  //   - Use scrollLock ref to prevent the tree selection change from
+  //     triggering scrollIntoView back (feedback loop)
+  // The lag comes from getItem/select/deselect triggering React re-renders
+  // on every scroll pause. Need to find a way to update the tree highlight
+  // without causing a full re-render (possibly via direct DOM manipulation
+  // on the tree's shadow DOM, or a @pierre/trees API that doesn't emit).
 
-  const committedChunks = useMemo(() => splitPatchByFile(diffData.committed), [diffData.committed]);
-  const stagedChunks = useMemo(() => splitPatchByFile(diffData.staged), [diffData.staged]);
-  const unstagedChunks = useMemo(() => splitPatchByFile(diffData.unstaged), [diffData.unstaged]);
-  const empty = !diffData.staged && !diffData.unstaged && !diffData.committed;
+  // ── Parsed diffs (using @pierre/diffs parser) ─────────────────────
+
+  const empty = diffData.files.length === 0;
 
   // ── Review comments ───────────────────────────────────────────────
-
-  const saveComment = useCallback(() => {
-    if (!commentDraft || !commentText.trim()) return;
-    if (commentDraft.editIndex !== undefined) {
-      // Edit existing
-      setComments(prev => prev.map((c, i) => i === commentDraft.editIndex ? { ...c, body: commentText.trim() } : c));
-    } else {
-      // Add new
-      setComments(prev => [...prev, { file: commentDraft.file, line: commentDraft.line, side: "new", body: commentText.trim() }]);
-    }
-    setCommentDraft(null);
-    setCommentText("");
-  }, [commentDraft, commentText]);
 
   const deleteComment = useCallback((index: number) => {
     setComments(prev => prev.filter((_, i) => i !== index));
@@ -279,10 +305,45 @@ export function App() {
   const editComment = useCallback((index: number) => {
     const c = comments[index];
     if (c) {
-      setCommentDraft({ file: c.file, line: c.line, editIndex: index });
-      setCommentText(c.body);
+      // Delete the old comment, then open a form at the same location pre-filled
+      // For now, delete and re-open a form so the user can re-type
+      setComments(prev => prev.filter((_, i) => i !== index));
+      const side: "deletions" | "additions" = c.side === "old" ? "deletions" : "additions";
+      setOpenForms(prev => {
+        if (prev.some(f => f.file === c.file && f.side === side && f.lineNumber === c.line)) return prev;
+        return [...prev, { file: c.file, side, lineNumber: c.line }];
+      });
     }
   }, [comments]);
+
+  const addCommentForm = useCallback((file: string, side: "deletions" | "additions", lineNumber: number) => {
+    setOpenForms(prev => {
+      if (prev.some(f => f.file === file && f.side === side && f.lineNumber === lineNumber)) return prev;
+      return [...prev, { file, side, lineNumber }];
+    });
+  }, []);
+
+  const submitComment = useCallback((file: string, side: "deletions" | "additions", lineNumber: number, body: string) => {
+    if (!body.trim()) return;
+    setComments(prev => [...prev, { file, line: lineNumber, side: side === "deletions" ? "old" : "new", body: body.trim() }]);
+    setOpenForms(prev => prev.filter(f => !(f.file === file && f.side === side && f.lineNumber === lineNumber)));
+  }, []);
+
+  const cancelCommentForm = useCallback((file: string, side: "deletions" | "additions", lineNumber: number) => {
+    setOpenForms(prev => prev.filter(f => !(f.file === file && f.side === side && f.lineNumber === lineNumber)));
+  }, []);
+
+  const resolveComment = useCallback((index: number) => {
+    setComments(prev => prev.map((c, i) => i === index ? { ...c, resolved: true } : c));
+  }, []);
+
+  const replyToComment = useCallback((index: number, body: string) => {
+    setComments(prev => prev.map((c, i) => {
+      if (i !== index) return c;
+      const replies = [...(c.replies || []), { author: "You", body, timestamp: "now" }];
+      return { ...c, replies };
+    }));
+  }, []);
 
   const publish = useCallback(() => {
     if (!comments.length) return;
@@ -291,14 +352,10 @@ export function App() {
     try { localStorage.removeItem("pidiff-comments"); } catch {}
   }, [comments, send]);
 
-  const openComment = useCallback((file: string, line: number) => {
-    setCommentDraft({ file, line });
-    setCommentText("");
-  }, []);
-
   // ── Render ────────────────────────────────────────────────────────
 
   return (
+    <WorkerPoolContextProvider poolOptions={WORKER_POOL_OPTIONS} highlighterOptions={HIGHLIGHTER_OPTIONS}>
     <div className="flex h-screen flex-col bg-background text-foreground">
 
       {/* ── Header ─────────────────────────────────────────────── */}
@@ -348,13 +405,111 @@ export function App() {
               <Button variant={diffStyle === "unified" ? "secondary" : "ghost"} size="sm"
                 className="h-6 px-2.5 text-[11px] rounded-none border-0" onClick={() => setDiffStyle("unified")}>Unified</Button>
             </div>
-            {!connected && <span className="text-[10px] text-red-400">● offline</span>}
+            {!connected && <span className="text-[10px] text-red-400">● disconnected</span>}
             {comments.length > 0 && (
               <Button size="sm" className="h-7 gap-1.5 bg-green-600 hover:bg-green-500 text-white text-[11px]" onClick={publish}>
                 <Send className="h-3 w-3" /> Publish ({comments.length})
               </Button>
             )}
           </div>
+        </div>
+
+        {/* Settings toolbar */}
+        <div className="flex items-center gap-3 px-4 py-1.5 bg-background/50 border-t border-border flex-wrap">
+          {/* Indicators */}
+          <div className="flex items-center rounded-md border border-border overflow-hidden">
+            {(["bars", "classic", "none"] as const).map(v => (
+              <button key={v} onClick={() => setDiffIndicators(v)}
+                className={cn("h-6 px-2 text-[10px] capitalize", diffIndicators === v ? "bg-secondary text-foreground" : "text-muted-foreground hover:text-foreground")}>
+                {v.charAt(0).toUpperCase() + v.slice(1)}
+              </button>
+            ))}
+          </div>
+
+          {/* Line diff type */}
+          <select value={lineDiffType} onChange={e => setLineDiffType(e.target.value as any)}
+            className="h-6 bg-card border border-border rounded-md px-1.5 text-[10px] text-foreground outline-none">
+            {(["word-alt", "word", "char", "none"] as const).map(v => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+
+          {/* Hunk separators */}
+          <select value={hunkSeparators} onChange={e => setHunkSeparators(e.target.value as any)}
+            className="h-6 bg-card border border-border rounded-md px-1.5 text-[10px] text-foreground outline-none">
+            {(["line-info", "line-info-basic", "metadata", "simple"] as const).map(v => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+
+          {/* Theme */}
+          <select value={theme} onChange={e => setTheme(e.target.value)}
+            className="h-6 bg-card border border-border rounded-md px-1.5 text-[10px] text-foreground outline-none">
+            <optgroup label="Pierre">
+              <option value="pierre-dark">pierre-dark</option>
+              <option value="pierre-light">pierre-light</option>
+            </optgroup>
+            <optgroup label="GitHub">
+              <option value="github-dark">github-dark</option>
+              <option value="github-dark-default">github-dark-default</option>
+              <option value="github-dark-dimmed">github-dark-dimmed</option>
+              <option value="github-light">github-light</option>
+              <option value="github-light-default">github-light-default</option>
+            </optgroup>
+            <optgroup label="Popular">
+              <option value="dracula">dracula</option>
+              <option value="dracula-soft">dracula-soft</option>
+              <option value="monokai">monokai</option>
+              <option value="nord">nord</option>
+              <option value="one-dark-pro">one-dark-pro</option>
+              <option value="tokyo-night">tokyo-night</option>
+              <option value="night-owl">night-owl</option>
+              <option value="vitesse-dark">vitesse-dark</option>
+              <option value="vitesse-light">vitesse-light</option>
+              <option value="poimandres">poimandres</option>
+              <option value="rose-pine">rose-pine</option>
+              <option value="rose-pine-moon">rose-pine-moon</option>
+              <option value="catppuccin-mocha">catppuccin-mocha</option>
+              <option value="catppuccin-frappe">catppuccin-frappe</option>
+              <option value="solarized-dark">solarized-dark</option>
+              <option value="solarized-light">solarized-light</option>
+              <option value="min-dark">min-dark</option>
+              <option value="min-light">min-light</option>
+              <option value="synthwave-84">synthwave-84</option>
+              <option value="houston">houston</option>
+              <option value="vesper">vesper</option>
+            </optgroup>
+            <optgroup label="Material">
+              <option value="material-theme">material-theme</option>
+              <option value="material-theme-darker">material-theme-darker</option>
+              <option value="material-theme-ocean">material-theme-ocean</option>
+              <option value="material-theme-palenight">material-theme-palenight</option>
+            </optgroup>
+          </select>
+
+          {/* Font size */}
+          <select value={fontSize} onChange={e => setFontSize(Number(e.target.value))}
+            className="h-6 bg-card border border-border rounded-md px-1.5 text-[10px] text-foreground outline-none">
+            {[11, 12, 13, 14, 15, 16].map(v => (
+              <option key={v} value={v}>{v}px</option>
+            ))}
+          </select>
+
+          <Separator orientation="vertical" className="h-4" />
+
+          {/* Toggles with proper Switch */}
+          <label className="flex items-center gap-1.5 text-[10px] text-foreground cursor-pointer">
+            <Switch checked={!disableBackground} onCheckedChange={c => setDisableBackground(!c)} />
+            Backgrounds
+          </label>
+          <label className="flex items-center gap-1.5 text-[10px] text-foreground cursor-pointer">
+            <Switch checked={overflow === "wrap"} onCheckedChange={c => setOverflow(c ? "wrap" : "scroll")} />
+            Wrapping
+          </label>
+          <label className="flex items-center gap-1.5 text-[10px] text-foreground cursor-pointer">
+            <Switch checked={!disableLineNumbers} onCheckedChange={c => setDisableLineNumbers(!c)} />
+            Line Numbers
+          </label>
         </div>
 
         {mode === "commits" && (
@@ -422,7 +577,7 @@ export function App() {
       ) : (
         <div className="flex flex-1 overflow-hidden">
           {/* ── File tree panel ─────────────────────────────────── */}
-          <aside className="flex w-[280px] flex-shrink-0 flex-col overflow-hidden">
+          <aside className="flex flex-shrink-0 flex-col overflow-hidden" style={{ width: explorer.width }}>
             <div className="flex-1 overflow-hidden p-2">
               <FileTree
                 className="dark min-h-0 flex-1 overflow-auto rounded-lg py-3 border border-neutral-200 dark:border-neutral-800"
@@ -461,169 +616,412 @@ export function App() {
             )}
           </aside>
 
+          {/* Resize handle (from @pierre/trees TreeApp pattern) */}
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize explorer"
+            onPointerDown={explorer.onPointerDown}
+            onPointerMove={explorer.onPointerMove}
+            onPointerUp={explorer.onPointerUp}
+            onPointerCancel={explorer.onPointerUp}
+            className="relative block w-px shrink-0 cursor-col-resize bg-white/0 after:absolute after:inset-y-0 after:-left-1 after:w-2 after:content-['']" />
+
           {/* ── Diff panes ─────────────────────────────────────── */}
           <main ref={scrollRef} className="flex-1 overflow-y-auto">
             <div className="p-4 space-y-4">
-              {committedChunks.map(chunk => (
-                <FileBlock key={`c-${chunk.path}`} chunk={chunk} diffStyle={diffStyle}
-                  comments={comments} onComment={openComment}
-                  onEditComment={editComment} onDeleteComment={deleteComment} />
-              ))}
-              {stagedChunks.length > 0 && (
-                <div className="px-4 py-1.5 bg-card text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Staged</div>
-              )}
-              {stagedChunks.map(chunk => (
-                <FileBlock key={`s-${chunk.path}`} chunk={chunk} diffStyle={diffStyle}
-                  comments={comments} onComment={openComment}
-                  onEditComment={editComment} onDeleteComment={deleteComment} />
-              ))}
-              {unstagedChunks.length > 0 && (
-                <div className="px-4 py-1.5 bg-card text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">Unstaged</div>
-              )}
-              {unstagedChunks.map(chunk => (
-                <FileBlock key={`u-${chunk.path}`} chunk={chunk} diffStyle={diffStyle}
-                  comments={comments} onComment={openComment}
-                  onEditComment={editComment} onDeleteComment={deleteComment} />
-              ))}
+              {(() => {
+                const sorted = [...diffData.files].sort((a, b) => {
+                  const aParts = a.name.split("/");
+                  const bParts = b.name.split("/");
+                  const len = Math.min(aParts.length, bParts.length);
+                  for (let i = 0; i < len; i++) {
+                    const aIsDir = i < aParts.length - 1;
+                    const bIsDir = i < bParts.length - 1;
+                    if (aIsDir && !bIsDir) return -1;
+                    if (!aIsDir && bIsDir) return 1;
+                    const cmp = aParts[i].localeCompare(bParts[i]);
+                    if (cmp !== 0) return cmp;
+                  }
+                  return aParts.length - bParts.length;
+                });
+
+                return sorted.map(file => (
+                  <FileBlock key={`${file.area[0]}-${file.name}`}
+                    oldFile={{ name: file.name, contents: file.oldContents || "" }}
+                    newFile={{ name: file.name, contents: file.newContents || "" }}
+                    path={file.name}
+                    diffStyle={diffStyle}
+                    diffIndicators={diffIndicators}
+                    lineDiffType={lineDiffType}
+                    disableBackground={disableBackground}
+                    overflow={overflow}
+                    disableLineNumbers={disableLineNumbers}
+                    hunkSeparators={hunkSeparators}
+                    fontSize={fontSize}
+                    theme={theme}
+                    area={file.area !== "committed" ? file.area : undefined}
+                    comments={comments} openForms={openForms} hasOpenForm={hasOpenForm}
+                    onAddCommentForm={addCommentForm} onSubmitComment={submitComment} onCancelCommentForm={cancelCommentForm}
+                    onEditComment={editComment} onDeleteComment={deleteComment}
+                    onResolveComment={resolveComment} onReplyComment={replyToComment} />
+                ));
+              })()}
             </div>
           </main>
         </div>
       )}
 
-      {/* ── Comment modal ──────────────────────────────────────── */}
-      {commentDraft && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setCommentDraft(null)}>
-          <div className="w-[480px] rounded-lg border border-border bg-card shadow-2xl" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-              <div>
-                <div className="text-sm font-medium">{commentDraft.editIndex !== undefined ? "Edit comment" : "Add comment"}</div>
-                <div className="text-[11px] text-muted-foreground font-mono mt-0.5">
-                  {commentDraft.file}{commentDraft.line > 0 ? ` line ${commentDraft.line}` : ""}
-                </div>
-              </div>
-              <button onClick={() => setCommentDraft(null)} className="text-muted-foreground hover:text-foreground">
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            <div className="p-4">
-              <textarea
-                className="w-full bg-background border border-border rounded-md px-3 py-2 text-sm outline-none focus:ring-1 focus:ring-ring resize-none"
-                rows={4} value={commentText} onChange={e => setCommentText(e.target.value)}
-                placeholder="Write your comment…" autoFocus
-                onKeyDown={e => {
-                  if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) saveComment();
-                  if (e.key === "Escape") setCommentDraft(null);
-                }}
-              />
-            </div>
-            <div className="flex items-center justify-between px-4 py-2.5 border-t border-border">
-              <span className="text-[10px] text-muted-foreground">⌘+Enter to submit</span>
-              <div className="flex gap-2">
-                <Button variant="ghost" size="sm" onClick={() => setCommentDraft(null)}>Cancel</Button>
-                <Button size="sm" onClick={saveComment} disabled={!commentText.trim()}>
-                  {commentDraft.editIndex !== undefined ? "Save" : "Add"}
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+
     </div>
+    </WorkerPoolContextProvider>
   );
+}
+
+// ── useExplorerWidth (from @pierre/trees TreeApp) ───────────────────
+
+function useExplorerWidth(initial: number, min: number, max: number) {
+  const clamp = useCallback(
+    (value: number) => Math.max(min, Math.min(max, value)),
+    [max, min],
+  );
+  const [width, setWidth] = useState(() => clamp(initial));
+  const dragStateRef = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      dragStateRef.current = { startWidth: width, startX: event.clientX };
+    },
+    [width],
+  );
+
+  const onPointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      const dragState = dragStateRef.current;
+      if (dragState == null) return;
+      const delta = event.clientX - dragState.startX;
+      setWidth(clamp(dragState.startWidth + delta));
+    },
+    [clamp],
+  );
+
+  const endDrag = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (dragStateRef.current == null) return;
+    dragStateRef.current = null;
+    const handle = event.currentTarget;
+    if (handle.hasPointerCapture(event.pointerId)) {
+      handle.releasePointerCapture(event.pointerId);
+    }
+  }, []);
+
+  return { onPointerDown, onPointerMove, onPointerUp: endDrag, width };
 }
 
 // ── FileBlock ───────────────────────────────────────────────────────
 
-function FileBlock({ chunk, diffStyle, comments, onComment, onEditComment, onDeleteComment }: {
-  chunk: { path: string; patch: string };
+function FileBlock({ oldFile, newFile, path, diffStyle, diffIndicators, lineDiffType, disableBackground, overflow, disableLineNumbers, hunkSeparators, fontSize, theme, area, comments, openForms, hasOpenForm, onAddCommentForm, onSubmitComment, onCancelCommentForm, onEditComment, onDeleteComment, onResolveComment, onReplyComment }: {
+  oldFile: FileContents;
+  newFile: FileContents;
+  path: string;
   diffStyle: "unified" | "split";
+  diffIndicators: "bars" | "classic" | "none";
+  lineDiffType: "word-alt" | "word" | "char" | "none";
+  disableBackground: boolean;
+  overflow: "scroll" | "wrap";
+  disableLineNumbers: boolean;
+  hunkSeparators: "line-info" | "line-info-basic" | "metadata" | "simple";
+  fontSize: number;
+  theme: string;
+  area?: "staged" | "unstaged";
   comments: ReviewComment[];
-  onComment: (file: string, line: number) => void;
+  openForms: Array<{ file: string; side: "deletions" | "additions"; lineNumber: number }>;
+  hasOpenForm: boolean;
+  onAddCommentForm: (file: string, side: "deletions" | "additions", lineNumber: number) => void;
+  onSubmitComment: (file: string, side: "deletions" | "additions", lineNumber: number, body: string) => void;
+  onCancelCommentForm: (file: string, side: "deletions" | "additions", lineNumber: number) => void;
   onEditComment: (index: number) => void;
   onDeleteComment: (index: number) => void;
+  onResolveComment: (index: number) => void;
+  onReplyComment: (index: number, body: string) => void;
 }) {
   const [selectedRange, setSelectedRange] = useState<{ start: number; end: number; side?: string; endSide?: string } | null>(null);
-  const fileComments = useMemo(
-    () => comments.map((c, i) => ({ ...c, globalIndex: i })).filter(c => c.file === chunk.path),
-    [comments, chunk.path],
-  );
+  const [collapsed, setCollapsed] = useState(false);
 
-  // Build lineAnnotations for @pierre/diffs — inserts comments at the correct line
-  const lineAnnotations = useMemo(() =>
-    fileComments.map(c => ({
-      side: "additions" as const,
-      lineNumber: c.line,
-      metadata: c,
-    })),
-    [fileComments],
-  );
+  // Build lineAnnotations: combine open forms + submitted comments
+  const lineAnnotations = useMemo(() => {
+    const annotations: Array<{ side: "deletions" | "additions"; lineNumber: number; metadata: any }> = [];
+
+    // Open comment forms for this file
+    for (const form of openForms) {
+      if (form.file === path) {
+        annotations.push({
+          side: form.side,
+          lineNumber: form.lineNumber,
+          metadata: { type: "form" as const, file: path, side: form.side, lineNumber: form.lineNumber },
+        });
+      }
+    }
+
+    // Submitted comments for this file
+    comments.forEach((c, i) => {
+      if (c.file === path && !c.resolved) {
+        annotations.push({
+          side: "additions" as const,
+          lineNumber: c.line,
+          metadata: { type: "thread" as const, comment: c, globalIndex: i },
+        });
+      }
+    });
+
+    return annotations;
+  }, [openForms, comments, path]);
+
+  const handleLineSelectionEnd = useCallback((range: { start: number; end: number; side?: string; endSide?: string } | null) => {
+    setSelectedRange(range);
+    if (!range) return;
+    const derivedSide = range.endSide ?? range.side;
+    const side: "deletions" | "additions" = derivedSide === "deletions" ? "deletions" : "additions";
+    onAddCommentForm(path, side, Math.max(range.end, range.start));
+  }, [path, onAddCommentForm]);
 
   const options = useMemo(() => ({
-    theme: "min-dark" as const,
+    theme: theme as any,
     themeType: "dark" as const,
     diffStyle,
-    disableFileHeader: true,
-    overflow: "scroll" as const,
-    unsafeCSS: `pre, [data-code], [data-gutter], [data-content], [data-separator-wrapper], [data-gutter-buffer] { background-color: oklch(0.145 0 0) !important; }
-[data-separator], [data-separator-content] { background-color: oklch(0.178 0 0) !important; }
-[data-line][data-line-type] { background-color: transparent !important; }
-[data-diff-type="split"] [data-code][data-additions]::-webkit-scrollbar-track { margin-right: 6px }
-[data-diff-type="split"] [data-code][data-deletions]::-webkit-scrollbar-track { margin-left: 6px }
-[data-file] [data-code]::-webkit-scrollbar-track, [data-diff-type="single"] [data-code]::-webkit-scrollbar-track { margin-inline: 6px; }`,
-    enableLineSelection: true,
-    enableGutterUtility: true,
-    onLineSelectionEnd: (range: { start: number; end: number; side?: string; endSide?: string } | null) => {
-      setSelectedRange(range);
-      if (!range) return;
-      const line = Math.max(range.start, range.end);
-      onComment(chunk.path, line);
-    },
-  }), [diffStyle, chunk.path, onComment]);
+    diffIndicators,
+    lineDiffType,
+    disableBackground,
+    overflow,
+    disableLineNumbers,
+    hunkSeparators,
+    expandUnchanged: false,
+    collapsed,
+    enableLineSelection: !hasOpenForm,
+    enableGutterUtility: !hasOpenForm,
+    onLineSelectionEnd: handleLineSelectionEnd,
+  }), [diffStyle, diffIndicators, lineDiffType, disableBackground, overflow, disableLineNumbers, hunkSeparators, collapsed, theme, hasOpenForm, handleLineSelectionEnd]);
 
   return (
-    <div data-diff-file={chunk.path} className="overflow-hidden rounded-lg border border-neutral-800">
-      {/* File header */}
-      <div className="flex items-center justify-between px-4 py-1.5 bg-card border-b border-neutral-800 sticky top-0 z-[1]">
-        <span className="text-xs font-mono text-foreground">{chunk.path}</span>
-        <Button variant="ghost" size="sm" className="h-6 gap-1 text-[10px] text-muted-foreground"
-          onClick={() => onComment(chunk.path, 0)}>
-          <MessageSquarePlus className="h-3 w-3" /> Comment
-        </Button>
-      </div>
-
-      {/* Diff with inline annotations */}
-      <PatchDiff
-        patch={chunk.patch}
+    <div data-diff-file={path} className="overflow-hidden rounded-lg border border-neutral-800">
+      <MultiFileDiff
+        oldFile={oldFile}
+        newFile={newFile}
         options={options}
+        style={{ fontSize }}
         selectedLines={selectedRange}
         lineAnnotations={lineAnnotations}
+        renderHeaderMetadata={() => (
+          <div className="ml-auto flex items-center gap-2 pr-2">
+            {area && (
+              <span className={cn(
+                "rounded px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wider",
+                area === "staged" ? "bg-green-500/15 text-green-400" : "bg-yellow-500/15 text-yellow-400",
+              )}>
+                {area}
+              </span>
+            )}
+            <button onClick={() => setCollapsed(c => !c)}
+              className="cursor-pointer px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:text-foreground">
+              {collapsed ? "Expand" : "Collapse"}
+            </button>
+          </div>
+        )}
         renderAnnotation={(annotation) => {
-          const c = (annotation as any).metadata;
-          if (!c) return null;
-          return (
-            <div style={{ overflow: "hidden", display: "flex", flexDirection: "row", gap: 1 }}>
-              <div style={{ width: "100%" }}>
-                <div className="max-w-[95%] sm:max-w-[70%]" style={{ whiteSpace: "normal", margin: 20, fontFamily: "Geist Variable, sans-serif" }}>
-                  <div className="bg-card rounded-lg border p-4 shadow-sm group">
-                    <div className="flex gap-2">
-                      <MessageSquarePlus className="h-4 w-4 text-blue-400 mt-0.5 flex-shrink-0" />
-                      <div className="flex-1 min-w-0">
-                        <p className="text-foreground text-sm leading-relaxed">{c.body}</p>
-                        <div className="mt-2 flex items-center gap-2">
-                          <Button size="sm" variant="ghost" className="h-7 text-xs text-muted-foreground"
-                            onClick={() => onEditComment(c.globalIndex)}>Edit</Button>
-                          <button onClick={() => onDeleteComment(c.globalIndex)}
-                            className="text-muted-foreground hover:text-red-400 text-xs px-2 py-1 transition-colors">Delete</button>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
+          const meta = (annotation as any).metadata;
+          if (!meta) return null;
+
+          if (meta.type === "form") {
+            return <InlineCommentForm
+              file={meta.file} side={meta.side} lineNumber={meta.lineNumber}
+              onSubmit={onSubmitComment} onCancel={onCancelCommentForm} />;
+          }
+
+          if (meta.type === "thread") {
+            return <InlineComment comment={meta.comment} globalIndex={meta.globalIndex}
+              onEdit={onEditComment} onDelete={onDeleteComment} onResolve={onResolveComment} onReply={onReplyComment} />;
+          }
+
+          return null;
+        }}
+      />
+    </div>
+  );
+}
+
+// Annotation components following @pierre/diffs Annotations example pattern.
+// Outer wrapper uses inline styles (required by @pierre/diffs annotation slot),
+// inner content uses tailwind classes exclusively.
+
+function InlineCommentForm({ file, side, lineNumber, onSubmit, onCancel }: {
+  file: string;
+  side: "deletions" | "additions";
+  lineNumber: number;
+  onSubmit: (file: string, side: "deletions" | "additions", lineNumber: number, body: string) => void;
+  onCancel: (file: string, side: "deletions" | "additions", lineNumber: number) => void;
+}) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [text, setText] = useState("");
+
+  useEffect(() => {
+    setTimeout(() => { textareaRef.current?.focus(); }, 0);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    onSubmit(file, side, lineNumber, text);
+  }, [file, side, lineNumber, text, onSubmit]);
+
+  const handleCancel = useCallback(() => {
+    onCancel(file, side, lineNumber);
+  }, [file, side, lineNumber, onCancel]);
+
+  return (
+    <div style={{ overflow: "hidden", display: "flex", flexDirection: "row", gap: 1 }}>
+      <div style={{ width: "100%" }}>
+        <div className="max-w-[95%] sm:max-w-[70%]" style={{ whiteSpace: "normal", margin: 20, fontFamily: "Geist Variable, sans-serif" }}>
+          <div className="bg-card rounded-lg border p-5 shadow-sm">
+            <div className="flex gap-2">
+              <div className="relative -mt-0.5 flex-shrink-0">
+                <div className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-500 text-xs font-bold text-white">Y</div>
+              </div>
+              <div className="flex-1">
+                <textarea
+                  ref={textareaRef}
+                  value={text}
+                  onChange={e => setText(e.target.value)}
+                  placeholder="Leave a comment"
+                  className="min-h-[60px] w-full resize-none rounded-md border bg-background p-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                  onKeyDown={e => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSubmit();
+                    if (e.key === "Escape") handleCancel();
+                  }}
+                />
+                <div className="mt-3 flex items-center gap-2">
+                  <Button size="sm" className="cursor-pointer" onClick={handleSubmit} disabled={!text.trim()}>
+                    Comment
+                  </Button>
+                  <button onClick={handleCancel}
+                    className="cursor-pointer px-3 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground">
+                    Cancel
+                  </button>
                 </div>
               </div>
             </div>
-          );
-        }}
-      />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function InlineComment({ comment, globalIndex, onEdit, onDelete, onResolve, onReply }: {
+  comment: ReviewComment;
+  globalIndex: number;
+  onEdit: (index: number) => void;
+  onDelete: (index: number) => void;
+  onResolve: (index: number) => void;
+  onReply: (index: number, body: string) => void;
+}) {
+  const [replying, setReplying] = useState(false);
+  const [replyText, setReplyText] = useState("");
+  const replyRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (replying) setTimeout(() => replyRef.current?.focus(), 0);
+  }, [replying]);
+
+  const handleSubmitReply = useCallback(() => {
+    if (!replyText.trim()) return;
+    onReply(globalIndex, replyText.trim());
+    setReplyText("");
+    setReplying(false);
+  }, [globalIndex, replyText, onReply]);
+
+  return (
+    <div className="max-w-[95%] sm:max-w-[70%]" style={{ whiteSpace: "normal", margin: 20, fontFamily: "Geist Variable, sans-serif" }}>
+      <div className="bg-card rounded-lg border p-5 shadow-sm">
+        {/* Main comment */}
+        <div className="flex gap-2">
+          <div className="relative -mt-0.5 flex-shrink-0">
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-500 text-xs font-bold text-white">Y</div>
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2">
+              <span className="font-semibold text-foreground">You</span>
+              <span className="text-sm text-muted-foreground">now</span>
+            </div>
+            <p className="leading-relaxed text-foreground">{comment.body}</p>
+          </div>
+        </div>
+
+        {/* Replies */}
+        {comment.replies && comment.replies.length > 0 && (
+          <div className="ml-8 mt-4 space-y-4 sm:ml-[32px]">
+            {comment.replies.map((reply, i) => (
+              <div key={i} className="flex gap-2">
+                <div className="relative -mt-0.5 flex-shrink-0">
+                  <div className="flex h-6 w-6 items-center justify-center rounded-full bg-emerald-600 text-xs font-bold text-white">
+                    {(reply.author || "pi")[0].toUpperCase()}
+                  </div>
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-baseline gap-2">
+                    <span className="font-semibold text-foreground">{reply.author || "pi"}</span>
+                    <span className="text-sm text-muted-foreground">{reply.timestamp || ""}</span>
+                  </div>
+                  <p className="leading-relaxed text-foreground">{reply.body}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Reply form */}
+        {replying && (
+          <div className="ml-8 mt-4 sm:ml-[32px]">
+            <textarea
+              ref={replyRef}
+              value={replyText}
+              onChange={e => setReplyText(e.target.value)}
+              placeholder="Write a reply..."
+              className="min-h-[60px] w-full resize-none rounded-md border bg-background p-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+              onKeyDown={e => {
+                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) handleSubmitReply();
+                if (e.key === "Escape") { setReplying(false); setReplyText(""); }
+              }}
+            />
+            <div className="mt-2 flex items-center gap-2">
+              <Button size="sm" className="cursor-pointer" onClick={handleSubmitReply} disabled={!replyText.trim()}>Reply</Button>
+              <button onClick={() => { setReplying(false); setReplyText(""); }}
+                className="cursor-pointer px-3 py-1 text-sm text-muted-foreground transition-colors hover:text-foreground">Cancel</button>
+            </div>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="ml-8 mt-4 flex items-center gap-4 sm:ml-[32px]">
+          {!replying && (
+            <button onClick={() => setReplying(true)}
+              className="cursor-pointer text-sm text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
+              Add reply...
+            </button>
+          )}
+          <button onClick={() => onEdit(globalIndex)}
+            className="cursor-pointer text-sm text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
+            Edit
+          </button>
+          <button onClick={() => onDelete(globalIndex)}
+            className="cursor-pointer text-sm text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
+            Delete
+          </button>
+          <button onClick={() => onResolve(globalIndex)}
+            className="cursor-pointer text-sm text-blue-600 transition-colors hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
+            Resolve
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/extensions/orchestrator/pidiff-ui/src/components/ui/switch.tsx
+++ b/extensions/orchestrator/pidiff-ui/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as SwitchPrimitives from '@radix-ui/react-switch';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      'peer focus-visible:ring-ring focus-visible:ring-offset-background data-[state=checked]:bg-primary data-[state=unchecked]:bg-input inline-flex h-4 w-6 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        'bg-background pointer-events-none block h-3 w-3 rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-2 data-[state=unchecked]:translate-x-0'
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/extensions/orchestrator/pidiff-ui/src/types.ts
+++ b/extensions/orchestrator/pidiff-ui/src/types.ts
@@ -1,8 +1,10 @@
-export type DiffMode = "working" | "branch" | "commits";
+export type DiffMode = "branch" | "commits";
 
-export interface FileChange {
-  path: string;
-  status: "added" | "modified" | "deleted" | "renamed" | "untracked";
+export interface FileDiffData {
+  name: string;
+  oldContents: string;
+  newContents: string;
+  status: "added" | "modified" | "deleted" | "renamed";
   area: "staged" | "unstaged" | "committed";
 }
 
@@ -15,11 +17,8 @@ export interface GitCommit {
 
 export interface DiffData {
   mode: DiffMode;
-  staged: string;
-  unstaged: string;
-  committed: string;
+  files: FileDiffData[];
   branch: string;
-  files: FileChange[];
   fromRef?: string;
   toRef?: string;
 }
@@ -31,9 +30,17 @@ export interface PiSession {
   repo: string;
 }
 
+export interface ReviewCommentReply {
+  author: string;
+  body: string;
+  timestamp?: string;
+}
+
 export interface ReviewComment {
   file: string;
   line: number;
   side: "old" | "new";
   body: string;
+  replies?: ReviewCommentReply[];
+  resolved?: boolean;
 }

--- a/extensions/orchestrator/pidiff.ts
+++ b/extensions/orchestrator/pidiff.ts
@@ -147,22 +147,21 @@ export function registerPidiff(pi: ExtensionAPI): void {
           const parsed = JSON.parse(data.toString());
           if (parsed.type === "publish-review" && parsed.comments?.length > 0) {
             log(`review received: ${parsed.comments.length} comments`);
-            const lines: string[] = ["## Code Review Comments", ""];
-            const byFile = new Map<string, Array<{ line: number; body: string }>>();
-            for (const c of parsed.comments) {
-              if (!byFile.has(c.file)) byFile.set(c.file, []);
-              byFile.get(c.file)!.push(c);
-            }
-            for (const [file, comments] of byFile) {
-              lines.push(`### ${file}`);
-              for (const c of comments) {
-                lines.push(c.line > 0 ? `**Line ${c.line}:** ${c.body}` : `**File comment:** ${c.body}`);
-              }
-              lines.push("");
-            }
-            if (parsed.summary) lines.push(`### Summary`, parsed.summary, "");
-            lines.push("Please address these review comments.");
-            pi.sendUserMessage(lines.join("\n"), { deliverAs: "followUp" });
+            const review = {
+              source: "pidiff",
+              type: "code-review",
+              comments: parsed.comments.map((c: any) => ({
+                file: c.file,
+                line: c.line,
+                side: c.side,
+                body: c.body,
+                ...(c.replies?.length ? { replies: c.replies } : {}),
+                ...(c.resolved ? { resolved: true } : {}),
+              })),
+              ...(parsed.summary ? { summary: parsed.summary } : {}),
+            };
+            const message = `## pidiff: Code Review Comments\n\n\`\`\`json\n${JSON.stringify(review, null, 2)}\n\`\`\`\n\nPlease address these review comments.`;
+            pi.sendUserMessage(message, { deliverAs: "followUp" });
           }
         } catch {}
       });

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -13,7 +13,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
-import { execSync } from "node:child_process";
+import { serveUi } from "./serve-ui.ts";
 
 const DEFAULT_PORT = 19190;
 const port = parseInt(process.env.PI_PIDASH_PORT || "", 10) || DEFAULT_PORT;
@@ -94,64 +94,7 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     return;
   }
 
-  // Serve static files from dist/
-  const MIME: Record<string, string> = {
-    ".html": "text/html", ".js": "application/javascript",
-    ".css": "text/css", ".json": "application/json",
-    ".woff2": "font/woff2", ".woff": "font/woff",
-    ".svg": "image/svg+xml", ".png": "image/png",
-  };
-
-  let filePath = url.pathname === "/" ? "/index.html" : url.pathname;
-  const absPath = path.join(UI_DIR, filePath);
-
-  // Security: prevent directory traversal
-  if (!absPath.startsWith(UI_DIR)) {
-    res.writeHead(403); res.end("Forbidden"); return;
-  }
-
-  try {
-    const data = fs.readFileSync(absPath);
-    const ext = path.extname(absPath).toLowerCase();
-    const headers: Record<string, string> = { "Content-Type": MIME[ext] || "application/octet-stream" };
-    // No cache for HTML, long cache for hashed assets
-    if (ext === ".html") {
-      headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
-    } else if (filePath.includes("/assets/")) {
-      headers["Cache-Control"] = "public, max-age=31536000, immutable";
-    }
-    res.writeHead(200, headers);
-    res.end(data);
-  } catch {
-    // SPA fallback — serve index.html for unknown routes
-    try {
-      const html = fs.readFileSync(path.join(UI_DIR, "index.html"));
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(html);
-    } catch {
-      // dist/ missing — try to build it
-      const uiSrcDir = path.join(UI_DIR, "..");
-      if (fs.existsSync(path.join(uiSrcDir, "package.json"))) {
-        try {
-          log("dist/ missing, building pidash-ui...");
-          execSync("npm install --production=false && npm run build", {
-            cwd: uiSrcDir,
-            stdio: "ignore",
-            timeout: 60000,
-          });
-          log("pidash-ui build complete");
-          const html = fs.readFileSync(path.join(UI_DIR, "index.html"));
-          res.writeHead(200, { "Content-Type": "text/html" });
-          res.end(html);
-          return;
-        } catch (buildErr: any) {
-          log(`pidash-ui build failed: ${buildErr.message}`);
-        }
-      }
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end("<h1>pidash</h1><p>UI build failed. Run <code>/pidash restart</code> from the pi TUI, then refresh this page.</p>");
-    }
-  }
+  serveUi(url.pathname, res, { uiDir: UI_DIR, name: "pidash-ui", log });
 });
 
 // ── WebSocket Server ────────────────────────────────────────────────

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -30,8 +30,20 @@ function log(msg: string) {
 
 const GIT_OPTS = { encoding: "utf-8" as const, timeout: 3000, stdio: ["ignore", "pipe", "ignore"] as const, maxBuffer: 10 * 1024 * 1024 };
 
+// Resolve git binary — PATH may be stripped when spawned as a daemon
+const GIT_BIN = (() => {
+  // Try PATH first
+  try { execFileSync("git", ["--version"], { stdio: "ignore" }); return "git"; } catch {}
+  // Common locations
+  for (const p of ["/home/linuxbrew/.linuxbrew/bin/git", "/opt/homebrew/bin/git", "/usr/local/bin/git", "/usr/bin/git"]) {
+    try { execFileSync(p, ["--version"], { stdio: "ignore" }); return p; } catch {}
+  }
+  log("WARNING: git binary not found — diffs will fail");
+  return "git";
+})();
+
 function gitExec(args: string[], cwd: string): string {
-  return execFileSync("git", args, { ...GIT_OPTS, cwd }).trim();
+  return execFileSync(GIT_BIN, args, { ...GIT_OPTS, cwd }).trim();
 }
 
 function getDefaultRemoteBranch(cwd: string): string {
@@ -58,64 +70,7 @@ function getStatus(cwd: string): { dirty: boolean; changes: number } {
   } catch { return { dirty: false, changes: 0 }; }
 }
 
-function getDiff(cwd: string): { staged: string; unstaged: string } {
-  try {
-    const staged = gitExec(["diff", "--staged"], cwd);
-    let unstaged = gitExec(["diff"], cwd);
 
-    // Include untracked files in the unstaged diff
-    try {
-      const untrackedRaw = gitExec(["ls-files", "--others", "--exclude-standard"], cwd);
-      if (untrackedRaw) {
-        const untrackedFiles = untrackedRaw.split("\n").filter(Boolean);
-        for (const file of untrackedFiles) {
-          try {
-            const content = execFileSync("git", ["diff", "--no-index", "--", "/dev/null", file], {
-              cwd, encoding: "utf-8", timeout: 3000,
-              stdio: ["ignore", "pipe", "ignore"], maxBuffer: 2 * 1024 * 1024,
-            }).trim();
-            if (content) unstaged += (unstaged ? "\n" : "") + content;
-          } catch (e: any) {
-            // git diff --no-index exits with code 1 when files differ (expected)
-            if (e.stdout) unstaged += (unstaged ? "\n" : "") + e.stdout.toString().trim();
-          }
-        }
-      }
-    } catch (e: any) {
-      log(`untracked files diff error: ${e.message}`);
-    }
-
-    return { staged, unstaged };
-  } catch (e: any) { log(`getDiff error: ${e.message}`); return { staged: "", unstaged: "" }; }
-}
-
-function getBranchDiff(cwd: string): string {
-  try {
-    const defaultBranch = getDefaultRemoteBranch(cwd);
-    if (!defaultBranch) return "";
-    const base = gitExec(["merge-base", defaultBranch, "HEAD"], cwd);
-    if (!base) return "";
-    return execFileSync("git", ["diff", base, "HEAD"], {
-      cwd, encoding: "utf-8", timeout: 5000,
-      stdio: ["ignore", "pipe", "ignore"], maxBuffer: 2 * 1024 * 1024,
-    }).trim();
-  } catch (e: any) { log(`getBranchDiff error: ${e.message}`); return ""; }
-}
-
-function getCommitDiff(cwd: string, fromRef: string, toRef: string): string {
-  try {
-    // Validate refs are hex hashes to prevent flag injection
-    const hexRef = /^[a-fA-F0-9]{4,40}$/;
-    if (!hexRef.test(fromRef) || !hexRef.test(toRef)) {
-      log(`getCommitDiff: invalid ref format: ${fromRef} / ${toRef}`);
-      return "";
-    }
-    return execFileSync("git", ["diff", "--", fromRef, toRef], {
-      cwd, encoding: "utf-8", timeout: 5000,
-      stdio: ["ignore", "pipe", "ignore"], maxBuffer: 2 * 1024 * 1024,
-    }).trim();
-  } catch (e: any) { log(`getCommitDiff error: ${e.message}`); return ""; }
-}
 
 function getLog(cwd: string, count: number = 30): Array<{ hash: string; short: string; subject: string; date: string }> {
   count = Math.min(count, 100); // Clamp to prevent DoS
@@ -136,43 +91,118 @@ function getLog(cwd: string, count: number = 30): Array<{ hash: string; short: s
   } catch (e: any) { log(`getLog error: ${e.message}`); return []; }
 }
 
+// ── File-contents diff helpers ───────────────────────────────────────
+
+interface FileContentsData {
+  name: string;
+  oldContents: string;
+  newContents: string;
+  status: "added" | "modified" | "deleted" | "renamed";
+}
+
+function getChangedFiles(cwd: string, baseRef: string, headRef: string = "HEAD"): FileContentsData[] {
+  try {
+    const raw = gitExec(["diff", "--name-status", baseRef, headRef], cwd);
+    if (!raw) return [];
+    const results: FileContentsData[] = [];
+    for (const line of raw.split("\n").filter(Boolean)) {
+      const parts = line.split("\t");
+      const statusChar = parts[0][0];
+      const fileName = parts.length > 2 ? parts[2] : parts[1];
+      const oldName = parts.length > 2 ? parts[1] : fileName;
+      let status: FileContentsData["status"] = "modified";
+      if (statusChar === "A") status = "added";
+      else if (statusChar === "D") status = "deleted";
+      else if (statusChar === "R") status = "renamed";
+      let oldContents = "";
+      let newContents = "";
+      try { if (status !== "added") oldContents = execFileSync(GIT_BIN, ["show", `${baseRef}:${oldName}`], { cwd, encoding: "utf-8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], maxBuffer: 5 * 1024 * 1024 }); } catch {}
+      try {
+        if (status !== "deleted") {
+          newContents = execFileSync(GIT_BIN, ["show", `${headRef}:${fileName}`], { cwd, encoding: "utf-8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], maxBuffer: 5 * 1024 * 1024 });
+        }
+      } catch {}
+      results.push({ name: fileName, oldContents, newContents, status });
+    }
+    return results;
+  } catch (e: any) { log(`getChangedFiles error: ${e.message}`); return []; }
+}
+
+function getWorkingTreeFiles(cwd: string): { staged: FileContentsData[]; unstaged: FileContentsData[] } {
+  const staged: FileContentsData[] = [];
+  const unstaged: FileContentsData[] = [];
+  try {
+    const stagedRaw = gitExec(["diff", "--name-status", "--staged"], cwd);
+    if (stagedRaw) {
+      for (const line of stagedRaw.split("\n").filter(Boolean)) {
+        const parts = line.split("\t");
+        const statusChar = parts[0][0];
+        const fileName = parts.length > 2 ? parts[2] : parts[1];
+        const oldName = parts.length > 2 ? parts[1] : fileName;
+        let status: FileContentsData["status"] = "modified";
+        if (statusChar === "A") status = "added";
+        else if (statusChar === "D") status = "deleted";
+        else if (statusChar === "R") status = "renamed";
+        let oldContents = "";
+        let newContents = "";
+        try { if (status !== "added") oldContents = execFileSync(GIT_BIN, ["show", `HEAD:${oldName}`], { cwd, encoding: "utf-8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], maxBuffer: 5 * 1024 * 1024 }); } catch {}
+        try { if (status !== "deleted") newContents = execFileSync(GIT_BIN, ["show", `:${fileName}`], { cwd, encoding: "utf-8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], maxBuffer: 5 * 1024 * 1024 }); } catch {}
+        staged.push({ name: fileName, oldContents, newContents, status });
+      }
+    }
+  } catch {}
+  try {
+    const unstagedRaw = gitExec(["diff", "--name-status"], cwd);
+    if (unstagedRaw) {
+      for (const line of unstagedRaw.split("\n").filter(Boolean)) {
+        const parts = line.split("\t");
+        const statusChar = parts[0][0];
+        const fileName = parts[1];
+        let status: FileContentsData["status"] = "modified";
+        if (statusChar === "D") status = "deleted";
+        let oldContents = "";
+        let newContents = "";
+        try { oldContents = execFileSync(GIT_BIN, ["show", `:${fileName}`], { cwd, encoding: "utf-8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"], maxBuffer: 5 * 1024 * 1024 }); } catch {}
+        try { if (status !== "deleted") newContents = fs.readFileSync(path.join(cwd, fileName), "utf-8"); } catch {}
+        unstaged.push({ name: fileName, oldContents, newContents, status });
+      }
+    }
+    const untrackedRaw = gitExec(["ls-files", "--others", "--exclude-standard"], cwd);
+    if (untrackedRaw) {
+      for (const file of untrackedRaw.split("\n").filter(Boolean)) {
+        try {
+          const newContents = fs.readFileSync(path.join(cwd, file), "utf-8");
+          unstaged.push({ name: file, oldContents: "", newContents, status: "added" });
+        } catch {}
+      }
+    }
+  } catch {}
+  return { staged, unstaged };
+}
+
 // ── Diff modes ──────────────────────────────────────────────────────
 
-type DiffMode = "working" | "branch" | "commits";
-
-// Cache per-cwd
-const branchDiffCache = new Map<string, { data: string; ts: number }>();
-const CACHE_TTL = 5000;
-
-function getCachedBranchDiff(cwd: string): string {
-  const cached = branchDiffCache.get(cwd);
-  if (cached && Date.now() - cached.ts < CACHE_TTL) return cached.data;
-  const data = getBranchDiff(cwd);
-  branchDiffCache.set(cwd, { data, ts: Date.now() });
-  return data;
-}
+type DiffMode = "branch" | "commits";
 
 function buildDiffPayload(cwd: string, mode: DiffMode, refs?: { from: string; to: string }): object {
   const branch = getBranch(cwd);
   const status = getStatus(cwd);
 
-  if (mode === "working") {
-    const diff = status.dirty ? getDiff(cwd) : { staged: "", unstaged: "" };
-    return { type: "diff_update", mode: "working", staged: diff.staged, unstaged: diff.unstaged, committed: "", branch };
-  }
-
   if (mode === "branch") {
-    const committed = getCachedBranchDiff(cwd);
-    const working = status.dirty ? getDiff(cwd) : { staged: "", unstaged: "" };
+    const defaultBranch = getDefaultRemoteBranch(cwd);
+    const base = defaultBranch ? gitExec(["merge-base", defaultBranch, "HEAD"], cwd) : "";
+    const committed = base ? getChangedFiles(cwd, base, "HEAD") : [];
+    const working = status.dirty ? getWorkingTreeFiles(cwd) : { staged: [], unstaged: [] };
+    log(`buildDiffPayload: branch mode, committed=${committed.length} staged=${working.staged.length} unstaged=${working.unstaged.length}`);
     return { type: "diff_update", mode: "branch", committed, staged: working.staged, unstaged: working.unstaged, branch };
   }
 
   if (mode === "commits" && refs) {
-    const committed = getCommitDiff(cwd, refs.from, refs.to);
-    return { type: "diff_update", mode: "commits", committed, staged: "", unstaged: "", branch, fromRef: refs.from, toRef: refs.to };
+    const committed = getChangedFiles(cwd, refs.from, refs.to);
+    return { type: "diff_update", mode: "commits", committed, staged: [], unstaged: [], branch, fromRef: refs.from, toRef: refs.to };
   }
 
-  return { type: "diff_update", mode, staged: "", unstaged: "", committed: "", branch };
+  return { type: "diff_update", mode, committed: [], staged: [], unstaged: [], branch };
 }
 
 // ── Session state ───────────────────────────────────────────────────
@@ -261,7 +291,6 @@ piWss.on("connection", (ws: any) => {
     if (piClient) {
       piClients.delete(piClient.session.sessionId);
       statusCache.delete(piClient.session.sessionId);
-      branchDiffCache.delete(piClient.session.cwd);
       log(`session disconnected: ${piClient.session.sessionId}`);
       broadcastToBrowsers({ type: "session_removed", sessionId: piClient.session.sessionId });
     }

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -17,6 +17,7 @@ const execFileAsync = promisify(execFile);
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
+import { serveUi } from "./serve-ui.ts";
 
 const DEFAULT_PORT = 19290;
 const port = parseInt(process.env.PI_PIDIFF_PORT || "", 10) || DEFAULT_PORT;
@@ -60,7 +61,30 @@ function getStatus(cwd: string): { dirty: boolean; changes: number } {
 function getDiff(cwd: string): { staged: string; unstaged: string } {
   try {
     const staged = gitExec(["diff", "--staged"], cwd);
-    const unstaged = gitExec(["diff"], cwd);
+    let unstaged = gitExec(["diff"], cwd);
+
+    // Include untracked files in the unstaged diff
+    try {
+      const untrackedRaw = gitExec(["ls-files", "--others", "--exclude-standard"], cwd);
+      if (untrackedRaw) {
+        const untrackedFiles = untrackedRaw.split("\n").filter(Boolean);
+        for (const file of untrackedFiles) {
+          try {
+            const content = execFileSync("git", ["diff", "--no-index", "--", "/dev/null", file], {
+              cwd, encoding: "utf-8", timeout: 3000,
+              stdio: ["ignore", "pipe", "ignore"], maxBuffer: 2 * 1024 * 1024,
+            }).trim();
+            if (content) unstaged += (unstaged ? "\n" : "") + content;
+          } catch (e: any) {
+            // git diff --no-index exits with code 1 when files differ (expected)
+            if (e.stdout) unstaged += (unstaged ? "\n" : "") + e.stdout.toString().trim();
+          }
+        }
+      }
+    } catch (e: any) {
+      log(`untracked files diff error: ${e.message}`);
+    }
+
     return { staged, unstaged };
   } catch (e: any) { log(`getDiff error: ${e.message}`); return { staged: "", unstaged: "" }; }
 }
@@ -173,13 +197,6 @@ const browserWatchMap = new WeakMap<any, string | null>(); // sessionId being wa
 
 const UI_DIR = path.join(path.dirname(process.argv[1] || __filename), "..", "extensions", "orchestrator", "pidiff-ui", "dist");
 
-const MIME: Record<string, string> = {
-  ".html": "text/html", ".js": "application/javascript",
-  ".css": "text/css", ".json": "application/json",
-  ".woff2": "font/woff2", ".woff": "font/woff",
-  ".svg": "image/svg+xml", ".png": "image/png",
-};
-
 const server = createServer((req: IncomingMessage, res: ServerResponse) => {
   const url = new URL(req.url || "/", `http://localhost`);
 
@@ -200,32 +217,7 @@ const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     return;
   }
 
-  // Serve static files
-  let filePath = url.pathname === "/" ? "/index.html" : url.pathname;
-  const absPath = path.resolve(path.join(UI_DIR, filePath));
-  if (!absPath.startsWith(path.resolve(UI_DIR))) { res.writeHead(403); res.end(); return; }
-
-  try {
-    const data = fs.readFileSync(absPath);
-    const ext = path.extname(absPath).toLowerCase();
-    const headers: Record<string, string> = { "Content-Type": MIME[ext] || "application/octet-stream" };
-    if (ext === ".html") {
-      headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
-    } else if (filePath.includes("/assets/")) {
-      headers["Cache-Control"] = "public, max-age=31536000, immutable";
-    }
-    res.writeHead(200, headers);
-    res.end(data);
-  } catch {
-    try {
-      const html = fs.readFileSync(path.join(UI_DIR, "index.html"));
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(html);
-    } catch {
-      res.writeHead(200, { "Content-Type": "text/html" });
-      res.end("<h1>pidiff</h1><p>UI not built. Run npm run build in pidiff-ui/</p>");
-    }
-  }
+  serveUi(url.pathname, res, { uiDir: UI_DIR, name: "pidiff-ui", log });
 });
 
 // ── WebSocket ───────────────────────────────────────────────────────

--- a/scripts/serve-ui.ts
+++ b/scripts/serve-ui.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared static UI serving for daemon servers (pidash, pidiff).
+ * Handles file serving, SPA fallback, and auto-build when dist/ is missing.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execSync } from "node:child_process";
+import type { ServerResponse } from "node:http";
+
+const MIME: Record<string, string> = {
+  ".html": "text/html", ".js": "application/javascript",
+  ".css": "text/css", ".json": "application/json",
+  ".woff2": "font/woff2", ".woff": "font/woff",
+  ".svg": "image/svg+xml", ".png": "image/png",
+};
+
+export interface ServeUiOptions {
+  /** Absolute path to the dist/ directory */
+  uiDir: string;
+  /** Name for logging (e.g., "pidash-ui", "pidiff-ui") */
+  name: string;
+  /** Logger function */
+  log: (msg: string) => void;
+}
+
+/**
+ * Serve a static file from the UI dist directory.
+ * Handles SPA fallback (serves index.html for unknown routes) and
+ * auto-builds the UI if dist/ is missing.
+ */
+export function serveUi(
+  pathname: string,
+  res: ServerResponse,
+  opts: ServeUiOptions,
+): void {
+  const filePath = pathname === "/" ? "/index.html" : pathname;
+  const absPath = path.resolve(path.join(opts.uiDir, filePath));
+
+  // Security: prevent directory traversal
+  if (!absPath.startsWith(path.resolve(opts.uiDir))) {
+    res.writeHead(403);
+    res.end("Forbidden");
+    return;
+  }
+
+  try {
+    const data = fs.readFileSync(absPath);
+    const ext = path.extname(absPath).toLowerCase();
+    const headers: Record<string, string> = {
+      "Content-Type": MIME[ext] || "application/octet-stream",
+    };
+    // No cache for HTML, long cache for hashed assets
+    if (ext === ".html") {
+      headers["Cache-Control"] = "no-cache, no-store, must-revalidate";
+    } else if (filePath.includes("/assets/")) {
+      headers["Cache-Control"] = "public, max-age=31536000, immutable";
+    }
+    res.writeHead(200, headers);
+    res.end(data);
+  } catch (err: any) {
+    // SPA fallback — only for missing files; log other errors
+    if (err?.code && err.code !== "ENOENT") {
+      opts.log(`static file error: ${absPath} (${err.code})`);
+    }
+    try {
+      const html = fs.readFileSync(path.join(opts.uiDir, "index.html"));
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(html);
+    } catch (err: any) {
+      // dist/ missing or unreadable — try to build it
+      if (err?.code && err.code !== "ENOENT") {
+        opts.log(`index.html unreadable: ${err.code}, attempting build`);
+      }
+      const uiSrcDir = path.join(opts.uiDir, "..");
+      if (fs.existsSync(path.join(uiSrcDir, "package.json"))) {
+        try {
+          opts.log(`dist/ missing, building ${opts.name}...`);
+          execSync("npm install --production=false && npm run build", {
+            cwd: uiSrcDir,
+            stdio: "ignore",
+            timeout: 60000,
+          });
+          opts.log(`${opts.name} build complete`);
+          const html = fs.readFileSync(path.join(opts.uiDir, "index.html"));
+          res.writeHead(200, { "Content-Type": "text/html" });
+          res.end(html);
+          return;
+        } catch (buildErr: any) {
+          opts.log(`${opts.name} build failed: ${buildErr.message}`);
+        }
+      }
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<h1>${opts.name.replace("-ui", "")}</h1><p>UI build failed. Run <code>/${opts.name.replace("-ui", "")} restart</code> from the pi TUI, then refresh this page.</p>`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Major pidiff overhaul — auto-build for missing UI dist, shared serve-ui utility, and complete UI rewrite following @pierre/diffs and @pierre/trees official patterns.

## Server Changes

- **serve-ui.ts** — extracted shared static file serving + SPA fallback + auto-build logic from both pidash-server and pidiff-server
- **pidiff-server.ts** — GIT_BIN resolution for daemon PATH issues, sends old+new file contents via `getChangedFiles`/`getWorkingTreeFiles` for MultiFileDiff support
- **pidash-server.ts** — uses shared `serveUi()` instead of inline code

## UI Rewrite (`pidiff-ui`)

### @pierre/diffs integration (official patterns)
- `MultiFileDiff` with `oldFile`/`newFile` for full expand/collapse support
- `WorkerPoolContextProvider` for offloading diff computation to web workers
- Built-in file headers via @pierre/diffs (removed custom headers)
- `renderHeaderMetadata` for area badges and collapse button
- Inline annotations following the Annotations example: `InlineCommentForm`, `InlineComment` with reply/edit/delete/resolve
- All diff options exposed: `diffStyle`, `diffIndicators`, `lineDiffType`, `hunkSeparators`, `disableBackground`, `overflow`, `disableLineNumbers`, `collapsed`, `expandUnchanged`, `theme`
- `@radix-ui/react-switch` for toggle switches (same as Pierre's docs)

### @pierre/trees integration (official patterns)
- `useFileTreeSelection` for reactive selection tracking
- `useExplorerWidth` hook for resizable tree panel (from TreeApp)
- Pointer-capture resize handle (from TreeApp)

### Features
- Settings toolbar: indicators, line diff type, hunk separators, theme selector (20+ shiki themes), font size, toggles
- Per-file collapse/expand
- Expand arrows on "N unmodified lines" separators
- Inline comment system with reply, edit, delete, resolve
- Session persistence in localStorage
- File deduplication (unstaged > staged > committed)
- Structured JSON review comments (`source: "pidiff"`, `type: "code-review"`)

## Other
- **AGENTS.md** — added serve-ui.ts to repo structure
- **.dev/deploy-pidiff.sh** — added serve-ui.ts copy

Closes #295