### PR TITLE
feat(cli): detect and auto-resume CodeRabbit reviews paused state

### DIFF
--- a/myk_pi_tools/coderabbit/rate_limit.py
+++ b/myk_pi_tools/coderabbit/rate_limit.py
@@ -1,8 +1,9 @@
-"""CodeRabbit rate limit handler.
+"""CodeRabbit rate limit and reviews-paused handler.
 
-Provides two composable operations:
+Provides composable operations:
 - run_check: detect rate limiting and return JSON status
 - run_trigger: wait, post review trigger, and poll until review starts
+- _post_resume_trigger: post resume trigger when reviews are paused
 """
 
 from __future__ import annotations
@@ -22,6 +23,10 @@ from myk_pi_tools.coderabbit.utils import (
 )
 
 _RATE_LIMITED_MARKER = "<!-- This is an auto-generated comment: rate limited by coderabbit.ai -->"
+_REVIEWS_PAUSED_MARKER = "<!-- This is an auto-generated comment: reviews paused by coderabbit.ai -->"
+# Fallback: match body text when HTML marker is absent — requires both strings
+_REVIEWS_PAUSED_FALLBACK_HEADING = "Reviews paused"
+_REVIEWS_PAUSED_FALLBACK_SETTING = "auto_pause_after_reviewed_commits"
 
 # Regex to parse wait time from rate limit message
 _WAIT_TIME_RE = re.compile(r"Please wait \*\*(?:(\d+) minutes? and )?(\d+) seconds?\*\*")
@@ -45,26 +50,36 @@ def _parse_wait_seconds(body: str) -> int | None:
     return minutes * 60 + seconds
 
 
-def _post_review_trigger(owner_repo: str, pr_number: int) -> int | None:
-    """Post @coderabbitai review comment on the PR. Returns comment ID or None."""
+def _post_coderabbit_comment(owner_repo: str, pr_number: int, command: str) -> int | None:
+    """Post @coderabbitai <command> comment on the PR. Returns comment ID or None."""
     owner, repo = owner_repo.split("/")
     code, stdout, stderr = _run_gh(
         [
             "api",
             f"repos/{owner}/{repo}/issues/{pr_number}/comments",
             "-f",
-            "body=@coderabbitai review",
+            f"body=@coderabbitai {command}",
         ],
         timeout=30,
     )
     if code != 0:
         if stderr:
-            print(f"Failed to post review trigger: {stderr}")
+            print(f"Failed to post {command} trigger: {stderr}")
         return None
     try:
         return json.loads(stdout).get("id")
     except (json.JSONDecodeError, AttributeError):
         return None
+
+
+def _post_review_trigger(owner_repo: str, pr_number: int) -> int | None:
+    """Post @coderabbitai review comment on the PR. Returns comment ID or None."""
+    return _post_coderabbit_comment(owner_repo, pr_number, "review")
+
+
+def _post_resume_trigger(owner_repo: str, pr_number: int) -> int | None:
+    """Post @coderabbitai resume comment on the PR. Returns comment ID or None."""
+    return _post_coderabbit_comment(owner_repo, pr_number, "resume")
 
 
 def _find_trigger_reply(owner_repo: str, pr_number: int, trigger_comment_id: int) -> bool | str:

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -16,7 +16,15 @@ import time
 from datetime import datetime, timezone
 
 from myk_pi_tools.coderabbit.approved import is_approved
-from myk_pi_tools.coderabbit.rate_limit import _RATE_LIMITED_MARKER, _parse_wait_seconds, run_trigger
+from myk_pi_tools.coderabbit.rate_limit import (
+    _RATE_LIMITED_MARKER,
+    _REVIEWS_PAUSED_FALLBACK_HEADING,
+    _REVIEWS_PAUSED_FALLBACK_SETTING,
+    _REVIEWS_PAUSED_MARKER,
+    _parse_wait_seconds,
+    _post_resume_trigger,
+    run_trigger,
+)
 from myk_pi_tools.coderabbit.utils import find_summary_comment
 from myk_pi_tools.reviews.fetch import get_pr_info, print_stderr
 from myk_pi_tools.reviews.fetch import run as fetch_run
@@ -73,6 +81,7 @@ def run(review_url: str = "") -> int:
     owner, repo, pr_number = get_pr_info(review_url)
     owner_repo = f"{owner}/{repo}"
     cycle = 0
+    resume_attempts = 0
 
     while True:
         cycle += 1
@@ -140,6 +149,45 @@ def run(review_url: str = "") -> int:
                 print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
                 print('{"approved": true}')
                 return 0
+
+        elif (
+            comment_id is not None
+            and body is not None
+            and (
+                _REVIEWS_PAUSED_MARKER in body
+                or (_REVIEWS_PAUSED_FALLBACK_HEADING in body and _REVIEWS_PAUSED_FALLBACK_SETTING in body)
+            )
+        ):
+            # Reviews paused — auto-resume (max 3 attempts per poll session)
+            resume_attempts += 1
+
+            if resume_attempts > 3:
+                print_stderr(
+                    "[poll] ⚠️  CodeRabbit still paused after 3 resume attempts. "
+                    "Continuing poll without resuming — manual intervention may be needed."
+                )
+            else:
+                print_stderr(
+                    f"[poll] ⚠️  CodeRabbit paused reviews (too many commits). "
+                    f"Auto-resuming (attempt {resume_attempts}/3)..."
+                )
+                print_stderr("[poll] 💡 To prevent this, add to .coderabbit.yaml:")
+                print_stderr("[poll]     reviews:")
+                print_stderr("[poll]       auto_review:")
+                print_stderr("[poll]         auto_pause_after_reviewed_commits: 0")
+
+                resume_id = _post_resume_trigger(owner_repo, int(pr_number))
+                if resume_id is not None:
+                    print_stderr(f"[poll] Posted @coderabbitai resume (comment ID: {resume_id})")
+
+                    # Re-check approval after resume (CodeRabbit may immediately approve)
+                    print_stderr("[poll] Re-checking approval after resume trigger...")
+                    if is_approved(owner_repo, int(pr_number)):
+                        print_stderr("[poll] CodeRabbit approved — no actionable comments.")
+                        print('{"approved": true}')
+                        return 0
+                else:
+                    print_stderr("[poll] Warning: Failed to post resume trigger. Will retry next cycle.")
 
         elif comment_id is None:
             if error and "No CodeRabbit summary comment found" in error:


### PR DESCRIPTION
## Summary

When a branch gets too many commits, CodeRabbit auto-pauses reviews. Previously, `reviews poll` didn't detect this — the autorabbit loop would poll forever waiting for comments that would never come.

## Changes

**`myk_pi_tools/coderabbit/rate_limit.py`:**
- Extract shared `_post_coderabbit_comment()` helper (DRY — `_post_review_trigger` and `_post_resume_trigger` now delegate to it)
- Add `_REVIEWS_PAUSED_MARKER` (HTML comment) and fallback detection constants
- Add `_post_resume_trigger()` to post `@coderabbitai resume`

**`myk_pi_tools/reviews/poll.py`:**
- Detect "Reviews paused" in the summary comment (HTML marker + fallback requiring both heading and setting name)
- Auto-post `@coderabbitai resume` when detected
- Cap at 3 resume attempts per poll session (prevents flooding PR with resume comments)
- Re-check approval after resume (avoid unnecessary 5-min delay)
- Print config fix suggestion to stderr

## Behavior

After resume, the poll loop continues normally — it does NOT exit. It only exits when CodeRabbit actually posts its review result (approved or actionable comments).

Closes #310