### PR TITLE
fix(subagent): include provider prefix in parentModelId — fixes #386

### DIFF
--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -554,7 +554,7 @@ export function registerSubagentTool(
       const discovery = discoverAgents(ctx.cwd, scope);
       const agents = discovery.agents;
       const confirm = params.confirmProjectAgents ?? true;
-      const parentModelId = ctx.model?.id;
+      const parentModelId = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
 
       const hasChain = (params.chain?.length ?? 0) > 0;
       const hasTasks = (params.tasks?.length ?? 0) > 0;


### PR DESCRIPTION
## Summary

Fix the remaining part of #386 — subagents now inherit the correct provider when the parent uses an extension-registered provider.

## Change

**`extensions/orchestrator/subagent-tool.ts`** — one line:

```diff
- const parentModelId = ctx.model?.id;
+ const parentModelId = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
```

Previously, `parentModelId` was set to just the model ID (e.g., `claude-opus-4-6`), which caused pi's model resolver to match the built-in Anthropic provider instead of the extension provider (e.g., `google-vertex-claude`). Now it passes `google-vertex-claude/claude-opus-4-6`, resolving to the correct provider.

## Context

#386 had two bugs:
1. ~~Stale context crash in async poller~~ — already fixed
2. **Wrong provider resolution in subagent-tool.ts** — fixed by this PR

Closes #386