### PR TITLE
feat: resume reminder on async results + fix async-only enforcement bug

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -188,9 +188,10 @@ export function registerAsyncAgents(
       if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
         const output = (data.output || "").slice(0, 3000);
+        const RESUME_REMINDER = "\n\n---\n⚠️ **Resume check:** Were you in the middle of a workflow before this result arrived? If yes, handle this result and then resume the workflow from the next pending step.";
         pi.sendMessage({
           customType: "async-agent-result",
-          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}`,
+          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${RESUME_REMINDER}`,
           display: true,
         }, { triggerTurn: true, deliverAs: "followUp" });
       }

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -589,14 +589,20 @@ export function registerSubagentTool(
         const violators = [...new Set(requested.filter(n => ASYNC_ONLY_AGENTS.has(n)))];
         if (violators.length > 0) {
           const inChain = params.chain?.some(s => ASYNC_ONLY_AGENTS.has(s.agent));
-          const msg = inChain
-            ? `These agents cannot be used in chain mode: ${violators.join(", ")}. Dispatch them as separate async tasks instead.`
-            : ASYNC_ONLY_ERROR(violators);
-          return {
-            content: [{ type: "text", text: msg }],
-            details: mkd("single")([]),
-            isError: true,
-          };
+          if (inChain) {
+            return {
+              content: [{ type: "text", text: `These agents cannot be used in chain mode: ${violators.join(", ")}. Dispatch them as separate async tasks instead.` }],
+              details: mkd("single")([]),
+              isError: true,
+            };
+          }
+          if (params.async !== true) {
+            return {
+              content: [{ type: "text", text: ASYNC_ONLY_ERROR(violators) }],
+              details: mkd("single")([]),
+              isError: true,
+            };
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Two changes:

### 1. Resume reminder on async agent results
When async agent results arrive mid-workflow, the LLM often forgets to resume the original task. Now every async result message includes a reminder:

> ⚠️ **Resume check:** Were you in the middle of a workflow before this result arrived? If yes, handle this result and then resume the workflow from the next pending step.

### 2. Fix async-only enforcement bug
PR #328 introduced async-only agent enforcement, but the chain error message fix accidentally removed the `params.async !== true` guard. This caused ALL calls to async-only agents to be rejected — even valid async ones.

Fixed by splitting into two checks:
- Chain mode with async-only agents → always rejected (chain doesn't support async)
- Single/parallel mode → only rejected when `async !== true`

## Files changed
- `extensions/orchestrator/async-agents.ts` — resume reminder injection
- `extensions/orchestrator/subagent-tool.ts` — fix async-only enforcement