### PR TITLE
fix(reviews): parse Major/Minor body-embedded CodeRabbit comments

### DIFF
--- a/myk_pi_tools/db/query.py
+++ b/myk_pi_tools/db/query.py
@@ -193,8 +193,8 @@ class ReviewDB:
         Retrieves comments that were dismissed during review processing:
         - ``not_addressed`` and ``skipped`` comments are always included (any type).
         - ``addressed`` comments are only included when their type is
-          ``outside_diff_comment``, ``nitpick_comment``, or
-          ``duplicate_comment``.  These types lack a GitHub review thread
+          ``outside_diff_comment``, ``major_comment``, ``minor_comment``,
+          ``nitpick_comment``, or ``duplicate_comment``.  These types lack a GitHub review thread
           that can be resolved, so the database is the only mechanism to
           auto-skip them on subsequent fetches.  Normal
           inline thread comments rely on GitHub's ``isResolved`` filter in
@@ -232,7 +232,10 @@ class ReviewDB:
                   AND (
                       c.status IN ('not_addressed', 'skipped')
                       OR (c.status = 'addressed'
-                          AND c.type IN ('outside_diff_comment', 'nitpick_comment', 'duplicate_comment'))
+                          AND c.type IN (
+                              'outside_diff_comment', 'major_comment',
+                              'minor_comment', 'nitpick_comment',
+                              'duplicate_comment'))
                   )
                 ORDER BY c.path, c.line
                 """,

--- a/myk_pi_tools/reviews/coderabbit_parser.py
+++ b/myk_pi_tools/reviews/coderabbit_parser.py
@@ -1,10 +1,12 @@
-"""Parse CodeRabbit review body comments (outside diff range, nitpick, and duplicate).
+"""Parse CodeRabbit review body comments (outside diff range, major, minor, nitpick, and duplicate).
 
 CodeRabbit embeds certain comments directly in the review body text
 (not as inline threads). This module extracts those comments into
-structured data. Three kinds of body-embedded sections are supported:
+structured data. Five kinds of body-embedded sections are supported:
 
 - **Outside diff range** comments (code outside the PR diff range)
+- **Major** comments (significant issues requiring attention)
+- **Minor** comments (less critical suggestions)
 - **Nitpick** comments (minor suggestions)
 - **Duplicate** comments (comments repeated from previous reviews)
 
@@ -25,6 +27,16 @@ from typing import Any
 # Matches the start of the outer "Outside diff range comments" section.
 _OUTSIDE_SECTION_START_RE = re.compile(
     r"<summary>\s*(?:\S+\s+)*?Outside diff range comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
+)
+
+# Matches the start of the outer "Major comments" section.
+_MAJOR_SECTION_START_RE = re.compile(
+    r"<summary>\s*(?:\S+\s+)*?Major comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
+)
+
+# Matches the start of the outer "Minor comments" section.
+_MINOR_SECTION_START_RE = re.compile(
+    r"<summary>\s*(?:\S+\s+)*?Minor comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
 )
 
 # Matches the start of the outer "Nitpick comments" section.
@@ -190,7 +202,7 @@ def _parse_single_comment(raw: str) -> dict[str, Any] | None:
 def _parse_section_comments(cleaned: str, section_re: re.Pattern[str]) -> list[dict[str, Any]]:
     """Extract and parse comments from a single section of a cleaned review body.
 
-    This is the shared logic for "outside diff range", "nitpick", and "duplicate"
+    This is the shared logic for "outside diff range", "major", "minor", "nitpick", and "duplicate"
     sections. The caller is responsible for cleaning the text first (stripping
     blockquote prefixes and trailing AI prompt blocks).
 
@@ -265,6 +277,62 @@ def parse_outside_diff_comments(body: str) -> list[dict[str, Any]]:
     return _parse_section_comments(cleaned, _OUTSIDE_SECTION_START_RE)
 
 
+def parse_major_comments(body: str) -> list[dict[str, Any]]:
+    """Parse 'major' comments from a CodeRabbit review body.
+
+    Args:
+        body: The review body text.
+
+    Returns:
+        List of dicts, each with keys:
+        - path: str (file path)
+        - line: int (start line)
+        - end_line: int | None (end line, or None if single line)
+        - body: str (the full comment body including title, but excluding AI prompt sections)
+        - category: str (e.g., "Potential issue")
+        - severity: str (e.g., "Major")
+    """
+    if not body:
+        return []
+
+    # Strip blockquote prefixes so we can parse clean HTML
+    cleaned = _strip_blockquote_prefix(body)
+
+    # Also strip a trailing AI prompt section that may appear outside the
+    # blockquote at the very end of the review body.
+    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
+
+    return _parse_section_comments(cleaned, _MAJOR_SECTION_START_RE)
+
+
+def parse_minor_comments(body: str) -> list[dict[str, Any]]:
+    """Parse 'minor' comments from a CodeRabbit review body.
+
+    Args:
+        body: The review body text.
+
+    Returns:
+        List of dicts, each with keys:
+        - path: str (file path)
+        - line: int (start line)
+        - end_line: int | None (end line, or None if single line)
+        - body: str (the full comment body including title, but excluding AI prompt sections)
+        - category: str (e.g., "Suggestion")
+        - severity: str (e.g., "Minor")
+    """
+    if not body:
+        return []
+
+    # Strip blockquote prefixes so we can parse clean HTML
+    cleaned = _strip_blockquote_prefix(body)
+
+    # Also strip a trailing AI prompt section that may appear outside the
+    # blockquote at the very end of the review body.
+    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
+
+    return _parse_section_comments(cleaned, _MINOR_SECTION_START_RE)
+
+
 def parse_nitpick_comments(body: str) -> list[dict[str, Any]]:
     """Parse 'nitpick' comments from a CodeRabbit review body.
 
@@ -325,17 +393,20 @@ def parse_review_body_comments(body: str) -> dict[str, list[dict[str, Any]]]:
     """Parse all body-embedded comments from a CodeRabbit review body.
 
     Returns:
-        Dict with keys ``'outside_diff'``, ``'nitpick'``, and ``'duplicate'``,
-        each containing a list of parsed comment dicts.
+        Dict with keys ``'outside_diff'``, ``'major'``, ``'minor'``,
+        ``'major'``, ``'minor'``, ``'nitpick'``, and ``'duplicate'``, each containing a list of
+        parsed comment dicts.
     """
     if not body:
-        return {"outside_diff": [], "nitpick": [], "duplicate": []}
+        return {"outside_diff": [], "major": [], "minor": [], "nitpick": [], "duplicate": []}
 
     cleaned = _strip_blockquote_prefix(body)
     cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
 
     return {
         "outside_diff": _parse_section_comments(cleaned, _OUTSIDE_SECTION_START_RE),
+        "major": _parse_section_comments(cleaned, _MAJOR_SECTION_START_RE),
+        "minor": _parse_section_comments(cleaned, _MINOR_SECTION_START_RE),
         "nitpick": _parse_section_comments(cleaned, _NITPICK_SECTION_START_RE),
         "duplicate": _parse_section_comments(cleaned, _DUPLICATE_SECTION_START_RE),
     }

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -533,6 +533,8 @@ def _build_body_comment_threads(
     threads: list[dict[str, Any]] = []
     for section_key, thread_type in (
         ("outside_diff", "outside_diff_comment"),
+        ("major", "major_comment"),
+        ("minor", "minor_comment"),
         ("nitpick", "nitpick_comment"),
         ("duplicate", "duplicate_comment"),
     ):
@@ -756,6 +758,24 @@ def get_thread_key(thread: dict[str, Any]) -> str | None:
         end_line = thread.get("end_line")
         if review_id is not None and path and line is not None:
             return f"odc:{review_id}:{path}:{line}:{end_line}"
+
+    # Major comments use review_id + location as composite key (stable across reordering)
+    if thread.get("type") == "major_comment":
+        review_id = thread.get("review_id")
+        path = thread.get("path")
+        line = thread.get("line")
+        end_line = thread.get("end_line")
+        if review_id is not None and path and line is not None:
+            return f"mjc:{review_id}:{path}:{line}:{end_line}"
+
+    # Minor comments use review_id + location as composite key (stable across reordering)
+    if thread.get("type") == "minor_comment":
+        review_id = thread.get("review_id")
+        path = thread.get("path")
+        line = thread.get("line")
+        end_line = thread.get("end_line")
+        if review_id is not None and path and line is not None:
+            return f"mnc:{review_id}:{path}:{line}:{end_line}"
 
     # Nitpick comments use review_id + location as composite key (stable across reordering)
     if thread.get("type") == "nitpick_comment":

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -399,7 +399,7 @@ def post_body_comment_replies(
     pr_number: str | int,
     body_comments: dict[str, list[dict[str, Any]]],
 ) -> tuple[int, list[dict[str, Any]]]:
-    """Post consolidated PR comments for body comments (outside_diff, nitpick, duplicate).
+    """Post consolidated PR comments for body comments (outside_diff, major, minor, nitpick, duplicate).
 
     Groups comments by reviewer author and posts one or more PR comments per reviewer
     mentioning the reviewer so they know the comments were reviewed.
@@ -506,6 +506,8 @@ def run(json_path: str) -> None:
     replied_not_resolved_count = 0
     already_posted_count = 0
     outside_diff_count = 0
+    major_count = 0
+    minor_count = 0
     nitpick_count = 0
     duplicate_count = 0
 
@@ -536,10 +538,17 @@ def run(json_path: str) -> None:
             resolved_at = thread_data.get("resolved_at", "") or ""
             path = thread_data.get("path", "unknown") or "unknown"
 
-            # Outside-diff and nitpick comments have no GitHub thread to post to or resolve.
+            # Body-embedded comments (outside-diff, major, minor, nitpick, duplicate)
+            # have no GitHub thread to post to or resolve.
             # They are tracked via the review database only.
             comment_type = thread_data.get("type")
-            if comment_type in ("outside_diff_comment", "nitpick_comment", "duplicate_comment"):
+            if comment_type in (
+                "outside_diff_comment",
+                "major_comment",
+                "minor_comment",
+                "nitpick_comment",
+                "duplicate_comment",
+            ):
                 if status == "pending":
                     pending_count += 1
                     eprint(f"Skipping {category}[{i}] ({path}): {comment_type} status is pending")
@@ -697,6 +706,10 @@ def run(json_path: str) -> None:
             comment_type = comment_data.get("type", "")
             if comment_type == "outside_diff_comment":
                 outside_diff_count += 1
+            elif comment_type == "major_comment":
+                major_count += 1
+            elif comment_type == "minor_comment":
+                minor_count += 1
             elif comment_type == "nitpick_comment":
                 nitpick_count += 1
             elif comment_type == "duplicate_comment":
@@ -711,7 +724,15 @@ def run(json_path: str) -> None:
 
     # Print summary
     total_resolved = addressed_count + skipped_count
-    total_processed = total_resolved + replied_not_resolved_count + outside_diff_count + nitpick_count + duplicate_count
+    total_processed = (
+        total_resolved
+        + replied_not_resolved_count
+        + outside_diff_count
+        + major_count
+        + minor_count
+        + nitpick_count
+        + duplicate_count
+    )
     eprint(f"Posted {total_processed} comment(s)")
     eprint("")
     eprint("=== Summary ===")
@@ -723,6 +744,12 @@ def run(json_path: str) -> None:
 
     if outside_diff_count > 0:
         eprint(f"  Outside-diff: {outside_diff_count} (replied via consolidated PR comment)")
+
+    if major_count > 0:
+        eprint(f"  Major: {major_count} (replied via consolidated PR comment)")
+
+    if minor_count > 0:
+        eprint(f"  Minor: {minor_count} (replied via consolidated PR comment)")
 
     if nitpick_count > 0:
         eprint(f"  Nitpick: {nitpick_count} (replied via consolidated PR comment)")

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -291,11 +291,11 @@ when threads are resolved.
 
 Post all replies to GitHub and store results in the database.
 
-**Body comments (outside-diff, nitpick, duplicate):**
+**Body comments (outside-diff, major, minor, nitpick, duplicate):**
 
 Comments that don't have GitHub review threads (e.g., CodeRabbit outside-diff,
-nitpick, and duplicate comments) are replied to via a single consolidated PR
-comment per reviewer. The comment mentions the reviewer (e.g., `@coderabbitai`)
+major, minor, nitpick, and duplicate comments) are replied to via a single
+consolidated PR comment per reviewer. The comment mentions the reviewer (e.g., `@coderabbitai`)
 and includes sections for each comment with the decision made. This ensures
 automated reviewers know their comments were reviewed and won't re-raise them.
 


### PR DESCRIPTION
CodeRabbit embeds Major and Minor comments in the review body HTML, same structure as Outside-diff and Nitpick. The parser was missing these two section types entirely — 0 of 24 comments captured.

**Changes:**
- `coderabbit_parser.py`: Add Major/Minor regex patterns + parse functions
- `fetch.py`: Add major/minor types in body thread builder + dedup keys
- `post.py`: Handle major/minor in reply posting flow + counters
- `db/query.py`: Include major/minor in dismissed comments SQL query
- `prompts/review-handler.md`: Update body comments reference

**Tested:** rootcoz PR #84 — now returns 21 major + 3 minor (was 0)

Closes #365