### PR TITLE
fix(docker): set TERM and COLORTERM for truecolor support in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ RUN chown -R node:node /home/node
 USER node
 RUN mkdir -p /home/node/.npm-global && npm config set prefix /home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:/home/node/.pi/agent/bin:/home/node/.local/bin:$PATH"
+ENV TERM=xterm-256color
+ENV COLORTERM=truecolor
 ENV PLAYWRIGHT_BROWSERS_PATH=/home/node/.cache/ms-playwright
 
 # Cursor auth: create config dir (auth.json mounted or symlinked at runtime)


### PR DESCRIPTION
## Problem

Pi v0.75.4 improved truecolor detection, but the container image doesn't set `TERM` or `COLORTERM` environment variables. Pi's new detection falls back to a degraded 256-color palette, making the TUI look ugly compared to running natively on the host (where the terminal sets `COLORTERM=truecolor`).

## Fix

Added `TERM=xterm-256color` and `COLORTERM=truecolor` to the Dockerfile so pi gets proper truecolor rendering inside containers.