### PR TITLE
fix(extensions): wrap WebSocket open handlers for stale ctx safety

### DIFF
--- a/extensions/orchestrator/pidash.ts
+++ b/extensions/orchestrator/pidash.ts
@@ -146,6 +146,7 @@ export function registerPidash(
         connected = true;
         connecting = false;
 
+        try {
         // Register this session
         const git = getGitStatus(ctx.cwd);
         const m = ctx.model;
@@ -273,6 +274,11 @@ export function registerPidash(
 
         // Signal replay is complete so the server can stop suppressing notifications
         try { wsClient.send(JSON.stringify({ type: "replay_complete" })); } catch {}
+
+        } catch (err) {
+          // ctx may be stale if session was replaced during WebSocket connect
+          debugLog(`open handler error (likely stale ctx): ${err}`);
+        }
 
         // Respond to pings (keepalive)
         wsClient.on("ping", () => {

--- a/extensions/orchestrator/pidiff.ts
+++ b/extensions/orchestrator/pidiff.ts
@@ -122,17 +122,23 @@ export function registerPidiff(pi: ExtensionAPI): void {
         ws = wsClient;
         connected = true;
         connecting = false;
-        setStatus(ctx);
 
-        // Register this session
-        const branch = getBranch(ctx.cwd);
-        wsClient.send(JSON.stringify({
-          type: "register",
-          pid: process.pid,
-          sessionId: `${process.pid}:${ctx.cwd}`,
-          cwd: ctx.cwd,
-          branch,
-        }));
+        try {
+          setStatus(ctx);
+
+          // Register this session
+          const branch = getBranch(ctx.cwd);
+          wsClient.send(JSON.stringify({
+            type: "register",
+            pid: process.pid,
+            sessionId: `${process.pid}:${ctx.cwd}`,
+            cwd: ctx.cwd,
+            branch,
+          }));
+        } catch {
+          // ctx may be stale if session was replaced during WebSocket connect
+          log("skipped registration — ctx is stale");
+        }
 
         // Keepalive
         wsClient.on("ping", () => { try { wsClient.pong(); } catch {} });


### PR DESCRIPTION
## Problem

When resuming a session, pi crashes with `uncaughtException: This extension ctx is stale` in the WebSocket `open` handler of pidiff.ts (and potentially pidash.ts). The `open` callback accesses `ctx.cwd`, `ctx.model`, `ctx.sessionManager` etc. — if the session was replaced before the WebSocket connects, these throw and crash pi.

Previous fix (PR #356) only wrapped `setStatus(ctx)` / `ctx.hasUI`, but missed the other `ctx` accesses in the same handler.

## Fix

Wrapped the entire ctx-accessing portion of WebSocket `open` handlers in both files with try-catch:

- **pidiff.ts**: `setStatus(ctx)` + registration block wrapped in try-catch
- **pidash.ts**: Registration + history loading + replay_complete block wrapped in try-catch

State updates (`ws`, `connected`, `connecting`) and keepalive/heartbeat code stay outside the try-catch since they don't access `ctx`.