### PR TITLE
chore: add Technical Honesty rule

### DIFF
--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -106,6 +106,22 @@ Provide clear, concise options. Include a 'no' or 'cancel' option when appropria
 
 ---
 
+## Technical Honesty (MANDATORY)
+
+**When the user proposes an idea, approach, or solution:**
+
+- ✅ **Evaluate it critically** — consider if there's a better technical alternative
+- ✅ **Present alternatives first** — if you know a better way, say so with clear reasoning before proceeding
+- ✅ **Show tradeoffs** — explain pros/cons of the user's approach vs alternatives
+- ✅ **Let the user decide** — after presenting alternatives, the user makes the final call
+- ❌ **NEVER agree blindly** — "you're right" without evaluation is not helpful
+- ❌ **NEVER disagree blindly** — push back only when you have concrete technical reasoning
+
+The user's idea may be the best option — but they should hear alternatives if they exist.
+After presenting your analysis, respect the user's decision.
+
+---
+
 ## Web Access (MANDATORY)
 
 **When accessing the web:**


### PR DESCRIPTION
Adds a mandatory rule that the AI must evaluate user proposals critically before agreeing. If a better technical alternative exists, present it with reasoning and tradeoffs. The user still makes the final decision, but they should hear alternatives first.

Prevents blind agreement / sycophantic behavior.