### PR TITLE
fix(coms): remove peer subscribe that corrupts TUI + cache notify-send path

### DIFF
--- a/extensions/coms/coms-swarm.ts
+++ b/extensions/coms/coms-swarm.ts
@@ -180,13 +180,6 @@ async function spawnPeer(
     if (purpose) comsStartCmd += ` --purpose "${purpose}"`;
     if (parentProject) comsStartCmd += ` --project "${parentProject}"`;
 
-    // Subscribe to events for logging
-    session.subscribe((event: any) => {
-        if (event.type === "agent_end") {
-            log(`peer ${name}: agent_end`);
-        }
-    });
-
     // Always send /coms start to register with coms
     // (even on resume — coms state doesn't persist in the session file)
     await session.prompt(comsStartCmd);

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -6,11 +6,32 @@ import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+/** Cached path to notify-send (null = not available, checked once) */
+let notifySendPath: string | null | undefined;
+
 /** Send a desktop notification via notify-send (Linux only, no-op if unavailable) */
 export function terminalNotify(title: string, body: string): void {
+  // Subagent children and coms peers don't own a terminal
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
+  // Check for notify-send once
+  if (notifySendPath === undefined) {
+    try {
+      notifySendPath = execFileSync("which", ["notify-send"], {
+        timeout: 2000,
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      }).trim() || null;
+    } catch (e: any) {
+      console.debug("[utils] notify-send lookup failed:", e?.message || e);
+      notifySendPath = null;
+    }
+  }
+  if (!notifySendPath) return;
+
   const project = path.basename(process.cwd());
   try {
-    execFileSync("notify-send", [`${title} (${project})`, body], {
+    execFileSync(notifySendPath, [`${title} (${project})`, body], {
       timeout: 2000,
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -6,36 +6,29 @@ import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-/** Cached path to notify-send (null = not available, checked once) */
-let notifySendPath: string | null | undefined;
+/** Whether notify-send is available (false = ENOENT, never retry) */
+let notifyAvailable: boolean | undefined;
 
 /** Send a desktop notification via notify-send (Linux only, no-op if unavailable) */
 export function terminalNotify(title: string, body: string): void {
   // Subagent children and coms peers don't own a terminal
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
-
-  // Check for notify-send once
-  if (notifySendPath === undefined) {
-    try {
-      notifySendPath = execFileSync("which", ["notify-send"], {
-        timeout: 2000,
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trim() || null;
-    } catch (e: any) {
-      console.debug("[utils] notify-send lookup failed:", e?.message || e);
-      notifySendPath = null;
-    }
-  }
-  if (!notifySendPath) return;
+  if (notifyAvailable === false) return;
 
   const project = path.basename(process.cwd());
   try {
-    execFileSync(notifySendPath, [`${title} (${project})`, body], {
+    execFileSync("notify-send", [`${title} (${project})`, body], {
       timeout: 2000,
       stdio: ["pipe", "pipe", "pipe"],
     });
-  } catch (e: any) { console.debug("[utils] notify-send failed:", e?.message || e); }
+    notifyAvailable = true;
+  } catch (e: any) {
+    if (e?.code === "ENOENT") {
+      notifyAvailable = false;
+    } else {
+      console.debug("[utils] notify-send failed:", e?.message || e);
+    }
+  }
 }
 
 /** Set SSH timeout for git operations — prevents hung connections */


### PR DESCRIPTION
## Summary

Two fixes for coms-related bugs:

### 1. TUI duplicates last line in swarm mode
The peer `session.subscribe` callback fired on every peer's `agent_end` and called `log()` → `pi.appendEntry("coms-swarm-log", ...)` on the **main session**. When a peer's turn ended while the main AI was streaming, this `appendEntry` caused a TUI re-render that didn't clear the streaming output — the last line appeared twice (truncated partial + full).

Fix: removed the `session.subscribe` block. Debug logging from peer events should not call `appendEntry` on the main session.

### 2. notify-send ENOENT in coms peers
`terminalNotify` called `execFileSync("notify-send", ...)` without checking availability. Coms peers (spawned via SDK) run in environments where it may not be in PATH.

Fix:
- Skip for subagent children (`PI_SUBAGENT_CHILD=1`) — they don't own a terminal
- Cache `notify-send` absolute path via `which` on first call
- If not found, silently no-op forever

Closes #400