### PR TITLE
fix(pidash): use thinking_level_select event instead of turn_end hack

### DIFF
--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -588,13 +588,11 @@ export function registerPidash(
     }
   });
 
-  // Sync thinking level on every turn
-  pi.on("turn_end", () => {
-    if (!ws || !connected) return;
-    try {
-      const level = (pi as any).getThinkingLevel?.();
-      if (level) ws.send(JSON.stringify({ type: "update_info", thinkingLevel: level }));
-    } catch {}
+  // Track thinking level changes via the official event
+  pi.on("thinking_level_select", (event: any) => {
+    if (ws && connected) {
+      ws.send(JSON.stringify({ type: "update_info", thinkingLevel: event.level }));
+    }
   });
 
   // Track diff viewer port


### PR DESCRIPTION
Replace the turn_end polling hack that called (pi as any).getThinkingLevel() on every turn with the official thinking_level_select event from pi 0.74.1. Fires only when thinking level actually changes — cleaner and more efficient.