### PR TITLE
feat: add image generation extension via Gemini API — fixes #407

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,8 +80,11 @@ pi-config/
 │   │   ├── pidiff.ts                # Diff viewer logic (spawns/connects to pidiff daemon)
 │   │   ├── daemon-manager.ts        # Daemon infrastructure (spawn, health check, WebSocket)
 │   │   └── pidiff-ui/               # React diff viewer UI (@pierre/diffs + @pierre/trees)
-│   └── acpx-provider/              # ACPX provider extension (acpx/runtime library API)
-│       └── index.ts                # Provider + exported discoverAcpxModels() for external consumers
+│   ├── acpx-provider/              # ACPX provider extension (acpx/runtime library API)
+│   │   └── index.ts                # Provider + exported discoverAcpxModels() for external consumers
+│   └── image-gen/                   # Image generation extension (standalone)
+│       ├── index.ts                # Entry point — registers generate_image tool
+│       └── image-gen.ts            # Gemini API image generation (env: PI_IMAGE_MODEL, GEMINI_API_KEY)
 ├── templates/                       # Immutable prompt templates (source files for /create-* commands)
 │   └── coms-feature-manager-prompt.md  # Coms feature manager template
 ├── prompts/                         # Prompt templates (slash commands)

--- a/README.md
+++ b/README.md
@@ -236,6 +236,21 @@ Agent system prompt here.
 
 Use `agentScope: "both"` in the subagent tool to include project agents.
 
+### Image Generation
+
+The `generate_image` tool creates images from structured descriptions via Gemini API.
+
+**Required environment variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `PI_IMAGE_MODEL` | Gemini model name (e.g., `gemini-3-pro-image`). No default. |
+| `GEMINI_API_KEY` or `GOOGLE_API_KEY` | Gemini API key |
+
+**Usage:** Ask naturally — "generate an image of a sunset" — or use structured params: `subject`, `action`, `scene`, `composition`, `lighting`, `style`, `text`, `aspect_ratio`.
+
+In containers, images are auto-served via HTTP for browser preview.
+
 ## Docker (Sandboxed Execution)
 
 Run pi inside a disposable container for **filesystem isolation** — the agent can only access your mounted project directory and pi settings. Everything else on the host is protected.
@@ -306,8 +321,11 @@ GITHUB_TOKEN=ghp_xxx
 GITHUB_API_TOKEN=ghp_xxx
 GH_CONFIG_DIR=/home/myakove/.config/gh
 
-# Gemini (optional)
+# Gemini (optional — required for image generation)
 GEMINI_API_KEY=xxx
+
+# Image generation model (required for generate_image tool)
+PI_IMAGE_MODEL=gemini-3-pro-image
 
 # acpx agents (optional)
 # ACPX_AGENTS=cursor

--- a/extensions/image-gen/image-gen.ts
+++ b/extensions/image-gen/image-gen.ts
@@ -1,0 +1,268 @@
+/**
+ * image-gen.ts — Image generation tool via Gemini API
+ *
+ * Generates images from structured parameters using Google's Gemini API.
+ * Model and API key are configured via environment variables:
+ *   - PI_IMAGE_MODEL: Gemini model name (e.g., "gemini-2.0-flash-exp")
+ *   - GEMINI_API_KEY or GOOGLE_API_KEY: API key
+ */
+
+import { Type } from "typebox";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ASPECT_RATIOS = ["1:1", "3:4", "4:3", "9:16", "16:9"] as const;
+const IMAGE_TIMEOUT = 3 * 60 * 1000; // 3 minutes
+
+const imageGenSchema = Type.Object({
+    subject: Type.String({ description: "Main subject of the image" }),
+    action: Type.Optional(Type.String({ description: "What the subject is doing" })),
+    scene: Type.Optional(Type.String({ description: "Location or environment" })),
+    composition: Type.Optional(Type.String({ description: "Camera angle and framing" })),
+    lighting: Type.Optional(Type.String({ description: "Lighting setup" })),
+    style: Type.Optional(Type.String({ description: "Artistic style (e.g., photorealistic, watercolor, pixel art)" })),
+    text: Type.Optional(Type.String({ description: "Text to render in the image" })),
+    aspect_ratio: Type.Optional(Type.Enum(
+        Object.fromEntries(ASPECT_RATIOS.map(r => [r, r])) as Record<string, string>,
+        { description: "Aspect ratio: 1:1, 3:4, 4:3, 9:16, 16:9" }
+    )),
+});
+
+interface GeminiPart {
+    text?: string;
+    inlineData?: { mimeType: string; data: string };
+}
+
+interface GeminiCandidate {
+    content?: { parts?: GeminiPart[] };
+}
+
+interface GeminiResponse {
+    candidates?: GeminiCandidate[];
+    promptFeedback?: { blockReason?: string };
+}
+
+function getApiKey(): string | null {
+    return process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY || null;
+}
+
+function getModel(): string | null {
+    return process.env.PI_IMAGE_MODEL || null;
+}
+
+function assemblePrompt(params: {
+    subject: string;
+    action?: string;
+    scene?: string;
+    composition?: string;
+    lighting?: string;
+    style?: string;
+    text?: string;
+}): string {
+    const parts: string[] = [];
+
+    const subjectParts = [params.subject];
+    if (params.action) subjectParts.push(params.action);
+    if (params.scene) subjectParts.push(params.scene);
+    parts.push(subjectParts.join(", "));
+
+    if (params.composition) parts.push(params.composition);
+    if (params.lighting) parts.push(params.lighting);
+    if (params.style) parts.push(params.style);
+
+    let prompt = `${parts.map(p => p.replace(/[.!,;:]+$/, "")).join(". ")}.`;
+
+    if (params.text) {
+        prompt += `\n\nText: ${params.text}`;
+    }
+
+    return prompt;
+}
+
+function getExtensionForMime(mimeType: string): string {
+    const map: Record<string, string> = {
+        "image/png": "png",
+        "image/jpeg": "jpg",
+        "image/gif": "gif",
+        "image/webp": "webp",
+    };
+    return map[mimeType] ?? "png";
+}
+
+function getTempDir(cwd: string): string {
+    const basename = path.basename(cwd);
+    const dir = path.join("/tmp/pi-work", basename);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+}
+
+export function createImageGenTool(): ToolDefinition {
+    return {
+        name: "generate_image",
+        label: "GenerateImage",
+        description: [
+            "Generate an image from a structured description using Gemini.",
+            "Provide a subject (required) and optional parameters for action, scene, composition, lighting, style, and text.",
+            "Returns the file path of the generated image.",
+            "Requires PI_IMAGE_MODEL and GEMINI_API_KEY/GOOGLE_API_KEY environment variables.",
+        ].join("\n"),
+        promptSnippet: "generate_image: Generate images from structured descriptions via Gemini API",
+        parameters: imageGenSchema,
+
+        async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+            const model = getModel();
+            if (!model) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: "Error: PI_IMAGE_MODEL environment variable is not set. Set it to a Gemini image model (e.g., PI_IMAGE_MODEL=gemini-2.0-flash-exp) and restart pi.",
+                    }],
+                };
+            }
+
+            const apiKey = getApiKey();
+            if (!apiKey) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: "Error: No API key found. Set GEMINI_API_KEY or GOOGLE_API_KEY environment variable and restart pi.",
+                    }],
+                };
+            }
+
+            const promptText = assemblePrompt(params);
+
+            const generationConfig: Record<string, unknown> = {
+                responseModalities: ["IMAGE"],
+            };
+            if (params.aspect_ratio) {
+                generationConfig.imageConfig = { aspectRatio: params.aspect_ratio };
+            }
+
+            const requestBody = {
+                contents: [{ role: "user" as const, parts: [{ text: promptText }] }],
+                generationConfig,
+            };
+
+            const abortSignal = signal ?? AbortSignal.timeout(IMAGE_TIMEOUT);
+
+            let response: Response;
+            try {
+                response = await fetch(
+                    `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`,
+                    {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                            "x-goog-api-key": apiKey,
+                        },
+                        body: JSON.stringify(requestBody),
+                        signal: abortSignal,
+                    },
+                );
+            } catch (err: any) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Error: Gemini API request failed: ${err?.message ?? String(err)}`,
+                    }],
+                };
+            }
+
+            const rawText = await response.text();
+            if (!response.ok) {
+                let message = rawText;
+                try {
+                    const parsed = JSON.parse(rawText) as { error?: { message?: string } };
+                    message = parsed.error?.message ?? message;
+                } catch {
+                    // Keep raw text
+                }
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Error: Gemini image request failed (${response.status}): ${message}`,
+                    }],
+                };
+            }
+
+            let data: GeminiResponse;
+            try {
+                data = JSON.parse(rawText) as GeminiResponse;
+            } catch {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Error: Failed to parse Gemini response: ${rawText.slice(0, 200)}`,
+                    }],
+                };
+            }
+
+            if (data.promptFeedback?.blockReason) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Error: Image generation blocked by safety filter: ${data.promptFeedback.blockReason}`,
+                    }],
+                };
+            }
+
+            const images: { data: string; mimeType: string }[] = [];
+            let responseText = "";
+
+            for (const candidate of data.candidates ?? []) {
+                for (const part of candidate.content?.parts ?? []) {
+                    if (part.inlineData?.data && part.inlineData?.mimeType) {
+                        images.push({
+                            data: part.inlineData.data,
+                            mimeType: part.inlineData.mimeType,
+                        });
+                    }
+                    if (part.text) {
+                        responseText += part.text;
+                    }
+                }
+            }
+
+            if (images.length === 0) {
+                const extra = responseText ? `\n\n${responseText}` : "";
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `No image data returned from Gemini.${extra}`,
+                    }],
+                };
+            }
+
+            const cwd = ctx?.cwd ?? process.cwd();
+            const tempDir = getTempDir(cwd);
+            const savedPaths: string[] = [];
+
+            for (const image of images) {
+                const ext = getExtensionForMime(image.mimeType);
+                const filename = `pi-image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+                const filepath = path.join(tempDir, filename);
+                const buffer = Buffer.from(image.data, "base64");
+                fs.writeFileSync(filepath, buffer);
+                savedPaths.push(filepath);
+            }
+
+            const lines = [
+                `Model: ${model}`,
+                `Generated ${savedPaths.length} image(s):`,
+                ...savedPaths.map(p => `  ${p}`),
+            ];
+            if (responseText.trim()) {
+                lines.push("", responseText.trim());
+            }
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: lines.join("\n"),
+                }],
+            };
+        },
+    };
+}

--- a/extensions/image-gen/image-gen.ts
+++ b/extensions/image-gen/image-gen.ts
@@ -11,6 +11,8 @@ import { Type } from "typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { execFileSync, spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 const ASPECT_RATIOS = ["1:1", "3:4", "4:3", "9:16", "16:9"] as const;
 const IMAGE_TIMEOUT = 3 * 60 * 1000; // 3 minutes
@@ -95,6 +97,43 @@ function getTempDir(cwd: string): string {
     const dir = path.join("/tmp/pi-work", basename);
     fs.mkdirSync(dir, { recursive: true });
     return dir;
+}
+
+function getHttpdPath(): string {
+    // Resolve relative to this extension's location → ../../scripts/httpd.py
+    const thisDir = path.dirname(fileURLToPath(import.meta.url));
+    return path.resolve(thisDir, "..", "..", "scripts", "httpd.py");
+}
+
+function serveImage(imagePath: string): { url: string } | null {
+    // Only serve via HTTP in containers (where user can't access local files)
+    if (!process.env.PI_CONTAINER) return null;
+
+    const httpd = getHttpdPath();
+    if (!fs.existsSync(httpd)) return null;
+
+    try {
+        // Find a free port
+        const port = execFileSync("uv", ["run", "python3", httpd, "--find-port"], {
+            encoding: "utf-8",
+            timeout: 5000,
+        }).trim();
+
+        const dir = path.dirname(imagePath);
+        const filename = path.basename(imagePath);
+        const logFile = path.join("/tmp/pi-work", `httpd-${port}.log`);
+
+        // Launch server in background
+        const child = spawn("uv", ["run", "python3", httpd, "--port", port, "--dir", dir], {
+            detached: true,
+            stdio: ["ignore", fs.openSync(logFile, "a"), fs.openSync(logFile, "a")],
+        });
+        child.unref();
+
+        return { url: `http://localhost:${port}/${filename}` };
+    } catch {
+        return null;
+    }
 }
 
 export function createImageGenTool(): ToolDefinition {
@@ -251,8 +290,16 @@ export function createImageGenTool(): ToolDefinition {
             const lines = [
                 `Model: ${model}`,
                 `Generated ${savedPaths.length} image(s):`,
-                ...savedPaths.map(p => `  ${p}`),
             ];
+            for (const p of savedPaths) {
+                const served = serveImage(p);
+                if (served) {
+                    lines.push(`  ${p}`);
+                    lines.push(`  Preview: ${served.url}`);
+                } else {
+                    lines.push(`  ${p}`);
+                }
+            }
             if (responseText.trim()) {
                 lines.push("", responseText.trim());
             }

--- a/extensions/image-gen/image-gen.ts
+++ b/extensions/image-gen/image-gen.ts
@@ -105,9 +105,13 @@ function getHttpdPath(): string {
     return path.resolve(thisDir, "..", "..", "scripts", "httpd.py");
 }
 
-function serveImage(imagePath: string): { url: string } | null {
+function serveImage(imagePath: string): { url: string; port: string; dir: string } | null {
     // Only serve via HTTP in containers (where user can't access local files)
-    if (!process.env.PI_CONTAINER) return null;
+    // Use filesystem checks matching orchestrator's isRunningInContainer()
+    const inContainer = fs.existsSync("/.dockerenv") ||
+        fs.existsSync("/run/.containerenv") ||
+        (() => { try { return fs.readFileSync("/proc/1/cgroup", "utf-8").includes("docker") || fs.readFileSync("/proc/1/cgroup", "utf-8").includes("containerd"); } catch { return false; } })();
+    if (!inContainer) return null;
 
     const httpd = getHttpdPath();
     if (!fs.existsSync(httpd)) return null;
@@ -121,16 +125,18 @@ function serveImage(imagePath: string): { url: string } | null {
 
         const dir = path.dirname(imagePath);
         const filename = path.basename(imagePath);
-        const logFile = path.join("/tmp/pi-work", `httpd-${port}.log`);
+        const logFile = path.join(dir, `httpd-${port}.log`);
 
-        // Launch server in background
+        // Launch server in background — close FDs after spawn
+        const logFd = fs.openSync(logFile, "a");
         const child = spawn("uv", ["run", "python3", httpd, "--port", port, "--dir", dir], {
             detached: true,
-            stdio: ["ignore", fs.openSync(logFile, "a"), fs.openSync(logFile, "a")],
+            stdio: ["ignore", logFd, logFd],
         });
         child.unref();
+        fs.closeSync(logFd);
 
-        return { url: `http://localhost:${port}/${filename}` };
+        return { url: `http://localhost:${port}/${filename}`, port, dir };
     } catch {
         return null;
     }
@@ -282,9 +288,21 @@ export function createImageGenTool(): ToolDefinition {
                 const ext = getExtensionForMime(image.mimeType);
                 const filename = `pi-image-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
                 const filepath = path.join(tempDir, filename);
-                const buffer = Buffer.from(image.data, "base64");
-                fs.writeFileSync(filepath, buffer);
-                savedPaths.push(filepath);
+                try {
+                    const buffer = Buffer.from(image.data, "base64");
+                    if (buffer.length === 0) continue; // Skip empty/malformed data
+                    fs.writeFileSync(filepath, buffer);
+                    savedPaths.push(filepath);
+                } catch (err: any) {
+                    // Skip corrupted image data — log but don't crash
+                    console.debug(`[image-gen] Failed to decode/save image: ${err?.message?.slice(0, 100)}`);
+                }
+            }
+
+            // Start a single preview server for all images (container only)
+            let previewServer: { url: string; port: string; dir: string } | null = null;
+            if (savedPaths.length > 0) {
+                previewServer = serveImage(savedPaths[0]);
             }
 
             const lines = [
@@ -292,12 +310,10 @@ export function createImageGenTool(): ToolDefinition {
                 `Generated ${savedPaths.length} image(s):`,
             ];
             for (const p of savedPaths) {
-                const served = serveImage(p);
-                if (served) {
-                    lines.push(`  ${p}`);
-                    lines.push(`  Preview: ${served.url}`);
-                } else {
-                    lines.push(`  ${p}`);
+                lines.push(`  ${p}`);
+                if (previewServer) {
+                    const filename = path.basename(p);
+                    lines.push(`  Preview: http://localhost:${previewServer.port}/${filename}`);
                 }
             }
             if (responseText.trim()) {

--- a/extensions/image-gen/index.ts
+++ b/extensions/image-gen/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Image Generation Extension for pi
+ *
+ * Registers a `generate_image` tool that generates images via Gemini API.
+ * Requires PI_IMAGE_MODEL and GEMINI_API_KEY/GOOGLE_API_KEY environment variables.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { createImageGenTool } from "./image-gen.js";
+
+export default function (pi: ExtensionAPI) {
+    pi.registerTool(createImageGenTool());
+}


### PR DESCRIPTION
## Summary

Standalone extension that registers a `generate_image` tool. Generates images via Gemini API from structured parameters.

## Usage

Set env vars:
- `PI_IMAGE_MODEL` — e.g., `gemini-3-pro-image` (no default, required)
- `GEMINI_API_KEY` or `GOOGLE_API_KEY` (required)

Then ask naturally: "generate an image of a cat in space"

## Tool Parameters

- `subject` (required) — main subject
- `action`, `scene`, `composition`, `lighting`, `style`, `text` (optional)
- `aspect_ratio` — 1:1, 3:4, 4:3, 9:16, 16:9

## Files

| File | Description |
|------|-------------|
| `extensions/image-gen/index.ts` | Extension entry — registers the tool |
| `extensions/image-gen/image-gen.ts` | Gemini API call, prompt assembly, image save |
| `AGENTS.md` | Updated structure |

## Tested

Generated images successfully with `gemini-3-pro-image`.

Fixes #407