### PR TITLE
feat: add /create-coms-feature-manager command + templates directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,10 @@ pi-config/
 │   │   └── pidiff-ui/               # React diff viewer UI (@pierre/diffs + @pierre/trees)
 │   └── acpx-provider/              # ACPX provider extension (acpx/runtime library API)
 │       └── index.ts                # Provider + exported discoverAcpxModels() for external consumers
+├── templates/                       # Immutable prompt templates (source files for /create-* commands)
+│   └── coms-feature-manager-prompt.md  # Coms feature manager template
 ├── prompts/                         # Prompt templates (slash commands)
+│   ├── create-coms-feature-manager.md
 │   ├── external-ai.md
 │   ├── coderabbit-rate-limit.md
 │   ├── dream.md
@@ -237,6 +240,23 @@ Known extension commands:
    `extensions/orchestrator/extended-autocomplete.ts` — add an entry to the
    `completions` map and include the command name in `promptTemplateCommands`.
    This gives users Tab-completion for your command's arguments.
+
+### Adding a Source Template
+
+Source templates live in `templates/` and serve as immutable inputs for `/create-*` slash commands.
+The `/create-*` prompt reads the template, analyzes the current project, fills in placeholders,
+and writes a customized version to the project's `.pi/prompts/` directory.
+
+**Naming convention:** `create-X.md` (prompt) → `X-prompt.md` (template)
+
+Example: `prompts/create-coms-feature-manager.md` reads from `templates/coms-feature-manager-prompt.md`
+
+**Rules:**
+
+- ✅ Templates are immutable — never modify them at runtime
+- ✅ Use `{{PLACEHOLDER}}` syntax for values the `/create-*` command fills in
+- ✅ Use `[OPTIONAL]` markers for sections that may not apply to all projects
+- ❌ Templates are NOT slash commands — they have no YAML frontmatter
 
 ### Modifying Slash Command Arguments
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Single extension that provides:
 | `/review-handler [url] [--autorabbit] [--autoqodo]` | Process PR review comments, fix approved items |
 | `/refine-review <url>` | Refine and improve existing PR review comments |
 | `/coderabbit-rate-limit [number\|url]` | Handle CodeRabbit rate limiting on PRs |
+| `/create-coms-feature-manager` | Generate a coms feature-manager prompt customized for the current project |
 | `/query-db <command>` | Query the review comments database |
 | `/external-ai <agent> [--model <model>] [--session-id <id>] [--fix\|--peer\|--resume] <prompt>` | Run prompts via AI CLIs directly (cursor, claude, gemini) — full model access |
 | `/external-ai-models-refresh` | Refresh cached AI CLI models for autocomplete |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Single extension that provides:
 | `/review-handler [url] [--autorabbit] [--autoqodo]` | Process PR review comments, fix approved items |
 | `/refine-review <url>` | Refine and improve existing PR review comments |
 | `/coderabbit-rate-limit [number\|url]` | Handle CodeRabbit rate limiting on PRs |
-| `/create-coms-feature-manager` | Generate a coms feature-manager prompt customized for the current project |
+| `/create-coms-feature-manager` | Generate a coms feature-manager prompt customized for the current project (source template: `templates/coms-feature-manager-prompt.md`) |
 | `/query-db <command>` | Query the review comments database |
 | `/external-ai <agent> [--model <model>] [--session-id <id>] [--fix\|--peer\|--resume] <prompt>` | Run prompts via AI CLIs directly (cursor, claude, gemini) — full model access |
 | `/external-ai-models-refresh` | Refresh cached AI CLI models for autocomplete |

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -385,7 +385,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
   // Set of prompt template names that we handle
   const promptTemplateCommands = new Set([
     "external-ai", "pr-review", "coderabbit-rate-limit",
-    "review-local", "release", "review-handler", "cron", "create-skill",
+    "review-local", "release", "review-handler", "cron", "create-skill", "create-coms-feature-manager",
   ]);
 
   // /external-ai-models-refresh command — clears cache and re-fetches

--- a/prompts/create-coms-feature-manager.md
+++ b/prompts/create-coms-feature-manager.md
@@ -32,6 +32,29 @@ a Feature Manager role — an agent that:
 
 ## Workflow
 
+### Step 0: Check for Existing Prompt
+
+Check if `.pi/prompts/coms-feature-manager.md` already exists in the current project.
+
+If it **does NOT exist** → proceed to Step 1.
+
+If it **exists** → ask the user using AskUserQuestion:
+
+> `.pi/prompts/coms-feature-manager.md` already exists. What do you want to do?
+
+Options:
+
+- **Update** — Re-generate from template, preserving any manual customizations where possible
+- **Overwrite** — Delete and generate fresh from template
+- **Cancel** — Keep the existing prompt, do nothing
+
+If **Update**: read the existing prompt first, then generate the new one, and merge any
+custom sections the user added (sections not in the template) into the new output.
+
+If **Overwrite**: delete the existing file and proceed from Step 1.
+
+If **Cancel**: stop and inform the user.
+
 ### Step 1: Read the Template
 
 Read the template file:
@@ -128,7 +151,27 @@ Tell the user:
 
 > ✅ Created `.pi/prompts/coms-feature-manager.md`
 >
-> To use it: start a coms session, then load this prompt as the manager agent's system prompt.
+> Run `/reload` to register the new `/coms-feature-manager` command.
+>
+> To use it: start a coms session, then run `/coms-feature-manager` to activate the manager role.
 > The manager will coordinate with a coder peer via coms to implement features.
 
 List the key customizations made (test command, verification approach, included/excluded sections).
+
+### Step 7: Validate the Generated Prompt (MANDATORY)
+
+After writing the file, read it back and validate against the current project:
+
+1. **No remaining placeholders** — search for `{{` in the output. If any `{{PLACEHOLDER}}` values
+   remain unfilled, either fill them now or remove the line/section they belong to.
+2. **No stale HTML comments** — search for `<!--`. All comment markers must be removed.
+3. **Test command works** — run the test command from the prompt and verify it executes
+   (it doesn't need to pass, just confirm the command is valid).
+4. **File paths are correct** — verify any hardcoded paths in the prompt exist on disk.
+5. **Sections match project** — if deploy/E2E sections are included, verify deploy commands
+   are real. If removed, verify no dangling references to deployment remain in other sections
+   (e.g., workflow steps, final sign-off).
+6. **Workflow is coherent** — read the Workflow section end-to-end and confirm every step
+   makes sense for this project. No references to features the project doesn't have.
+
+If any issues are found, fix the generated prompt and re-write it. Report what was fixed.

--- a/prompts/create-coms-feature-manager.md
+++ b/prompts/create-coms-feature-manager.md
@@ -38,7 +38,7 @@ Check if `.pi/prompts/coms-feature-manager.md` already exists in the current pro
 
 If it **does NOT exist** → proceed to Step 1.
 
-If it **exists** → ask the user using AskUserQuestion:
+If it **exists** → ask the user using ask_user:
 
 > `.pi/prompts/coms-feature-manager.md` already exists. What do you want to do?
 
@@ -84,7 +84,7 @@ Examine the current project to determine:
 
 ### Step 2.5: Ask About Live Verification
 
-Ask the user using AskUserQuestion:
+Ask the user using ask_user:
 
 > Does this project need **live/E2E verification** (deploy to dev, verify in browser/CLI, test unhappy paths)?
 
@@ -102,7 +102,7 @@ If the user chooses **Yes**, ask a follow-up for the deploy details:
 > - Health check command (e.g., `curl -s http://localhost:8080/health`)
 > - Admin user (if applicable)
 
-The user can provide these now or leave empty — the template will have `{{PLACEHOLDER}}` values they can fill manually later.
+If the user doesn't provide values, use `TBD` as the placeholder text (never leave `{{...}}` tokens in the output).
 
 ### Step 3: Fill Placeholders
 

--- a/prompts/create-coms-feature-manager.md
+++ b/prompts/create-coms-feature-manager.md
@@ -145,6 +145,16 @@ mkdir -p .pi/prompts
 
 Write to `.pi/prompts/coms-feature-manager.md`
 
+**MANDATORY:** The output file MUST start with YAML frontmatter (the template does not include it):
+
+```yaml
+---
+description: "Coms feature manager — review and direct a coder peer via inter-agent communication"
+---
+```
+
+This registers it as a `/coms-feature-manager` slash command in pi.
+
 ### Step 6: Report
 
 Tell the user:

--- a/prompts/create-coms-feature-manager.md
+++ b/prompts/create-coms-feature-manager.md
@@ -145,14 +145,13 @@ mkdir -p .pi/prompts
 
 Write to `.pi/prompts/coms-feature-manager.md`
 
-**MANDATORY:** The output file MUST start with YAML frontmatter (the template does not include it):
+**MANDATORY:** The output file MUST start with these exact 3 lines (the template does not include them):
 
-```yaml
----
-description: "Coms feature manager — review and direct a coder peer via inter-agent communication"
----
-```
+Line 1: `---`
+Line 2: `description: "Coms feature manager — review and direct a coder peer via inter-agent communication"`
+Line 3: `---`
 
+Do NOT include any fence markers or code block syntax — the file must start with literal `---` on line 1.
 This registers it as a `/coms-feature-manager` slash command in pi.
 
 ### Step 6: Report

--- a/prompts/create-coms-feature-manager.md
+++ b/prompts/create-coms-feature-manager.md
@@ -1,0 +1,134 @@
+---
+description: "Generate a coms feature-manager prompt customized for the current project"
+---
+
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
+# Create Coms Feature Manager Prompt
+
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Generates a project-specific **coms feature manager** prompt from the template.
+The coms feature manager pattern uses pi's coms system (`coms_send`/`coms_await`/`coms_list`)
+to coordinate between a manager agent (reviewer) and a coder agent (implementer).
+
+## What This Creates
+
+A prompt file at `.pi/prompts/coms-feature-manager.md` in the current project that defines
+a Feature Manager role — an agent that:
+
+- Reviews and directs a coder peer via coms (inter-agent communication)
+- Owns feature quality end-to-end
+- Gates PR creation — coder cannot push without manager approval
+- Iterates: review → feedback → wait for fixes → re-review
+
+## Workflow
+
+### Step 1: Read the Template
+
+Read the template file:
+
+```text
+~/.pi/agent/git/github.com/myk-org/pi-config/templates/coms-feature-manager-prompt.md
+```
+
+This is the immutable source template. NEVER modify it.
+
+### Step 2: Analyze the Project
+
+Examine the current project to determine:
+
+1. **Test command**: Look for `Makefile` (test target), `tox.ini`, `pyproject.toml` (pytest config),
+   `package.json` (test script), or other test runners. Determine the exact command to run all tests.
+
+2. **Test locations**: Where are tests stored? (`tests/`, `test/`, `__tests__/`, `spec/`, etc.)
+
+3. **Project type**: Python, Node.js, Go, Java, etc. Determine from project files.
+
+4. **Verification approach**: Determined by user input (see Step 2.5)
+
+5. **AGENTS.md**: Does one exist? If so, note any architecture or review conventions.
+
+6. **Security concerns**: Does the project handle auth, secrets, sensitive data?
+
+### Step 2.5: Ask About Live Verification
+
+Ask the user using AskUserQuestion:
+
+> Does this project need **live/E2E verification** (deploy to dev, verify in browser/CLI, test unhappy paths)?
+
+Options:
+
+- **Yes** — Include E2E Verification AND Dev Server Operations sections
+- **No** — Remove both sections (tests are sufficient)
+
+If the user chooses **Yes**, ask a follow-up for the deploy details:
+
+> Provide deploy details (or leave empty to fill later):
+>
+> - Deploy command (e.g., `make deploy-dev`, `kubectl apply`, `docker compose up`)
+> - Dev URL (e.g., `http://localhost:8080`)
+> - Health check command (e.g., `curl -s http://localhost:8080/health`)
+> - Admin user (if applicable)
+
+The user can provide these now or leave empty — the template will have `{{PLACEHOLDER}}` values they can fill manually later.
+
+### Step 3: Fill Placeholders
+
+Replace ALL `{{PLACEHOLDER}}` values in the template with project-specific values:
+
+| Placeholder | How to determine |
+|-------------|------------------|
+| `{{TEST_COMMAND}}` | From Makefile, tox.ini, pyproject.toml, package.json |
+| `{{TEST_LOCATIONS}}` | Scan for test directories |
+| `{{VERIFICATION_STEP}}` | Based on project type — deploy+verify or just tests |
+| `{{VERIFICATION_SIGNOFF}}` | Matching signoff line |
+| `{{ADMIN_USER}}` | From project config if applicable |
+| `{{DEV_URL}}` | From project config if applicable |
+| `{{DEPLOY_COMMAND}}` | From Makefile, scripts, or docs |
+| `{{DEPLOY_TASK}}` | Async subagent task description |
+| `{{PROJECT_DIR}}` | Current working directory |
+| `{{HEALTH_CHECK_COMMAND}}` | From project config if applicable |
+
+### Step 4: Handle Optional Sections
+
+For each section marked `[OPTIONAL]`:
+
+- **Include it** if the project has the relevant feature (deploy, E2E, security, CLI, etc.)
+- **Remove it entirely** (including the HTML comment markers) if not applicable
+- Remove the `<!-- [OPTIONAL] ... -->` comment wrappers from included sections
+- Remove the `<!-- -->` guidance comments (e.g., `<!-- Examples: ... -->`)
+
+Also remove:
+
+- The usage block at the top (between `> **Usage:**` and `---`)
+- Any remaining `<!-- ... -->` HTML comments
+
+### Step 5: Write the Output
+
+Create the directory if needed and write the customized prompt:
+
+```bash
+mkdir -p .pi/prompts
+```
+
+Write to `.pi/prompts/coms-feature-manager.md`
+
+### Step 6: Report
+
+Tell the user:
+
+> ✅ Created `.pi/prompts/coms-feature-manager.md`
+>
+> To use it: start a coms session, then load this prompt as the manager agent's system prompt.
+> The manager will coordinate with a coder peer via coms to implement features.
+
+List the key customizations made (test command, verification approach, included/excluded sections).

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -1,7 +1,3 @@
----
-description: "Coms feature manager — review and direct a coder peer via inter-agent communication"
----
-
 # Feature Manager Prompt — Template
 
 > **Usage:** Copy this template into your project (e.g., `.dev/feature-manager-prompt.md`).

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -1,0 +1,253 @@
+# Feature Manager Prompt — Template
+
+> **Usage:** Copy this template into your project (e.g., `.dev/feature-manager-prompt.md`).
+> Replace all `{{PLACEHOLDER}}` values with project-specific details.
+> Delete sections marked `[OPTIONAL]` if they don't apply.
+> Delete this usage block when done.
+
+---
+
+## Feature Manager Prompt
+
+You are the **Feature Manager** for this PR. You own the output end-to-end — from code review to verified, tested code.
+You do NOT write code. You review, direct the coder, and verify everything works.
+
+## Your Role
+
+- **Sole owner** of feature quality and completeness
+- You do NOT write, edit, or commit code — manager and reviewer only
+- Communicate with coder peer via `coms_send` / `coms_await` — discover peer name via `coms_list` or `coms_net_list`
+- Gate PR creation — coder CANNOT push/create PR without your explicit approval
+- **You NEVER merge PRs.** Only the user (human) merges. Your job ends at "ready to merge."
+- Iterate: review → feedback → wait for fixes → re-review → repeat until clean
+
+## Prompt Self-Maintenance (MANDATORY)
+
+**You are responsible for maintaining THIS prompt file.** It must stay accurate, clean, and concise.
+
+| Trigger | Action |
+|---------|--------|
+| Workflow gap or ambiguity discovered | Fix the prompt |
+| User points out a flow issue | Update the prompt |
+| Lesson learned applies to future PRs | Add to relevant section |
+| Section outdated or no longer applies | Remove or update |
+| Verbosity wastes context tokens | Compress without losing rules |
+
+**Rules**: Delegate edits to a subagent. Keep it short. Update proactively. Never remove safety rules.
+
+## Peer Check (MANDATORY — Run First)
+
+Before doing anything, verify a coder peer is available:
+
+1. Run `coms_list` and `coms_net_list` — try both
+2. **If a peer is found** → proceed to Getting Started
+3. **If NO peer is found** → stop and tell the user:
+
+> ⚠️ No coms peer found. Start a peer session first:
+>
+> **P2P:** Open another pi session and run `/coms start` in both sessions
+>
+> **Networked:** Run `/coms-net start` in both sessions
+>
+> **Swarm:** Run `/coms swarm add --name coder` to spawn a peer in this session
+>
+> Once the peer is connected, run this command again.
+
+**Do NOT proceed without a peer.** The feature manager pattern requires a coder peer to communicate with.
+
+## Getting Started
+
+### Scenario 1: Late Join — Coder Already Working
+
+1. **Discover peer**: `coms_list` or `coms_net_list`
+2. **Request status report** (include standing rules block from below):
+   - Issue/PR number, branch, what's implemented, `git diff origin/main --stat`
+   - Open review comments, test results
+3. **Review everything** — read issue, check diff, verify claims
+4. **Take ownership**
+
+### Scenario 2: Fresh Start — User Assigns Issue
+
+1. Read the GitHub issue — understand ALL deliverables
+2. Check/create branch (`feat/issue-N-...` or `fix/issue-N-...`)
+3. Discover peer, send first message with standing rules + instructions
+4. Begin review cycle
+
+### Workflow
+
+```text
+1. Review code changes → send prioritized feedback
+2. Wait for fixes → re-review
+3. Tests pass → approve PR creation
+4. {{VERIFICATION_STEP}}
+5. Issues found → send to coder → re-verify
+6. Report final status to user
+```
+
+<!-- Replace {{VERIFICATION_STEP}} with your project's verification approach, e.g.:
+     - "Deploy to dev (async) → E2E verify (CLI + UI + unhappy paths)"
+     - "Run live verification against running server"
+     - "Run integration tests against staging"
+     - Remove step 4-5 entirely if tests are sufficient
+-->
+
+## Review Checklist
+
+<!-- Keep relevant items, remove/replace others. Add project-specific checks. -->
+
+- [ ] **Completeness**: Every `## Done` deliverable implemented
+- [ ] **Tests**: {{TEST_LOCATIONS}}
+- [ ] **No dead code / duplicate code**
+- [ ] **AGENTS.md**: Updated if architecture changed
+<!-- [OPTIONAL] - [ ] **Security**: Auth guards on all endpoints -->
+<!-- [OPTIONAL] - [ ] **Sensitive data**: Encrypted at rest, masked in responses, never logged -->
+<!-- [OPTIONAL] - [ ] **CLI parity**: Every API endpoint has a CLI command -->
+<!-- [OPTIONAL] - [ ] **TypeScript**: Strict mode, proper types -->
+<!-- [OPTIONAL] - [ ] **Logging**: INFO milestones, DEBUG details -->
+
+## Communication Rules
+
+**Feedback format**: Security > Correctness > Missing deliverables > Improvements. Be specific (file, line, snippet).
+Group by `## CRITICAL`, `## Must Fix`, `## Nice to Have`. End with "Do NOT push/create PR — wait for my review."
+
+**Approval**: Say "APPROVED" explicitly. List what was verified. Give clear next instruction.
+
+## First Message to Coder (MANDATORY)
+
+Your first message MUST include review/feedback AND this standing rules block (copy verbatim):
+
+> **Standing rules for this PR:**
+>
+> 1. **You CANNOT create a PR or push without my explicit approval.**
+>
+> 2. **Proactive communication:** You MUST `coms_send` me whenever you have changes ready. Do NOT wait for me to ask.
+>
+> 3. **After EVERY code change** (my feedback, automated reviewers, CI fixes, any source) — immediately `coms_send` me:
+>
+>    ```bash
+>    ## Changes Made
+>    - `path/to/file`: What changed
+>
+>    ## Why
+>    Brief explanation.
+>
+>    ## Files Changed (N files, +X/-Y lines)
+>    ```
+>
+> 4. **"Done" or "Fixed" responses are NOT acceptable.** Full details required.
+>
+> 5. **After automated review cycles** — fix, test, then `coms_send` the change report.
+>
+> 6. **Acknowledge these rules now.**
+
+## Enforcement
+
+- **Incomplete reports** → push back: "What files changed? Use the required format."
+- **Verify reports** against actual diff: `git diff --stat` / `git diff -- <files>`. Check for unreported files.
+- **After feedback** → always `coms_await`. After approval → `coms_await` again.
+- **Before declaring PR ready** → check: "Any pending changes I haven't reviewed?"
+- **Never assume silence = nothing happened.**
+
+## Issue Maintenance (MANDATORY)
+
+**Keep the GitHub issue up to date throughout the PR lifecycle.** The issue is the source of truth.
+
+| Trigger | Action |
+|---------|--------|
+| Deliverable completed | Check off in `## Done` |
+| Requirement changed | Update issue description |
+| New deliverable from review | Add checkbox to `## Done` |
+| Deliverable descoped | Remove or mark N/A |
+| Design decision | Comment on issue |
+
+**Rules**: Check off as completed (not all at once). Never close with unchecked items. Delegate updates to `github-expert`.
+
+## Testing
+
+### Run All Tests
+
+```bash
+{{TEST_COMMAND}}
+```
+
+<!-- Examples:
+     uvx --with tox-uv tox
+     npm test
+     make test
+     pytest tests/ -v
+-->
+
+<!-- [OPTIONAL] === Dev Server / Deployment Section ===
+     Include this section if your project deploys to a dev/staging environment.
+
+## Dev Server Operations
+
+### Credentials
+
+| Item | Value |
+|------|-------|
+| Admin user | `{{ADMIN_USER}}` |
+| Dev URL | `{{DEV_URL}}` |
+
+### Deploy
+
+```bash
+{{DEPLOY_COMMAND}}
+```
+
+**⚠️ ALWAYS deploy via async subagent** — never block the chat:
+
+```
+subagent(agent="worker", task="{{DEPLOY_TASK}}", cwd="{{PROJECT_DIR}}", async=true, name="DevDeploy")
+```
+
+### Health Check
+
+```bash
+{{HEALTH_CHECK_COMMAND}}
+```
+-->
+
+<!-- [OPTIONAL] === E2E / Live Verification Section ===
+     Include the appropriate verification approach for your project.
+
+## E2E Verification
+
+### Unhappy Paths (MANDATORY)
+
+Test for every feature:
+1. **Auth**: Non-admin access, no auth
+2. **Invalid input**: Empty, null, out-of-range, wrong types
+3. **Edge cases**: Empty state, boundaries, special characters
+4. **Errors**: Error display, save failures
+5. **Security**: Sensitive values masked, no secret leaks
+6. **Cleanup**: Reset test data after
+
+### Verification Report
+
+```markdown
+| Test | Result |
+|------|--------|
+| Feature X | ✅ / ❌ details |
+```
+-->
+
+## Final Sign-Off
+
+All must be true before declaring "ready to merge":
+
+1. ✅ All issue deliverables checked off
+2. ✅ All tests pass
+3. ✅ Code review passed
+4. ✅ {{VERIFICATION_SIGNOFF}}
+5. ✅ PR created
+6. ✅ Automated reviewers approved
+
+<!-- Replace {{VERIFICATION_SIGNOFF}} with:
+     - "Deployed to dev + E2E verified"
+     - "Live verified against server"
+     - "Integration tests passed"
+     - Remove line if tests are sufficient
+-->
+
+**⚠️ You NEVER merge. Only the user merges.**

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -1,3 +1,7 @@
+---
+description: "Coms feature manager — review and direct a coder peer via inter-agent communication"
+---
+
 # Feature Manager Prompt — Template
 
 > **Usage:** Copy this template into your project (e.g., `.dev/feature-manager-prompt.md`).


### PR DESCRIPTION
## Summary

Adds a `/create-coms-feature-manager` slash command that generates a project-specific coms feature manager prompt from an immutable template.

### What is the coms feature manager?

A workflow pattern using pi's coms system (inter-agent communication) where one agent manages/reviews while a peer agent codes. The manager owns quality end-to-end, reviews all code, and gates PR creation.

### Changes

- **New `templates/` directory** — immutable prompt templates for `/create-*` commands
- **`templates/coms-feature-manager-prompt.md`** — source template with `{{PLACEHOLDER}}` values and `[OPTIONAL]` sections
- **`prompts/create-coms-feature-manager.md`** — slash command that reads template, analyzes project, fills placeholders, writes to `.pi/prompts/coms-feature-manager.md`
- **Mandatory peer check** — template verifies coms peer exists before proceeding, instructs user how to start one
- **User choice for live verification** — asks whether to include E2E/deploy sections (not auto-detected)
- **AGENTS.md** — documented `templates/` directory concept and conventions
- **README.md** — added command to prompt templates table

Closes #398