### PR TITLE
fix(coms): wrap stale ctx access in cleanShutdown + fix status-line pollers

### DIFF
--- a/extensions/coms/upstream-coms/coms-net.ts
+++ b/extensions/coms/upstream-coms/coms-net.ts
@@ -1623,10 +1623,12 @@ export default function (pi: ExtensionAPI) {
 			} catch { /* best-effort */ }
 		}
 
-		if (currentCtx?.hasUI) {
-			try { currentCtx.ui.setWidget("coms-net-pool", undefined); } catch { /* ignore */ }
-			try { currentCtx.ui.setStatus("coms-net", ""); } catch { /* ignore */ }
-		}
+		try {
+			if (currentCtx?.hasUI) {
+				currentCtx.ui.setWidget("coms-net-pool", undefined);
+				currentCtx.ui.setStatus("coms-net", "");
+			}
+		} catch { /* ctx may be stale on shutdown */ }
 	}
 
 	pi.on("session_shutdown", async () => { await cleanShutdown(); });

--- a/extensions/coms/upstream-coms/coms-net.ts
+++ b/extensions/coms/upstream-coms/coms-net.ts
@@ -1625,8 +1625,8 @@ export default function (pi: ExtensionAPI) {
 
 		try {
 			if (currentCtx?.hasUI) {
-				currentCtx.ui.setWidget("coms-net-pool", undefined);
-				currentCtx.ui.setStatus("coms-net", "");
+				try { currentCtx.ui.setWidget("coms-net-pool", undefined); } catch { /* best-effort */ }
+				try { currentCtx.ui.setStatus("coms-net", ""); } catch { /* best-effort */ }
 			}
 		} catch { /* ctx may be stale on shutdown */ }
 	}

--- a/extensions/coms/upstream-coms/coms.ts
+++ b/extensions/coms/upstream-coms/coms.ts
@@ -1586,9 +1586,11 @@ export default function (pi: ExtensionAPI) {
 				pi.appendEntry("coms-log", { event: "shutdown", session_id: identity.session_id });
 			} catch { /* best-effort */ }
 		}
-		if (currentCtx?.hasUI) {
-			try { currentCtx.ui.setWidget("coms-pool", undefined); } catch { /* ignore */ }
-		}
+		try {
+			if (currentCtx?.hasUI) {
+				currentCtx.ui.setWidget("coms-pool", undefined);
+			}
+		} catch { /* ctx may be stale on shutdown */ }
 	}
 
 	pi.on("session_shutdown", async () => { await cleanShutdown(); });

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -90,7 +90,7 @@ export function registerStatusLine(
       lastCtx.ui.theme; // probe for stale ctx
       updateBranch(null, lastCtx);
     } catch {
-      // ctx is stale or other error — skip this cycle, don't clear interval
+      lastCtx = null; // stale — wait for next session_start to refresh
     }
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
@@ -134,7 +134,7 @@ export function registerStatusLine(
       lastCtx.ui.theme; // probe for stale ctx
       updateTimestamp(lastCtx);
     } catch {
-      // ctx is stale or other error — skip this cycle, don't clear interval
+      lastCtx = null; // stale — wait for next session_start to refresh
     }
   }, 30_000);
   if (timePoller.unref) timePoller.unref();

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -87,9 +87,10 @@ export function registerStatusLine(
   const gitPoller = setInterval(() => {
     if (!lastCtx) return;
     try {
+      lastCtx.ui.theme; // probe for stale ctx
       updateBranch(null, lastCtx);
     } catch {
-      clearInterval(gitPoller);
+      // ctx is stale or other error — skip this cycle, don't clear interval
     }
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
@@ -130,9 +131,10 @@ export function registerStatusLine(
   const timePoller = setInterval(() => {
     if (!lastCtx || !lastActivityTime) return;
     try {
+      lastCtx.ui.theme; // probe for stale ctx
       updateTimestamp(lastCtx);
     } catch {
-      clearInterval(timePoller);
+      // ctx is stale or other error — skip this cycle, don't clear interval
     }
   }, 30_000);
   if (timePoller.unref) timePoller.unref();

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -89,8 +89,9 @@ export function registerStatusLine(
     try {
       lastCtx.ui.theme; // probe for stale ctx
       updateBranch(null, lastCtx);
-    } catch {
-      lastCtx = null; // stale — wait for next session_start to refresh
+    } catch (e: any) {
+      console.debug("[status-line] git poller error, pausing until next session_start:", e?.message || e);
+      lastCtx = null;
     }
   }, 5000);
   if (gitPoller.unref) gitPoller.unref();
@@ -133,8 +134,9 @@ export function registerStatusLine(
     try {
       lastCtx.ui.theme; // probe for stale ctx
       updateTimestamp(lastCtx);
-    } catch {
-      lastCtx = null; // stale — wait for next session_start to refresh
+    } catch (e: any) {
+      console.debug("[status-line] time poller error, pausing until next session_start:", e?.message || e);
+      lastCtx = null;
     }
   }, 30_000);
   if (timePoller.unref) timePoller.unref();


### PR DESCRIPTION
## Summary

Fixes stale ctx crashes when coms/swarm is active:

### 1. Crash on Ctrl+C (SIGINT/SIGTERM)
`cleanShutdown()` in coms.ts and coms-net.ts accessed `currentCtx?.hasUI` which throws because the `hasUI` getter calls `assertActive()` on a stale ctx. The try/catch only wrapped `setWidget`, not the `hasUI` check.

Fix: wrap entire block (including `hasUI` check) in single try/catch.

### 2. status-line pollers die permanently
`gitPoller` (5s) and `timePoller` (30s) used `clearInterval` on error, permanently disabling status updates after a transient stale ctx (e.g., swarm peer stop).

Fix: skip the cycle on error instead of killing the poller. Next `session_start` provides a fresh ctx.

**Note:** coms.ts and coms-net.ts are upstream-synced files — these fixes will need re-applying after next `sync-coms-upstream.sh` run.

Closes #402