### PR TITLE
feat(cli): use ai-cli-runner session API in ai-cli prompt

### DIFF
--- a/myk_pi_tools/ai_cli/commands.py
+++ b/myk_pi_tools/ai_cli/commands.py
@@ -14,16 +14,21 @@ def ai_cli() -> None:
 @click.argument("prompt")
 @click.option("--provider", "-p", required=True, type=click.Choice(["cursor", "claude", "gemini"]), help="AI provider")
 @click.option("--model", "-m", default="", help="Model name (e.g., gpt-5.4-high). Empty = provider default")
-@click.option("--resume", is_flag=True, help="Continue the last session")
+@click.option("--resume", is_flag=True, help="Continue the most recent session")
+@click.option("--session-id", default=None, help="Resume a specific session by ID")
 @click.option("--cwd", default=None, help="Working directory (default: current)")
-def run_cmd(prompt: str, provider: str, model: str, resume: bool, cwd: str | None) -> None:
+def run_cmd(prompt: str, provider: str, model: str, resume: bool, session_id: str | None, cwd: str | None) -> None:
     """Run a prompt via AI CLI.
 
     PROMPT: The prompt text to send to the AI CLI.
     """
     from myk_pi_tools.ai_cli.run import run
 
-    sys.exit(run(prompt=prompt, provider=provider, model=model, resume=resume, cwd=cwd))
+    if session_id and resume:
+        click.echo("Error: --session-id and --resume are mutually exclusive.", err=True)
+        sys.exit(1)
+
+    sys.exit(run(prompt=prompt, provider=provider, model=model, resume=resume, session_id=session_id, cwd=cwd))
 
 
 @ai_cli.command("save-config")

--- a/myk_pi_tools/ai_cli/run.py
+++ b/myk_pi_tools/ai_cli/run.py
@@ -19,13 +19,6 @@ _DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini-2.5-flash",
 }
 
-# Session resume flags per provider
-_RESUME_FLAGS: dict[str, list[str]] = {
-    "cursor": ["--continue"],
-    "claude": ["-c"],
-    "gemini": ["--resume", "latest"],
-}
-
 
 async def _run_async(
     prompt: str,
@@ -33,6 +26,8 @@ async def _run_async(
     model: str,
     cwd: Path,
     cli_flags: list[str],
+    session_id: str | None = None,
+    continue_session: bool = False,
 ) -> AIResult:
     """Load pricing and run the AI CLI call in a single event loop."""
     from ai_cli_runner import call_ai_cli, pricing_cache
@@ -45,6 +40,8 @@ async def _run_async(
         ai_model=model,
         cli_flags=cli_flags,
         output_format="json",
+        session_id=session_id,
+        continue_session=continue_session,
     )
 
 
@@ -53,6 +50,7 @@ def run(
     provider: str,
     model: str = "",
     resume: bool = False,
+    session_id: str | None = None,
     cwd: str | None = None,
 ) -> int:
     """Run a prompt via ai-cli-runner.
@@ -67,8 +65,10 @@ def run(
     effective_cwd = Path(cwd) if cwd else Path.cwd()
 
     cli_flags: list[str] = []
-    if resume:
-        cli_flags.extend(_RESUME_FLAGS.get(provider, []))
+    # --session-id and --resume are mutually exclusive (validated in commands.py)
+    # --session-id: resume a specific session by ID
+    # --resume: continue the most recent session (continue_session=True)
+    continue_session = resume and not session_id
 
     click.echo(f"[ai-cli] {provider.upper()} ({effective_model})", err=True)
 
@@ -80,6 +80,8 @@ def run(
                 model=effective_model,
                 cwd=effective_cwd,
                 cli_flags=cli_flags,
+                session_id=session_id,
+                continue_session=continue_session,
             )
         )
     except Exception as e:
@@ -94,6 +96,8 @@ def run(
 
     if result.success:
         output["text"] = result.text
+        if result.session_id:
+            output["session_id"] = result.session_id
         if result.usage:
             output["usage"] = {
                 "provider": result.usage.provider,

--- a/prompts/external-ai.md
+++ b/prompts/external-ai.md
@@ -163,27 +163,25 @@ or selecting from the interactive prompts above.
 ### Step 3: Session Management
 
 Sessions allow the AI CLI to maintain conversation context across prompts.
+`ai-cli-runner` exposes `session_id` and `continue_session` params, and returns
+`session_id` in the result. The `myk-pi-tools ai-cli run` command supports:
+
+- `--resume` — continue the most recent session (`continue_session=True`)
+- `--session-id <id>` — resume a specific session by ID (exact targeting)
 
 **Session behavior by mode:**
 
 | Mode | Session behavior |
 |------|------------------|
 | **Normal** (no flags) | Stateless — fresh session each call |
-| **`--resume`** | Continue the last session — adds session resume flag to CLI |
-| **`--fix`** | Stateless by default. Combine with `--resume` to continue a session |
-| **`--fix --resume`** | Continue the last session in fix mode |
-| **`--peer`** | Automatic sessions — first round is fresh, all subsequent rounds use `--continue`/`-c`/`--resume latest` to maintain conversation context. Do NOT combine with `--resume` |
+| **`--resume`** | Continue the most recent session |
+| **`--session-id <id>`** | Resume a specific session by ID |
+| **`--fix`** | Stateless by default. Combine with `--resume` or `--session-id` to continue a session |
+| **`--peer`** | Automatic sessions — first round is fresh, subsequent rounds use `--session-id <id>` captured from the first round's output to maintain exact conversation context. Do NOT combine with `--resume` |
 
-**Session resume flags per provider:**
-
-| Provider | Resume flag | Binary |
-|----------|------------|--------|
-| `cursor` | `--continue` | `agent` |
-| `claude` | `-c` | `claude` |
-| `gemini` | `--resume latest` | `gemini` |
-
-When `--resume` is active or in peer mode follow-up rounds, pass `--resume`
-to the `myk-pi-tools ai-cli run` command.
+When `--resume` is active, pass `--resume` to the `myk-pi-tools ai-cli run` command.
+In peer mode follow-up rounds, pass `--session-id <id>` instead of `--resume`
+for exact session targeting (see Step 9).
 
 ### Step 4: Workspace Safety Check (--fix and --peer modes)
 
@@ -437,9 +435,14 @@ Original prompt: <user's prompt>
 ```
 
 Execute via `myk-pi-tools ai-cli run` (read-only mode — append the read-only guard to the prompt).
-This first round is a **fresh session** — do NOT pass `--resume`.
+This first round is a **fresh session** — do NOT pass `--resume` or `--session-id`.
 Do NOT display intermediate results to the user.
 If the command fails, abort the peer loop and report the error.
+
+**Capture session_id:** Parse the JSON output from the first round. Extract
+`session_id` from the response. Store it per-provider for use in subsequent
+rounds (Step 9c). The `session_id` enables exact session targeting instead
+of generic `--resume`.
 
 **Multi-agent:** Send the peer framing prompt to ALL agents in parallel
 using `run_parallel_with_limit`. Collect and merge findings from all agents,
@@ -447,7 +450,7 @@ deduplicating where the same issue is raised by multiple agents.
 
 **Multi-agent group context:** In the first round, each agent reviews
 independently (no group context yet). Their individual responses are
-collected for use in subsequent rounds.
+collected for use in subsequent rounds. Store each provider's `session_id`.
 
 If ALL agents report no findings, skip to Step 9e.
 If only SOME agents report no findings, continue to Step 9b with the findings
@@ -528,11 +531,14 @@ build on other peers' findings.
 When sending to peer A, include findings from peers B, C, etc.
 When sending to peer B, include findings from peers A, C, etc.
 
-Execute via `myk-pi-tools ai-cli run --resume`. Do NOT display intermediate results.
-**Use `--resume`** for this and all subsequent rounds so the peer agent has full
-conversation context from previous rounds.
+Execute via `myk-pi-tools ai-cli run --session-id <id>` using the `session_id`
+captured in Step 9a. Do NOT display intermediate results.
+**Use `--session-id <id>`** for this and all subsequent rounds so the peer agent
+resumes the exact conversation session from previous rounds. If `session_id` was
+not captured (provider didn't return one), fall back to `--resume`.
 
-**Multi-agent:** Send the response to ALL agents in parallel. Each agent uses `--resume`.
+**Multi-agent:** Send the response to ALL agents in parallel. Each agent uses
+its own `--session-id <id>` captured from its first-round output.
 
 #### 9d: Loop Until Convergence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["click>=8.0.0", "tomli>=2.0.0; python_version < '3.11'", "ai-cli-runner"]
+dependencies = ["click>=8.0.0", "tomli>=2.0.0; python_version < '3.11'", "ai-cli-runner>=0.4.0"]
 
 [project.scripts]
 myk-pi-tools = "myk_pi_tools.cli:main"

--- a/uv.lock
+++ b/uv.lock
@@ -4,13 +4,13 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ai-cli-runner"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "python-simple-logger" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/a2/a03bd995c8278ea985423ad0401c328195480ff74b7e1d846b87faad5721/ai_cli_runner-0.3.0.tar.gz", hash = "sha256:bbb0cdf1ecb80203aa3d659e631ed13123dbb2ee1ac0b78a2c76a8e5ed45bd90", size = 45632, upload-time = "2026-05-04T16:05:43.296Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/7e407155a39351c4ecf6592195c6e22718fc79eb1db1d4963071d0043c09/ai_cli_runner-0.4.0.tar.gz", hash = "sha256:f4051a79cd2bf220f665dbd86421cc60aa1422ad6075940706c1f430fb3c0105", size = 47905, upload-time = "2026-05-13T04:19:02.173Z" }
 
 [[package]]
 name = "anyio"
@@ -138,7 +138,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ai-cli-runner" },
+    { name = "ai-cli-runner", specifier = ">=0.4.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]


### PR DESCRIPTION
## Summary

Integrates the session management API from [ai-cli-runner#23](https://github.com/myk-org/ai-cli-runner/pull/23) (now merged) into `myk-pi-tools ai-cli run`.

## Changes

### `myk_pi_tools/ai_cli/run.py`
- Add `session_id` parameter for resuming a specific session by ID
- Change `--resume` to use `continue_session=True` (continue latest session) instead of provider-specific CLI flags
- Remove `_RESUME_FLAGS` dict — session management now delegated to `ai-cli-runner`
- Output `session_id` from `AIResult` in JSON output

### `myk_pi_tools/ai_cli/commands.py`
- Add `--session-id` click option to the `run` command
- Add mutual exclusion validation: `--session-id` and `--resume` cannot be used together

### `prompts/external-ai.md`
- Step 3: Document new `--session-id` and updated `--resume` behavior
- Step 9a: Capture `session_id` from first peer review round output
- Step 9c+: Use `--session-id <id>` for follow-up rounds (exact session targeting instead of generic `--resume`)

### Dependencies
- Bump `ai-cli-runner` to `>=0.4.0` (includes session management API)
- Update `uv.lock`

Closes #314