### PR TITLE
fix(acpx-provider): skip registration in subagent child processes

### DIFF
--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -512,6 +512,14 @@ function streamAcpx(
 // =============================================================================
 
 export default function (pi: ExtensionAPI) {
+	// Subagent child processes must NOT register acpx providers.
+	// acpx models are session-scoped to the parent pi process — child processes
+	// would create independent sessions to the coding agent (e.g., Cursor),
+	// losing conversation context and triggering agent-side sub-task protocols
+	// (like cursor/task) that our streaming code doesn't handle.
+	// Children fall back to standard API-based models instead.
+	if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
 	// Capture cwd at extension load time, before pi potentially changes to /tmp.
 	// acpx needs this to find session markers in the project directory tree.
 	projectCwd = process.cwd();


### PR DESCRIPTION
## Problem

When the user's default model is an acpx model (e.g., `cursor:claude-opus-4-6`), subagent child processes (both sync and async) would also try to register and use acpx providers. This caused failures because:

1. Each child created its own independent acpx runtime/session to the coding agent (Cursor)
2. The coding agent tried to invoke its sub-task protocol (`cursor/task` JSON-RPC method)
3. Our `streamAcpx` code skips `tool_call` events, so the agent's sub-tasks were silently ignored
4. Sessions failed with unhandled `cursor/task` errors

## Fix

Check `PI_SUBAGENT_CHILD` environment variable at the top of the extension entry point. When set (by both `subagent-tool.ts` and `async-agents.ts`), skip all acpx provider registration. Child processes fall back to standard API-based models instead.

## Testing

- Verified both sync (`subagent-tool.ts` line 419) and async (`async-agents.ts` line 304) set `PI_SUBAGENT_CHILD=1`
- The guard matches the pattern already used by `subagent-tool.ts` (line 510) to prevent infinite recursion