### PR TITLE
fix(refine-review): simplify submit action + use GraphQL for pending comments

### DIFF
--- a/myk_pi_tools/reviews/pending_fetch.py
+++ b/myk_pi_tools/reviews/pending_fetch.py
@@ -162,6 +162,7 @@ def fetch_pending_review_comments(
     for c in raw_comments:
         comment: dict[str, Any] = {
             "id": c.get("id"),
+            "node_id": c.get("node_id"),
             "path": c.get("path"),
             "line": c.get("line"),
             "side": c.get("side", "RIGHT"),

--- a/myk_pi_tools/reviews/pending_update.py
+++ b/myk_pi_tools/reviews/pending_update.py
@@ -85,6 +85,10 @@ def backfill_node_ids(
         print_stderr("Warning: Could not fetch review comments for node_id backfill")
         return
 
+    if not isinstance(api_comments, list):
+        print_stderr("Warning: Unexpected API response format for node_id backfill")
+        return
+
     id_to_node: dict[int, str] = {
         int(c["id"]): c["node_id"] for c in api_comments if c.get("id") is not None and c.get("node_id") is not None
     }

--- a/myk_pi_tools/reviews/pending_update.py
+++ b/myk_pi_tools/reviews/pending_update.py
@@ -1,22 +1,28 @@
 """Update pending review comment bodies and optionally submit the review.
 
 This module reads a JSON file produced by pending_fetch (and refined by an AI),
-updates each accepted comment's body via the GitHub API, and optionally submits
-the review with a specified action (COMMENT, APPROVE, REQUEST_CHANGES).
+updates each accepted comment's body via the GitHub GraphQL API, and optionally
+submits the review with a specified action (COMMENT, APPROVE, REQUEST_CHANGES).
 
-Expected JSON structure:
+Comment updates use the GraphQL ``updatePullRequestReviewComment`` mutation with
+the comment's ``node_id``.  This works for pending (unsubmitted) review comments,
+which return 404 when accessed through the REST API.
+
+Expected JSON structure::
+
   {
     "metadata": {
       "owner": "...",
       "repo": "...",
       "pr_number": 123,
       "review_id": 456,
-      "submit_action": "COMMENT",        # optional
+      "submit_action": "REQUEST_CHANGES",        # optional
       "submit_summary": "Summary text"    # optional
     },
     "comments": [
       {
         "id": 789,
+        "node_id": "PRRC_kwDOABC123",
         "path": "src/main.py",
         "line": 42,
         "body": "original comment",
@@ -53,32 +59,47 @@ def check_dependencies() -> None:
         sys.exit(1)
 
 
-def update_comment_body(
-    owner: str,
-    repo: str,
-    comment_id: int,
-    refined_body: str,
-) -> str:
-    """Update a pull request review comment body via the GitHub API.
+# GraphQL mutation template for updating a pending review comment body.
+_UPDATE_COMMENT_MUTATION = """
+mutation($id: ID!, $body: String!) {
+  updatePullRequestReviewComment(input: {
+    pullRequestReviewCommentId: $id,
+    body: $body
+  }) {
+    pullRequestReviewComment { id body databaseId }
+  }
+}
+""".strip()
 
-    Uses stdin (--input -) to pass the body safely, handling multiline content,
-    apostrophes, code blocks, and other special characters.
+
+def update_comment_body(node_id: str | None, refined_body: str) -> str:
+    """Update a pull request review comment body via the GitHub GraphQL API.
+
+    Uses the ``updatePullRequestReviewComment`` mutation with the comment's
+    ``node_id``.  The JSON payload is passed via stdin (``--input -``) so that
+    special characters in the body (quotes, newlines, code blocks) are handled
+    safely by ``json.dumps``.
 
     Args:
-        owner: Repository owner.
-        repo: Repository name.
-        comment_id: The comment ID to update.
+        node_id: The GraphQL node ID of the comment (e.g. ``PRRC_kwDOABC123``).
         refined_body: The new body text.
 
     Returns:
-        "success" on success, "not_found" on 404, or "error" on other failures.
+        "success" on success, "not_found" if the comment no longer exists,
+        or "error" on other failures.
     """
-    endpoint = f"/repos/{owner}/{repo}/pulls/comments/{comment_id}"
-    payload = json.dumps({"body": refined_body})
+    if not node_id:
+        print_stderr("Error: node_id is required")
+        return "error"
+
+    payload = json.dumps({
+        "query": _UPDATE_COMMENT_MUTATION,
+        "variables": {"id": node_id, "body": refined_body},
+    })
 
     try:
         result = subprocess.run(
-            ["gh", "api", "--method", "PATCH", endpoint, "--input", "-"],
+            ["gh", "api", "graphql", "--input", "-"],
             input=payload,
             capture_output=True,
             text=True,
@@ -86,13 +107,28 @@ def update_comment_body(
             encoding="utf-8",
         )
     except subprocess.TimeoutExpired:
-        print_stderr(f"Error: Update comment {comment_id} timed out after 120 seconds")
+        print_stderr(f"Error: Update comment {node_id} timed out after 120 seconds")
         return "error"
 
     if result.returncode != 0:
         stderr = result.stderr or ""
-        print_stderr(f"Error updating comment {comment_id}: {stderr.strip()}")
-        if "404" in stderr or "Not Found" in stderr:
+        print_stderr(f"Error updating comment {node_id}: {stderr.strip()}")
+        if "NOT_FOUND" in stderr or "Could not resolve" in stderr:
+            return "not_found"
+        return "error"
+
+    # GraphQL can return 200 with errors in the response body.
+    try:
+        response = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        print_stderr(f"Warning: Could not parse GraphQL response for {node_id}")
+        return "error"
+
+    if "errors" in response:
+        error_msgs = [e.get("message", "") for e in response["errors"]]
+        combined = "; ".join(error_msgs)
+        print_stderr(f"GraphQL error updating comment {node_id}: {combined}")
+        if any("NOT_FOUND" in m or "Could not resolve" in m for m in error_msgs):
             return "not_found"
         return "error"
 
@@ -205,7 +241,7 @@ def run(json_path: str, *, submit: bool = False) -> int:
     fail_count = 0
 
     for i, comment in enumerate(comments):
-        comment_id = comment.get("id")
+        node_id = comment.get("node_id")
         refined_body = comment.get("refined_body")
         status = comment.get("status", "pending")
         path = comment.get("path", "unknown")
@@ -223,20 +259,14 @@ def run(json_path: str, *, submit: bool = False) -> int:
             print_stderr(f"Skipping comment [{i}] ({path}): refined_body unchanged")
             continue
 
-        if comment_id is None:
+        if not node_id:
             fail_count += 1
-            print_stderr(f"Error: Comment [{i}] ({path}) has no ID")
+            print_stderr(f"Error: Comment [{i}] ({path}) has no node_id")
             continue
 
-        try:
-            comment_id = int(comment_id)
-        except (TypeError, ValueError):
-            print_stderr(f"Warning: Skipping comment [{i}] ({path}): invalid comment ID: {comment_id!r}")
-            fail_count += 1
-            continue
-        print_stderr(f"Updating comment [{i}] ({path}, id={comment_id})...")
+        print_stderr(f"Updating comment [{i}] ({path}, node_id={node_id})...")
 
-        result = update_comment_body(owner, repo, comment_id, refined_body)
+        result = update_comment_body(node_id, refined_body)
         if result == "success":
             success_count += 1
             print_stderr("  Updated successfully")

--- a/myk_pi_tools/reviews/pending_update.py
+++ b/myk_pi_tools/reviews/pending_update.py
@@ -52,6 +52,87 @@ from myk_pi_tools.reviews.fetch import print_stderr
 VALID_SUBMIT_ACTIONS = {"COMMENT", "APPROVE", "REQUEST_CHANGES"}
 
 
+def backfill_node_ids(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    review_id: int,
+    comments: list[dict[str, Any]],
+) -> None:
+    """Backfill missing node_id values for accepted comments from the GitHub API.
+
+    Checks if any accepted comment with a refined_body is missing its node_id.
+    If so, fetches review comments from the REST API and fills in the gaps.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: Pull request number.
+        review_id: Review ID.
+        comments: List of comment dicts (mutated in place).
+    """
+    needs_backfill = [
+        c for c in comments if c.get("status") == "accepted" and c.get("refined_body") and not c.get("node_id")
+    ]
+    if not needs_backfill:
+        return
+
+    print_stderr(f"Backfilling node_id for {len(needs_backfill)} comment(s) from GitHub API...")
+
+    endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews/{review_id}/comments"
+    try:
+        result = subprocess.run(
+            ["gh", "api", endpoint, "--paginate"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            encoding="utf-8",
+        )
+    except subprocess.TimeoutExpired:
+        print_stderr("Warning: Fetching review comments for node_id backfill timed out")
+        return
+
+    if result.returncode != 0:
+        stderr = result.stderr or ""
+        print_stderr(f"Warning: Failed to fetch review comments for backfill: {stderr.strip()}")
+        return
+
+    try:
+        data = json.loads(f"[{result.stdout.replace('][', ',')}]")
+        api_comments: list[dict[str, Any]] = []
+        for item in data:
+            if isinstance(item, list):
+                api_comments.extend(item)
+            else:
+                api_comments.append(item)
+    except (json.JSONDecodeError, TypeError):
+        print_stderr("Warning: Could not parse review comments API response")
+        return
+
+    id_to_node: dict[int, str] = {
+        int(c["id"]): c["node_id"] for c in api_comments if c.get("id") is not None and c.get("node_id") is not None
+    }
+
+    filled = 0
+    for comment in needs_backfill:
+        comment_id = comment.get("id")
+        if comment_id is None:
+            continue
+        try:
+            cid = int(comment_id)
+        except (TypeError, ValueError):
+            continue
+        if cid in id_to_node:
+            comment["node_id"] = id_to_node[cid]
+            path = comment.get("path", "unknown")
+            print_stderr(f"  Backfilled node_id for comment {comment_id} ({path})")
+            filled += 1
+
+    if filled == 0:
+        print_stderr("Warning: Could not match any comments by ID — node_ids remain empty")
+    print_stderr(f"Backfilled {filled}/{len(needs_backfill)} comment(s)")
+
+
 def check_dependencies() -> None:
     """Check required dependencies are available."""
     if shutil.which("gh") is None:
@@ -230,8 +311,11 @@ def run(json_path: str, *, submit: bool = False) -> int:
 
     print_stderr(f"Processing pending review {review_id} for {owner}/{repo}#{pr_number}")
 
-    # Process comments
+    # Backfill missing node_ids before processing
     comments = data.get("comments", [])
+    backfill_node_ids(owner, repo, pr_number, review_id, comments)
+
+    # Process comments
     if not comments:
         print_stderr("No comments to process")
         return 0
@@ -261,7 +345,7 @@ def run(json_path: str, *, submit: bool = False) -> int:
 
         if not node_id:
             fail_count += 1
-            print_stderr(f"Error: Comment [{i}] ({path}) has no node_id")
+            print_stderr(f"Error: Comment [{i}] ({path}) has no node_id. Re-run 'reviews pending-fetch' to refresh.")
             continue
 
         print_stderr(f"Updating comment [{i}] ({path}, node_id={node_id})...")

--- a/myk_pi_tools/reviews/pending_update.py
+++ b/myk_pi_tools/reviews/pending_update.py
@@ -46,7 +46,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from myk_pi_tools.reviews.fetch import print_stderr
+from myk_pi_tools.reviews.fetch import print_stderr, run_gh_api
 
 # Valid submit actions for a review
 VALID_SUBMIT_ACTIONS = {"COMMENT", "APPROVE", "REQUEST_CHANGES"}
@@ -80,33 +80,9 @@ def backfill_node_ids(
     print_stderr(f"Backfilling node_id for {len(needs_backfill)} comment(s) from GitHub API...")
 
     endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews/{review_id}/comments"
-    try:
-        result = subprocess.run(
-            ["gh", "api", endpoint, "--paginate"],
-            capture_output=True,
-            text=True,
-            timeout=120,
-            encoding="utf-8",
-        )
-    except subprocess.TimeoutExpired:
-        print_stderr("Warning: Fetching review comments for node_id backfill timed out")
-        return
-
-    if result.returncode != 0:
-        stderr = result.stderr or ""
-        print_stderr(f"Warning: Failed to fetch review comments for backfill: {stderr.strip()}")
-        return
-
-    try:
-        data = json.loads(f"[{result.stdout.replace('][', ',')}]")
-        api_comments: list[dict[str, Any]] = []
-        for item in data:
-            if isinstance(item, list):
-                api_comments.extend(item)
-            else:
-                api_comments.append(item)
-    except (json.JSONDecodeError, TypeError):
-        print_stderr("Warning: Could not parse review comments API response")
+    api_comments = run_gh_api(endpoint, paginate=True)
+    if api_comments is None:
+        print_stderr("Warning: Could not fetch review comments for node_id backfill")
         return
 
     id_to_node: dict[int, str] = {

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -121,15 +121,14 @@ Update the JSON file at `json_path`:
 
 Ask the user using AskUserQuestion:
 
-> Submit the review with **Request Changes**?
+> Submit the review with **Request Changes**? (yes/no)
 
 Options:
 
 - **Yes** - Submit with Request Changes
-- **Yes, with summary** - Submit with Request Changes and add a review summary
-- **Don't submit yet** - Keep the review pending (comments are already updated)
+- **No** - Keep the review pending (comments are already updated)
 
-If user chooses "Yes, with summary", ask for the summary text.
+If user chooses "Yes", ask a follow-up: "Add a review summary? (leave empty to skip)"
 
 Update the JSON metadata:
 
@@ -144,7 +143,7 @@ If user chose to submit (Phase 6), run with `--submit` flag:
 myk-pi-tools reviews pending-update "<json_path>" --submit
 ```
 
-If user chose "Don't submit yet", run without `--submit`:
+If user chose "No", run without `--submit`:
 
 ```bash
 myk-pi-tools reviews pending-update "<json_path>"

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -119,21 +119,22 @@ Update the JSON file at `json_path`:
 
 ### Phase 6: Submit Decision
 
-Ask the user what review action to take using AskUserQuestion:
+Ask the user using AskUserQuestion:
+
+> Submit the review with **Request Changes**?
 
 Options:
 
-- **Comment** - Submit as general feedback
-- **Approve** - Approve the PR
-- **Request changes** - Request changes
-- **Don't submit yet** - Keep the review pending
+- **Yes** - Submit with Request Changes
+- **Yes, with summary** - Submit with Request Changes and add a review summary
+- **Don't submit yet** - Keep the review pending (comments are already updated)
 
-If user chooses to submit, optionally ask for a review summary (can be empty).
+If user chooses "Yes, with summary", ask for the summary text.
 
 Update the JSON metadata:
 
-- Set `submit_action` to the chosen action (COMMENT/APPROVE/REQUEST_CHANGES), or omit if keeping pending
-- Set `submit_summary` to the summary text
+- If submitting: set `submit_action` to `REQUEST_CHANGES` and `submit_summary` to the summary text (or empty string)
+- If keeping pending: do not set `submit_action`
 
 ### Phase 7: Execute Updates
 
@@ -158,7 +159,7 @@ If the command fails, display the error. If it reports a 404, inform the user th
 Display:
 
 - Number of comments refined vs kept as original
-- Review action taken (submitted as COMMENT/APPROVE/REQUEST_CHANGES, or kept pending)
+- Review action taken (submitted as Request Changes, or kept pending)
 - PR URL for reference
 
 ---


### PR DESCRIPTION
## Summary

Fixes two bugs in the `/refine-review` command:

**Bug 1: Unnecessary submit action question**
Phase 6 previously offered 4 options (Comment/Approve/Request Changes/Don't submit). Since refining review comments inherently means requesting changes, simplified to 3 options: Yes / Yes with summary / Don't submit — always submitting as Request Changes.

**Bug 2: `pending-update` fails with 404 on pending comments**
`update_comment_body` used the REST API (`PATCH /pulls/comments/{id}`) which returns 404 for pending (unsubmitted) review comments. Migrated to GraphQL `updatePullRequestReviewComment` mutation using `node_id`, which works for both pending and submitted comments.

### Additional improvements
- Return error on unparseable GraphQL responses instead of silently falling through to success
- Phase 8 summary text updated for consistency with new Phase 6
- GraphQL mutation response selects `body` and `databaseId` for debuggability
- `node_id` parameter typed as `str | None` with explicit guard

Closes #393