### PR TITLE
fix(acpx-provider): handle stale ctx in async session_start notifications

### DIFF
--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -608,6 +608,15 @@ export default function (pi: ExtensionAPI) {
 				}),
 			);
 
+			const safeNotify = (message: string, type: "info" | "warning" | "error") => {
+				try {
+					ctx.ui.notify(message, type);
+				} catch {
+					// ctx may be stale if session was replaced during async init
+					(type === "error" ? console.error : console.log)(`[acpx] ${message}`);
+				}
+			};
+
 			for (const result of results) {
 				if (result.status === "rejected") continue;
 
@@ -630,12 +639,12 @@ export default function (pi: ExtensionAPI) {
 							models,
 							streamSimple: streamAcpx,
 						});
-						ctx.ui.notify(`acpx-${agent}: ${modelIds.length} models discovered`, "info");
+						safeNotify(`acpx-${agent}: ${modelIds.length} models discovered`, "info");
 					} else {
-						ctx.ui.notify(`acpx-${agent}: no models discovered`, "warning");
+						safeNotify(`acpx-${agent}: no models discovered`, "warning");
 					}
 				} catch (err) {
-					ctx.ui.notify(`acpx-${agent}: setup failed: ${err}`, "error");
+					safeNotify(`acpx-${agent}: setup failed: ${err}`, "error");
 				}
 			}
 		})().catch((err) => {


### PR DESCRIPTION
## Problem

On pi startup, the acpx-provider `session_start` handler fires off async model discovery. If the session gets replaced or reloaded before discovery finishes, the captured `ctx` becomes stale and `ctx.ui.notify()` throws:

```
[acpx] session_start initialization failed: Error: This extension ctx is stale after session replacement or reload.
```

## Fix

Added a `safeNotify` helper that wraps `ctx.ui.notify` in a try-catch. If the context is stale, notifications fall back to `console.log` (info/warning) or `console.error` (errors). These are purely informational notifications, so the fallback is safe.