### PR TITLE
fix: remove unnecessary mkdir from entrypoint

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,9 +3,6 @@
 # HOME is set to /home/$PI_HOST_USER if configured, otherwise /home/node.
 set -e
 
-# Create temp dir for this project (persists across container restarts when mounted)
-mkdir -p "/tmp/pi-work/$(basename "$PWD")"
-
 # Always install/update pi to get the latest version on every container start
 npm install -g @earendil-works/pi-coding-agent
 


### PR DESCRIPTION
The `mkdir -p /tmp/pi-work/...` in entrypoint.sh is unnecessary — the AI creates the directory on demand when it needs temp files. Removing it also avoids the host-side permission issue where Docker/Podman creates the mount point as root before the container starts.