### PR TITLE
fix: handle stale ctx in async-agents poller

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -129,7 +129,13 @@ export function registerAsyncAgents(
   function ensureAsyncPoller() {
     if (asyncState.poller) return;
     asyncState.poller = setInterval(() => {
-      if (!asyncState.lastCtx?.hasUI) return;
+      try {
+        if (!asyncState.lastCtx?.hasUI) return;
+      } catch {
+        // ctx is stale (session ended) — stop polling
+        if (asyncState.poller) { clearInterval(asyncState.poller); asyncState.poller = null; }
+        return;
+      }
       if (asyncState.jobs.size === 0) {
         updateAsyncWidget();
         return;


### PR DESCRIPTION
## Problem

When pi runs in non-interactive mode (`-p`, `--mode json`), the session processes the prompt and exits. The extension context (`ctx`) becomes stale, but the async-agents `setInterval` poller keeps running and accesses `ctx.hasUI` — pi throws "This extension ctx is stale" and crashes the Node process.

## Fix

Wrap the `ctx.hasUI` access in the poller with try/catch. On stale ctx, stop the poller cleanly instead of crashing.

## Impact

This crash affects any non-interactive pi session that loads pi-config extensions (subagents, CI, SDK consumers). It also blocked the upcoming coms swarm feature which spawns headless peer sessions.