### PR TITLE
feat(memory): add `memory forget` CLI command

### DIFF
--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -304,8 +304,12 @@ export function registerPidash(
         if ((heartbeat as any).unref) (heartbeat as any).unref();
 
         // Show status
-        if (ctx.hasUI) {
-          ctx.ui.setStatus("5-pidash", ctx.ui.theme.fg("accent", `🌐 http://localhost:${PIDASH_PORT}`));
+        try {
+          if (ctx.hasUI) {
+            ctx.ui.setStatus("5-pidash", ctx.ui.theme.fg("accent", `🌐 http://localhost:${PIDASH_PORT}`));
+          }
+        } catch {
+          // ctx may be stale if session was replaced during WebSocket connect
         }
       });
 

--- a/extensions/orchestrator/pidiff.ts
+++ b/extensions/orchestrator/pidiff.ts
@@ -64,8 +64,12 @@ export function registerPidiff(pi: ExtensionAPI): void {
   let lastCtx: any = null;
 
   function setStatus(ctx: any): void {
-    if (ctx?.hasUI) {
-      ctx.ui.setStatus("4-diff", ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${PIDIFF_PORT}`));
+    try {
+      if (ctx?.hasUI) {
+        ctx.ui.setStatus("4-diff", ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${PIDIFF_PORT}`));
+      }
+    } catch {
+      // ctx may be stale if session was replaced during WebSocket connect
     }
     pi.events?.emit("diff-viewer:port", PIDIFF_PORT);
   }

--- a/myk_pi_tools/memory/commands.py
+++ b/myk_pi_tools/memory/commands.py
@@ -85,6 +85,33 @@ def memory_migrate(ctx: click.Context) -> None:
         click.echo("No DB found or empty — nothing to migrate.", err=True)
 
 
+@memory.command("forget")
+@click.option(
+    "--category",
+    "-c",
+    required=True,
+    type=click.Choice(["lesson", "decision", "mistake", "pattern", "done", "preference"]),
+    help="Memory category",
+)
+@click.option("--summary", "-s", required=True, help="Entry text to forget")
+@click.pass_context
+def memory_forget(ctx: click.Context, category: str, summary: str) -> None:
+    """Remove a memory entry.
+
+    Examples:
+
+        myk-pi-tools memory forget -c lesson -s "buildah chown -R skips target dir"
+
+        myk-pi-tools memory forget -c pattern -s "Container build monitor: old pattern"
+    """
+    mem = ctx.obj["mem"]
+    removed = mem.forget(category, summary)
+    if removed:
+        click.echo(f"Forgotten: [{category}] {summary}", err=True)
+    else:
+        click.echo(f"Not found: [{category}] {summary}", err=True)
+
+
 @memory.command("path")
 @click.pass_context
 def memory_path(ctx: click.Context) -> None:

--- a/myk_pi_tools/memory/store.py
+++ b/myk_pi_tools/memory/store.py
@@ -17,6 +17,7 @@ Each topic file has format:
     - [category] entry text
 """
 
+import json
 import sqlite3
 import sys
 from pathlib import Path
@@ -26,6 +27,15 @@ from myk_pi_tools.db.query import _get_git_root
 
 def log(message: str) -> None:
     print(message, file=sys.stderr)
+
+
+def _entry_hash(text: str) -> str:
+    """FNV-1a hash matching the TypeScript implementation in memory-scoring.ts."""
+    h = 0x811C9DC5
+    for ch in text:
+        h ^= ord(ch)
+        h = (h * 0x01000193) & 0xFFFFFFFF
+    return f"{h:08x}"
 
 
 CATEGORY_TO_TOPIC: dict[str, str] = {
@@ -148,6 +158,47 @@ class MemoryFile:
         self._cleanup_db_files()
 
         return len(rows)
+
+    def forget(self, category: str, summary: str) -> bool:
+        """Remove a memory entry from the topic file and optionally from memory-scores.json.
+
+        Returns True if removed, False if not found.
+        """
+        topic_path = self._topic_path(category)
+        if not topic_path.exists():
+            return False
+
+        content = topic_path.read_text()
+        pinned_line = f"- [{category}] {summary} *(pinned)*"
+        learned_line = f"- [{category}] {summary}"
+
+        lines = content.splitlines(keepends=True)
+        removed_line: str | None = None
+        for candidate in (pinned_line, learned_line):
+            if any(line.rstrip("\n") == candidate for line in lines):
+                removed_line = candidate
+                break
+
+        if removed_line is None:
+            return False
+
+        # Remove the line from the topic file
+        new_lines = [line for line in lines if line.rstrip("\n") != removed_line]
+        topic_path.write_text("".join(new_lines))
+
+        # Clean up memory-scores.json
+        scores_path = self.file_path.parent / "memory-scores.json"
+        if scores_path.exists():
+            try:
+                scores = json.loads(scores_path.read_text())
+                h = _entry_hash(removed_line)
+                if h in scores.get("entries", {}):
+                    del scores["entries"][h]
+                    scores_path.write_text(json.dumps(scores))
+            except (json.JSONDecodeError, OSError) as e:
+                log(f"Failed to clean memory-scores.json: {e}")
+
+        return True
 
     def _cleanup_db_files(self) -> None:
         """Remove SQLite DB and related files."""

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -118,6 +118,7 @@ stability = cue_weight × exp(-Δt / half_life) × ln(1 + evidence_count)
 ```bash
 uv run myk-pi-tools memory add -c <category> -s "summary"             # Add to Learned
 uv run myk-pi-tools memory add -c <category> -s "summary" --pinned    # Add to Pinned
+uv run myk-pi-tools memory forget -c <category> -s "summary"          # Remove an entry
 uv run myk-pi-tools memory show                                       # Show memory file
 uv run myk-pi-tools memory migrate                                    # One-time DB→md migration
 uv run myk-pi-tools memory path                                       # Print file path

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,11 +1,12 @@
 """Tests for the memory module."""
 
+import json
 import sqlite3
 from pathlib import Path
 
 import pytest
 
-from myk_pi_tools.memory.store import CATEGORY_TO_TOPIC, MemoryFile, _topic_template
+from myk_pi_tools.memory.store import CATEGORY_TO_TOPIC, MemoryFile, _entry_hash, _topic_template
 
 
 @pytest.fixture
@@ -125,6 +126,54 @@ class TestMixedEntries:
         lesson_pos = content.index("A lesson")
         mistake_pos = content.index("A mistake")
         assert lesson_pos < mistake_pos
+
+
+class TestForget:
+    def test_forget_learned_entry(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("lesson", "Some lesson")
+        assert memory_file.forget("lesson", "Some lesson") is True
+        content = (memory_file.file_path / "lessons.md").read_text()
+        assert "Some lesson" not in content
+
+    def test_forget_pinned_entry(self, memory_file: MemoryFile) -> None:
+        memory_file.add_pinned("preference", "Always use uv")
+        assert memory_file.forget("preference", "Always use uv") is True
+        content = (memory_file.file_path / "preferences.md").read_text()
+        assert "Always use uv" not in content
+
+    def test_forget_nonexistent_entry(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("lesson", "Existing lesson")
+        assert memory_file.forget("lesson", "Does not exist") is False
+
+    def test_forget_nonexistent_topic_file(self, memory_file: MemoryFile) -> None:
+        assert memory_file.forget("lesson", "No topic file") is False
+
+    def test_forget_leaves_other_entries(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("lesson", "Keep this")
+        memory_file.add_learned("lesson", "Remove this")
+        assert memory_file.forget("lesson", "Remove this") is True
+        content = (memory_file.file_path / "lessons.md").read_text()
+        assert "Keep this" in content
+        assert "Remove this" not in content
+
+    def test_forget_cleans_scores_file(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("lesson", "Some lesson")
+        line = "- [lesson] Some lesson"
+        scores = {"entries": {_entry_hash(line): {"class": "lesson", "score": 1.0}}}
+        # scores file lives in parent of topics dir
+        scores_path = memory_file.file_path.parent / "memory-scores.json"
+        scores_path.parent.mkdir(parents=True, exist_ok=True)
+        scores_path.write_text(json.dumps(scores))
+
+        assert memory_file.forget("lesson", "Some lesson") is True
+        updated = json.loads(scores_path.read_text())
+        assert _entry_hash(line) not in updated["entries"]
+
+    def test_forget_no_scores_file(self, memory_file: MemoryFile) -> None:
+        memory_file.add_learned("lesson", "Some lesson")
+        scores_path = memory_file.file_path.parent / "memory-scores.json"
+        assert not scores_path.exists()
+        assert memory_file.forget("lesson", "Some lesson") is True
 
 
 class TestMigration:


### PR DESCRIPTION
## Summary

Adds a `memory forget` CLI command to remove memory entries, and fixes stale context crashes in pidiff/pidash WebSocket handlers.

## Changes

### Memory forget command
- Added `_entry_hash()` FNV-1a hash function (matching TypeScript implementation in memory-scoring.ts)
- Added `MemoryFile.forget(category, summary)` method — removes entry from topic file and cleans up `memory-scores.json`
- Added `memory forget` CLI command with `-c` (category) and `-s` (summary) options
- Added 7 tests covering: learned/pinned removal, nonexistent entries, scores cleanup, graceful handling without scores file
- Updated CLI docs in `rules/35-memory.md`

### Stale context fix (pidiff + pidash)
- Wrapped `ctx.hasUI` access in `pidiff.ts` `setStatus()` and `pidash.ts` WebSocket `open` handler with try-catch
- Prevents pi crash when session is replaced during async WebSocket connection

## Usage

```bash
# Remove a learned or pinned entry
uv run myk-pi-tools memory forget -c pattern -s "Container build monitor: old pattern"
uv run myk-pi-tools memory forget -c lesson -s "buildah chown -R skips target dir"
```

Closes #355