### PR TITLE
feat(coms): add /coms swarm command to spawn peer agents via SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ Known extension commands:
 | `/cron` | `cron.ts` | Schedule recurring tasks |
 | `/nvim-changed-files` | `nvim.ts` | Send changed files to nvim quickfix |
 | `/coms` | `coms/coms.ts` | P2P agent communication (start/stop/status) |
-| `/coms-net` | `coms/coms-net.ts` | Networked agent communication (start/stop/status/server-stop) |
+| `/coms-net` | `coms/coms-net.ts` | Networked agent communication (start/connect/disconnect/stop/status) |
 | `/external-ai-models-refresh` | `extended-autocomplete.ts` | Refresh AI CLI model cache |
 
 ### Adding a Prompt Template

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Single extension that provides:
 | `/nvim-changed-files` | Send git changed files to nvim's quickfix list (only inside nvim) |
 | `/pidiff start\|stop\|restart\|status` | Manage the pidiff diff viewer daemon |
 | `/coms start\|stop\|status` | P2P local agent communication (Unix socket) |
-| `/coms-net start\|stop\|status\|server-stop` | Networked agent communication (HTTP/SSE hub) |
+| `/coms-net start\|connect\|disconnect\|stop\|status` | Networked agent communication (HTTP/SSE hub) |
 
 ### Inter-Agent Communication (coms & coms-net)
 
@@ -89,6 +89,8 @@ Two systems for Pi agents to communicate with each other, activated on-demand vi
 
 ```text
 /coms-net start --name dev --purpose "Development agent"
+/coms-net connect
+/coms-net disconnect
 /coms-net stop
 /coms-net status
 ```

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -616,8 +616,7 @@ export default function (pi: ExtensionAPI) {
 				try {
 					ctx.ui.notify(message, type);
 				} catch {
-					// ctx may be stale if session was replaced during async init
-					(type === "error" ? console.error : console.log)(`[acpx] ${message}`);
+					// ctx is stale after session resume/reload — silently ignore
 				}
 			};
 

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -184,6 +184,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     try { ctx.ui.notify("📡 coms-net already active", "warning"); } catch {}
                     return;
                 }
+                state.flagValues = new Map();
                 parseFlags(parts.slice(1), state.flagValues);
                 // Default project to cwd so sessions in different dirs are isolated
                 if (!state.flagValues.has("project")) {

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -208,7 +208,7 @@ export function registerComsNet(pi: ExtensionAPI) {
     // User can explicitly stop it with /coms-net server-stop.
 
     pi.registerCommand("coms-net", {
-        description: "Networked agent communication: /coms-net start | stop | status | server-stop",
+        description: "Networked agent communication: /coms-net start | connect | stop | status | server-stop",
         getArgumentCompletions: (prefix: string) => {
             const tokens = prefix.trim().split(/\s+/).filter(Boolean);
             const atNextToken = prefix.endsWith(" ") || tokens.length === 0;
@@ -220,7 +220,8 @@ export function registerComsNet(pi: ExtensionAPI) {
 
             if (completed.length === 0) {
                 return mk([
-                    { v: "start", l: "start", d: "Start networked agent communication" },
+                    { v: "start", l: "start", d: "Start local server and connect" },
+                    { v: "connect", l: "connect", d: "Connect to a running server" },
                     { v: "stop", l: "stop", d: "Stop coms-net" },
                     { v: "status", l: "status", d: "Show coms-net + server status" },
                     { v: "server-stop", l: "server-stop", d: "Stop the hub server" },
@@ -234,10 +235,20 @@ export function registerComsNet(pi: ExtensionAPI) {
                     { v: "--project ", l: "--project", d: "Project namespace" },
                     { v: "--color ", l: "--color", d: "Hex color #RRGGBB" },
                     { v: "--explicit", l: "--explicit", d: "Hide from auto-discovery" },
-                    { v: "--server-url ", l: "--server-url", d: "Hub server URL" },
-                    { v: "--auth-token ", l: "--auth-token", d: "Bearer token for the hub" },
                     { v: "--port ", l: "--port", d: "Server port" },
                     { v: "--host ", l: "--host", d: "Server bind address (e.g. 0.0.0.0)" },
+                ].filter(f => !used.has(f.v.trim())));
+            }
+            if (completed[0] === "connect" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(completed.filter(p => p.startsWith("--")));
+                return mk([
+                    { v: "--name ", l: "--name", d: "Agent name" },
+                    { v: "--purpose ", l: "--purpose", d: "Agent purpose" },
+                    { v: "--project ", l: "--project", d: "Project namespace" },
+                    { v: "--color ", l: "--color", d: "Hex color #RRGGBB" },
+                    { v: "--explicit", l: "--explicit", d: "Hide from auto-discovery" },
+                    { v: "--server-url ", l: "--server-url", d: "Hub server URL" },
+                    { v: "--auth-token ", l: "--auth-token", d: "Bearer token for the hub" },
                 ].filter(f => !used.has(f.v.trim())));
             }
             return null;
@@ -276,22 +287,8 @@ export function registerComsNet(pi: ExtensionAPI) {
                     return;
                 }
 
-                // If user passed --server-url, skip auto-start — they're connecting to a remote server
-                const serverUrl = state.flagValues.get("server-url") as string | undefined;
                 const port = state.flagValues.get("port") as string | undefined;
                 const host = state.flagValues.get("host") as string | undefined;
-                if (serverUrl) {
-                    // Remote server — don't auto-start, just connect
-                    try {
-                        await state.capturedSessionStart({}, ctx);
-                        state.active = true;
-                        persistState(pi, PERSIST_KEY, state);
-                        try { ctx.ui.notify(`📡 coms-net active — connected to ${serverUrl}`, "info"); } catch {}
-                    } catch (err: any) {
-                        try { ctx.ui.notify(`📡 coms-net start failed: ${err?.message ?? String(err)}`, "error"); } catch {}
-                    }
-                    return;
-                }
 
                 // Auto-start server, or restart if port/host mismatch
                 const alreadyRunning = await isServerHealthy(project);
@@ -334,6 +331,46 @@ export function registerComsNet(pi: ExtensionAPI) {
                 } catch (err: any) {
                     try { ctx.ui.notify(`📡 coms-net start failed: ${err?.message ?? String(err)}`, "error"); } catch {}
                 }
+            } else if (subcommand === "connect") {
+                if (state.active) {
+                    try { ctx.ui.notify("📡 coms-net already active", "warning"); } catch {}
+                    return;
+                }
+                state.flagValues = new Map();
+                parseFlags(parts.slice(1), state.flagValues);
+                // Default project to cwd so sessions in different dirs are isolated
+                if (!state.flagValues.has("project")) {
+                    const cwd = ctx.cwd || "";
+                    const proj = cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
+                    if (!proj) {
+                        try { ctx.ui.notify("📡 coms-net: cannot connect from /. Run from a project directory.", "error"); } catch {}
+                        return;
+                    }
+                    state.flagValues.set("project", proj);
+                }
+                const project = state.flagValues.get("project") as string;
+                if (!isValidProject(project)) {
+                    try { ctx.ui.notify("📡 coms-net: invalid project name", "error"); } catch {}
+                    return;
+                }
+                activeProject = project;
+
+                if (!state.capturedSessionStart) {
+                    try { ctx.ui.notify("📡 coms-net: internal error — no session handler captured", "error"); } catch {}
+                    return;
+                }
+
+                const serverUrl = state.flagValues.get("server-url") as string | undefined;
+                try {
+                    await state.capturedSessionStart({}, ctx);
+                    state.active = true;
+                    persistState(pi, PERSIST_KEY, state);
+                    serverStartedByUs = false;
+                    const displayUrl = serverUrl || "local server";
+                    try { ctx.ui.notify(`📡 coms-net active — connected to ${displayUrl}`, "info"); } catch {}
+                } catch (err: any) {
+                    try { ctx.ui.notify(`📡 coms-net connect failed: ${err?.message ?? String(err)}`, "error"); } catch {}
+                }
             } else if (subcommand === "stop") {
                 if (!state.active) {
                     try { ctx.ui.notify("📡 coms-net not active", "info"); } catch {}
@@ -365,7 +402,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 if (serverStartedByUs) msg += "(server started by this session)";
                 try { ctx.ui.notify(msg, "info"); } catch {}
             } else {
-                try { ctx.ui.notify(`📡 coms-net: unknown subcommand "${subcommand}". Use: start | stop | status | server-stop`, "warning"); } catch {}
+                try { ctx.ui.notify(`📡 coms-net: unknown subcommand "${subcommand}". Use: start | connect | stop | status | server-stop`, "warning"); } catch {}
             }
         },
     });

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -356,54 +356,9 @@ export function registerComsNet(pi: ExtensionAPI) {
     });
 
     // Kill server on session shutdown if we started it and no other peers are connected
-    pi.on("session_shutdown", async () => {
+    pi.on("session_shutdown", () => {
         if (!serverStartedByUs) return;
-        try {
-            const sj = readServerJson(activeProject);
-            if (sj?.local_url) {
-                // Resolve auth token (env or server.secret.json)
-                let token = process.env.PI_COMS_NET_AUTH_TOKEN || "";
-                if (!token) {
-                    const secretPath = path.join(COMS_NET_DIR, "projects", activeProject, "server.secret.json");
-                    try {
-                        const sec = JSON.parse(fs.readFileSync(secretPath, "utf-8"));
-                        token = sec?.token || "";
-                    } catch (e: any) { console.debug("[coms-net] read secret token failed:", e?.message || e); }
-                }
-                const headers: Record<string, string> = {};
-                if (token) headers["Authorization"] = `Bearer ${token}`;
-                // Validate local_url is loopback to prevent token leak
-                try {
-                    const parsed = new URL(sj.local_url);
-                    if (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost" && parsed.hostname !== "::1") {
-                        log("server url is not loopback, skipping peer check");
-                        return;
-                    }
-                } catch {
-                    log("shutdown: invalid local_url in server.json, skipping peer check");
-                    return;
-                }
-                const url = `${sj.local_url}/v1/agents?project=${encodeURIComponent(activeProject)}&include_explicit=true`;
-                const resp = await fetch(url, {
-                    headers,
-                    signal: AbortSignal.timeout(2000),
-                });
-                if (resp.ok) {
-                    const agents = await resp.json();
-                    const otherAgents = (agents?.agents || []).length;
-                    if (otherAgents <= 1) {
-                        killServer(activeProject, log);
-                        log("server killed on shutdown (no other peers)");
-                    } else {
-                        log(`server kept alive (${otherAgents - 1} other peer(s) connected)`);
-                    }
-                    return;
-                }
-            }
-        } catch (e: any) { console.debug("[coms-net] shutdown peer check failed:", e?.message || e); }
-        // If we can't verify peers, keep server alive to avoid killing shared hubs
-        // Can't verify peers — kill it since we started it. Better than zombie servers.
         killServer(activeProject, log);
-        log("server killed on shutdown (couldn't verify peer count, we started it)");
+        log("server killed on shutdown (we started it)");
     });
 }

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -116,7 +116,7 @@ async function ensureServerRunning(
         env: {
             ...process.env,
             PI_COMS_NET_PROJECT: project,
-            PI_COMS_NET_PORT: process.env.PI_COMS_NET_PORT || "0",
+            PI_COMS_NET_PORT: /^\d+$/.test(process.env.PI_COMS_NET_PORT || "") ? process.env.PI_COMS_NET_PORT! : "0",
         },
     });
     child.unref();

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -263,12 +263,31 @@ export function registerComsNet(pi: ExtensionAPI) {
                     return;
                 }
 
-                // Auto-start server if not running
+                // Auto-start server, or restart if port/host mismatch
+                const port = state.flagValues.get("port") as string | undefined;
+                const host = state.flagValues.get("host") as string | undefined;
                 const alreadyRunning = await isServerHealthy(project);
-                if (!alreadyRunning) {
+                if (alreadyRunning) {
+                    // Check if running server matches requested port/host
+                    const sj = readServerJson(project);
+                    const wantPort = port || process.env.PI_COMS_NET_PORT;
+                    const wantHost = host || process.env.PI_COMS_NET_HOST;
+                    const mismatch = (wantPort && sj?.port !== Number(wantPort)) ||
+                                     (wantHost && sj?.host !== wantHost);
+                    if (mismatch) {
+                        log(`server port/host mismatch — restarting (want ${wantHost || "*"}:${wantPort || "*"}, have ${sj?.host}:${sj?.port})`);
+                        killServer(project, log);
+                        await new Promise(r => setTimeout(r, 1000));
+                        try { ctx.ui.notify("📡 Restarting coms-net server (port/host changed)...", "info"); } catch {}
+                        const started = await ensureServerRunning(project, log, { port, host });
+                        if (!started) {
+                            try { ctx.ui.notify("📡 coms-net: failed to restart server.", "error"); } catch {}
+                            return;
+                        }
+                        serverStartedByUs = true;
+                    }
+                } else {
                     try { ctx.ui.notify("📡 Starting coms-net server...", "info"); } catch {}
-                    const port = state.flagValues.get("port") as string | undefined;
-                    const host = state.flagValues.get("host") as string | undefined;
                     const started = await ensureServerRunning(project, log, { port, host });
                     if (!started) {
                         try { ctx.ui.notify("📡 coms-net: failed to start server. Is Bun installed?", "error"); } catch {}

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -186,7 +186,7 @@ export function registerComsNet(pi: ExtensionAPI) {
         flagValues: new Map(),
         active: false,
     };
-    let activeProject = "default";
+    let activeProject = "";
     let serverStartedByUs = false;
 
     const log = (msg: string) => {

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -205,10 +205,10 @@ export function registerComsNet(pi: ExtensionAPI) {
 
     // Don't auto-kill the server on session shutdown — other sessions may
     // be connected. The server has its own stale detection and cleanup.
-    // User can explicitly stop it with /coms-net server-stop.
+
 
     pi.registerCommand("coms-net", {
-        description: "Networked agent communication: /coms-net start | connect | stop | status | server-stop",
+        description: "Networked agent communication: /coms-net start | connect | stop | status",
         getArgumentCompletions: (prefix: string) => {
             const tokens = prefix.trim().split(/\s+/).filter(Boolean);
             const atNextToken = prefix.endsWith(" ") || tokens.length === 0;
@@ -224,7 +224,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     { v: "connect", l: "connect", d: "Connect to a running server" },
                     { v: "stop", l: "stop", d: "Stop coms-net" },
                     { v: "status", l: "status", d: "Show coms-net + server status" },
-                    { v: "server-stop", l: "server-stop", d: "Stop the hub server" },
+
                 ]);
             }
             if (completed[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
@@ -247,7 +247,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     { v: "--project ", l: "--project", d: "Project namespace" },
                     { v: "--color ", l: "--color", d: "Hex color #RRGGBB" },
                     { v: "--explicit", l: "--explicit", d: "Hide from auto-discovery" },
-                    { v: "--server-url ", l: "--server-url", d: "Hub server URL" },
+                    { v: "--url ", l: "--url", d: "Hub server URL" },
                     { v: "--auth-token ", l: "--auth-token", d: "Bearer token for the hub" },
                 ].filter(f => !used.has(f.v.trim())));
             }
@@ -360,6 +360,10 @@ export function registerComsNet(pi: ExtensionAPI) {
                     return;
                 }
 
+                // Map --url to server-url for upstream compatibility
+                if (state.flagValues.has("url")) {
+                    state.flagValues.set("server-url", state.flagValues.get("url"));
+                }
                 const serverUrl = state.flagValues.get("server-url") as string | undefined;
                 try {
                     await state.capturedSessionStart({}, ctx);
@@ -385,10 +389,6 @@ export function registerComsNet(pi: ExtensionAPI) {
                 killServer(activeProject, log);
                 serverStartedByUs = false;
                 try { ctx.ui.notify("📡 coms-net stopped", "info"); } catch {}
-            } else if (subcommand === "server-stop") {
-                killServer(activeProject, log);
-                serverStartedByUs = false;
-                try { ctx.ui.notify("📡 coms-net server stopped", "info"); } catch {}
             } else if (subcommand === "status") {
                 const project = (state.flagValues.get("project") as string) || ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__") || "unknown";
                 if (!isValidProject(project)) {
@@ -402,7 +402,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 if (serverStartedByUs) msg += "(server started by this session)";
                 try { ctx.ui.notify(msg, "info"); } catch {}
             } else {
-                try { ctx.ui.notify(`📡 coms-net: unknown subcommand "${subcommand}". Use: start | connect | stop | status | server-stop`, "warning"); } catch {}
+                try { ctx.ui.notify(`📡 coms-net: unknown subcommand "${subcommand}". Use: start | connect | stop | status`, "warning"); } catch {}
             }
         },
     });

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -414,8 +414,10 @@ export function registerComsNet(pi: ExtensionAPI) {
     });
 
     // Kill server on session shutdown if we started it and no other peers are connected
-    pi.on("session_shutdown", () => {
+    pi.on("session_shutdown", (event: any) => {
         if (!serverStartedByUs) return;
+        // Don't kill server on reload — it will be reused after reload
+        if (event?.reason === "reload") return;
         killServer(activeProject, log);
         log("server killed on shutdown (we started it)");
     });

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -329,11 +329,9 @@ export function registerComsNet(pi: ExtensionAPI) {
                 }
                 state.active = false;
                 persistState(pi, PERSIST_KEY, state);
-                // Kill server if we started it and no other peers
-                if (serverStartedByUs) {
-                    killServer(activeProject, log);
-                    serverStartedByUs = false;
-                }
+                // User explicitly stopped — kill server unconditionally
+                killServer(activeProject, log);
+                serverStartedByUs = false;
                 try { ctx.ui.notify("📡 coms-net stopped", "info"); } catch {}
             } else if (subcommand === "server-stop") {
                 killServer(activeProject, log);

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -82,6 +82,7 @@ function getServerScriptPath(): string {
 async function ensureServerRunning(
     project: string,
     log: (msg: string) => void,
+    options?: { port?: string; host?: string },
 ): Promise<boolean> {
     if (await isServerHealthy(project)) {
         log("server already running");
@@ -116,7 +117,8 @@ async function ensureServerRunning(
         env: {
             ...process.env,
             PI_COMS_NET_PROJECT: project,
-            PI_COMS_NET_PORT: process.env.PI_COMS_NET_PORT || "0",
+            PI_COMS_NET_PORT: options?.port || process.env.PI_COMS_NET_PORT || "0",
+            ...(options?.host ? { PI_COMS_NET_HOST: options.host } : {}),
         },
     });
     child.unref();
@@ -209,6 +211,8 @@ export function registerComsNet(pi: ExtensionAPI) {
                     { v: "--explicit", l: "--explicit", d: "Hide from auto-discovery" },
                     { v: "--server-url ", l: "--server-url", d: "Hub server URL" },
                     { v: "--auth-token ", l: "--auth-token", d: "Bearer token for the hub" },
+                    { v: "--port ", l: "--port", d: "Server port" },
+                    { v: "--host ", l: "--host", d: "Server bind address (e.g. 0.0.0.0)" },
                 ].filter(f => !used.has(f.v.trim())));
             }
             return null;
@@ -251,7 +255,9 @@ export function registerComsNet(pi: ExtensionAPI) {
                 const alreadyRunning = await isServerHealthy(project);
                 if (!alreadyRunning) {
                     try { ctx.ui.notify("📡 Starting coms-net server...", "info"); } catch {}
-                    const started = await ensureServerRunning(project, log);
+                    const port = state.flagValues.get("port") as string | undefined;
+                    const host = state.flagValues.get("host") as string | undefined;
+                    const started = await ensureServerRunning(project, log, { port, host });
                     if (!started) {
                         try { ctx.ui.notify("📡 coms-net: failed to start server. Is Bun installed?", "error"); } catch {}
                         return;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -216,17 +216,6 @@ export function registerComsNet(pi: ExtensionAPI) {
         }
     }
 
-    // Restore serverStartedByUs after reload
-    pi.on("session_start", (event: any) => {
-        if (event?.reason !== "reload") return;
-        if (state.extra?.serverStartedByUs) {
-            serverStartedByUs = true;
-        }
-        if (state.extra?.activeProject) {
-            activeProject = state.extra.activeProject;
-        }
-    });
-
     const log = (msg: string) => {
         try {
             pi.appendEntry("coms-net-log", { event: "wrapper", ts: new Date().toISOString(), msg });
@@ -240,6 +229,18 @@ export function registerComsNet(pi: ExtensionAPI) {
     );
 
     upstreamComsNetInit(proxyPi as any);
+
+    // Restore serverStartedByUs after reload — MUST be registered after
+    // createDeferredProxy/upstreamComsNetInit so the proxy hydrates state.extra first
+    pi.on("session_start", (event: any) => {
+        if (event?.reason !== "reload") return;
+        if (state.extra?.serverStartedByUs) {
+            serverStartedByUs = true;
+        }
+        if (state.extra?.activeProject) {
+            activeProject = state.extra.activeProject;
+        }
+    });
 
     // Don't auto-kill the server on session shutdown — other sessions may
     // be connected. The server has its own stale detection and cleanup.

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -193,7 +193,9 @@ export function registerComsNet(pi: ExtensionAPI) {
         const fromFlags = state.flagValues.get("project") as string;
         if (fromFlags) return fromFlags;
         const cwd = ctx?.cwd || process.cwd() || "";
-        return cwd.replace(/^[\\/]/, "").replace(/[\\/]/g, "__") || "unknown";
+        const proj = cwd.replace(/^[\\/]/, "").replace(/[\\/]/g, "__");
+        if (!proj) throw new Error("coms-net: cannot determine project — no cwd available");
+        return proj;
     }
     let serverStartedByUs = false;
 

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -276,9 +276,24 @@ export function registerComsNet(pi: ExtensionAPI) {
                     return;
                 }
 
-                // Auto-start server, or restart if port/host mismatch
+                // If user passed --server-url, skip auto-start — they're connecting to a remote server
+                const serverUrl = state.flagValues.get("server-url") as string | undefined;
                 const port = state.flagValues.get("port") as string | undefined;
                 const host = state.flagValues.get("host") as string | undefined;
+                if (serverUrl) {
+                    // Remote server — don't auto-start, just connect
+                    try {
+                        await state.capturedSessionStart({}, ctx);
+                        state.active = true;
+                        persistState(pi, PERSIST_KEY, state);
+                        try { ctx.ui.notify(`📡 coms-net active — connected to ${serverUrl}`, "info"); } catch {}
+                    } catch (err: any) {
+                        try { ctx.ui.notify(`📡 coms-net start failed: ${err?.message ?? String(err)}`, "error"); } catch {}
+                    }
+                    return;
+                }
+
+                // Auto-start server, or restart if port/host mismatch
                 const alreadyRunning = await isServerHealthy(project);
                 if (alreadyRunning) {
                     // Check if running server matches requested port/host

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -167,7 +167,7 @@ export function registerComsNet(pi: ExtensionAPI) {
     const log = (msg: string) => {
         try {
             pi.appendEntry("coms-net-log", { event: "wrapper", ts: new Date().toISOString(), msg });
-        } catch {}
+        } catch (e: any) { console.debug("[coms-net] log append failed:", e?.message || e); }
     };
 
     const PERSIST_KEY = "coms-net-state";
@@ -321,7 +321,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     try {
                         const sec = JSON.parse(fs.readFileSync(secretPath, "utf-8"));
                         token = sec?.token || "";
-                    } catch {}
+                    } catch (e: any) { console.debug("[coms-net] read secret token failed:", e?.message || e); }
                 }
                 const headers: Record<string, string> = {};
                 if (token) headers["Authorization"] = `Bearer ${token}`;
@@ -353,7 +353,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     return;
                 }
             }
-        } catch {}
+        } catch (e: any) { console.debug("[coms-net] shutdown peer check failed:", e?.message || e); }
         // If we can't verify peers, keep server alive to avoid killing shared hubs
         log("server kept alive on shutdown (couldn't verify peer count)");
     });

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -199,6 +199,22 @@ export function registerComsNet(pi: ExtensionAPI) {
     }
     let serverStartedByUs = false;
 
+    function persist() {
+        state.extra = { serverStartedByUs, activeProject: getProject() };
+        persistState(pi, PERSIST_KEY, state);
+    }
+
+    // Restore serverStartedByUs after reload
+    pi.on("session_start", (event: any) => {
+        if (event?.reason !== "reload") return;
+        if (state.extra?.serverStartedByUs) {
+            serverStartedByUs = true;
+        }
+        if (state.extra?.activeProject) {
+            activeProject = state.extra.activeProject;
+        }
+    });
+
     const log = (msg: string) => {
         try {
             pi.appendEntry("coms-net-log", { event: "wrapper", ts: new Date().toISOString(), msg });
@@ -342,7 +358,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     await state.capturedSessionStart({}, ctx);
                     state.active = true;
                     serverStartedByUs = true;
-                    persistState(pi, PERSIST_KEY, state);
+                    persist();
                     const sj = readServerJson(project);
                     const serverAddr = (sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.public_url || sj?.local_url) || "unknown";
                     try { ctx.ui.notify(`📡 coms-net active — server at ${serverAddr}`, "info"); } catch {}
@@ -386,7 +402,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 try {
                     await state.capturedSessionStart({}, ctx);
                     state.active = true;
-                    persistState(pi, PERSIST_KEY, state);
+                    persist();
                     serverStartedByUs = false;
                     const displayUrl = serverUrl || "local server";
                     try { ctx.ui.notify(`📡 coms-net active — connected to ${displayUrl}`, "info"); } catch {}
@@ -406,7 +422,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     try { await state.capturedSessionShutdown(); } catch {}
                 }
                 state.active = false;
-                persistState(pi, PERSIST_KEY, state);
+                persist();
                 try { ctx.ui.notify("📡 coms-net disconnected", "info"); } catch {}
             } else if (subcommand === "stop") {
                 if (!state.active) {
@@ -421,7 +437,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     try { await state.capturedSessionShutdown(); } catch {}
                 }
                 state.active = false;
-                persistState(pi, PERSIST_KEY, state);
+                persist();
                 // User explicitly stopped — kill server unconditionally
                 killServer(getProject(), log);
                 serverStartedByUs = false;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -12,6 +12,14 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import { fuzzyFilter } from "@earendil-works/pi-tui";
+
+function fuzzy(items: AutocompleteItem[], query: string): AutocompleteItem[] | null {
+    if (!query.trim()) return items.length > 0 ? items : null;
+    const result = fuzzyFilter(items, query, i => `${i.label} ${i.description || ""}`);
+    return result.length > 0 ? result : null;
+}
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -174,6 +182,35 @@ export function registerComsNet(pi: ExtensionAPI) {
 
     pi.registerCommand("coms-net", {
         description: "Networked agent communication: /coms-net start | stop | status | server-stop",
+        getArgumentCompletions: (prefix: string) => {
+            const parts = prefix.split(/\s+/);
+            const lastPart = parts[parts.length - 1] || "";
+            const base = lastPart === "" ? prefix : prefix.slice(0, prefix.length - lastPart.length);
+            const mk = (items: {v: string; l: string; d: string}[]) =>
+                fuzzy(items.map(i => ({ value: base + i.v, label: i.l, description: i.d })), lastPart);
+
+            if (parts.length <= 1) {
+                return mk([
+                    { v: "start", l: "start", d: "Start networked agent communication" },
+                    { v: "stop", l: "stop", d: "Stop coms-net" },
+                    { v: "status", l: "status", d: "Show coms-net + server status" },
+                    { v: "server-stop", l: "server-stop", d: "Stop the hub server" },
+                ]);
+            }
+            if (parts[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(parts.filter(p => p.startsWith("--")));
+                return mk([
+                    { v: "--name ", l: "--name", d: "Agent name" },
+                    { v: "--purpose ", l: "--purpose", d: "Agent purpose" },
+                    { v: "--project ", l: "--project", d: "Project namespace" },
+                    { v: "--color ", l: "--color", d: "Hex color #RRGGBB" },
+                    { v: "--explicit", l: "--explicit", d: "Hide from auto-discovery" },
+                    { v: "--server-url ", l: "--server-url", d: "Hub server URL" },
+                    { v: "--auth-token ", l: "--auth-token", d: "Bearer token for the hub" },
+                ].filter(f => !used.has(f.v.trim())));
+            }
+            return null;
+        },
         handler: async (args: string, ctx: any) => {
             const trimmed = (args || "").trim();
             const parts = tokenizeArgs(trimmed);

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -187,6 +187,14 @@ export function registerComsNet(pi: ExtensionAPI) {
         active: false,
     };
     let activeProject = "";
+
+    function getProject(ctx?: any): string {
+        if (activeProject) return activeProject;
+        const fromFlags = state.flagValues.get("project") as string;
+        if (fromFlags) return fromFlags;
+        const cwd = ctx?.cwd || process.cwd() || "";
+        return cwd.replace(/^[\\/]/, "").replace(/[\\/]/g, "__") || "unknown";
+    }
     let serverStartedByUs = false;
 
     const log = (msg: string) => {
@@ -262,7 +270,7 @@ export function registerComsNet(pi: ExtensionAPI) {
             if (subcommand === "start") {
                 if (state.active) {
                     // Check if server is actually still running
-                    if (await isServerHealthy(activeProject)) {
+                    if (await isServerHealthy(getProject(ctx))) {
                         try { ctx.ui.notify("📡 coms-net already active", "warning"); } catch {}
                         return;
                     }
@@ -413,11 +421,11 @@ export function registerComsNet(pi: ExtensionAPI) {
                 state.active = false;
                 persistState(pi, PERSIST_KEY, state);
                 // User explicitly stopped — kill server unconditionally
-                killServer(activeProject, log);
+                killServer(getProject(), log);
                 serverStartedByUs = false;
                 try { ctx.ui.notify("📡 coms-net stopped", "info"); } catch {}
             } else if (subcommand === "status") {
-                const project = activeProject || (state.flagValues.get("project") as string) || ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__") || "unknown";
+                const project = getProject(ctx);
                 if (!isValidProject(project)) {
                     try { ctx.ui.notify("📡 coms-net: invalid project name", "error"); } catch {}
                     return;
@@ -439,7 +447,7 @@ export function registerComsNet(pi: ExtensionAPI) {
         if (!serverStartedByUs) return;
         // Don't kill server on reload — it will be reused after reload
         if (event?.reason === "reload") return;
-        killServer(activeProject, log);
+        killServer(getProject(), log);
         log("server killed on shutdown (we started it)");
     });
 }

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -402,6 +402,10 @@ export function registerComsNet(pi: ExtensionAPI) {
                     try { ctx.ui.notify("📡 coms-net not active", "info"); } catch {}
                     return;
                 }
+                if (!serverStartedByUs) {
+                    try { ctx.ui.notify("📡 coms-net: you didn't start the server — use /coms-net disconnect instead", "warning"); } catch {}
+                    return;
+                }
                 if (state.capturedSessionShutdown) {
                     try { await state.capturedSessionShutdown(); } catch {}
                 }

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -331,6 +331,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 try {
                     await state.capturedSessionStart({}, ctx);
                     state.active = true;
+                    serverStartedByUs = true;
                     persistState(pi, PERSIST_KEY, state);
                     const sj = readServerJson(project);
                     const serverAddr = (sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.public_url || sj?.local_url) || "unknown";

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -32,43 +32,6 @@ const COMS_NET_DIR = path.join(os.homedir(), ".pi", "coms-net");
 const SERVER_STARTUP_TIMEOUT_MS = 10_000;
 const SERVER_POLL_INTERVAL_MS = 300;
 
-/**
- * Resolve PI_COMS_NET_* env vars — checks process.env first, falls back to shell
- * (shell profiles may set them after Node starts).
- */
-function resolveComsNetEnv(): Record<string, string> {
-    const vars = ["PI_COMS_NET_PORT", "PI_COMS_NET_HOST", "PI_COMS_NET_AUTH_TOKEN"];
-    const result: Record<string, string> = {};
-    const missing: string[] = [];
-
-    for (const name of vars) {
-        if (process.env[name]) {
-            result[name] = process.env[name]!;
-        } else {
-            missing.push(name);
-        }
-    }
-
-    if (missing.length > 0) {
-        try {
-            const cmd = missing.map(n => `echo \${${n}}`).join(";");
-            const out = execSync(`bash -lc '${cmd}'`, { encoding: "utf-8", timeout: 3000 }).trim().split("\n");
-            for (let i = 0; i < missing.length; i++) {
-                const val = (out[i] || "").trim();
-                if (val) result[missing[i]] = val;
-            }
-        } catch {}
-    }
-
-    // Validate port
-    if (result.PI_COMS_NET_PORT && !/^\d+$/.test(result.PI_COMS_NET_PORT)) {
-        delete result.PI_COMS_NET_PORT;
-    }
-    if (!result.PI_COMS_NET_PORT) result.PI_COMS_NET_PORT = "0";
-
-    return result;
-}
-
 function serverJsonPath(project: string): string {
     return path.join(COMS_NET_DIR, "projects", project, "server.json");
 }
@@ -153,7 +116,7 @@ async function ensureServerRunning(
         env: {
             ...process.env,
             PI_COMS_NET_PROJECT: project,
-            ...resolveComsNetEnv(),
+            PI_COMS_NET_PORT: process.env.PI_COMS_NET_PORT || "0",
         },
     });
     child.unref();

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -32,6 +32,43 @@ const COMS_NET_DIR = path.join(os.homedir(), ".pi", "coms-net");
 const SERVER_STARTUP_TIMEOUT_MS = 10_000;
 const SERVER_POLL_INTERVAL_MS = 300;
 
+/**
+ * Resolve PI_COMS_NET_* env vars — checks process.env first, falls back to shell
+ * (shell profiles may set them after Node starts).
+ */
+function resolveComsNetEnv(): Record<string, string> {
+    const vars = ["PI_COMS_NET_PORT", "PI_COMS_NET_HOST", "PI_COMS_NET_AUTH_TOKEN"];
+    const result: Record<string, string> = {};
+    const missing: string[] = [];
+
+    for (const name of vars) {
+        if (process.env[name]) {
+            result[name] = process.env[name]!;
+        } else {
+            missing.push(name);
+        }
+    }
+
+    if (missing.length > 0) {
+        try {
+            const cmd = missing.map(n => `echo \${${n}}`).join(";");
+            const out = execSync(`bash -lc '${cmd}'`, { encoding: "utf-8", timeout: 3000 }).trim().split("\n");
+            for (let i = 0; i < missing.length; i++) {
+                const val = (out[i] || "").trim();
+                if (val) result[missing[i]] = val;
+            }
+        } catch {}
+    }
+
+    // Validate port
+    if (result.PI_COMS_NET_PORT && !/^\d+$/.test(result.PI_COMS_NET_PORT)) {
+        delete result.PI_COMS_NET_PORT;
+    }
+    if (!result.PI_COMS_NET_PORT) result.PI_COMS_NET_PORT = "0";
+
+    return result;
+}
+
 function serverJsonPath(project: string): string {
     return path.join(COMS_NET_DIR, "projects", project, "server.json");
 }
@@ -116,7 +153,7 @@ async function ensureServerRunning(
         env: {
             ...process.env,
             PI_COMS_NET_PROJECT: project,
-            PI_COMS_NET_PORT: /^\d+$/.test(process.env.PI_COMS_NET_PORT || "") ? process.env.PI_COMS_NET_PORT! : "0",
+            ...resolveComsNetEnv(),
         },
     });
     child.unref();

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -152,14 +152,27 @@ async function ensureServerRunning(
 
 function killServer(project: string, log: (msg: string) => void): void {
     const sj = readServerJson(project);
-    if (sj?.pid && Number.isInteger(sj.pid) && sj.pid > 0) {
-        try {
-            process.kill(sj.pid, "SIGTERM");
-            log(`sent SIGTERM to server pid ${sj.pid}`);
-        } catch {
-            // already dead
-        }
+    if (!sj?.pid || !Number.isInteger(sj.pid) || sj.pid <= 0) return;
+    const pid = sj.pid;
+    try {
+        process.kill(pid, "SIGTERM");
+        log(`sent SIGTERM to server pid ${pid}`);
+    } catch {
+        log(`server pid ${pid} already dead`);
+        return;
     }
+    // Wait up to 3s for clean exit, then SIGKILL
+    let waited = 0;
+    const check = () => {
+        try { process.kill(pid, 0); } catch { return; } // dead
+        waited += 100;
+        if (waited >= 3000) {
+            try { process.kill(pid, "SIGKILL"); log(`sent SIGKILL to server pid ${pid}`); } catch {}
+            return;
+        }
+        setTimeout(check, 100);
+    };
+    setTimeout(check, 100);
 }
 
 function isValidProject(project: string): boolean {
@@ -386,6 +399,8 @@ export function registerComsNet(pi: ExtensionAPI) {
             }
         } catch (e: any) { console.debug("[coms-net] shutdown peer check failed:", e?.message || e); }
         // If we can't verify peers, keep server alive to avoid killing shared hubs
-        log("server kept alive on shutdown (couldn't verify peer count)");
+        // Can't verify peers — kill it since we started it. Better than zombie servers.
+        killServer(activeProject, log);
+        log("server killed on shutdown (couldn't verify peer count, we started it)");
     });
 }

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -208,7 +208,7 @@ export function registerComsNet(pi: ExtensionAPI) {
 
 
     pi.registerCommand("coms-net", {
-        description: "Networked agent communication: /coms-net start | connect | stop | status",
+        description: "Networked agent communication: /coms-net start | connect | disconnect | stop | status",
         getArgumentCompletions: (prefix: string) => {
             const tokens = prefix.trim().split(/\s+/).filter(Boolean);
             const atNextToken = prefix.endsWith(" ") || tokens.length === 0;
@@ -222,7 +222,8 @@ export function registerComsNet(pi: ExtensionAPI) {
                 return mk([
                     { v: "start", l: "start", d: "Start local server and connect" },
                     { v: "connect", l: "connect", d: "Connect to a running server" },
-                    { v: "stop", l: "stop", d: "Stop coms-net" },
+                    { v: "disconnect", l: "disconnect", d: "Disconnect from server (keep server running)" },
+                    { v: "stop", l: "stop", d: "Stop coms-net + kill server" },
                     { v: "status", l: "status", d: "Show coms-net + server status" },
 
                 ]);
@@ -381,6 +382,21 @@ export function registerComsNet(pi: ExtensionAPI) {
                 } catch (err: any) {
                     try { ctx.ui.notify(`📡 coms-net connect failed: ${err?.message ?? String(err)}`, "error"); } catch {}
                 }
+            } else if (subcommand === "disconnect") {
+                if (!state.active) {
+                    try { ctx.ui.notify("📡 coms-net not active", "info"); } catch {}
+                    return;
+                }
+                if (serverStartedByUs) {
+                    try { ctx.ui.notify("📡 coms-net: you started the server — use /coms-net stop instead", "warning"); } catch {}
+                    return;
+                }
+                if (state.capturedSessionShutdown) {
+                    try { await state.capturedSessionShutdown(); } catch {}
+                }
+                state.active = false;
+                persistState(pi, PERSIST_KEY, state);
+                try { ctx.ui.notify("📡 coms-net disconnected", "info"); } catch {}
             } else if (subcommand === "stop") {
                 if (!state.active) {
                     try { ctx.ui.notify("📡 coms-net not active", "info"); } catch {}
@@ -408,7 +424,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 if (serverStartedByUs) msg += "(server started by this session)";
                 try { ctx.ui.notify(msg, "info"); } catch {}
             } else {
-                try { ctx.ui.notify(`📡 coms-net: unknown subcommand "${subcommand}". Use: start | connect | stop | status`, "warning"); } catch {}
+                try { ctx.ui.notify(`📡 coms-net: unknown subcommand "${subcommand}". Use: start | connect | disconnect | stop | status`, "warning"); } catch {}
             }
         },
     });

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -167,12 +167,12 @@ function killServer(project: string, log: (msg: string) => void): void {
         try { process.kill(pid, 0); } catch { return; } // dead
         waited += 100;
         if (waited >= 3000) {
-            try { process.kill(pid, "SIGKILL"); log(`sent SIGKILL to server pid ${pid}`); } catch {}
+            try { process.kill(pid, "SIGKILL"); log(`sent SIGKILL to server pid ${pid}`); } catch (e: any) { log(`SIGKILL to pid ${pid} failed: ${e?.message}`); }
             return;
         }
-        setTimeout(check, 100);
+        setTimeout(check, 100).unref();
     };
-    setTimeout(check, 100);
+    setTimeout(check, 100).unref();
 }
 
 function isValidProject(project: string): boolean {
@@ -189,10 +189,15 @@ export function registerComsNet(pi: ExtensionAPI) {
     let activeProject = "";
 
     function getProject(ctx?: any): string {
+        // When ctx provides cwd, derive from it to avoid stale cache after resume/dir-change
+        if (ctx?.cwd) {
+            const proj = ctx.cwd.replace(/^[\\/]/, "").replace(/[\\/]/g, "__");
+            if (proj) return proj;
+        }
         if (activeProject) return activeProject;
         const fromFlags = state.flagValues.get("project") as string;
         if (fromFlags) return fromFlags;
-        const cwd = ctx?.cwd || process.cwd() || "";
+        const cwd = process.cwd() || "";
         const proj = cwd.replace(/^[\\/]/, "").replace(/[\\/]/g, "__");
         if (!proj) throw new Error("coms-net: cannot determine project — no cwd available");
         return proj;
@@ -201,7 +206,14 @@ export function registerComsNet(pi: ExtensionAPI) {
 
     function persist() {
         state.extra = { serverStartedByUs, activeProject: getProject() };
-        persistState(pi, PERSIST_KEY, state);
+        // Don't persist auth token to disk — security sensitive
+        const authToken = state.flagValues.get('auth-token');
+        if (authToken !== undefined) state.flagValues.delete('auth-token');
+        try {
+            persistState(pi, PERSIST_KEY, state);
+        } finally {
+            if (authToken !== undefined) state.flagValues.set('auth-token', authToken);
+        }
     }
 
     // Restore serverStartedByUs after reload

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -308,14 +308,26 @@ export function registerComsNet(pi: ExtensionAPI) {
         try {
             const sj = readServerJson(activeProject);
             if (sj?.local_url) {
-                const resp = await fetch(`${sj.local_url}/v1/agents`, {
+                // Resolve auth token (env or server.secret.json)
+                let token = process.env.PI_COMS_NET_AUTH_TOKEN || "";
+                if (!token) {
+                    const secretPath = path.join(COMS_NET_DIR, "projects", activeProject, "server.secret.json");
+                    try {
+                        const sec = JSON.parse(fs.readFileSync(secretPath, "utf-8"));
+                        token = sec?.token || "";
+                    } catch {}
+                }
+                const headers: Record<string, string> = {};
+                if (token) headers["Authorization"] = `Bearer ${token}`;
+                const url = `${sj.local_url}/v1/agents?project=${encodeURIComponent(activeProject)}&include_explicit=true`;
+                const resp = await fetch(url, {
+                    headers,
                     signal: AbortSignal.timeout(2000),
                 });
                 if (resp.ok) {
                     const agents = await resp.json();
                     const otherAgents = (agents?.agents || []).length;
                     if (otherAgents <= 1) {
-                        // Only us (or nobody) — safe to kill
                         killServer(activeProject, log);
                         log("server killed on shutdown (no other peers)");
                     } else {
@@ -325,8 +337,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 }
             }
         } catch {}
-        // If we can't check peers, kill anyway since we started it
-        killServer(activeProject, log);
-        log("server killed on shutdown (couldn't verify peers)");
+        // If we can't verify peers, keep server alive to avoid killing shared hubs
+        log("server kept alive on shutdown (couldn't verify peer count)");
     });
 }

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -36,7 +36,7 @@ function serverJsonPath(project: string): string {
     return path.join(COMS_NET_DIR, "projects", project, "server.json");
 }
 
-function readServerJson(project: string): { local_url?: string; pid?: number } | null {
+function readServerJson(project: string): { local_url?: string; public_url?: string; host?: string; port?: number; pid?: number } | null {
     const p = serverJsonPath(project);
     try {
         if (!fs.existsSync(p)) return null;
@@ -116,7 +116,7 @@ async function ensureServerRunning(
         env: {
             ...process.env,
             PI_COMS_NET_PROJECT: project,
-            PI_COMS_NET_PORT: "0",
+            PI_COMS_NET_PORT: process.env.PI_COMS_NET_PORT || "0",
         },
     });
     child.unref();
@@ -264,7 +264,8 @@ export function registerComsNet(pi: ExtensionAPI) {
                     state.active = true;
                     persistState(pi, PERSIST_KEY, state);
                     const sj = readServerJson(project);
-                    try { ctx.ui.notify(`📡 coms-net active — server at ${sj?.local_url || "unknown"}`, "info"); } catch {}
+                    const serverAddr = sj?.public_url || sj?.local_url || "unknown";
+                    try { ctx.ui.notify(`📡 coms-net active — server at ${serverAddr}`, "info"); } catch {}
                 } catch (err: any) {
                     try { ctx.ui.notify(`📡 coms-net start failed: ${err?.message ?? String(err)}`, "error"); } catch {}
                 }
@@ -292,7 +293,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 const serverUp = await isServerHealthy(project);
                 const sj = readServerJson(project);
                 let msg = `📡 coms-net: ${state.active ? "active" : "inactive"}\n`;
-                msg += `Server: ${serverUp ? `running at ${sj?.local_url}` : "not running"}\n`;
+                msg += `Server: ${serverUp ? `running at ${sj?.public_url || sj?.local_url}` : "not running"}\n`;
                 if (serverStartedByUs) msg += "(server started by this session)";
                 try { ctx.ui.notify(msg, "info"); } catch {}
             } else {

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -225,7 +225,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 parseFlags(parts.slice(1), state.flagValues);
                 // Default project to cwd so sessions in different dirs are isolated
                 if (!state.flagValues.has("project")) {
-                    const proj = ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
+                    const proj = ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
                     if (!proj) {
                         try { ctx.ui.notify("📡 coms-net: cannot start from /. Run from a project directory.", "error"); } catch {}
                         return;
@@ -281,7 +281,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 serverStartedByUs = false;
                 try { ctx.ui.notify("📡 coms-net server stopped", "info"); } catch {}
             } else if (subcommand === "status") {
-                const project = (state.flagValues.get("project") as string) || ctx.cwd.replace(/^\//,"").replace(/\//g, "__") || "unknown";
+                const project = (state.flagValues.get("project") as string) || ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__") || "unknown";
                 if (!isValidProject(project)) {
                     try { ctx.ui.notify("📡 coms-net: invalid project name", "error"); } catch {}
                     return;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -314,7 +314,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     state.active = true;
                     persistState(pi, PERSIST_KEY, state);
                     const sj = readServerJson(project);
-                    const serverAddr = sj?.public_url || (sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.local_url) || "unknown";
+                    const serverAddr = (sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.public_url || sj?.local_url) || "unknown";
                     try { ctx.ui.notify(`📡 coms-net active — server at ${serverAddr}`, "info"); } catch {}
                 } catch (err: any) {
                     try { ctx.ui.notify(`📡 coms-net start failed: ${err?.message ?? String(err)}`, "error"); } catch {}
@@ -346,7 +346,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 const serverUp = await isServerHealthy(project);
                 const sj = readServerJson(project);
                 let msg = `📡 coms-net: ${state.active ? "active" : "inactive"}\n`;
-                msg += `Server: ${serverUp ? `running at ${sj?.public_url || (sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.local_url)}` : "not running"}\n`;
+                msg += `Server: ${serverUp ? `running at ${sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.public_url || sj?.local_url}` : "not running"}\n`;
                 if (serverStartedByUs) msg += "(server started by this session)";
                 try { ctx.ui.notify(msg, "info"); } catch {}
             } else {

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -329,6 +329,11 @@ export function registerComsNet(pi: ExtensionAPI) {
                 }
                 state.active = false;
                 persistState(pi, PERSIST_KEY, state);
+                // Kill server if we started it and no other peers
+                if (serverStartedByUs) {
+                    killServer(activeProject, log);
+                    serverStartedByUs = false;
+                }
                 try { ctx.ui.notify("📡 coms-net stopped", "info"); } catch {}
             } else if (subcommand === "server-stop") {
                 killServer(activeProject, log);

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -183,13 +183,15 @@ export function registerComsNet(pi: ExtensionAPI) {
     pi.registerCommand("coms-net", {
         description: "Networked agent communication: /coms-net start | stop | status | server-stop",
         getArgumentCompletions: (prefix: string) => {
-            const parts = prefix.split(/\s+/);
-            const lastPart = parts[parts.length - 1] || "";
-            const base = lastPart === "" ? prefix : prefix.slice(0, prefix.length - lastPart.length);
+            const tokens = prefix.trim().split(/\s+/).filter(Boolean);
+            const atNextToken = prefix.endsWith(" ") || tokens.length === 0;
+            const lastPart = atNextToken ? "" : tokens[tokens.length - 1];
+            const completed = atNextToken ? tokens : tokens.slice(0, -1);
+            const base = atNextToken ? prefix : prefix.slice(0, prefix.length - lastPart.length);
             const mk = (items: {v: string; l: string; d: string}[]) =>
                 fuzzy(items.map(i => ({ value: base + i.v, label: i.l, description: i.d })), lastPart);
 
-            if (parts.length <= 1) {
+            if (completed.length === 0) {
                 return mk([
                     { v: "start", l: "start", d: "Start networked agent communication" },
                     { v: "stop", l: "stop", d: "Stop coms-net" },
@@ -197,8 +199,8 @@ export function registerComsNet(pi: ExtensionAPI) {
                     { v: "server-stop", l: "server-stop", d: "Stop the hub server" },
                 ]);
             }
-            if (parts[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
-                const used = new Set(parts.filter(p => p.startsWith("--")));
+            if (completed[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(completed.filter(p => p.startsWith("--")));
                 return mk([
                     { v: "--name ", l: "--name", d: "Agent name" },
                     { v: "--purpose ", l: "--purpose", d: "Agent purpose" },
@@ -225,7 +227,8 @@ export function registerComsNet(pi: ExtensionAPI) {
                 parseFlags(parts.slice(1), state.flagValues);
                 // Default project to cwd so sessions in different dirs are isolated
                 if (!state.flagValues.has("project")) {
-                    const proj = ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
+                    const cwd = ctx.cwd || "";
+                    const proj = cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
                     if (!proj) {
                         try { ctx.ui.notify("📡 coms-net: cannot start from /. Run from a project directory.", "error"); } catch {}
                         return;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -187,7 +187,12 @@ export function registerComsNet(pi: ExtensionAPI) {
                 parseFlags(parts.slice(1), state.flagValues);
                 // Default project to cwd so sessions in different dirs are isolated
                 if (!state.flagValues.has("project")) {
-                    state.flagValues.set("project", ctx.cwd.replace(/^\//,"").replace(/\//g, "__"));
+                    const proj = ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
+                    if (!proj) {
+                        try { ctx.ui.notify("📡 coms-net: cannot start from /. Run from a project directory.", "error"); } catch {}
+                        return;
+                    }
+                    state.flagValues.set("project", proj);
                 }
                 const project = state.flagValues.get("project") as string;
                 if (!isValidProject(project)) {
@@ -238,7 +243,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 serverStartedByUs = false;
                 try { ctx.ui.notify("📡 coms-net server stopped", "info"); } catch {}
             } else if (subcommand === "status") {
-                const project = (state.flagValues.get("project") as string) || ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
+                const project = (state.flagValues.get("project") as string) || ctx.cwd.replace(/^\//,"").replace(/\//g, "__") || "unknown";
                 if (!isValidProject(project)) {
                     try { ctx.ui.notify("📡 coms-net: invalid project name", "error"); } catch {}
                     return;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -301,4 +301,32 @@ export function registerComsNet(pi: ExtensionAPI) {
             }
         },
     });
+
+    // Kill server on session shutdown if we started it and no other peers are connected
+    pi.on("session_shutdown", async () => {
+        if (!serverStartedByUs) return;
+        try {
+            const sj = readServerJson(activeProject);
+            if (sj?.local_url) {
+                const resp = await fetch(`${sj.local_url}/v1/agents`, {
+                    signal: AbortSignal.timeout(2000),
+                });
+                if (resp.ok) {
+                    const agents = await resp.json();
+                    const otherAgents = (agents?.agents || []).length;
+                    if (otherAgents <= 1) {
+                        // Only us (or nobody) — safe to kill
+                        killServer(activeProject, log);
+                        log("server killed on shutdown (no other peers)");
+                    } else {
+                        log(`server kept alive (${otherAgents - 1} other peer(s) connected)`);
+                    }
+                    return;
+                }
+            }
+        } catch {}
+        // If we can't check peers, kill anyway since we started it
+        killServer(activeProject, log);
+        log("server killed on shutdown (couldn't verify peers)");
+    });
 }

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -319,6 +319,14 @@ export function registerComsNet(pi: ExtensionAPI) {
                 }
                 const headers: Record<string, string> = {};
                 if (token) headers["Authorization"] = `Bearer ${token}`;
+                // Validate local_url is loopback to prevent token leak
+                try {
+                    const parsed = new URL(sj.local_url);
+                    if (parsed.hostname !== "127.0.0.1" && parsed.hostname !== "localhost" && parsed.hostname !== "::1") {
+                        log("server url is not loopback, skipping peer check");
+                        return;
+                    }
+                } catch { return; }
                 const url = `${sj.local_url}/v1/agents?project=${encodeURIComponent(activeProject)}&include_explicit=true`;
                 const resp = await fetch(url, {
                     headers,

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -260,8 +260,14 @@ export function registerComsNet(pi: ExtensionAPI) {
 
             if (subcommand === "start") {
                 if (state.active) {
-                    try { ctx.ui.notify("📡 coms-net already active", "warning"); } catch {}
-                    return;
+                    // Check if server is actually still running
+                    if (await isServerHealthy(activeProject)) {
+                        try { ctx.ui.notify("📡 coms-net already active", "warning"); } catch {}
+                        return;
+                    }
+                    // Server died — reset state and allow restart
+                    state.active = false;
+                    serverStartedByUs = false;
                 }
                 state.flagValues = new Map();
                 parseFlags(parts.slice(1), state.flagValues);
@@ -390,7 +396,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 serverStartedByUs = false;
                 try { ctx.ui.notify("📡 coms-net stopped", "info"); } catch {}
             } else if (subcommand === "status") {
-                const project = (state.flagValues.get("project") as string) || ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__") || "unknown";
+                const project = activeProject || (state.flagValues.get("project") as string) || ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__") || "unknown";
                 if (!isValidProject(project)) {
                     try { ctx.ui.notify("📡 coms-net: invalid project name", "error"); } catch {}
                     return;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -84,9 +84,21 @@ async function ensureServerRunning(
     log: (msg: string) => void,
     options?: { port?: string; host?: string },
 ): Promise<boolean> {
+    // If port/host explicitly requested, check if running server matches
     if (await isServerHealthy(project)) {
-        log("server already running");
-        return true;
+        const sj = readServerJson(project);
+        const wantPort = options?.port;
+        const wantHost = options?.host;
+        const needRestart = (wantPort && sj?.port !== Number(wantPort)) ||
+                            (wantHost && sj?.host !== wantHost);
+        if (needRestart) {
+            log(`server running but port/host mismatch — restarting`);
+            killServer(project, log);
+            await new Promise(r => setTimeout(r, 1000));
+        } else {
+            log("server already running");
+            return true;
+        }
     }
 
     const bunPath = findBun();

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -314,7 +314,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                     state.active = true;
                     persistState(pi, PERSIST_KEY, state);
                     const sj = readServerJson(project);
-                    const serverAddr = sj?.public_url || sj?.local_url || "unknown";
+                    const serverAddr = sj?.public_url || (sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.local_url) || "unknown";
                     try { ctx.ui.notify(`📡 coms-net active — server at ${serverAddr}`, "info"); } catch {}
                 } catch (err: any) {
                     try { ctx.ui.notify(`📡 coms-net start failed: ${err?.message ?? String(err)}`, "error"); } catch {}
@@ -343,7 +343,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 const serverUp = await isServerHealthy(project);
                 const sj = readServerJson(project);
                 let msg = `📡 coms-net: ${state.active ? "active" : "inactive"}\n`;
-                msg += `Server: ${serverUp ? `running at ${sj?.public_url || sj?.local_url}` : "not running"}\n`;
+                msg += `Server: ${serverUp ? `running at ${sj?.public_url || (sj?.host && sj?.port ? `http://${sj.host}:${sj.port}` : sj?.local_url)}` : "not running"}\n`;
                 if (serverStartedByUs) msg += "(server started by this session)";
                 try { ctx.ui.notify(msg, "info"); } catch {}
             } else {

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -326,7 +326,10 @@ export function registerComsNet(pi: ExtensionAPI) {
                         log("server url is not loopback, skipping peer check");
                         return;
                     }
-                } catch { return; }
+                } catch {
+                    log("shutdown: invalid local_url in server.json, skipping peer check");
+                    return;
+                }
                 const url = `${sj.local_url}/v1/agents?project=${encodeURIComponent(activeProject)}&include_explicit=true`;
                 const resp = await fetch(url, {
                     headers,

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -173,7 +173,7 @@ export function registerComsNet(pi: ExtensionAPI) {
     // User can explicitly stop it with /coms-net server-stop.
 
     pi.registerCommand("coms-net", {
-        description: "Networked agent communication: /coms-net start [--name X --purpose Y --project Z --color #HEX] | stop | status | server-stop",
+        description: "Networked agent communication: /coms-net start | stop | status | server-stop",
         handler: async (args: string, ctx: any) => {
             const trimmed = (args || "").trim();
             const parts = tokenizeArgs(trimmed);
@@ -185,7 +185,11 @@ export function registerComsNet(pi: ExtensionAPI) {
                     return;
                 }
                 parseFlags(parts.slice(1), state.flagValues);
-                const project = (state.flagValues.get("project") as string) || "default";
+                // Default project to cwd so sessions in different dirs are isolated
+                if (!state.flagValues.has("project")) {
+                    state.flagValues.set("project", ctx.cwd.replace(/^\//,"").replace(/\//g, "__"));
+                }
+                const project = state.flagValues.get("project") as string;
                 if (!isValidProject(project)) {
                     try { ctx.ui.notify("📡 coms-net: invalid project name", "error"); } catch {}
                     return;
@@ -234,7 +238,7 @@ export function registerComsNet(pi: ExtensionAPI) {
                 serverStartedByUs = false;
                 try { ctx.ui.notify("📡 coms-net server stopped", "info"); } catch {}
             } else if (subcommand === "status") {
-                const project = (state.flagValues.get("project") as string) || "default";
+                const project = (state.flagValues.get("project") as string) || ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
                 if (!isValidProject(project)) {
                     try { ctx.ui.notify("📡 coms-net: invalid project name", "error"); } catch {}
                     return;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -87,8 +87,8 @@ async function ensureServerRunning(
     // If port/host explicitly requested, check if running server matches
     if (await isServerHealthy(project)) {
         const sj = readServerJson(project);
-        const wantPort = options?.port;
-        const wantHost = options?.host;
+        const wantPort = options?.port || process.env.PI_COMS_NET_PORT;
+        const wantHost = options?.host || process.env.PI_COMS_NET_HOST;
         const needRestart = (wantPort && sj?.port !== Number(wantPort)) ||
                             (wantHost && sj?.host !== wantHost);
         if (needRestart) {

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -68,6 +68,8 @@ export interface DeferredUpstream {
     flagValues: Map<string, any>;
     /** Whether the upstream extension is active */
     active: boolean;
+    /** Extra persisted state (e.g., serverStartedByUs for coms-net) */
+    extra?: Record<string, any>;
 }
 
 /**
@@ -140,14 +142,17 @@ export function createDeferredProxy(
                                 // Check if coms was active before reload
                                 let wasActive = false;
                                 let savedFlags: Record<string, any> = {};
+                                let savedExtra: Record<string, any> = {};
                                 for (const entry of ctx.sessionManager.getEntries()) {
                                     if (entry.type === "custom" && entry.customType === persistKey) {
                                         wasActive = entry.data?.active === true;
                                         savedFlags = entry.data?.flags || {};
+                                        savedExtra = entry.data?.extra || {};
                                     }
                                 }
                                 if (wasActive) {
                                     state.flagValues = new Map(Object.entries(savedFlags));
+                                    state.extra = savedExtra;
                                     try {
                                         await handler(evt, ctx);
                                         state.active = true;
@@ -183,6 +188,6 @@ export function persistState(pi: ExtensionAPI, persistKey: string, state: Deferr
     try {
         const flags: Record<string, any> = {};
         for (const [k, v] of state.flagValues) flags[k] = v;
-        pi.appendEntry(persistKey, { active: state.active, flags });
+        pi.appendEntry(persistKey, { active: state.active, flags, extra: state.extra || {} });
     } catch (e: any) { console.debug("[coms-shared] persist state failed:", e?.message || e); }
 }

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -184,5 +184,5 @@ export function persistState(pi: ExtensionAPI, persistKey: string, state: Deferr
         const flags: Record<string, any> = {};
         for (const [k, v] of state.flagValues) flags[k] = v;
         pi.appendEntry(persistKey, { active: state.active, flags });
-    } catch {}
+    } catch (e: any) { console.debug("[coms-shared] persist state failed:", e?.message || e); }
 }

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -414,11 +414,14 @@ export function registerComsSwarm(pi: ExtensionAPI): {
                 ? Array.from(peers.keys())
                 : [targetName];
 
-            for (const name of targets) {
-                if (!peers.has(name)) {
-                    try { ctx.ui.notify(`📡 swarm send: peer "${name}" not found`, "warning"); } catch {}
-                    continue;
-                }
+            const validTargets = targets.filter(n => peers.has(n));
+            let pending = validTargets.length;
+            const invalidTargets = targets.filter(n => !peers.has(n));
+            for (const name of invalidTargets) {
+                try { ctx.ui.notify(`📡 swarm send: peer "${name}" not found`, "warning"); } catch {}
+            }
+
+            for (const name of validTargets) {
                 const peer = peers.get(name)!;
 
                 // Fire each peer prompt — response surfaces via sendMessage as it completes
@@ -458,9 +461,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
                 log(`sent to ${name}: ${message.slice(0, 100)}`);
             }
 
-            const validTargets = targets.filter(n => peers.has(n));
             const targetDesc = targetName ? `"${targetName}"` : `all ${validTargets.length} peer(s)`;
-            let pending = validTargets.length;
             try { ctx.ui.setStatus("2-swarm", ctx.ui.theme.fg("warning", `⏳ swarm: waiting...`)); } catch {}
             return true;
         }

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -313,7 +313,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
             }
 
             // Use cwd with slashes replaced — matches the parent session's coms project
-            const parentProject = ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
+            const parentProject = ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
 
             for (const name of args.names) {
                 if (peers.has(name)) {

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -421,6 +421,11 @@ export function registerComsSwarm(pi: ExtensionAPI): {
                 try { ctx.ui.notify(`📡 swarm send: peer "${name}" not found`, "warning"); } catch {}
             }
 
+            if (validTargets.length === 0) {
+                try { ctx.ui.notify("📡 swarm send: no valid peers to send to", "warning"); } catch {}
+                return true;
+            }
+
             for (const name of validTargets) {
                 const peer = peers.get(name)!;
 

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -45,9 +45,13 @@ function cleanupPeerRegistry(name: string, project: string): void {
             // Read socket path before deleting
             const data = JSON.parse(fs.readFileSync(registryFile, "utf-8"));
             fs.unlinkSync(registryFile);
-            // Remove socket
+            // Remove socket (validate it's in the coms sockets dir)
             if (data.endpoint) {
-                try { fs.unlinkSync(data.endpoint); } catch {}
+                const socketsDir = path.join(comsDir, "sockets");
+                const resolved = path.resolve(data.endpoint);
+                if (resolved.startsWith(socketsDir + path.sep)) {
+                    try { fs.unlinkSync(resolved); } catch {}
+                }
             }
         }
     } catch {}

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -13,8 +13,10 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
+    AuthStorage,
     createAgentSession,
     DefaultResourceLoader,
+    ModelRegistry,
     SessionManager,
     getAgentDir,
 } from "@earendil-works/pi-coding-agent";
@@ -144,6 +146,27 @@ async function spawnPeer(
 
     if (tools) {
         sessionOptions.tools = tools;
+    }
+
+    // Apply model if specified
+    if (modelPattern) {
+        try {
+            const authStorage = AuthStorage.create();
+            const modelRegistry = ModelRegistry.create(authStorage);
+            const available = await modelRegistry.getAvailable();
+            const match = available.find(
+                (m: any) => m.id.includes(modelPattern) || m.name?.includes(modelPattern)
+            );
+            if (match) {
+                sessionOptions.model = match;
+                sessionOptions.authStorage = authStorage;
+                sessionOptions.modelRegistry = modelRegistry;
+            } else {
+                log(`model "${modelPattern}" not found, using default`);
+            }
+        } catch (err: any) {
+            log(`model lookup failed: ${err.message}`);
+        }
     }
 
     const { session } = await createAgentSession(sessionOptions);

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -174,7 +174,7 @@ async function spawnPeer(
     // Build the /coms start command for this peer
     let comsStartCmd = `/coms start --name ${name}`;
     if (purpose) comsStartCmd += ` --purpose "${purpose}"`;
-    if (parentProject) comsStartCmd += ` --project ${parentProject}`;
+    if (parentProject) comsStartCmd += ` --project "${parentProject}"`;
 
     // Subscribe to events for logging
     session.subscribe((event: any) => {

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -1,0 +1,483 @@
+/**
+ * coms-swarm.ts — Spawn and manage headless peer pi sessions via SDK
+ *
+ * Adds /coms swarm subcommands:
+ *   /coms swarm add --name <name> [--purpose <text>] [--system-prompt <text>] [--model <pattern>] [--read-only]
+ *   /coms swarm status
+ *   /coms swarm stop [--name <name>]
+ *
+ * Each peer is an AgentSession created via the pi SDK, loaded with only
+ * the coms extension. Peers auto-connect to P2P coms and stay alive
+ * via the coms Unix socket listener.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+    createAgentSession,
+    DefaultResourceLoader,
+    SessionManager,
+    getAgentDir,
+} from "@earendil-works/pi-coding-agent";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface SwarmPeer {
+    name: string;
+    purpose: string;
+    model: string;
+    systemPrompt: string;
+    readOnly: boolean;
+    session: any; // AgentSession
+    project: string;
+    sessionFile: string;
+    startedAt: number;
+}
+
+function cleanupPeerRegistry(name: string, project: string): void {
+    const comsDir = process.env.PI_COMS_DIR || path.join(os.homedir(), ".pi", "coms");
+    const registryFile = path.join(comsDir, "projects", project, "agents", `${name}.json`);
+    try {
+        if (fs.existsSync(registryFile)) {
+            // Read socket path before deleting
+            const data = JSON.parse(fs.readFileSync(registryFile, "utf-8"));
+            fs.unlinkSync(registryFile);
+            // Remove socket
+            if (data.endpoint) {
+                try { fs.unlinkSync(data.endpoint); } catch {}
+            }
+        }
+    } catch {}
+}
+
+const peers = new Map<string, SwarmPeer>();
+
+function getComsExtensionPath(): string {
+    // Path to this extension's index.ts (coms extension entry point)
+    return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "index.ts");
+}
+
+function parseSwarmArgs(parts: string[]): {
+    names: string[];
+    purpose: string;
+    systemPrompt: string;
+    model: string;
+    readOnly: boolean;
+} {
+    const names: string[] = [];
+    let purpose = "";
+    let systemPrompt = "";
+    let model = "";
+    let readOnly = false;
+
+    let i = 0;
+    while (i < parts.length) {
+        const arg = parts[i];
+        if (arg === "--name" && i + 1 < parts.length) {
+            names.push(parts[++i]);
+        } else if (arg === "--purpose" && i + 1 < parts.length) {
+            purpose = parts[++i];
+        } else if (arg === "--system-prompt" && i + 1 < parts.length) {
+            systemPrompt = parts[++i];
+        } else if (arg === "--model" && i + 1 < parts.length) {
+            model = parts[++i];
+        } else if (arg === "--read-only") {
+            readOnly = true;
+        }
+        i++;
+    }
+
+    return { names, purpose, systemPrompt, model, readOnly };
+}
+
+async function spawnPeer(
+    name: string,
+    purpose: string,
+    systemPrompt: string,
+    modelPattern: string,
+    readOnly: boolean,
+    cwd: string,
+    parentProject: string,
+    log: (msg: string) => void,
+    existingSessionFile?: string,
+): Promise<SwarmPeer> {
+    log(`spawning peer: ${name}`);
+
+    const effectiveSystemPrompt = systemPrompt ||
+        "You are a peer agent in a multi-agent swarm. Respond to requests from other agents via coms. Be concise and helpful.";
+
+    // Full resource loader but exclude UI extensions
+    const EXCLUDE_EXTENSIONS = ["pidash", "pidiff"];
+    const resourceLoader = new DefaultResourceLoader({
+        cwd,
+        agentDir: getAgentDir(),
+    });
+    await resourceLoader.reload();
+
+    // Filter out pidash/pidiff extensions
+    const origGetExtensions = resourceLoader.getExtensions.bind(resourceLoader);
+    resourceLoader.getExtensions = () => {
+        const result = origGetExtensions();
+        result.extensions = result.extensions.filter(
+            (ext: any) => !EXCLUDE_EXTENSIONS.some(name => (ext.path || "").includes(`/${name}/`))
+        );
+        return result;
+    };
+
+    // Override system prompt
+    resourceLoader.getSystemPrompt = () => effectiveSystemPrompt;
+
+    const tools = readOnly
+        ? ["read", "ls", "find", "grep"] as string[]
+        : undefined; // undefined = all default tools
+
+    // Resume from existing session file if available, otherwise create new
+    const sessionManager = existingSessionFile && fs.existsSync(existingSessionFile)
+        ? SessionManager.open(existingSessionFile)
+        : SessionManager.create(cwd);
+    const sessionOptions: any = {
+        cwd,
+        resourceLoader,
+        sessionManager,
+    };
+
+    if (tools) {
+        sessionOptions.tools = tools;
+    }
+
+    const { session } = await createAgentSession(sessionOptions);
+
+    // Build the /coms start command for this peer
+    let comsStartCmd = `/coms start --name ${name}`;
+    if (purpose) comsStartCmd += ` --purpose "${purpose}"`;
+    if (parentProject) comsStartCmd += ` --project ${parentProject}`;
+
+    // Subscribe to events for logging
+    session.subscribe((event: any) => {
+        if (event.type === "agent_end") {
+            log(`peer ${name}: agent_end`);
+        }
+    });
+
+    // Always send /coms start to register with coms
+    // (even on resume — coms state doesn't persist in the session file)
+    await session.prompt(comsStartCmd);
+
+    const peer: SwarmPeer = {
+        name,
+        purpose,
+        project: parentProject,
+        model: modelPattern || "default",
+        systemPrompt: effectiveSystemPrompt,
+        readOnly,
+        session,
+        sessionFile: session.sessionFile || "",
+        startedAt: Date.now(),
+    };
+
+    log(`peer ${name} spawned and coms started`);
+    return peer;
+}
+
+const SWARM_PERSIST_KEY = "coms-swarm-state";
+
+interface PeerConfig {
+    name: string;
+    purpose: string;
+    systemPrompt: string;
+    model: string;
+    readOnly: boolean;
+    project: string;
+    sessionFile: string;
+}
+
+function persistSwarm(pi: ExtensionAPI, peerConfigs: PeerConfig[]): void {
+    try {
+        pi.appendEntry(SWARM_PERSIST_KEY, { peers: peerConfigs });
+    } catch {}
+}
+
+export function registerComsSwarm(pi: ExtensionAPI): {
+    handleSwarmCommand: (subcommand: string, parts: string[], ctx: any) => Promise<boolean>;
+} {
+    let lastCtx: any = null;
+
+    function updateSwarmStatus(ctx?: any) {
+        const c = ctx || lastCtx;
+        if (!c) return;
+        try {
+            c.ui.setStatus("2-swarm", c.ui.theme.fg("muted", `💤 swarm: 0`));
+        } catch {}
+    }
+
+    pi.on("session_start", (_event: any, ctx: any) => {
+        lastCtx = ctx;
+        updateSwarmStatus(ctx);
+    });
+    pi.on("turn_end", (_event: any, ctx: any) => { lastCtx = ctx; });
+
+    const log = (msg: string) => {
+        try {
+            pi.appendEntry("coms-swarm-log", { event: "swarm", ts: new Date().toISOString(), msg });
+        } catch {}
+    };
+
+    function savePeerConfigs(): void {
+        const configs: PeerConfig[] = [];
+        for (const [, peer] of peers) {
+            configs.push({
+                name: peer.name,
+                purpose: peer.purpose,
+                systemPrompt: peer.systemPrompt,
+                model: peer.model,
+                readOnly: peer.readOnly,
+                project: peer.project,
+                sessionFile: peer.sessionFile,
+            });
+        }
+        persistSwarm(pi, configs);
+    }
+
+    // Restore peers on reload
+    pi.on("session_start", async (event: any, ctx: any) => {
+        if (event?.reason !== "reload") return;
+        let savedPeers: PeerConfig[] = [];
+        try {
+            for (const entry of ctx.sessionManager.getEntries()) {
+                if (entry.type === "custom" && entry.customType === SWARM_PERSIST_KEY) {
+                    savedPeers = entry.data?.peers || [];
+                }
+            }
+        } catch {}
+        if (savedPeers.length === 0) return;
+
+        log(`reload: restoring ${savedPeers.length} swarm peer(s)`);
+        for (const config of savedPeers) {
+            if (peers.has(config.name)) continue;
+            try {
+                const peer = await spawnPeer(
+                    config.name,
+                    config.purpose,
+                    config.systemPrompt,
+                    config.model,
+                    config.readOnly,
+                    ctx.cwd,
+                    config.project,
+                    log,
+                    config.sessionFile,
+                );
+                peers.set(config.name, peer);
+                log(`reload: restored peer ${config.name}`);
+            } catch (err: any) {
+                console.error(`[coms-swarm] reload: failed to restore ${config.name}:`, err);
+            }
+        }
+    });
+
+    async function handleSwarmCommand(subcommand: string, parts: string[], ctx: any): Promise<boolean> {
+        if (subcommand !== "swarm") return false;
+
+        const action = parts[1] || "status";
+        const actionParts = parts.slice(2);
+
+        if (action === "add") {
+            const args = parseSwarmArgs(actionParts);
+
+            if (args.names.length === 0) {
+                try { ctx.ui.notify("📡 swarm add: --name is required", "error"); } catch {}
+                return true;
+            }
+
+            // Use cwd with slashes replaced — matches the parent session's coms project
+            const parentProject = ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
+
+            for (const name of args.names) {
+                if (peers.has(name)) {
+                    try { ctx.ui.notify(`📡 swarm add: peer "${name}" already exists`, "warning"); } catch {}
+                    continue;
+                }
+
+                console.log(`[coms-swarm] spawning peer: ${name}, project: ${parentProject}, cwd: ${ctx.cwd}`);
+                try {
+                    const peer = await spawnPeer(
+                        name,
+                        args.purpose,
+                        args.systemPrompt,
+                        args.model,
+                        args.readOnly,
+                        ctx.cwd,
+                        parentProject,
+                        log,
+                    );
+                    peers.set(name, peer);
+                    savePeerConfigs();
+                    updateSwarmStatus(ctx);
+                    try { ctx.ui.notify(`📡 swarm: peer "${name}" spawned`, "info"); } catch {}
+                } catch (err: any) {
+                    console.error(`[coms-swarm] spawn failed for ${name}:`, err);
+                    log(`spawn failed for ${name}: ${err.message}`);
+                    try { ctx.ui.notify(`📡 swarm add: failed to spawn "${name}": ${err.message}`, "error"); } catch {}
+                }
+            }
+
+            return true;
+        }
+
+        if (action === "stop") {
+            const args = parseSwarmArgs(actionParts);
+
+            if (args.names.length > 0) {
+                // Stop specific peers
+                for (const name of args.names) {
+                    const peer = peers.get(name);
+                    if (!peer) {
+                        try { ctx.ui.notify(`📡 swarm stop: peer "${name}" not found`, "warning"); } catch {}
+                        continue;
+                    }
+                    try { peer.session.dispose(); } catch {}
+                    cleanupPeerRegistry(name, peer.project);
+                    peers.delete(name);
+                    savePeerConfigs();
+                    updateSwarmStatus(ctx);
+                    try { ctx.ui.notify(`📡 swarm: peer "${name}" stopped`, "info"); } catch {}
+                }
+            } else {
+                // Stop all peers
+                const count = peers.size;
+                for (const [name, peer] of peers) {
+                    try { peer.session.dispose(); } catch {}
+                    cleanupPeerRegistry(name, peer.project);
+                    log(`stopped peer: ${name}`);
+                }
+                peers.clear();
+                savePeerConfigs();
+                updateSwarmStatus(ctx);
+                try { ctx.ui.notify(`📡 swarm: stopped ${count} peer(s)`, "info"); } catch {}
+            }
+
+            return true;
+        }
+
+        if (action === "status") {
+            if (peers.size === 0) {
+                try { ctx.ui.notify("📡 swarm: no active peers. Use `/coms swarm add --name <name>` to spawn.", "info"); } catch {}
+                return true;
+            }
+
+            let msg = `📡 swarm: ${peers.size} active peer(s)\n\n`;
+            for (const [name, peer] of peers) {
+                const uptime = Math.floor((Date.now() - peer.startedAt) / 1000);
+                const uptimeStr = uptime < 60 ? `${uptime}s` : `${Math.floor(uptime / 60)}m${uptime % 60}s`;
+                const ro = peer.readOnly ? " [read-only]" : "";
+                msg += `  • ${name} — ${peer.purpose || "general"}${ro} (${peer.model}, ${uptimeStr})\n`;
+            }
+            try { ctx.ui.notify(msg.trim(), "info"); } catch {}
+            return true;
+        }
+
+        if (action === "send") {
+            if (peers.size === 0) {
+                try { ctx.ui.notify("📡 swarm send: no active peers", "warning"); } catch {}
+                return true;
+            }
+
+            // Parse --name / --all / --msg
+            let targetName = "";
+            let sendAll = false;
+            let message = "";
+            let i = 0;
+            while (i < actionParts.length) {
+                if (actionParts[i] === "--name" && i + 1 < actionParts.length) {
+                    targetName = actionParts[++i];
+                } else if (actionParts[i] === "--all") {
+                    sendAll = true;
+                } else if (actionParts[i] === "--msg") {
+                    // Everything after --msg is the message
+                    message = actionParts.slice(i + 1).join(" ");
+                    break;
+                }
+                i++;
+            }
+
+            if (!message) {
+                try { ctx.ui.notify("📡 swarm send: --msg is required", "error"); } catch {}
+                return true;
+            }
+
+            if (!targetName && !sendAll) {
+                try { ctx.ui.notify("📡 swarm send: specify --name <peer> or --all", "error"); } catch {}
+                return true;
+            }
+
+            const targets = sendAll
+                ? Array.from(peers.keys())
+                : [targetName];
+
+            for (const name of targets) {
+                if (!peers.has(name)) {
+                    try { ctx.ui.notify(`📡 swarm send: peer "${name}" not found`, "warning"); } catch {}
+                    continue;
+                }
+                const peer = peers.get(name)!;
+
+                // Fire each peer prompt — response surfaces via sendMessage as it completes
+                (async () => {
+                    let text = "";
+                    const unsub = peer.session.subscribe((event: any) => {
+                        if (event.type === "message_update" && event.assistantMessageEvent?.type === "text_delta") {
+                            text += event.assistantMessageEvent.delta;
+                        }
+                    });
+                    try {
+                        await peer.session.prompt(message);
+                    } catch (err: any) {
+                        text = `(error: ${err.message})`;
+                    }
+                    unsub();
+                    const responseContent = [
+                        `---`,
+                        ``,
+                        `## 📡 Swarm peer ${name}`,
+                        ``,
+                        text,
+                        ``,
+                    ].join("\n");
+                    pi.sendMessage({
+                        customType: "swarm-response",
+                        content: responseContent,
+                        display: true,
+                    }, { triggerTurn: false, deliverAs: "followUp" });
+                    pending--;
+                    if (pending <= 0) {
+                        updateSwarmStatus(ctx);
+                    } else {
+                        try { ctx.ui.setStatus("2-swarm", ctx.ui.theme.fg("warning", `⏳ swarm: ${pending} responding...`)); } catch {}
+                    }
+                })();
+                log(`sent to ${name}: ${message.slice(0, 100)}`);
+            }
+
+            const validTargets = targets.filter(n => peers.has(n));
+            const targetDesc = targetName ? `"${targetName}"` : `all ${validTargets.length} peer(s)`;
+            let pending = validTargets.length;
+            try { ctx.ui.setStatus("2-swarm", ctx.ui.theme.fg("warning", `⏳ swarm: waiting...`)); } catch {}
+            return true;
+        }
+
+        try { ctx.ui.notify(`📡 swarm: unknown action "${action}". Use: add | stop | status | send`, "warning"); } catch {}
+        return true;
+    }
+
+    // Clean up all peers on session shutdown
+    pi.on("session_shutdown", () => {
+        for (const [name, peer] of peers) {
+            try { peer.session.dispose(); } catch {}
+            cleanupPeerRegistry(name, peer.project);
+            log(`shutdown: stopped peer ${name}`);
+        }
+        peers.clear();
+    });
+
+    return { handleSwarmCommand };
+}

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -222,7 +222,7 @@ function persistSwarm(pi: ExtensionAPI, peerConfigs: PeerConfig[]): void {
 }
 
 export function registerComsSwarm(pi: ExtensionAPI): {
-    handleSwarmCommand: (subcommand: string, parts: string[], ctx: any) => Promise<boolean>;
+    handleSwarmCommand: (subcommand: string, parts: string[], ctx: any, parentProject?: string) => Promise<boolean>;
 } {
     let lastCtx: any = null;
 
@@ -298,7 +298,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
         }
     });
 
-    async function handleSwarmCommand(subcommand: string, parts: string[], ctx: any): Promise<boolean> {
+    async function handleSwarmCommand(subcommand: string, parts: string[], ctx: any, parentProject?: string): Promise<boolean> {
         if (subcommand !== "swarm") return false;
 
         const action = parts[1] || "status";
@@ -313,7 +313,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
             }
 
             // Use cwd with slashes replaced — matches the parent session's coms project
-            const parentProject = ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
+            const project = parentProject || (ctx.cwd || "").replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
 
             for (const name of args.names) {
                 if (peers.has(name)) {
@@ -321,7 +321,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
                     continue;
                 }
 
-                console.log(`[coms-swarm] spawning peer: ${name}, project: ${parentProject}, cwd: ${ctx.cwd}`);
+                console.log(`[coms-swarm] spawning peer: ${name}, project: ${project}, cwd: ${ctx.cwd}`);
                 try {
                     const peer = await spawnPeer(
                         name,
@@ -330,7 +330,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
                         args.model,
                         args.readOnly,
                         ctx.cwd,
-                        parentProject,
+                        project,
                         log,
                     );
                     peers.set(name, peer);

--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -54,7 +54,7 @@ function cleanupPeerRegistry(name: string, project: string): void {
                 }
             }
         }
-    } catch {}
+    } catch (e: any) { console.debug("[coms-swarm] cleanup discovery file failed:", e?.message || e); }
 }
 
 const peers = new Map<string, SwarmPeer>();
@@ -222,7 +222,7 @@ interface PeerConfig {
 function persistSwarm(pi: ExtensionAPI, peerConfigs: PeerConfig[]): void {
     try {
         pi.appendEntry(SWARM_PERSIST_KEY, { peers: peerConfigs });
-    } catch {}
+    } catch (e: any) { console.debug("[coms-swarm] persist swarm failed:", e?.message || e); }
 }
 
 export function registerComsSwarm(pi: ExtensionAPI): {
@@ -247,7 +247,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
     const log = (msg: string) => {
         try {
             pi.appendEntry("coms-swarm-log", { event: "swarm", ts: new Date().toISOString(), msg });
-        } catch {}
+        } catch (e: any) { console.debug("[coms-swarm] log append failed:", e?.message || e); }
     };
 
     function savePeerConfigs(): void {
@@ -276,7 +276,7 @@ export function registerComsSwarm(pi: ExtensionAPI): {
                     savedPeers = entry.data?.peers || [];
                 }
             }
-        } catch {}
+        } catch (e: any) { console.debug("[coms-swarm] restore peers failed:", e?.message || e); }
         if (savedPeers.length === 0) return;
 
         log(`reload: restoring ${savedPeers.length} swarm peer(s)`);

--- a/extensions/coms/coms.ts
+++ b/extensions/coms/coms.ts
@@ -110,7 +110,12 @@ export function registerComs(pi: ExtensionAPI) {
 
                 // Default project to cwd so sessions in different dirs are isolated
                 if (!state.flagValues.has("project")) {
-                    state.flagValues.set("project", ctx.cwd.replace(/^\//,"").replace(/\//g, "__"));
+                    const proj = ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
+                    if (!proj) {
+                        try { ctx.ui.notify("📡 coms: cannot start from /. Run from a project directory.", "error"); } catch {}
+                        return;
+                    }
+                    state.flagValues.set("project", proj);
                 }
 
                 if (!state.capturedSessionStart) {

--- a/extensions/coms/coms.ts
+++ b/extensions/coms/coms.ts
@@ -106,6 +106,7 @@ export function registerComs(pi: ExtensionAPI) {
                     try { ctx.ui.notify("📡 coms already active", "warning"); } catch {}
                     return;
                 }
+                state.flagValues = new Map();
                 parseFlags(parts.slice(1), state.flagValues);
 
                 // Default project to cwd so sessions in different dirs are isolated

--- a/extensions/coms/coms.ts
+++ b/extensions/coms/coms.ts
@@ -141,9 +141,18 @@ export function registerComs(pi: ExtensionAPI) {
                     ctx.ui.notify(state.active ? "📡 coms: active (P2P)" : "📡 coms: inactive — run /coms start", "info");
                 } catch {}
             } else if (subcommand === "swarm") {
+                const action = parts[1] || "";
+                if (action === "add" && !state.active) {
+                    try { ctx.ui.notify("📡 swarm add: Run `/coms start` first.", "error"); } catch {}
+                    return;
+                }
+                if (action === "send" && !state.active) {
+                    try { ctx.ui.notify("📡 swarm send: Run `/coms start` first.", "error"); } catch {}
+                    return;
+                }
                 const handled = await swarmHandler.handleSwarmCommand(subcommand, parts, ctx);
                 if (!handled) {
-                    try { ctx.ui.notify('📡 swarm: use add | stop | status', "warning"); } catch {}
+                    try { ctx.ui.notify('📡 swarm: use add | stop | status | send', "warning"); } catch {}
                 }
             } else {
                 try { ctx.ui.notify(`📡 coms: unknown subcommand "${subcommand}". Use: start | stop | status | swarm`, "warning"); } catch {}

--- a/extensions/coms/coms.ts
+++ b/extensions/coms/coms.ts
@@ -6,8 +6,17 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
+import { fuzzyFilter } from "@earendil-works/pi-tui";
 import { parseFlags, tokenizeArgs, createDeferredProxy, persistState, type DeferredUpstream } from "./coms-shared.js";
 import upstreamComsInit from "./upstream-coms/coms.js";
+import { registerComsSwarm } from "./coms-swarm.js";
+
+function fuzzy(items: AutocompleteItem[], query: string): AutocompleteItem[] | null {
+    if (!query.trim()) return items.length > 0 ? items : null;
+    const result = fuzzyFilter(items, query, i => `${i.label} ${i.description || ""}`);
+    return result.length > 0 ? result : null;
+}
 
 export function registerComs(pi: ExtensionAPI) {
     const state: DeferredUpstream = {
@@ -25,8 +34,68 @@ export function registerComs(pi: ExtensionAPI) {
 
     upstreamComsInit(proxyPi as any);
 
+    const swarmHandler = registerComsSwarm(pi);
+
     pi.registerCommand("coms", {
-        description: "P2P agent communication: /coms start [--name X --purpose Y --project Z --color #HEX] | stop | status",
+        description: "P2P agent communication: /coms start | stop | status | swarm add/stop/status",
+        getArgumentCompletions: (prefix: string) => {
+            const parts = prefix.split(/\s+/);
+            const lastPart = parts[parts.length - 1] || "";
+            const base = lastPart === "" ? prefix : prefix.slice(0, prefix.length - lastPart.length);
+            const mk = (items: {v: string; l: string; d: string}[]) =>
+                fuzzy(items.map(i => ({ value: base + i.v, label: i.l, description: i.d })), lastPart);
+
+            if (parts.length <= 1) {
+                return mk([
+                    { v: "start", l: "start", d: "Start P2P agent communication" },
+                    { v: "stop", l: "stop", d: "Stop coms" },
+                    { v: "status", l: "status", d: "Show coms status" },
+                    { v: "swarm", l: "swarm", d: "Manage peer agent swarm" },
+                ]);
+            }
+            if (parts[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(parts.filter(p => p.startsWith("--")));
+                return mk([
+                    { v: "--name ", l: "--name", d: "Agent name" },
+                    { v: "--purpose ", l: "--purpose", d: "Agent purpose" },
+                    { v: "--project ", l: "--project", d: "Project namespace" },
+                    { v: "--color ", l: "--color", d: "Hex color #RRGGBB" },
+                    { v: "--explicit", l: "--explicit", d: "Hide from auto-discovery" },
+                ].filter(f => !used.has(f.v.trim())));
+            }
+            if (parts[0] === "swarm" && parts.length <= 2) {
+                return mk([
+                    { v: "add", l: "add", d: "Spawn a peer agent" },
+                    { v: "stop", l: "stop", d: "Stop swarm peers" },
+                    { v: "status", l: "status", d: "Show swarm peers" },
+                    { v: "send", l: "send", d: "Send message to peer(s)" },
+                ]);
+            }
+            if (parts[0] === "swarm" && parts[1] === "add" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(parts.filter(p => p.startsWith("--")));
+                return mk([
+                    { v: "--name ", l: "--name", d: "Peer name" },
+                    { v: "--purpose ", l: "--purpose", d: "Peer purpose" },
+                    { v: "--system-prompt ", l: "--system-prompt", d: "Peer system prompt" },
+                    { v: "--model ", l: "--model", d: "Peer model" },
+                    { v: "--read-only", l: "--read-only", d: "Read-only peer" },
+                ].filter(f => !used.has(f.v.trim())));
+            }
+            if (parts[0] === "swarm" && parts[1] === "stop" && (lastPart.startsWith("-") || lastPart === "")) {
+                return mk([
+                    { v: "--name ", l: "--name", d: "Peer to stop (omit for all)" },
+                ]);
+            }
+            if (parts[0] === "swarm" && parts[1] === "send" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(parts.filter(p => p.startsWith("--")));
+                return mk([
+                    { v: "--name ", l: "--name", d: "Send to specific peer" },
+                    { v: "--all ", l: "--all", d: "Broadcast to all peers" },
+                    { v: "--msg ", l: "--msg", d: "Message to send" },
+                ].filter(f => !used.has(f.v.trim())));
+            }
+            return null;
+        },
         handler: async (args: string, ctx: any) => {
             const trimmed = (args || "").trim();
             const parts = tokenizeArgs(trimmed);
@@ -38,6 +107,11 @@ export function registerComs(pi: ExtensionAPI) {
                     return;
                 }
                 parseFlags(parts.slice(1), state.flagValues);
+
+                // Default project to cwd so sessions in different dirs are isolated
+                if (!state.flagValues.has("project")) {
+                    state.flagValues.set("project", ctx.cwd.replace(/^\//,"").replace(/\//g, "__"));
+                }
 
                 if (!state.capturedSessionStart) {
                     try { ctx.ui.notify("📡 coms: internal error — no session handler captured", "error"); } catch {}
@@ -66,8 +140,13 @@ export function registerComs(pi: ExtensionAPI) {
                 try {
                     ctx.ui.notify(state.active ? "📡 coms: active (P2P)" : "📡 coms: inactive — run /coms start", "info");
                 } catch {}
+            } else if (subcommand === "swarm") {
+                const handled = await swarmHandler.handleSwarmCommand(subcommand, parts, ctx);
+                if (!handled) {
+                    try { ctx.ui.notify('📡 swarm: use add | stop | status', "warning"); } catch {}
+                }
             } else {
-                try { ctx.ui.notify(`📡 coms: unknown subcommand "${subcommand}". Use: start | stop | status`, "warning"); } catch {}
+                try { ctx.ui.notify(`📡 coms: unknown subcommand "${subcommand}". Use: start | stop | status | swarm`, "warning"); } catch {}
             }
         },
     });

--- a/extensions/coms/coms.ts
+++ b/extensions/coms/coms.ts
@@ -111,7 +111,7 @@ export function registerComs(pi: ExtensionAPI) {
 
                 // Default project to cwd so sessions in different dirs are isolated
                 if (!state.flagValues.has("project")) {
-                    const proj = ctx.cwd.replace(/^\//,"").replace(/\//g, "__");
+                    const proj = ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
                     if (!proj) {
                         try { ctx.ui.notify("📡 coms: cannot start from /. Run from a project directory.", "error"); } catch {}
                         return;

--- a/extensions/coms/coms.ts
+++ b/extensions/coms/coms.ts
@@ -39,13 +39,16 @@ export function registerComs(pi: ExtensionAPI) {
     pi.registerCommand("coms", {
         description: "P2P agent communication: /coms start | stop | status | swarm add/stop/status",
         getArgumentCompletions: (prefix: string) => {
-            const parts = prefix.split(/\s+/);
-            const lastPart = parts[parts.length - 1] || "";
-            const base = lastPart === "" ? prefix : prefix.slice(0, prefix.length - lastPart.length);
+            // Parse: split on whitespace, trailing space means "next token position"
+            const tokens = prefix.trim().split(/\s+/).filter(Boolean);
+            const atNextToken = prefix.endsWith(" ") || tokens.length === 0;
+            const lastPart = atNextToken ? "" : tokens[tokens.length - 1];
+            const completed = atNextToken ? tokens : tokens.slice(0, -1);
+            const base = atNextToken ? prefix : prefix.slice(0, prefix.length - lastPart.length);
             const mk = (items: {v: string; l: string; d: string}[]) =>
                 fuzzy(items.map(i => ({ value: base + i.v, label: i.l, description: i.d })), lastPart);
 
-            if (parts.length <= 1) {
+            if (completed.length === 0) {
                 return mk([
                     { v: "start", l: "start", d: "Start P2P agent communication" },
                     { v: "stop", l: "stop", d: "Stop coms" },
@@ -53,8 +56,8 @@ export function registerComs(pi: ExtensionAPI) {
                     { v: "swarm", l: "swarm", d: "Manage peer agent swarm" },
                 ]);
             }
-            if (parts[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
-                const used = new Set(parts.filter(p => p.startsWith("--")));
+            if (completed[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(completed.filter(p => p.startsWith("--")));
                 return mk([
                     { v: "--name ", l: "--name", d: "Agent name" },
                     { v: "--purpose ", l: "--purpose", d: "Agent purpose" },
@@ -63,7 +66,7 @@ export function registerComs(pi: ExtensionAPI) {
                     { v: "--explicit", l: "--explicit", d: "Hide from auto-discovery" },
                 ].filter(f => !used.has(f.v.trim())));
             }
-            if (parts[0] === "swarm" && parts.length <= 2) {
+            if (completed[0] === "swarm" && completed.length === 1) {
                 return mk([
                     { v: "add", l: "add", d: "Spawn a peer agent" },
                     { v: "stop", l: "stop", d: "Stop swarm peers" },
@@ -71,8 +74,8 @@ export function registerComs(pi: ExtensionAPI) {
                     { v: "send", l: "send", d: "Send message to peer(s)" },
                 ]);
             }
-            if (parts[0] === "swarm" && parts[1] === "add" && (lastPart.startsWith("-") || lastPart === "")) {
-                const used = new Set(parts.filter(p => p.startsWith("--")));
+            if (completed[0] === "swarm" && completed[1] === "add" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(completed.filter(p => p.startsWith("--")));
                 return mk([
                     { v: "--name ", l: "--name", d: "Peer name" },
                     { v: "--purpose ", l: "--purpose", d: "Peer purpose" },
@@ -81,13 +84,13 @@ export function registerComs(pi: ExtensionAPI) {
                     { v: "--read-only", l: "--read-only", d: "Read-only peer" },
                 ].filter(f => !used.has(f.v.trim())));
             }
-            if (parts[0] === "swarm" && parts[1] === "stop" && (lastPart.startsWith("-") || lastPart === "")) {
+            if (completed[0] === "swarm" && completed[1] === "stop" && (lastPart.startsWith("-") || lastPart === "")) {
                 return mk([
                     { v: "--name ", l: "--name", d: "Peer to stop (omit for all)" },
                 ]);
             }
-            if (parts[0] === "swarm" && parts[1] === "send" && (lastPart.startsWith("-") || lastPart === "")) {
-                const used = new Set(parts.filter(p => p.startsWith("--")));
+            if (completed[0] === "swarm" && completed[1] === "send" && (lastPart.startsWith("-") || lastPart === "")) {
+                const used = new Set(completed.filter(p => p.startsWith("--")));
                 return mk([
                     { v: "--name ", l: "--name", d: "Send to specific peer" },
                     { v: "--all ", l: "--all", d: "Broadcast to all peers" },
@@ -111,7 +114,8 @@ export function registerComs(pi: ExtensionAPI) {
 
                 // Default project to cwd so sessions in different dirs are isolated
                 if (!state.flagValues.has("project")) {
-                    const proj = ctx.cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
+                    const cwd = ctx.cwd || "";
+                    const proj = cwd.replace(/^[\\/]/,"").replace(/[\\/]/g, "__");
                     if (!proj) {
                         try { ctx.ui.notify("📡 coms: cannot start from /. Run from a project directory.", "error"); } catch {}
                         return;
@@ -156,7 +160,8 @@ export function registerComs(pi: ExtensionAPI) {
                     try { ctx.ui.notify("📡 swarm send: Run `/coms start` first.", "error"); } catch {}
                     return;
                 }
-                const handled = await swarmHandler.handleSwarmCommand(subcommand, parts, ctx);
+                const parentProject = state.flagValues.get("project") as string || "";
+                const handled = await swarmHandler.handleSwarmCommand(subcommand, parts, ctx, parentProject);
                 if (!handled) {
                     try { ctx.ui.notify('📡 swarm: use add | stop | status | send', "warning"); } catch {}
                 }

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -165,7 +165,7 @@ export function registerAsyncAgents(
         for (const file of files) {
           processResultFile(path.join(ASYNC_RESULTS_DIR, file));
         }
-      } catch {}
+      } catch (e: any) { console.debug("[async-agents] result file scan failed:", e?.message || e); }
 
       // Remove completed/failed jobs older than 30s
       for (const [id, job] of asyncState.jobs.entries()) {
@@ -235,7 +235,7 @@ export function registerAsyncAgents(
         setTimeout(() => processResultFile(resultPath), 100);
       });
       if (asyncState.watcher.unref) asyncState.watcher.unref();
-    } catch {}
+    } catch (e: any) { console.debug("[async-agents] watcher setup failed:", e?.message || e); }
   }
 
   function spawnAsyncAgent(
@@ -298,7 +298,7 @@ export function registerAsyncAgents(
       const piPkgDir = path.dirname(require.resolve("@earendil-works/pi-coding-agent/package.json"));
       const candidate = path.join(piPkgDir, "node_modules/jiti/lib/jiti-cli.mjs");
       if (fs.existsSync(candidate)) jitiCliPath = candidate;
-    } catch {}
+    } catch (e: any) { console.debug("[async-agents] jiti path resolution failed:", e?.message || e); }
 
     const spawnArgs = jitiCliPath
       ? [jitiCliPath, runnerPath, configPath]
@@ -352,7 +352,7 @@ export function registerAsyncAgents(
           }
         }
       }
-    } catch {}
+    } catch (e: any) { console.debug("[async-agents] orphan cleanup failed:", e?.message || e); }
 
     // Restore jobs from status files in ASYNC_DIR that belong to this session
     try {
@@ -391,13 +391,13 @@ export function registerAsyncAgents(
           asyncLog(`restored job: ${id} state=${job.status}`);
         }
       }
-    } catch {}
+    } catch (e: any) { console.debug("[async-agents] job restore failed:", e?.message || e); }
 
     // Start poller if we have jobs or unprocessed result files
     let hasResultFiles = false;
     try {
       hasResultFiles = fs.existsSync(ASYNC_RESULTS_DIR) && fs.readdirSync(ASYNC_RESULTS_DIR).some(f => f.endsWith(".json"));
-    } catch {}
+    } catch (e: any) { console.debug("[async-agents] result files check failed:", e?.message || e); }
     if (asyncState.jobs.size > 0 || hasResultFiles) {
       ensureAsyncPoller();
     }
@@ -520,7 +520,7 @@ export function registerAsyncAgents(
               cachedLines = undefined;
               tui.requestRender();
             }
-          } catch {}
+          } catch (e: any) { console.debug("[async-agents] live output read failed:", e?.message || e); }
         }
 
         // Poll for new content every 500ms

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -107,9 +107,9 @@ export function registerAsyncAgents(
     const changed = widgetKey !== lastWidgetKey;
     lastWidgetKey = widgetKey;
     if (running.length > 0) {
-      ctx.ui.setStatus("1-async", ctx.ui.theme.fg("warning", `⏳ ${running.length} async agent${running.length > 1 ? "s" : ""}`));
+      ctx.ui.setStatus("1-async", ctx.ui.theme.fg("warning", `⏳ async: ${running.length}`));
     } else if (changed) {
-      ctx.ui.setStatus("1-async", ctx.ui.theme.fg("muted", `⏳ 0 async agents`));
+      ctx.ui.setStatus("1-async", ctx.ui.theme.fg("muted", `💤 async: 0`));
     }
     // Always emit to pidash — browser may have reconnected and needs fresh state
     pi.events.emit("pidash:async-status", {

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -493,6 +493,7 @@ export function registerAsyncAgents(
         // Read existing output and watch for new content
         let filePos = 0;
         let textBuffer = "";
+        let lastLoggedError = "";
 
         function readNewContent() {
           if (closed) return;
@@ -520,7 +521,14 @@ export function registerAsyncAgents(
               cachedLines = undefined;
               tui.requestRender();
             }
-          } catch (e: any) { console.debug("[async-agents] live output read failed:", e?.message || e); }
+          } catch (e: any) {
+            if (e?.code === "ENOENT") return;
+            const msg = e?.message || String(e);
+            if (msg !== lastLoggedError) {
+              lastLoggedError = msg;
+              console.debug("[async-agents] live output read failed:", msg);
+            }
+          }
         }
 
         // Poll for new content every 500ms

--- a/extensions/orchestrator/async-runner.ts
+++ b/extensions/orchestrator/async-runner.ts
@@ -153,7 +153,7 @@ async function run(config: RunConfig): Promise<void> {
           if (pidashWs?.readyState === 1) {
             pidashWs.send(JSON.stringify({ type: "async_event", id: config.id, event: ev }));
           }
-        } catch {}
+        } catch (e: any) { console.debug("[async-runner] event processing failed:", e?.message || e); }
       }
 
       // Update status periodically (every ~10 lines)
@@ -191,7 +191,7 @@ async function run(config: RunConfig): Promise<void> {
           if (p.type === "text") finalOutput = p.text;
         }
       }
-    } catch {}
+    } catch (e: any) { console.debug("[async-runner] final line parse failed:", e?.message || e); }
   }
 
   // Write final status

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -39,7 +39,7 @@ const CRON_FILE = path.join(os.tmpdir(), `pi-cron-${process.pid}.json`);
 function saveCrons(tasks: CronTask[]): void {
   try {
     fs.writeFileSync(CRON_FILE, JSON.stringify(tasks), { mode: 0o600 });
-  } catch {}
+  } catch (e: any) { console.debug("[cron] save crons failed:", e?.message || e); }
 }
 
 function loadCrons(): CronTask[] {
@@ -62,7 +62,7 @@ function cleanupOrphanedCronFiles(): void {
         }
       }
     }
-  } catch {}
+  } catch (e: any) { console.debug("[cron] cleanup orphaned cron files failed:", e?.message || e); }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -330,7 +330,7 @@ export function registerCron(
             });
             sections.push(`**${label}:**\n${lines.join("\n")}`);
           }
-        } catch {}
+        } catch (e: any) { console.debug("[cron] list-all scan failed:", e?.message || e); }
         if (sections.length === 0) {
           return { content: [{ type: "text", text: "No scheduled tasks in any session." }] };
         }
@@ -405,7 +405,7 @@ export function registerCron(
             });
             sections.push(`${label}:\n${lines.join("\n")}`);
           }
-        } catch {}
+        } catch (e: any) { console.debug("[cron] list-all command scan failed:", e?.message || e); }
         if (ctx.hasUI) ctx.ui.notify(sections.length > 0 ? sections.join("\n\n") : "No crons in any session.", "info");
         return;
       }

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -113,9 +113,9 @@ export function registerCron(
     saveCrons([...tasks.values()]);
     if (lastCtx?.hasUI) {
       if (count > 0) {
-        lastCtx.ui.setStatus("2-crons", lastCtx.ui.theme.fg("muted", `⏰ ${count} cron${count > 1 ? "s" : ""}`));
+        lastCtx.ui.setStatus("3-crons", lastCtx.ui.theme.fg("muted", `⏰ ${count} cron${count > 1 ? "s" : ""}`));
       } else {
-        lastCtx.ui.setStatus("2-crons", lastCtx.ui.theme.fg("muted", `⏰ 0 crons`));
+        lastCtx.ui.setStatus("3-crons", lastCtx.ui.theme.fg("muted", `⏰ 0 crons`));
       }
     }
     pi.events.emit("pidash:cron-status", {

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -76,7 +76,7 @@ export function registerDreaming(
     // After dream completes, rebuild scores and reorganize topics
     if (id) setTimeout(() => {
       dreamInFlight = false;
-      try { rebuildAndOrganize(cwd); } catch {}
+      try { rebuildAndOrganize(cwd); } catch (e: any) { console.debug("[dreaming] rebuildAndOrganize failed:", e?.message || e); }
     }, 5 * 60 * 1000);
     else dreamInFlight = false;
   }
@@ -97,7 +97,7 @@ export function registerDreaming(
     if (!rebuildTimer) {
       rebuildTimer = setInterval(() => {
         if (enabled && lastCwd) {
-          try { rebuildAndOrganize(lastCwd); } catch {}
+          try { rebuildAndOrganize(lastCwd); } catch (e: any) { console.debug("[dreaming] rebuildAndOrganize failed:", e?.message || e); }
         }
       }, REBUILD_INTERVAL_MS);
       if (rebuildTimer.unref) rebuildTimer.unref();
@@ -158,6 +158,6 @@ export function registerDreaming(
     // (can't use spawnAsyncAgent since the session is ending)
     try {
       runDreamAsync(lastCwd);
-    } catch {}
+    } catch (e: any) { console.debug("[dreaming] shutdown dream failed:", e?.message || e); }
   });
 }

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -42,7 +42,7 @@ function readRepeatState(): { lastCmd: string; count: number } {
 function writeRepeatState(state: { lastCmd: string; count: number }): void {
   try {
     writeFileSync(REPEAT_FILE, JSON.stringify(state));
-  } catch {}
+  } catch (e: any) { console.debug("[enforcement] write repeat state failed:", e?.message || e); }
 }
 
 export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): void {

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -17,8 +17,6 @@
  *   /create-skill <Tab>          → (free-text name)
  *   /cron <Tab>                  → add, list, list-all, remove
  *   /dream-auto <Tab>            → on, off
- *   /coms <Tab>                  → start, stop, status + --name, --purpose, --project, --color, --explicit
- *   /coms-net <Tab>              → start, stop, status, server-stop + --name, --purpose, --project, --color, --explicit, --server-url, --auth-token
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -364,53 +362,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       }
       return null;
     },
-    "coms": (prefix: string) => {
-      const parts = prefix.split(/\s+/);
-      const lastPart = parts[parts.length - 1] || "";
-      if (parts.length <= 1) {
-        return filter([
-          { value: "start ", label: "start", description: "Start P2P agent communication" },
-          { value: "stop", label: "stop", description: "Stop coms (on session end)" },
-          { value: "status", label: "status", description: "Show coms status" },
-        ], lastPart);
-      }
-      if (parts[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
-        const usedFlags = new Set(parts.filter((p) => p.startsWith("--")));
-        return filter([
-          { value: "--name ", label: "--name", description: "Agent name" },
-          { value: "--purpose ", label: "--purpose", description: "Agent purpose description" },
-          { value: "--project ", label: "--project", description: "Project namespace (default: default)" },
-          { value: "--color ", label: "--color", description: "Hex color #RRGGBB" },
-          { value: "--explicit", label: "--explicit", description: "Hide from auto-discovery" },
-        ].filter((f) => !usedFlags.has(f.value.trim())), lastPart);
-      }
-      return null;
-    },
-    "coms-net": (prefix: string) => {
-      const parts = prefix.split(/\s+/);
-      const lastPart = parts[parts.length - 1] || "";
-      if (parts.length <= 1) {
-        return filter([
-          { value: "start ", label: "start", description: "Start networked agent communication (auto-starts server)" },
-          { value: "stop", label: "stop", description: "Stop coms-net (on session end)" },
-          { value: "status", label: "status", description: "Show coms-net + server status" },
-          { value: "server-stop", label: "server-stop", description: "Stop the coms-net hub server" },
-        ], lastPart);
-      }
-      if (parts[0] === "start" && (lastPart.startsWith("-") || lastPart === "")) {
-        const usedFlags = new Set(parts.filter((p) => p.startsWith("--")));
-        return filter([
-          { value: "--name ", label: "--name", description: "Agent name" },
-          { value: "--purpose ", label: "--purpose", description: "Agent purpose description" },
-          { value: "--project ", label: "--project", description: "Project namespace (default: default)" },
-          { value: "--color ", label: "--color", description: "Hex color #RRGGBB" },
-          { value: "--explicit", label: "--explicit", description: "Hide from auto-discovery" },
-          { value: "--server-url ", label: "--server-url", description: "Hub server URL (overrides auto-discovery)" },
-          { value: "--auth-token ", label: "--auth-token", description: "Bearer token for the hub" },
-        ].filter((f) => !usedFlags.has(f.value.trim())), lastPart);
-      }
-      return null;
-    },
+
   };
 
   // ── Mechanism 1: registerCommand wrapping for extension commands ─
@@ -434,7 +386,6 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
   const promptTemplateCommands = new Set([
     "external-ai", "pr-review", "coderabbit-rate-limit",
     "review-local", "release", "review-handler", "cron", "create-skill",
-    "coms", "coms-net",
   ]);
 
   // /external-ai-models-refresh command — clears cache and re-fetches

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -101,7 +101,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
         }));
         prCache.timestamp = Date.now();
       }
-    } catch {}
+    } catch (e: any) { console.debug("[autocomplete] PR fetch failed:", e?.message || e); }
     prCache.loading = false;
   }
 
@@ -133,7 +133,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
         branchCache.data = items;
         branchCache.timestamp = Date.now();
       }
-    } catch {}
+    } catch (e: any) { console.debug("[autocomplete] branch fetch failed:", e?.message || e); }
     branchCache.loading = false;
   }
 
@@ -165,11 +165,11 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
               }
             }
           }
-        } catch {}
+        } catch (e: any) { console.debug("[autocomplete] model JSON parse failed:", e?.message || e); }
         cache.data = items;
         cache.timestamp = Date.now();
       }
-    } catch {}
+    } catch (e: any) { console.debug("[autocomplete] model fetch failed:", e?.message || e); }
     cache.loading = false;
   }
 
@@ -190,7 +190,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
           .map((t) => ({ value: t, label: t, description: "git tag" }));
         tagCache.timestamp = Date.now();
       }
-    } catch {}
+    } catch (e: any) { console.debug("[autocomplete] tag fetch failed:", e?.message || e); }
     tagCache.loading = false;
   }
 
@@ -357,7 +357,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
               description: t.description || t.task || "",
             })), lastPart);
           }
-        } catch {}
+        } catch (e: any) { console.debug("[autocomplete] cron task fetch failed:", e?.message || e); }
         return null;
       }
       return null;

--- a/extensions/orchestrator/github-autocomplete.ts
+++ b/extensions/orchestrator/github-autocomplete.ts
@@ -197,7 +197,7 @@ export function registerGithubAutocomplete(pi: ExtensionAPI): void {
           for (const issue of issues) {
             items.push({ ...issue, state: issue.state.toLowerCase(), kind: "issue", url: issue.url || "" });
           }
-        } catch {}
+        } catch (e: any) { console.debug("[github-autocomplete] issues JSON parse failed:", e?.message || e); }
       }
 
       if (prsResult.code === 0) {
@@ -206,7 +206,7 @@ export function registerGithubAutocomplete(pi: ExtensionAPI): void {
           for (const pr of prs) {
             items.push({ ...pr, state: pr.state.toLowerCase(), kind: "pr", url: pr.url || "" });
           }
-        } catch {}
+        } catch (e: any) { console.debug("[github-autocomplete] PRs JSON parse failed:", e?.message || e); }
       }
 
       if (items.length === 0) return undefined;

--- a/extensions/orchestrator/memory-tree.ts
+++ b/extensions/orchestrator/memory-tree.ts
@@ -138,7 +138,7 @@ function archiveColdTopics(topicsDir: string, topics: TopicInfo[], now: number):
       if (!hasPinned) {
         try {
           unlinkSync(topic.path);
-        } catch {}
+        } catch (e: any) { console.debug("[memory-tree] archive topic delete failed:", e?.message || e); }
       }
     }
   }
@@ -161,7 +161,7 @@ export function readAllTopicEntries(cwd: string): { text: string; category: Memo
       const topicFile = readTopicFile(join(topicsDir, file));
       all.push(...topicFile.entries);
     }
-  } catch {}
+  } catch (e: any) { console.debug("[memory-tree] read topic entries failed:", e?.message || e); }
   return all;
 }
 
@@ -206,7 +206,7 @@ export function listTopics(cwd: string): TopicInfo[] {
         chars: readFileSync(path, "utf-8").length,
       });
     }
-  } catch {}
+  } catch (e: any) { console.debug("[memory-tree] list topics failed:", e?.message || e); }
 
   return infos.sort((a, b) => b.hotness - a.hotness);
 }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -22,7 +22,7 @@ export function registerRules(
     try {
       rebuildAndOrganize(ctx.cwd);
       rebuildDone = true;
-    } catch {}
+    } catch (e: any) { console.debug("[rules] rebuildAndOrganize on session_start failed:", e?.message || e); }
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
@@ -31,7 +31,7 @@ export function registerRules(
       try {
         rebuildAndOrganize(ctx.cwd);
         rebuildDone = true;
-      } catch {}
+      } catch (e: any) { console.debug("[rules] rebuildAndOrganize on agent_start failed:", e?.message || e); }
     }
     let extra = "";
 
@@ -88,6 +88,6 @@ function loadMemoriesWithScoring(cwd: string, isSubagent: boolean): string {
       }
       return result + "\n";
     }
-  } catch {}
+  } catch (e: any) { console.debug("[rules] situation report failed:", e?.message || e); }
   return "";
 }

--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -230,7 +230,7 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
           "prek — pre-commit wrapper (.pre-commit-config.yaml detected). Install: https://github.com/j178/prek",
         );
       }
-    } catch {}
+    } catch (e: any) { console.debug("[session-validation] tool detection failed:", e?.message || e); }
 
     if (missing.length > 0 || optional.length > 0) {
       const parts: string[] = [];
@@ -262,7 +262,7 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
               currentVersion = pkg.version;
               break;
             }
-          } catch {}
+          } catch (e: any) { console.debug("[session-validation] package.json parse failed:", e?.message || e); }
         }
         searchDir = path.dirname(searchDir);
       }
@@ -275,14 +275,14 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
           let lastVersion: string | null = null;
           try {
             lastVersion = fs.readFileSync(versionFile, "utf-8").trim();
-          } catch {}
+          } catch (e: any) { console.debug("[session-validation] read last version failed:", e?.message || e); }
 
           if (!lastVersion) {
             // First run — just record the version, no notification
             try {
               fs.mkdirSync(path.dirname(versionFile), { recursive: true });
               fs.writeFileSync(versionFile, currentVersion, "utf-8");
-            } catch {}
+            } catch (e: any) { console.debug("[session-validation] write version file failed:", e?.message || e); }
           } else if (lastVersion !== currentVersion && hasCmd("gh")) {
             // Version changed — fetch release notes (5s timeout, no shell)
             const tag = `v${currentVersion}`;
@@ -305,17 +305,17 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
                 );
                 notified = true;
               }
-            } catch {}
+            } catch (e: any) { console.debug("[session-validation] release notes fetch failed:", e?.message || e); }
             // Only update version file after successful notification
             // so failed attempts retry on next session
             if (notified) {
               try {
                 fs.mkdirSync(path.dirname(versionFile), { recursive: true });
                 fs.writeFileSync(versionFile, currentVersion, "utf-8");
-              } catch {}
+              } catch (e: any) { console.debug("[session-validation] write version after notify failed:", e?.message || e); }
             }
           }
       }
-    } catch {}
+    } catch (e: any) { console.debug("[session-validation] upgrade changelog failed:", e?.message || e); }
   });
 }

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -24,10 +24,10 @@ export function registerStatusLine(
     const text = parts.join(ctx.ui.theme.fg("dim", ICON_SEP));
     if (text === lastStatusText) return; // Skip redundant re-renders
     lastStatusText = text;
-    ctx.ui.setStatus("3-git", text);
+    ctx.ui.setStatus("4-git", text);
     // Clear individual statuses to avoid duplicates
     ctx.ui.setStatus("container", undefined);
-    ctx.ui.setStatus("git", undefined);
+    ctx.ui.setStatus("4-git", undefined);
   };
 
   // ── Git branch status line ─────────────────────────────────────────────
@@ -85,7 +85,12 @@ export function registerStatusLine(
     lastCtx = ctx;
   });
   const gitPoller = setInterval(() => {
-    if (lastCtx) updateBranch(null, lastCtx);
+    if (!lastCtx) return;
+    try {
+      updateBranch(null, lastCtx);
+    } catch {
+      clearInterval(gitPoller);
+    }
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
 
@@ -123,7 +128,12 @@ export function registerStatusLine(
   pi.on("tool_execution_end", touchActivity);
 
   const timePoller = setInterval(() => {
-    if (lastCtx && lastActivityTime) updateTimestamp(lastCtx);
+    if (!lastCtx || !lastActivityTime) return;
+    try {
+      updateTimestamp(lastCtx);
+    } catch {
+      clearInterval(timePoller);
+    }
   }, 30_000);
   if (timePoller.unref) timePoller.unref();
 

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -25,9 +25,9 @@ export function registerStatusLine(
     if (text === lastStatusText) return; // Skip redundant re-renders
     lastStatusText = text;
     ctx.ui.setStatus("4-git", text);
-    // Clear individual statuses to avoid duplicates
+    // Clear legacy status keys to avoid duplicates
     ctx.ui.setStatus("container", undefined);
-    ctx.ui.setStatus("4-git", undefined);
+    ctx.ui.setStatus("git", undefined);
   };
 
   // ── Git branch status line ─────────────────────────────────────────────

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -71,7 +71,7 @@ export function registerStatusLine(
         changes.length > 0 ? `${icon} ${changes.join(" ")}` : icon;
 
       buildStatus(ctx, gitPart);
-    } catch {}
+    } catch (e: any) { console.debug("[status-line] git status update failed:", e?.message || e); }
   };
 
   pi.on("session_start", updateBranch);

--- a/extensions/orchestrator/status.ts
+++ b/extensions/orchestrator/status.ts
@@ -84,7 +84,7 @@ export function registerStatus(
           const stateText = dirtyCount > 0 ? `${dirtyCount} changed file${dirtyCount > 1 ? "s" : ""}` : "clean";
           lines.push(`🔀 Git: ${branch} ${stateIcon} ${stateText} (${repoName})`);
         }
-      } catch {}
+      } catch (e: any) { console.debug("[status] git status failed:", e?.message || e); }
 
       // ── Container ──────────────────────────────────────────────────
       if (inContainer) {

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -14,7 +14,7 @@ export function terminalNotify(title: string, body: string): void {
       timeout: 2000,
       stdio: ["pipe", "pipe", "pipe"],
     });
-  } catch {}
+  } catch (e: any) { console.debug("[utils] notify-send failed:", e?.message || e); }
 }
 
 /** Set SSH timeout for git operations — prevents hung connections */
@@ -36,7 +36,7 @@ export function isRunningInContainer(): boolean {
     // Check cgroup for container runtimes
     const cgroup = fs.readFileSync("/proc/1/cgroup", "utf-8");
     if (/docker|containerd|kubepods|libpod/.test(cgroup)) return true;
-  } catch {}
+  } catch (e: any) { console.debug("[utils] container detection failed:", e?.message || e); }
   return false;
 }
 

--- a/extensions/pidash/daemon-manager.ts
+++ b/extensions/pidash/daemon-manager.ts
@@ -85,7 +85,7 @@ export function findJitiPath(): string | undefined {
       );
       if (fs.existsSync(globalCandidate)) jitiPath = globalCandidate;
     }
-  } catch {}
+  } catch (e: any) { console.debug("[pidash-daemon] jiti path resolution failed:", e?.message || e); }
   return jitiPath;
 }
 

--- a/extensions/pidash/pidash.ts
+++ b/extensions/pidash/pidash.ts
@@ -164,7 +164,7 @@ export function registerPidash(
         let thinking = "medium";
         try {
           thinking = (pi as any).getThinkingLevel?.() || "medium";
-        } catch {}
+        } catch (e: any) { console.debug("[pidash] getThinkingLevel failed:", e?.message || e); }
         const reg = JSON.stringify({
           type: "register",
           pid: process.pid,

--- a/extensions/pidiff/daemon-manager.ts
+++ b/extensions/pidiff/daemon-manager.ts
@@ -85,7 +85,7 @@ export function findJitiPath(): string | undefined {
       );
       if (fs.existsSync(globalCandidate)) jitiPath = globalCandidate;
     }
-  } catch {}
+  } catch (e: any) { console.debug("[pidiff-daemon] jiti path resolution failed:", e?.message || e); }
   return jitiPath;
 }
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -139,10 +139,14 @@ Returns JSON with:
 > If autoqodo mode is ON:
 >
 > 1. **Qodo comments → auto-approved based on finding type:**
->    - `qodo_bug` → **MUST address.** No skip allowed.
->    - `qodo_rule_violation` → **MUST address.** No skip allowed.
->    - `qodo_requirement_gap` → **Address unless you have a specific, documented reason not to.** If skipping, the reply MUST explain why.
->    - `qodo_finding` (other) → **Address unless you have a good reason.** If skipping, explain why.
+>    - `qodo_bug` → **MUST address.** Fix the code. No skip allowed.
+>    - `qodo_rule_violation` → **MUST address.** Fix the code. No skip allowed.
+>    - `qodo_requirement_gap` → **MUST address.** Either fix the code OR update the issue requirements to document the design decision. No skip allowed.
+>    - `qodo_finding` (other) → **MUST address.** Either fix the code OR update the issue requirements. No skip allowed.
+>
+>    **No finding type is optional. Every finding gets a code fix or an issue update.**
+>    **"Not a realistic issue", "by design", or "not applicable" are NOT valid skip reasons**
+>    **unless the issue has been updated to explicitly document that decision.**
 >
 > Combined behavior:
 >

--- a/rules/55-coms-protocol.md
+++ b/rules/55-coms-protocol.md
@@ -9,7 +9,9 @@ Two communication systems are available for talking to other pi sessions:
 | **P2P** (coms) | `/coms start` | `coms_` | Direct peer-to-peer |
 | **Networked** (coms-net) | `/coms-net start` | `coms_net_` | Hub server relay |
 
-Only one system is active at a time. **Don't mix tool prefixes** — check which is active first.
+Both systems can be active. When asked to list peers, send messages, or interact with coms —
+**try both** `coms_list` and `coms_net_list`. If one fails, use the other.
+Don't assume which system is active.
 
 ---
 
@@ -97,4 +99,4 @@ To START a new conversation with a peer, use the send tool then await the respon
    Use them freely for outbound conversations.
 2. **Never call send tools to reply** to inbound messages — your assistant text is the reply
 3. **Always check peers first** — use list tools before sending to verify the peer exists
-4. **Don't mix prefixes** — `coms_` tools only work with `/coms`, `coms_net_` tools only work with `/coms-net`
+4. **Try both systems** — when asked to interact with peers without specifying which system, try `coms_` first, then `coms_net_` if it fails (or vice versa)


### PR DESCRIPTION
## Summary

Adds `/coms swarm` subcommands to spawn and manage headless peer pi sessions from a single session using the pi SDK.

### New commands

| Command | Description |
|---------|-------------|
| `/coms swarm add --name X` | Spawn a peer agent |
| `/coms swarm stop [--name X]` | Stop specific or all peers |
| `/coms swarm status` | Show active peers |
| `/coms swarm send --name X --msg Y` | Send message to a peer |
| `/coms swarm send --all --msg Y` | Broadcast to all peers |

### Flags for `swarm add`

`--name`, `--purpose`, `--system-prompt`, `--model`, `--read-only`

### How it works

- Peers spawned via `createAgentSession()` SDK — full pi experience (all extensions except pidash/pidiff)
- Peers auto-connect to P2P coms with the same project as the parent session
- Peer responses from `swarm send` surface in chat via `pi.sendMessage`
- Status bar shows `⏳ swarm: waiting...` during active sends
- Peers persist across reload (file-backed sessions + config saved to session entries)
- Registry files and sockets cleaned up on peer stop

### Other changes

- Default coms project set to cwd (slashes → `__`) for session isolation
- Moved coms/coms-net autocomplete from orchestrator to standalone extensions with fuzzy filtering
- Fixed stale ctx crash in `status-line.ts` git/time pollers
- Fixed acpx-provider stale ctx log noise on session resume
- Status bar ordering: time → async → swarm → cron → git

Closes #391