### PR TITLE
feat(pidiff): worktree support, chokidar file watching, real-time change detection

### DIFF
--- a/extensions/orchestrator/pidiff-ui/src/App.tsx
+++ b/extensions/orchestrator/pidiff-ui/src/App.tsx
@@ -185,6 +185,10 @@ export function App() {
         if (activeSessionRef.current?.sessionId === ev.sessionId) {
           setActiveSession(null);
           activeSessionRef.current = null;
+          setActiveWorktree(null);
+          activeWorktreeRef.current = null;
+          setStale(false);
+          setStaleWorktrees(new Set());
           setDiffData({ mode: "branch", files: [], branch: "" });
         }
       }

--- a/extensions/orchestrator/pidiff-ui/src/App.tsx
+++ b/extensions/orchestrator/pidiff-ui/src/App.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Switch } from "@/components/ui/switch";
 import { useWebSocket } from "@/hooks/useWebSocket";
-import type { DiffMode, DiffData, FileDiffData, GitCommit, ReviewComment, PiSession } from "@/types";
+import type { DiffMode, DiffData, FileDiffData, GitCommit, ReviewComment, PiSession, Worktree } from "@/types";
 
 // ── WorkerPool (offloads diff computation to web workers) ───────────
 const WORKER_POOL_OPTIONS: WorkerPoolOptions = {
@@ -61,6 +61,8 @@ export function App() {
   const [activeSession, setActiveSession] = useState<PiSession | null>(() => {
     try { const s = localStorage.getItem("pidiff-session"); return s ? JSON.parse(s) : null; } catch { return null; }
   });
+  const [activeWorktree, setActiveWorktree] = useState<Worktree | null>(null);
+  const activeWorktreeRef = useRef<Worktree | null>(null);
 
   const [diffData, setDiffData] = useState<DiffData>({
     mode: "branch", files: [], branch: "",
@@ -82,6 +84,7 @@ export function App() {
   const [fontSize, setFontSize] = useState(13);
   const [theme, setTheme] = useState<string>("pierre-dark");
   const [stale, setStale] = useState(false);
+  const [staleWorktrees, setStaleWorktrees] = useState<Set<string>>(new Set());
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
 
   // Review comments — persist in localStorage
@@ -128,14 +131,27 @@ export function App() {
         for (const f of committed) { if (!seen.has(f.name)) allFiles.push(f); }
         setDiffData({ mode: ev.mode || "branch", files: allFiles, branch: ev.branch || "", fromRef: ev.fromRef, toRef: ev.toRef });
         setLoading(false);
-        setStale(false);
+        // Don't clear stale here — only Refresh button clears it
         if (loadingTimeout.current) clearTimeout(loadingTimeout.current);
       }
       if (ev.type === "commits-list" && ev.commits) {
         setCommits(ev.commits);
       }
       if (ev.type === "status_changed") {
-        setStale(true);
+        if (ev.changedWorktrees && Array.isArray(ev.changedWorktrees)) {
+          setStaleWorktrees(prev => {
+            const next = new Set(prev);
+            for (const p of ev.changedWorktrees) next.add(p);
+            return next;
+          });
+          // Show banner ONLY if the currently active tab is stale
+          const activePath = activeWorktreeRef.current?.path || activeSessionRef.current?.cwd;
+          if (activePath && ev.changedWorktrees.includes(activePath)) {
+            setStale(true);
+          }
+        } else {
+          setStale(true);
+        }
       }
       if (ev.type === "sessions-list" && ev.sessions) {
         setSessions(ev.sessions);
@@ -192,6 +208,8 @@ export function App() {
 
   const switchSession = useCallback((s: PiSession) => {
     setActiveSession(s);
+    setActiveWorktree(null);
+    activeWorktreeRef.current = null;
     activeSessionRef.current = s;
     setMode("branch");
     modeRef.current = "branch";
@@ -202,6 +220,21 @@ export function App() {
     setLoading(true);
     send({ type: "watch", sessionId: s.sessionId });
   }, [send]);
+
+  const switchWorktree = useCallback((wt: Worktree) => {
+    setActiveWorktree(wt);
+    activeWorktreeRef.current = wt;
+    setMode("branch");
+    modeRef.current = "branch";
+    setCommits(null);
+    commitsRequested.current = false;
+    // Show stale banner if this tab has pending changes
+    setStale(staleWorktrees.has(wt.path));
+    // Always load data for the tab (no per-tab caching yet)
+    setDiffData({ mode: "branch", files: [], branch: wt.branch });
+    setLoading(true);
+    send({ type: "watch-worktree", worktreePath: wt.path });
+  }, [send, staleWorktrees]);
 
   const switchMode = useCallback((m: DiffMode) => {
     setMode(m);
@@ -325,9 +358,11 @@ export function App() {
 
   const submitComment = useCallback((file: string, side: "deletions" | "additions", lineNumber: number, body: string) => {
     if (!body.trim()) return;
-    setComments(prev => [...prev, { file, line: lineNumber, side: side === "deletions" ? "old" : "new", body: body.trim() }]);
+    const branch = activeWorktree?.branch || diffData.branch;
+    const worktreePath = activeWorktree?.path;
+    setComments(prev => [...prev, { file, line: lineNumber, side: side === "deletions" ? "old" : "new", body: body.trim(), branch, worktreePath }]);
     setOpenForms(prev => prev.filter(f => !(f.file === file && f.side === side && f.lineNumber === lineNumber)));
-  }, []);
+  }, [activeWorktree, diffData.branch]);
 
   const cancelCommentForm = useCallback((file: string, side: "deletions" | "additions", lineNumber: number) => {
     setOpenForms(prev => prev.filter(f => !(f.file === file && f.side === side && f.lineNumber === lineNumber)));
@@ -350,7 +385,7 @@ export function App() {
     send({ type: "publish-review", comments });
     setComments([]);
     try { localStorage.removeItem("pidiff-comments"); } catch {}
-  }, [comments, send]);
+  }, [comments, send, activeWorktree, diffData.branch]);
 
   // ── Render ────────────────────────────────────────────────────────
 
@@ -381,7 +416,7 @@ export function App() {
             {activeSession && (
               <div className="flex items-center gap-1.5">
                 <GitBranch className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-xs text-muted-foreground">{diffData.branch}</span>
+                <span className="text-xs text-muted-foreground">{activeWorktree?.branch || diffData.branch}</span>
               </div>
             )}
             <Separator orientation="vertical" className="h-5" />
@@ -539,6 +574,32 @@ export function App() {
             </>)}
           </div>
         )}
+        {/* Workspace tabs — always shown. Each branch/worktree is a tab. */}
+        {activeSession && (() => {
+          const tabs = activeSession.worktrees && activeSession.worktrees.length > 0
+            ? activeSession.worktrees
+            : [{ path: activeSession.cwd, branch: diffData.branch || activeSession.branch, head: "", isMain: true }];
+          return (
+            <div className="flex items-center gap-1 px-4 py-1 bg-card border-t border-border overflow-x-auto">
+              {tabs.map(wt => {
+                const isActive = activeWorktree ? activeWorktree.path === wt.path : wt.isMain;
+                const isStale = staleWorktrees.has(wt.path);
+                return (
+                  <button key={wt.path} onClick={() => switchWorktree(wt)}
+                    className={cn(
+                      "flex items-center gap-1.5 px-3 py-1 rounded-md text-xs whitespace-nowrap transition-colors",
+                      isActive ? "bg-secondary text-foreground" : "text-muted-foreground hover:text-foreground hover:bg-secondary/50",
+                    )}>
+                    <GitBranch className="h-3 w-3" />
+                    {wt.branch}
+                    {wt.isMain && tabs.length > 1 && <span className="text-[9px] text-muted-foreground">(root)</span>}
+                    {isStale && !isActive && <span className="h-2 w-2 rounded-full bg-amber-400 flex-shrink-0" />}
+                  </button>
+                );
+              })}
+            </div>
+          );
+        })()}
       </header>
 
       {/* Stale banner */}
@@ -548,6 +609,8 @@ export function App() {
           <Button size="sm" variant="outline" className="h-6 text-[11px] border-amber-500/30 text-amber-400 hover:bg-amber-500/20"
             onClick={() => {
               setStale(false);
+              const activePath = activeWorktree?.path || activeSession?.cwd;
+              if (activePath) setStaleWorktrees(prev => { const next = new Set(prev); next.delete(activePath); return next; });
               setLoading(true);
               send({ type: "request-diffs", mode: modeRef.current });
             }}>

--- a/extensions/orchestrator/pidiff-ui/src/types.ts
+++ b/extensions/orchestrator/pidiff-ui/src/types.ts
@@ -23,11 +23,19 @@ export interface DiffData {
   toRef?: string;
 }
 
+export interface Worktree {
+  path: string;
+  branch: string;
+  head: string;
+  isMain: boolean;
+}
+
 export interface PiSession {
   sessionId: string;
   cwd: string;
   branch: string;
   repo: string;
+  worktrees: Worktree[];
 }
 
 export interface ReviewCommentReply {
@@ -41,6 +49,8 @@ export interface ReviewComment {
   line: number;
   side: "old" | "new";
   body: string;
+  branch?: string;
+  worktreePath?: string;
   replies?: ReviewCommentReply[];
   resolved?: boolean;
 }

--- a/extensions/orchestrator/pidiff.ts
+++ b/extensions/orchestrator/pidiff.ts
@@ -155,6 +155,8 @@ export function registerPidiff(pi: ExtensionAPI): void {
                 line: c.line,
                 side: c.side,
                 body: c.body,
+                ...(c.branch ? { branch: c.branch } : {}),
+                ...(c.worktreePath ? { worktreePath: c.worktreePath } : {}),
                 ...(c.replies?.length ? { replies: c.replies } : {}),
                 ...(c.resolved ? { resolved: true } : {}),
               })),

--- a/package.json
+++ b/package.json
@@ -2,14 +2,21 @@
   "name": "pi-orchestrator-config",
   "version": "2.2.0",
   "description": "Orchestrator pattern for pi: specialist subagents, enforcement, code review loop, workflow commands",
-  "keywords": ["pi-package"],
+  "keywords": [
+    "pi-package"
+  ],
   "license": "MIT",
   "dependencies": {
+    "chokidar": "^5.0.0",
     "discord.js": "^14.0.0",
     "ws": "^8.0.0"
   },
   "pi": {
-    "extensions": ["./extensions"],
-    "prompts": ["./prompts"]
+    "extensions": [
+      "./extensions"
+    ],
+    "prompts": [
+      "./prompts"
+    ]
   }
 }

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -387,7 +387,18 @@ browserWss.on("connection", (ws: any) => {
         const client = piClients.get(watchInfo.sessionId);
         if (!client) return;
 
-        const worktreePath = parsed.worktreePath || client.session.cwd;
+        const requestedPath = parsed.worktreePath || client.session.cwd;
+        // Validate: only allow known worktree paths or session cwd
+        const allowedPaths = new Set([
+          path.resolve(client.session.cwd),
+          ...client.session.worktrees.map(w => path.resolve(w.path)),
+        ]);
+        const resolvedPath = path.resolve(requestedPath);
+        if (!allowedPaths.has(resolvedPath)) {
+          log(`watch-worktree rejected: ${requestedPath} not in allowed paths for session ${watchInfo.sessionId}`);
+          return;
+        }
+        const worktreePath = resolvedPath;
         browserWatchMap.set(ws, { ...watchInfo, worktreePath });
         log(`browser watching worktree: ${worktreePath}`);
 
@@ -482,8 +493,19 @@ let _chokidar: any = null;
 import("chokidar").then(m => { _chokidar = m; log("chokidar loaded"); }).catch(e => log(`chokidar load failed: ${e.message}`));
 const activeWatchers = new Map<string, { watcher: any; debounceTimer: ReturnType<typeof setTimeout> | null }>();
 
+const chokidarRetries = new Map<string, number>();
+const MAX_CHOKIDAR_RETRIES = 10;
+
 function startWatching(sessionId: string, worktreePath: string) {
-  if (!_chokidar) { log(`chokidar not loaded yet, retrying in 1s for ${worktreePath}`); setTimeout(() => startWatching(sessionId, worktreePath), 1000); return; }
+  const retryKey = `${sessionId}:${worktreePath}`;
+  if (!_chokidar) {
+    const retries = chokidarRetries.get(retryKey) || 0;
+    if (retries >= MAX_CHOKIDAR_RETRIES) { log(`chokidar failed to load after ${MAX_CHOKIDAR_RETRIES} retries, giving up on ${worktreePath}`); return; }
+    chokidarRetries.set(retryKey, retries + 1);
+    setTimeout(() => startWatching(sessionId, worktreePath), 1000 * Math.min(retries + 1, 5));
+    return;
+  }
+  chokidarRetries.delete(retryKey);
   const key = `${sessionId}:${worktreePath}`;
   if (activeWatchers.has(key)) return;
 
@@ -492,13 +514,11 @@ function startWatching(sessionId: string, worktreePath: string) {
     ignoreInitial: true,
     persistent: true,
     ignored: (filePath: string) => {
-      // Ignore .git internals and common heavy directories
-      const rel = filePath.slice(worktreePath.length + 1);
-      if (!rel) return false;
-      return rel.startsWith(".git/") || rel.startsWith(".git\\") ||
-             rel === ".git" ||
-             rel.startsWith("node_modules/") || rel.startsWith("node_modules\\") ||
-             rel.startsWith(".worktrees/") || rel.startsWith(".worktrees\\");
+      const rel = path.relative(worktreePath, filePath);
+      if (rel === "") return false; // watch root itself — don't ignore
+      if (rel.startsWith("..")) return true; // outside watch root — ignore
+      const first = rel.split(path.sep)[0];
+      return first === ".git" || first === "node_modules" || first === ".worktrees" || first === ".venv" || first === "dist" || first === "__pycache__";
     },
     depth: 20,
   });
@@ -554,7 +574,9 @@ const worktreeRefreshInterval = setInterval(() => {
   for (const [sessionId, client] of piClients) {
     try {
       const freshWorktrees = getWorktrees(client.session.cwd);
-      if (freshWorktrees.length !== client.session.worktrees.length) {
+      const oldFingerprint = client.session.worktrees.map(w => `${w.path}:${w.branch}`).sort().join("|");
+      const newFingerprint = freshWorktrees.map(w => `${w.path}:${w.branch}`).sort().join("|");
+      if (oldFingerprint !== newFingerprint) {
         // Start/stop watchers for new/removed worktrees
         const oldPaths = new Set(client.session.worktrees.map(w => w.path));
         const newPaths = new Set(freshWorktrees.map(w => w.path));

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -62,6 +62,41 @@ function getBranch(cwd: string): string {
   try { return gitExec(["branch", "--show-current"], cwd); } catch { return ""; }
 }
 
+interface WorktreeInfo {
+  path: string;
+  branch: string;
+  head: string;
+  isMain: boolean;
+}
+
+function getWorktrees(cwd: string): WorktreeInfo[] {
+  try {
+    const raw = execFileSync(GIT_BIN, ["worktree", "list", "--porcelain"], {
+      cwd, encoding: "utf-8", timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"], maxBuffer: 1024 * 1024,
+    });
+    const worktrees: WorktreeInfo[] = [];
+    let current: Partial<WorktreeInfo> = {};
+    for (const line of raw.split("\n")) {
+      if (line.startsWith("worktree ")) {
+        if (current.path) worktrees.push(current as WorktreeInfo);
+        current = { path: line.slice(9), isMain: worktrees.length === 0 };
+      } else if (line.startsWith("HEAD ")) {
+        current.head = line.slice(5);
+      } else if (line.startsWith("branch ")) {
+        // "branch refs/heads/main" → "main"
+        current.branch = line.slice(7).replace("refs/heads/", "");
+      } else if (line === "detached") {
+        current.branch = `(detached)`;
+      } else if (line === "") {
+        if (current.path) { worktrees.push(current as WorktreeInfo); current = {}; }
+      }
+    }
+    if (current.path) worktrees.push(current as WorktreeInfo);
+    return worktrees;
+  } catch (e: any) { log(`getWorktrees error: ${e.message}`); return []; }
+}
+
 function getStatus(cwd: string): { dirty: boolean; changes: number } {
   try {
     const s = gitExec(["status", "--porcelain"], cwd);
@@ -212,6 +247,7 @@ interface SessionInfo {
   cwd: string;
   branch: string;
   repo: string; // basename of cwd
+  worktrees: WorktreeInfo[];
 }
 
 interface PiClient {
@@ -221,7 +257,7 @@ interface PiClient {
 
 const piClients = new Map<string, PiClient>();
 const browserClients = new Set<any>();
-const browserWatchMap = new WeakMap<any, string | null>(); // sessionId being watched
+const browserWatchMap = new WeakMap<any, { sessionId: string | null; worktreePath: string | null }>();
 
 // ── HTTP Server ─────────────────────────────────────────────────────
 
@@ -266,16 +302,22 @@ piWss.on("connection", (ws: any) => {
 
       if (parsed.type === "register") {
         const sessionId = parsed.sessionId || `${parsed.pid}:${parsed.cwd}`;
+        const cwd = parsed.cwd || "";
+        const worktrees = getWorktrees(cwd);
         const session: SessionInfo = {
           sessionId,
-          cwd: parsed.cwd || "",
+          cwd,
           branch: parsed.branch || "",
-          repo: (parsed.cwd || "").split("/").pop() || "",
+          repo: cwd.split("/").pop() || "",
+          worktrees,
         };
         piClient = { ws, session };
         piClients.set(sessionId, piClient);
         log(`session registered: ${sessionId} (${session.repo})`);
         broadcastToBrowsers({ type: "session_added", session });
+        // Start file watchers for all worktrees
+        for (const wt of session.worktrees) startWatching(sessionId, wt.path);
+        if (session.worktrees.length === 0) startWatching(sessionId, session.cwd);
         return;
       }
 
@@ -289,8 +331,8 @@ piWss.on("connection", (ws: any) => {
 
   ws.on("close", () => {
     if (piClient) {
+      stopAllWatchers(piClient.session.sessionId);
       piClients.delete(piClient.session.sessionId);
-      statusCache.delete(piClient.session.sessionId);
       log(`session disconnected: ${piClient.session.sessionId}`);
       broadcastToBrowsers({ type: "session_removed", sessionId: piClient.session.sessionId });
     }
@@ -298,6 +340,7 @@ piWss.on("connection", (ws: any) => {
 
   ws.on("error", () => {
     if (piClient) {
+      stopAllWatchers(piClient.session.sessionId);
       piClients.delete(piClient.session.sessionId);
       broadcastToBrowsers({ type: "session_removed", sessionId: piClient.session.sessionId });
     }
@@ -308,7 +351,7 @@ piWss.on("connection", (ws: any) => {
 const browserWss = new WebSocket.Server({ noServer: true });
 browserWss.on("connection", (ws: any) => {
   browserClients.add(ws);
-  browserWatchMap.set(ws, null);
+  browserWatchMap.set(ws, { sessionId: null, worktreePath: null });
   log(`browser connected (total: ${browserClients.size})`);
 
   // Send session list
@@ -322,16 +365,14 @@ browserWss.on("connection", (ws: any) => {
       // Watch a session
       if (parsed.type === "watch") {
         const watchId = parsed.sessionId ?? null;
-        browserWatchMap.set(ws, watchId);
+        browserWatchMap.set(ws, { sessionId: watchId, worktreePath: null });
         log(`browser watching: ${watchId}`);
 
         if (watchId) {
           const client = piClients.get(watchId);
           if (client) {
-            // Send initial branch diff
             const payload = buildDiffPayload(client.session.cwd, "branch");
             try { ws.send(JSON.stringify(payload)); } catch {}
-            // Send commits
             const commits = getLog(client.session.cwd, 30);
             try { ws.send(JSON.stringify({ type: "commits-list", commits })); } catch {}
           }
@@ -339,39 +380,59 @@ browserWss.on("connection", (ws: any) => {
         return;
       }
 
-      // Request diffs for watched session
-      if (parsed.type === "request-diffs") {
-        const watchId = browserWatchMap.get(ws);
-        if (!watchId) return;
-        const client = piClients.get(watchId);
+      // Watch a specific worktree within a session
+      if (parsed.type === "watch-worktree") {
+        const watchInfo = browserWatchMap.get(ws);
+        if (!watchInfo?.sessionId) return;
+        const client = piClients.get(watchInfo.sessionId);
         if (!client) return;
 
+        const worktreePath = parsed.worktreePath || client.session.cwd;
+        browserWatchMap.set(ws, { ...watchInfo, worktreePath });
+        log(`browser watching worktree: ${worktreePath}`);
+
+        const payload = buildDiffPayload(worktreePath, "branch");
+        try { ws.send(JSON.stringify(payload)); } catch {}
+        const commits = getLog(worktreePath, 30);
+        try { ws.send(JSON.stringify({ type: "commits-list", commits })); } catch {}
+        return;
+      }
+
+      // Request diffs for watched session
+      if (parsed.type === "request-diffs") {
+        const watchInfo = browserWatchMap.get(ws);
+        if (!watchInfo?.sessionId) return;
+        const client = piClients.get(watchInfo.sessionId);
+        if (!client) return;
+
+        const cwd = watchInfo.worktreePath || client.session.cwd;
         const mode: DiffMode = parsed.mode || "branch";
         const refs = parsed.fromRef && parsed.toRef ? { from: parsed.fromRef, to: parsed.toRef } : undefined;
-        const payload = buildDiffPayload(client.session.cwd, mode, refs);
+        const payload = buildDiffPayload(cwd, mode, refs);
         try { ws.send(JSON.stringify(payload)); } catch {}
         return;
       }
 
       // Request commits
       if (parsed.type === "request-commits") {
-        const watchId = browserWatchMap.get(ws);
-        if (!watchId) return;
-        const client = piClients.get(watchId);
+        const watchInfo = browserWatchMap.get(ws);
+        if (!watchInfo?.sessionId) return;
+        const client = piClients.get(watchInfo.sessionId);
         if (!client) return;
 
-        const commits = getLog(client.session.cwd, 30);
+        const cwd = watchInfo.worktreePath || client.session.cwd;
+        const commits = getLog(cwd, 30);
         try { ws.send(JSON.stringify({ type: "commits-list", commits })); } catch {}
         return;
       }
 
       // Publish review comments → forward to the watched pi session
       if (parsed.type === "publish-review") {
-        const watchId = browserWatchMap.get(ws);
-        if (!watchId) return;
-        const client = piClients.get(watchId);
+        const watchInfo = browserWatchMap.get(ws);
+        if (!watchInfo?.sessionId) return;
+        const client = piClients.get(watchInfo.sessionId);
         if (client?.ws) {
-          log(`review published for ${watchId}: ${parsed.comments?.length || 0} comments`);
+          log(`review published for ${watchInfo.sessionId}: ${parsed.comments?.length || 0} comments`);
           try { client.ws.send(JSON.stringify(parsed)); } catch {}
         }
         return;
@@ -415,46 +476,101 @@ server.on("upgrade", (req: IncomingMessage, socket: any, head: Buffer) => {
 
 // ── Change detection — notify browsers ──────────────────────────────
 
-const statusCache = new Map<string, string>();
-let changeDetectorRunning = false;
+// ── File watcher (chokidar) ─ real-time change detection ───────────────
 
-async function checkForChanges() {
-  if (browserClients.size === 0 || changeDetectorRunning) return;
-  changeDetectorRunning = true;
-  try {
-    for (const [sessionId, client] of piClients) {
-      const cwd = client.session.cwd;
-      try {
-        const [statusResult, branchResult] = await Promise.all([
-          execFileAsync("git", ["status", "--porcelain"], { cwd, timeout: 3000, maxBuffer: 2 * 1024 * 1024 }).catch(() => ({ stdout: "" })),
-          execFileAsync("git", ["branch", "--show-current"], { cwd, timeout: 3000 }).catch(() => ({ stdout: "" })),
-        ]);
-        const statusOut = (statusResult.stdout || "").trim();
-        const changes = statusOut ? statusOut.split("\n").length : 0;
-        const dirty = changes > 0;
-        const branch = (branchResult.stdout || "").trim();
-        const hash = `${branch}:${dirty}:${changes}`;
-        const prev = statusCache.get(sessionId);
-        if (hash === prev) continue;
-        statusCache.set(sessionId, hash);
+let _chokidar: any = null;
+import("chokidar").then(m => { _chokidar = m; log("chokidar loaded"); }).catch(e => log(`chokidar load failed: ${e.message}`));
+const activeWatchers = new Map<string, { watcher: any; debounceTimer: ReturnType<typeof setTimeout> | null }>();
 
-        client.session.branch = branch;
+function startWatching(sessionId: string, worktreePath: string) {
+  if (!_chokidar) { log(`chokidar not loaded yet, retrying in 1s for ${worktreePath}`); setTimeout(() => startWatching(sessionId, worktreePath), 1000); return; }
+  const key = `${sessionId}:${worktreePath}`;
+  if (activeWatchers.has(key)) return;
 
-        const msg = JSON.stringify({ type: "status_changed", sessionId, dirty, changes, branch });
-        for (const browser of browserClients) {
-          if (browserWatchMap.get(browser) === sessionId) {
-            try { browser.send(msg); } catch {}
-          }
+  log(`starting chokidar watch: ${worktreePath}`);
+  const watcher = _chokidar.watch(worktreePath, {
+    ignoreInitial: true,
+    persistent: true,
+    ignored: (filePath: string) => {
+      // Ignore .git internals and common heavy directories
+      const rel = filePath.slice(worktreePath.length + 1);
+      if (!rel) return false;
+      return rel.startsWith(".git/") || rel.startsWith(".git\\") ||
+             rel === ".git" ||
+             rel.startsWith("node_modules/") || rel.startsWith("node_modules\\") ||
+             rel.startsWith(".worktrees/") || rel.startsWith(".worktrees\\");
+    },
+    depth: 20,
+  });
+
+  const state = { watcher, debounceTimer: null as ReturnType<typeof setTimeout> | null };
+  activeWatchers.set(key, state);
+
+  const onChange = () => {
+    if (state.debounceTimer) clearTimeout(state.debounceTimer);
+    state.debounceTimer = setTimeout(() => {
+      state.debounceTimer = null;
+      // Notify all browsers watching this session
+      const msg = JSON.stringify({ type: "status_changed", sessionId, changedWorktrees: [worktreePath] });
+      for (const browser of browserClients) {
+        const watchInfo = browserWatchMap.get(browser);
+        if (watchInfo?.sessionId === sessionId) {
+          try { browser.send(msg); } catch {}
         }
-      } catch {}
-    }
-  } finally {
-    changeDetectorRunning = false;
+      }
+    }, 500);
+  };
+
+  watcher.on("add", onChange);
+  watcher.on("change", onChange);
+  watcher.on("unlink", onChange);
+  watcher.on("addDir", onChange);
+  watcher.on("unlinkDir", onChange);
+}
+
+function stopWatching(sessionId: string, worktreePath: string) {
+  const key = `${sessionId}:${worktreePath}`;
+  const state = activeWatchers.get(key);
+  if (state) {
+    log(`stopping chokidar watch: ${worktreePath}`);
+    if (state.debounceTimer) clearTimeout(state.debounceTimer);
+    state.watcher.close();
+    activeWatchers.delete(key);
   }
 }
 
-const changeDetector = setInterval(checkForChanges, 5000);
-if (changeDetector.unref) changeDetector.unref();
+function stopAllWatchers(sessionId: string) {
+  for (const [key, state] of activeWatchers) {
+    if (key.startsWith(`${sessionId}:`)) {
+      if (state.debounceTimer) clearTimeout(state.debounceTimer);
+      state.watcher.close();
+      activeWatchers.delete(key);
+    }
+  }
+}
+
+// Periodically refresh worktree list (worktrees may be added/removed)
+const worktreeRefreshInterval = setInterval(() => {
+  for (const [sessionId, client] of piClients) {
+    try {
+      const freshWorktrees = getWorktrees(client.session.cwd);
+      if (freshWorktrees.length !== client.session.worktrees.length) {
+        // Start/stop watchers for new/removed worktrees
+        const oldPaths = new Set(client.session.worktrees.map(w => w.path));
+        const newPaths = new Set(freshWorktrees.map(w => w.path));
+        for (const wt of freshWorktrees) {
+          if (!oldPaths.has(wt.path)) startWatching(sessionId, wt.path);
+        }
+        for (const wt of client.session.worktrees) {
+          if (!newPaths.has(wt.path)) stopWatching(sessionId, wt.path);
+        }
+        client.session.worktrees = freshWorktrees;
+        broadcastToBrowsers({ type: "session_updated", session: client.session });
+      }
+    } catch {}
+  }
+}, 10000);
+if (worktreeRefreshInterval.unref) worktreeRefreshInterval.unref();
 
 // Ping pi clients
 const pingInterval = setInterval(() => {


### PR DESCRIPTION
## Summary

Adds git worktree support to pidiff, replacing 5s polling with chokidar-based real-time file watching.

## Worktree Support
- Discover worktrees via `git worktree list --porcelain`
- Workspace tabs in UI — each branch/worktree is a tab with independent diff, mode, and stale state
- Tabs always visible (even single branch)
- `watch-worktree` WebSocket message to switch between worktrees
- Per-comment `branch` and `worktreePath` in published review JSON
- Worktree list auto-refreshes (detects added/removed worktrees)

## Real-time File Watching (chokidar)
- Replace 5s polling with native filesystem events via chokidar
- 500ms debounce per worktree
- Ignores `.git/`, `node_modules/`, `.worktrees/`, `.venv/`, `dist/`, `__pycache__/`
- Amber dot indicator on tabs with changes
- Stale banner only shown on active tab
- Bounded retry (max 10) with backoff if chokidar fails to load

## Security (from cursor peer review)
- Validate `worktreePath` against allowed paths (session cwd + known worktrees)
- Clear worktree/stale state on session removal
- Worktree refresh uses path+branch fingerprint (not count-only)
- `path.relative` for chokidar ignored check

## Dependencies
- Added `chokidar` (+ `readdirp`) to package.json

Closes #300