### PR TITLE
fix(cli): session API review fixes — wiring, validation, logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Single extension that provides:
 | `/refine-review <url>` | Refine and improve existing PR review comments |
 | `/coderabbit-rate-limit [number\|url]` | Handle CodeRabbit rate limiting on PRs |
 | `/query-db <command>` | Query the review comments database |
-| `/external-ai <agent> [--model <model>] [--fix\|--peer\|--resume] <prompt>` | Run prompts via AI CLIs directly (cursor, claude, gemini) — full model access |
+| `/external-ai <agent> [--model <model>] [--session-id <id>] [--fix\|--peer\|--resume] <prompt>` | Run prompts via AI CLIs directly (cursor, claude, gemini) — full model access |
 | `/external-ai-models-refresh` | Refresh cached AI CLI models for autocomplete |
 | `/dream` | Run memory consolidation — extract, deduplicate, maintain memory.md |
 | `/remember <what>` | Save a memory for future sessions |

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -50,6 +50,7 @@ const AI_CLI_FLAGS: AutocompleteItem[] = [
   { value: "--fix", label: "--fix", description: "Agent can modify files" },
   { value: "--peer", label: "--peer", description: "AI-to-AI peer review loop" },
   { value: "--resume", label: "--resume", description: "Continue most recent session" },
+  { value: "--session-id ", label: "--session-id", description: "Resume a specific session by ID" },
   { value: "--model ", label: "--model", description: "Set model (e.g., gpt-5.4-high)" },
 ];
 

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -49,7 +49,7 @@ const AI_CLI_PROVIDERS: AutocompleteItem[] = [
 const AI_CLI_FLAGS: AutocompleteItem[] = [
   { value: "--fix", label: "--fix", description: "Agent can modify files" },
   { value: "--peer", label: "--peer", description: "AI-to-AI peer review loop" },
-  { value: "--resume", label: "--resume", description: "Continue last session" },
+  { value: "--resume", label: "--resume", description: "Continue most recent session" },
   { value: "--model ", label: "--model", description: "Set model (e.g., gpt-5.4-high)" },
 ];
 

--- a/myk_pi_tools/ai_cli/commands.py
+++ b/myk_pi_tools/ai_cli/commands.py
@@ -22,11 +22,15 @@ def run_cmd(prompt: str, provider: str, model: str, resume: bool, session_id: st
 
     PROMPT: The prompt text to send to the AI CLI.
     """
-    from myk_pi_tools.ai_cli.run import run
-
     if session_id and resume:
         click.echo("Error: --session-id and --resume are mutually exclusive.", err=True)
         sys.exit(1)
+
+    if session_id and session_id.startswith("-"):
+        click.echo("Error: --session-id value must not start with '-'", err=True)
+        sys.exit(1)
+
+    from myk_pi_tools.ai_cli.run import run
 
     sys.exit(run(prompt=prompt, provider=provider, model=model, resume=resume, session_id=session_id, cwd=cwd))
 

--- a/myk_pi_tools/ai_cli/run.py
+++ b/myk_pi_tools/ai_cli/run.py
@@ -57,6 +57,12 @@ def run(
 
     Returns exit code (0 = success, 1 = error).
     """
+    session_id = session_id or None
+
+    if resume and session_id:
+        click.echo("Error: --session-id and --resume are mutually exclusive.", err=True)
+        return 1
+
     effective_model = model or _DEFAULT_MODELS.get(provider, "")
     if not effective_model:
         click.echo(f"Error: No default model for provider '{provider}' and no --model specified.", err=True)
@@ -70,7 +76,8 @@ def run(
     # --resume: continue the most recent session (continue_session=True)
     continue_session = resume and not session_id
 
-    click.echo(f"[ai-cli] {provider.upper()} ({effective_model})", err=True)
+    suffix = f", session={session_id}" if session_id else ", resume" if continue_session else ""
+    click.echo(f"[ai-cli] {provider.upper()} ({effective_model}{suffix})", err=True)
 
     try:
         result = asyncio.run(
@@ -85,7 +92,15 @@ def run(
             )
         )
     except Exception as e:
-        print(json.dumps({"success": False, "provider": provider, "model": effective_model, "error": str(e)}, indent=2))
+        error_out: dict[str, object] = {
+            "success": False,
+            "provider": provider,
+            "model": effective_model,
+            "error": str(e),
+        }
+        if session_id:
+            error_out["session_id"] = session_id
+        print(json.dumps(error_out, indent=2))
         return 1
 
     output: dict[str, object] = {
@@ -111,6 +126,8 @@ def run(
             }
     else:
         output["error"] = result.text or "Unknown error (no details from provider)"
+        if session_id:
+            output["session_id"] = session_id
 
     print(json.dumps(output, indent=2))
     return 0 if result.success else 1

--- a/myk_pi_tools/ai_cli/run.py
+++ b/myk_pi_tools/ai_cli/run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -57,7 +58,7 @@ def run(
 
     Returns exit code (0 = success, 1 = error).
     """
-    session_id = session_id or None
+    session_id = session_id or None  # Normalize "" to None for programmatic callers
 
     # Defense-in-depth: also validated in commands.py CLI layer
     if resume and session_id:
@@ -94,6 +95,7 @@ def run(
             )
         )
     except Exception as e:
+        click.echo(traceback.format_exc(), err=True)
         error_out: dict[str, object] = {
             "success": False,
             "provider": provider,
@@ -115,6 +117,8 @@ def run(
         output["text"] = result.text
         if result.session_id:
             output["session_id"] = result.session_id
+        elif session_id:
+            output["session_id"] = session_id
         if result.usage:
             output["usage"] = {
                 "provider": result.usage.provider,
@@ -126,8 +130,6 @@ def run(
                 "cost_usd": result.usage.cost_usd,
                 "duration_ms": result.usage.duration_ms,
             }
-        if session_id:
-            output["session_id"] = session_id
     else:
         output["error"] = result.text or "Unknown error (no details from provider)"
         if session_id:

--- a/myk_pi_tools/ai_cli/run.py
+++ b/myk_pi_tools/ai_cli/run.py
@@ -124,6 +124,8 @@ def run(
                 "cost_usd": result.usage.cost_usd,
                 "duration_ms": result.usage.duration_ms,
             }
+        if session_id:
+            output["session_id"] = session_id
     else:
         output["error"] = result.text or "Unknown error (no details from provider)"
         if session_id:

--- a/myk_pi_tools/ai_cli/run.py
+++ b/myk_pi_tools/ai_cli/run.py
@@ -59,8 +59,13 @@ def run(
     """
     session_id = session_id or None
 
+    # Defense-in-depth: also validated in commands.py CLI layer
     if resume and session_id:
         click.echo("Error: --session-id and --resume are mutually exclusive.", err=True)
+        return 1
+
+    if session_id and session_id.startswith("-"):
+        click.echo("Error: --session-id value must not start with '-'", err=True)
         return 1
 
     effective_model = model or _DEFAULT_MODELS.get(provider, "")
@@ -71,10 +76,7 @@ def run(
     effective_cwd = Path(cwd) if cwd else Path.cwd()
 
     cli_flags: list[str] = []
-    # --session-id and --resume are mutually exclusive (validated in commands.py)
-    # --session-id: resume a specific session by ID
-    # --resume: continue the most recent session (continue_session=True)
-    continue_session = resume and not session_id
+    continue_session = resume  # session_id mutual exclusivity already guarded above
 
     suffix = f", session={session_id}" if session_id else ", resume" if continue_session else ""
     click.echo(f"[ai-cli] {provider.upper()} ({effective_model}{suffix})", err=True)


### PR DESCRIPTION
## Summary

Follow-up fixes from code review of PR #318 (session API integration).

### Critical fix
- `session_id` and `continue_session` are now actually passed to `call_ai_cli` via `_run_async` — previously they were validated and logged but never forwarded

### Improvements
- Log session state in stderr status line (session ID or resume)
- Defensive mutual exclusivity guard in `run()` with comment
- Normalize empty `session_id` to `None`
- Include `session_id` in both success and error JSON output
- Validate `session_id` format in both CLI and library layers
- Simplify `continue_session = resume` (guard above ensures exclusivity)
- Update `--resume` autocomplete description