### PR TITLE
fix: subagent abort doesn't kill child process and leaves spinner stuck

### DIFF
--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -538,6 +538,10 @@ function streamAcpx(
 // =============================================================================
 
 export default function (pi: ExtensionAPI) {
+	// Subagents don't need acpx providers — they use the parent's model via --model flag.
+	// Without this guard, cursor-agent spawns as a child and prevents the subagent from exiting.
+	if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
 	// Suppress noisy ACP SDK errors for unhandled agent extension methods
 	installConsoleErrorSuppression();
 

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -476,9 +476,7 @@ export async function runSingleAgent(
           aborted = true;
           proc.kill("SIGTERM");
           setTimeout(() => {
-            if (proc.pid == null) return;
-            try { process.kill(proc.pid, 0); } catch { return; }
-            try { proc.kill("SIGKILL"); } catch {}
+            if (!proc.killed) proc.kill("SIGKILL");
           }, 5000);
         };
         if (signal.aborted) kill();
@@ -801,23 +799,19 @@ export function registerSubagentTool(
           activeAgents.clear();
           activeAgents.add(s.agent);
           updateWorking();
-          let r: SingleResult;
-          try {
-            r = await runSingleAgent(
-              agents,
-              s.agent,
-              t,
-              s.cwd,
-              i + 1,
-              signal,
-              chainUpdate,
-              mkd("chain"),
-              parentModelId,
-            );
-          } finally {
-            activeAgents.delete(s.agent);
-            updateWorking();
-          }
+          const r = await runSingleAgent(
+            agents,
+            s.agent,
+            t,
+            s.cwd,
+            i + 1,
+            signal,
+            chainUpdate,
+            mkd("chain"),
+            parentModelId,
+          );
+          activeAgents.delete(s.agent);
+          updateWorking();
           results.push(r);
           if (
             r.exitCode !== 0 ||
@@ -941,29 +935,25 @@ export function registerSubagentTool(
             const label = t.name || t.agent;
             activeAgents.add(label);
             updateWorking();
-            let r: SingleResult;
-            try {
-              r = await runSingleAgent(
-                agents,
-                t.agent,
-                t.task,
-                t.cwd,
-                undefined,
-                signal,
-                (p) => {
-                  if (p.details?.results[0]) {
-                    all[i] = p.details.results[0];
-                    emitAll();
-                  }
-                },
-                mkd("parallel"),
-                parentModelId,
-              );
-            } finally {
-              activeAgents.delete(label);
-              updateWorking();
-            }
+            const r = await runSingleAgent(
+              agents,
+              t.agent,
+              t.task,
+              t.cwd,
+              undefined,
+              signal,
+              (p) => {
+                if (p.details?.results[0]) {
+                  all[i] = p.details.results[0];
+                  emitAll();
+                }
+              },
+              mkd("parallel"),
+              parentModelId,
+            );
             all[i] = r;
+            activeAgents.delete(t.name || t.agent);
+            updateWorking();
             emitAll();
             return r;
           },
@@ -1023,23 +1013,19 @@ export function registerSubagentTool(
         const label = params.name || params.agent;
         activeAgents.add(label);
         updateWorking();
-        let r: SingleResult;
-        try {
-          r = await runSingleAgent(
-            agents,
-            params.agent,
-            params.task,
-            params.cwd,
-            undefined,
-            signal,
-            onUpdate,
-            mkd("single"),
-            parentModelId,
-          );
-        } finally {
-          activeAgents.delete(label);
-          updateWorking();
-        }
+        const r = await runSingleAgent(
+          agents,
+          params.agent,
+          params.task,
+          params.cwd,
+          undefined,
+          signal,
+          onUpdate,
+          mkd("single"),
+          parentModelId,
+        );
+        activeAgents.delete(label);
+        updateWorking();
         const err =
           r.exitCode !== 0 ||
           r.stopReason === "error" ||

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -476,7 +476,9 @@ export async function runSingleAgent(
           aborted = true;
           proc.kill("SIGTERM");
           setTimeout(() => {
-            if (!proc.killed) proc.kill("SIGKILL");
+            if (proc.pid == null) return;
+            try { process.kill(proc.pid, 0); } catch { return; }
+            try { proc.kill("SIGKILL"); } catch {}
           }, 5000);
         };
         if (signal.aborted) kill();
@@ -799,19 +801,23 @@ export function registerSubagentTool(
           activeAgents.clear();
           activeAgents.add(s.agent);
           updateWorking();
-          const r = await runSingleAgent(
-            agents,
-            s.agent,
-            t,
-            s.cwd,
-            i + 1,
-            signal,
-            chainUpdate,
-            mkd("chain"),
-            parentModelId,
-          );
-          activeAgents.delete(s.agent);
-          updateWorking();
+          let r: SingleResult;
+          try {
+            r = await runSingleAgent(
+              agents,
+              s.agent,
+              t,
+              s.cwd,
+              i + 1,
+              signal,
+              chainUpdate,
+              mkd("chain"),
+              parentModelId,
+            );
+          } finally {
+            activeAgents.delete(s.agent);
+            updateWorking();
+          }
           results.push(r);
           if (
             r.exitCode !== 0 ||
@@ -935,25 +941,29 @@ export function registerSubagentTool(
             const label = t.name || t.agent;
             activeAgents.add(label);
             updateWorking();
-            const r = await runSingleAgent(
-              agents,
-              t.agent,
-              t.task,
-              t.cwd,
-              undefined,
-              signal,
-              (p) => {
-                if (p.details?.results[0]) {
-                  all[i] = p.details.results[0];
-                  emitAll();
-                }
-              },
-              mkd("parallel"),
-              parentModelId,
-            );
+            let r: SingleResult;
+            try {
+              r = await runSingleAgent(
+                agents,
+                t.agent,
+                t.task,
+                t.cwd,
+                undefined,
+                signal,
+                (p) => {
+                  if (p.details?.results[0]) {
+                    all[i] = p.details.results[0];
+                    emitAll();
+                  }
+                },
+                mkd("parallel"),
+                parentModelId,
+              );
+            } finally {
+              activeAgents.delete(label);
+              updateWorking();
+            }
             all[i] = r;
-            activeAgents.delete(t.name || t.agent);
-            updateWorking();
             emitAll();
             return r;
           },
@@ -1013,19 +1023,23 @@ export function registerSubagentTool(
         const label = params.name || params.agent;
         activeAgents.add(label);
         updateWorking();
-        const r = await runSingleAgent(
-          agents,
-          params.agent,
-          params.task,
-          params.cwd,
-          undefined,
-          signal,
-          onUpdate,
-          mkd("single"),
-          parentModelId,
-        );
-        activeAgents.delete(label);
-        updateWorking();
+        let r: SingleResult;
+        try {
+          r = await runSingleAgent(
+            agents,
+            params.agent,
+            params.task,
+            params.cwd,
+            undefined,
+            signal,
+            onUpdate,
+            mkd("single"),
+            parentModelId,
+          );
+        } finally {
+          activeAgents.delete(label);
+          updateWorking();
+        }
         const err =
           r.exitCode !== 0 ||
           r.stopReason === "error" ||


### PR DESCRIPTION
## Summary

Fixes subagent processes hanging after completion, requiring pi restart.

### Root Cause

`extensions/acpx-provider/index.ts` did not check `PI_SUBAGENT_CHILD` environment variable. When `ACPX_AGENTS=cursor` is set, every subagent spawned a `cursor-agent` child process on `session_start`. This long-lived child process prevented the subagent from exiting (`proc.on('close')` never fires while a child is alive).

### Fix

Add `PI_SUBAGENT_CHILD` guard at the top of the acpx-provider extension, matching the pattern used by pidash, pidiff, cron, and dreaming extensions.

Closes #384