### PR TITLE
feat(enforcement): reject sync calls to review agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ pi-config/
 │   │   ├── nvim.ts                  # Neovim integration (quickfix, /nvim-changed-files)
 │   │   ├── status.ts                # /status command — unified session status snapshot
 │   │   ├── status-line.ts           # Git status, notifications, container indicator, last-activity timestamp
-│   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent
+│   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent (async-only enforcement for reviewers)
 │   │   └── utils.ts                 # Shared utilities
 │   └── acpx-provider/              # ACPX provider extension
 │       └── index.ts
@@ -151,6 +151,23 @@ pi-config/
 - Edit files in the `rules/` directory.
 - Rules auto-load in **alphabetical order** (hence the numeric prefixes).
 - Changes take effect on the **next pi session** — no restart of running sessions.
+
+### Async-Only Agents
+
+Some agents are enforced to only run with `async: true` — sync calls are rejected
+by `subagent-tool.ts` with an error. This prevents the LLM from blocking the session
+waiting for long-running agents.
+
+**Currently enforced:**
+
+- `code-reviewer-quality`
+- `code-reviewer-guidelines`
+- `code-reviewer-security`
+
+**To add/remove agents from the async-only list:**
+
+1. Edit the `ASYNC_ONLY_AGENTS` set in `extensions/orchestrator/subagent-tool.ts`
+2. Update this section in `AGENTS.md`
 
 ### Adding an Extension Command
 

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -40,6 +40,15 @@ const SYNC_TIME_EXCEEDED_ERROR = (seconds: number) =>
   `Estimated time ${seconds}s meets or exceeds ${MAX_SYNC_SECONDS}s sync limit. Use async: true instead.`;
 const MISSING_ESTIMATE_ERROR = "Missing required parameter: estimatedSeconds. Provide an estimated duration in seconds for sync agent tasks.";
 
+/** Agents that MUST be dispatched with async: true. Sync calls are rejected. */
+const ASYNC_ONLY_AGENTS = new Set([
+  "code-reviewer-quality",
+  "code-reviewer-guidelines",
+  "code-reviewer-security",
+]);
+const ASYNC_ONLY_ERROR = (names: string[]) =>
+  `These agents MUST use async: true: ${names.join(", ")}. Review agents run in the background — never block the session waiting for them.`;
+
 // ── Schemas ──────────────────────────────────────────────────────────────
 
 const TaskItem = Type.Object({
@@ -568,6 +577,22 @@ export function registerSubagentTool(
           details: mkd("single")([]),
           isError: errors.length > 0 && killed.length === 0,
         };
+      }
+
+      // Enforce async-only agents — reject sync calls for reviewers etc.
+      if (params.async !== true) {
+        const requested: string[] = [];
+        if (params.agent) requested.push(params.agent);
+        if (params.tasks) for (const t of params.tasks) requested.push(t.agent);
+        if (params.chain) for (const s of params.chain) requested.push(s.agent);
+        const violators = [...new Set(requested.filter(n => ASYNC_ONLY_AGENTS.has(n)))];
+        if (violators.length > 0) {
+          return {
+            content: [{ type: "text", text: ASYNC_ONLY_ERROR(violators) }],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
       }
 
       if (modes !== 1) {

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -40,7 +40,8 @@ const SYNC_TIME_EXCEEDED_ERROR = (seconds: number) =>
   `Estimated time ${seconds}s meets or exceeds ${MAX_SYNC_SECONDS}s sync limit. Use async: true instead.`;
 const MISSING_ESTIMATE_ERROR = "Missing required parameter: estimatedSeconds. Provide an estimated duration in seconds for sync agent tasks.";
 
-/** Agents that MUST be dispatched with async: true. Sync calls are rejected. */
+/** Agents that MUST be dispatched with async: true. Sync calls are rejected.
+ *  Keep in sync with rules/20-code-review-loop.md when changing this list. */
 const ASYNC_ONLY_AGENTS = new Set([
   "code-reviewer-quality",
   "code-reviewer-guidelines",

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -580,16 +580,20 @@ export function registerSubagentTool(
         };
       }
 
-      // Enforce async-only agents — reject sync calls for reviewers etc.
-      if (params.async !== true) {
+      // Enforce async-only agents — reject sync/chain calls for reviewers etc.
+      {
         const requested: string[] = [];
         if (params.agent) requested.push(params.agent);
         if (params.tasks) for (const t of params.tasks) requested.push(t.agent);
         if (params.chain) for (const s of params.chain) requested.push(s.agent);
         const violators = [...new Set(requested.filter(n => ASYNC_ONLY_AGENTS.has(n)))];
         if (violators.length > 0) {
+          const inChain = params.chain?.some(s => ASYNC_ONLY_AGENTS.has(s.agent));
+          const msg = inChain
+            ? `These agents cannot be used in chain mode: ${violators.join(", ")}. Dispatch them as separate async tasks instead.`
+            : ASYNC_ONLY_ERROR(violators);
           return {
-            content: [{ type: "text", text: ASYNC_ONLY_ERROR(violators) }],
+            content: [{ type: "text", text: msg }],
             details: mkd("single")([]),
             isError: true,
           };


### PR DESCRIPTION
## Summary

Review agents (`code-reviewer-quality`, `code-reviewer-guidelines`, `code-reviewer-security`) must always be dispatched with `async: true`. The LLM frequently ignores the rule and calls them synchronously, blocking the session.

## Changes

Added hard enforcement in `subagent-tool.ts`:
- New `ASYNC_ONLY_AGENTS` set defining which agents require async
- Early check in `execute()` rejects sync calls with a clear error message
- Covers all modes: single, parallel (`tasks`), and chain
- LLM gets an `isError: true` response and must retry with `async: true`

## Why code, not rules

Rules can be ignored. Code can't. The tool call literally fails if the LLM tries to call reviewers synchronously.