### PR TITLE
chore: remove tokenjuice from project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,17 +228,6 @@ or extension command):
 - Prompt templates: update the entry in `completions` AND ensure the command is in `promptTemplateCommands`
 - If adding a new completable command, follow the existing patterns (static items, cached fetchers, etc.)
 
-### TokenJuice — Tool Output Compression
-
-[TokenJuice](https://github.com/vincentkoc/tokenjuice) is an external pi extension that
-compresses bash tool output using pattern-based JSON rules. Pre-installed in the Docker image.
-
-**Install (native):** `npm install -g tokenjuice && tokenjuice install pi`
-
-**Commands:** `/tj status`, `/tj on`, `/tj off`, `/tj raw-next`
-
-**Source:** Inspired by [OpenHuman's TokenJuice](https://github.com/tinyhumansai/openhuman) (issue #334)
-
 ### Memory Evolution — Scored Learning, Situation Reports, Memory Tree
 
 Three-layer memory system with scored,

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ COPY --chmod=755 scripts/docker-safe /usr/local/bin/docker-safe
 
 # Install acpx, agent-browser, pi-web-access, gemini-cli (pi itself is installed at runtime in entrypoint.sh)
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-  npm install -g acpx agent-browser pi-web-access @google/gemini-cli tokenjuice
+  npm install -g acpx agent-browser pi-web-access @google/gemini-cli
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)
 RUN chown -R node:node /home/node

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Single extension that provides:
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
 | **Pidiff viewer** | Standalone diff viewer with review comments — branch diffs, file tree, inline comments |
-| **TokenJuice** | Tool output compression — [tokenjuice](https://github.com/vincentkoc/tokenjuice) compresses bash results using pattern-based rules to save context window tokens |
 | **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains topic-based memory |
 | **Upgrade changelog** | Shows release notes on session start after pi-config version upgrade |
 | **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |
@@ -105,8 +104,6 @@ uv tool install git+https://github.com/myk-org/pi-config
 npm install -g acpx           # External AI agent proxy (cursor, codex, gemini)
 npm install -g pi-web-access  # Web search/fetch skills (librarian)
 uvx install mcp-launchpad     # MCP server CLI (mcpl)
-npm install -g tokenjuice    # Tool output compression
-tokenjuice install pi         # Install pi extension
 ```
 
 #### Optional: Vertex AI (Claude via Google Cloud)
@@ -418,30 +415,6 @@ PI_PIDIFF_ENABLE=false pi
 /pidiff restart   # Restart the daemon
 ```
 
-### TokenJuice — tool output compression
-
-[TokenJuice](https://github.com/vincentkoc/tokenjuice) compresses bash tool output before it reaches the LLM
-context window. Uses pattern-based JSON rules to strip noise and keep only the important parts of CLI
-output — saving 60-80% of tokens on typical commands.
-
-Pre-installed in the Docker image. For native installs:
-
-```bash
-npm install -g tokenjuice
-tokenjuice install pi
-```
-
-After installing, reload pi (`/reload`). The `/tj` command controls the extension:
-
-```bash
-/tj status     # Show compression stats
-/tj on         # Enable compression
-/tj off        # Disable compression
-/tj raw-next   # Bypass compression for next command
-```
-
-TokenJuice ships with 100+ built-in rules for common CLI tools (git, pytest, npm, docker, kubectl, rg, eslint, etc.).
-
 ### Optional mounts
 
 | Mount | Purpose |
@@ -472,7 +445,6 @@ TokenJuice ships with 100+ built-in rules for common CLI tools (git, pytest, npm
 | `acpx` | Agent proxy for remote models |
 | `kubectl` / `oc` | Kubernetes and OpenShift CLI |
 | `agent-browser` | Browser automation CLI (navigate, click, screenshot, forms) |
-| `tokenjuice` | Tool output compression — compresses CLI output to save context tokens |
 | `procps` | Process utilities (ps, top, pgrep, pkill) |
 | `docker` / `podman` | Container CLIs (used via `docker-safe` read-only wrapper) |
 | `docker-safe` | Restricted Docker/Podman wrapper — container only (ps, logs, inspect, top, stats) |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,10 +30,6 @@ if ! grep -q 'pi-web-access' "$HOME/.pi/agent/settings.json" 2>/dev/null; then
     pi install npm:pi-web-access 2>/dev/null || true
 fi
 
-# tokenjuice: install pi extension if not already present
-if [ ! -f "$HOME/.pi/agent/extensions/tokenjuice.js" ]; then
-    tokenjuice install pi 2>/dev/null || true
-fi
 
 
 # Fix host-specific paths in mounted .gitconfig (read-only mount, can't write in-place)


### PR DESCRIPTION
Remove tokenjuice from Dockerfile, entrypoint.sh, AGENTS.md, and README.md.