### PR TITLE
fix(ai-cli): inject --force for cursor non-interactive mode

### DIFF
--- a/myk_pi_tools/ai_cli/run.py
+++ b/myk_pi_tools/ai_cli/run.py
@@ -20,6 +20,11 @@ _DEFAULT_MODELS: dict[str, str] = {
     "gemini": "gemini-2.5-flash",
 }
 
+# Provider-specific flags required for non-interactive execution
+_PROVIDER_CLI_FLAGS: dict[str, list[str]] = {
+    "cursor": ["--force"],  # Skip workspace trust prompts in --print mode
+}
+
 
 async def _run_async(
     prompt: str,
@@ -77,7 +82,7 @@ def run(
 
     effective_cwd = Path(cwd).resolve() if cwd else Path.cwd()
 
-    effective_flags: list[str] = list(cli_flags or [])
+    effective_flags: list[str] = list(_PROVIDER_CLI_FLAGS.get(provider, [])) + list(cli_flags or [])
 
     continue_session = resume  # session_id mutual exclusivity already guarded above
 


### PR DESCRIPTION
## Problem

Cursor CLI's `--print` mode requires `--force` to skip workspace trust prompts. Without it, non-interactive execution via `myk-pi-tools ai-cli run --provider cursor` blocks on trust dialogs that can't be answered.

## Fix

Add `_PROVIDER_CLI_FLAGS` dict in `myk_pi_tools/ai_cli/run.py` to inject provider-specific default CLI flags automatically. For cursor, `--force` is always prepended before user-supplied `--cli-flags`.

## Changes

- `myk_pi_tools/ai_cli/run.py`: Add `_PROVIDER_CLI_FLAGS` constant and use it when building `effective_flags`