### PR TITLE
fix: make terminalNotify async to prevent TUI duplicate lines

### DIFF
--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -2,7 +2,7 @@
  * Shared utilities used across orchestrator modules.
  */
 
-import { execFileSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
@@ -16,19 +16,19 @@ export function terminalNotify(title: string, body: string): void {
   if (notifyAvailable === false) return;
 
   const project = path.basename(process.cwd());
-  try {
-    execFileSync("notify-send", [`${title} (${project})`, body], {
-      timeout: 2000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    notifyAvailable = true;
-  } catch (e: any) {
-    if (e?.code === "ENOENT") {
-      notifyAvailable = false;
+  execFile("notify-send", [`${title} (${project})`, body], {
+    timeout: 2000,
+  }, (err) => {
+    if (err) {
+      if ((err as any).code === "ENOENT") {
+        notifyAvailable = false;
+      } else {
+        console.debug("[utils] notify-send failed:", err.message);
+      }
     } else {
-      console.debug("[utils] notify-send failed:", e?.message || e);
+      notifyAvailable = true;
     }
-  }
+  });
 }
 
 /** Set SSH timeout for git operations — prevents hung connections */

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -16,7 +16,7 @@ export function terminalNotify(title: string, body: string): void {
   if (notifyAvailable === false) return;
 
   const project = path.basename(process.cwd());
-  execFile("notify-send", [`${title} (${project})`, body], {
+  const child = execFile("notify-send", [`${title} (${project})`, body], {
     timeout: 2000,
   }, (err) => {
     if (err) {
@@ -29,6 +29,7 @@ export function terminalNotify(title: string, body: string): void {
       notifyAvailable = true;
     }
   });
+  child.unref();
 }
 
 /** Set SSH timeout for git operations — prevents hung connections */


### PR DESCRIPTION
## Summary

`terminalNotify` used `execFileSync("notify-send", ...)` which blocked the event loop for up to 2 seconds. When called from the `agent_end` handler in status-line.ts, this interrupted the TUI's post-streaming cleanup, causing the last line of AI output to render twice (truncated partial + full text).

Fix: replaced `execFileSync` with async `execFile` (callback-based, fire-and-forget). The notification doesn't need to be synchronous.

This was the root cause of the duplicate last line issue reported in #400 — it happens in all coms modes (P2P, networked, swarm), not just swarm.

Closes #404