### PR TITLE
feat: add /review-handler status — query reviews DB, TUI table, dark HTML report — fixes #415

### DIFF
--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -314,6 +314,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
 
     "review-handler": (prefix: string) => {
       return filter([
+        { value: "status", label: "status", description: "Show all review comments from DB for current PR" },
         { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
         { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
       ], prefix);

--- a/myk_pi_tools/reviews/commands.py
+++ b/myk_pi_tools/reviews/commands.py
@@ -106,7 +106,8 @@ def reviews_pending_update(json_path: str, submit: bool) -> None:  # noqa: FBT00
 
 
 @reviews.command("status")
-def reviews_status() -> None:
+@click.option("--pr", type=int, default=None, help="PR number (default: auto-detect from current branch)")
+def reviews_status(pr: int | None) -> None:
     """Show review status for current PR.
 
     Queries the reviews database and displays all comments across all
@@ -114,7 +115,7 @@ def reviews_status() -> None:
     """
     from myk_pi_tools.reviews.status import run
 
-    run()
+    run(pr_number=pr)
 
 
 @reviews.command("store")

--- a/myk_pi_tools/reviews/commands.py
+++ b/myk_pi_tools/reviews/commands.py
@@ -105,6 +105,18 @@ def reviews_pending_update(json_path: str, submit: bool) -> None:  # noqa: FBT00
     sys.exit(exit_code)
 
 
+@reviews.command("status")
+def reviews_status() -> None:
+    """Show review status for current PR.
+
+    Queries the reviews database and displays all comments across all
+    review cycles. Outputs a TUI table and generates an HTML report.
+    """
+    from myk_pi_tools.reviews.status import run
+
+    run()
+
+
 @reviews.command("store")
 @click.argument("json_path")
 def reviews_store(json_path: str) -> None:

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 from html import escape
 from pathlib import Path
+from urllib.parse import quote
 
 
 def log(message: str) -> None:
@@ -239,9 +240,13 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
 
     owner = pr_info.get("owner", "")
     repo = pr_info.get("repo", "")
-    pr_url = f"https://github.com/{owner}/{repo}/pull/{pr_info['number']}" if owner and repo else ""
+    pr_url = (
+        f"https://github.com/{quote(owner, safe='')}/{quote(repo, safe='')}/pull/{pr_info['number']}"
+        if owner and repo
+        else ""
+    )
     pr_link = (
-        f'<a href="{pr_url}" target="_blank" rel="noopener noreferrer"'
+        f'<a href="{escape(pr_url)}" target="_blank" rel="noopener noreferrer"'
         f' style="color: #58a6ff; text-decoration: none;">PR #{pr_info["number"]}</a>'
         if pr_url
         else f"PR #{pr_info['number']}"

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -430,11 +430,11 @@ def run(pr_number: int | None = None) -> None:
                     timeout=5,
                 )
                 if port_result.returncode != 0 or not port_result.stdout.strip():
-                    print(f"\nHTML report saved: {html_path}")
+                    print(f"\nHTML report saved: {html_path} — open in browser to view")
                     return
                 port = port_result.stdout.strip()
                 if not port.isdigit():
-                    print(f"\nHTML report saved: {html_path}")
+                    print(f"\nHTML report saved: {html_path} — open in browser to view")
                     return
                 subprocess.Popen(
                     ["uv", "run", "python3", str(httpd), "--port", port, "--dir", str(html_path.parent)],
@@ -444,12 +444,12 @@ def run(pr_number: int | None = None) -> None:
                 )
                 print(f"\nHTML report: http://localhost:{port}/{html_path.name}")
             except Exception as e:
-                print(f"\nHTML report saved: {html_path}")
+                print(f"\nHTML report saved: {html_path} — open in browser to view")
                 log(f"Warning: Could not start HTTP server: {e}")
         else:
-            print(f"\nHTML report saved: {html_path}")
+            print(f"\nHTML report saved: {html_path} — open in browser to view")
     else:
-        print(f"\nHTML report saved: {html_path}")
+        print(f"\nHTML report saved: {html_path} — open in browser to view")
 
 
 if __name__ == "__main__":

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -165,8 +165,9 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
         "Source": 10,
         "File": 25,
         "Line": 5,
-        "Summary": 45,
+        "Summary": 40,
         "Status": 12,
+        "Reply": 40,
     }
 
     def pad(text: str, width: int) -> str:
@@ -182,7 +183,8 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
         f"{'File':<{col_widths['File']}} "
         f"{'Line':<{col_widths['Line']}} "
         f"{'Summary':<{col_widths['Summary']}} "
-        f"{'Status':<{col_widths['Status']}}"
+        f"{'Status':<{col_widths['Status']}} "
+        f"{'Reply':<{col_widths['Reply']}}"
     )
     separator = "  " + "─" * (sum(col_widths.values()) + len(col_widths) - 1)
 
@@ -196,13 +198,15 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
         file_name = (c.get("path") or "").split("/")[-1]
         line_num = str(c.get("line") or "")
 
+        reply = (c.get("reply") or c.get("skip_reason") or "")[: col_widths["Reply"]]
         row = (
             f"  {pad(str(i), col_widths['#'])} "
             f"{pad(c['source'], col_widths['Source'])} "
             f"{pad(file_name, col_widths['File'])} "
             f"{pad(line_num, col_widths['Line'])} "
             f"{pad(summary, col_widths['Summary'])} "
-            f"{pad(status, col_widths['Status'])}"
+            f"{pad(status, col_widths['Status'])} "
+            f"{pad(reply, col_widths['Reply'])}"
         )
         lines.append(row)
 
@@ -232,6 +236,8 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
         "not_addressed": "#f85149",
         "pending": "#8b949e",
     }
+
+    pr_url = f"https://github.com/{pr_info.get('owner', '')}/{pr_info.get('repo', '')}/pull/{pr_info['number']}"
 
     rows_html = ""
     for i, c in enumerate(comments, 1):
@@ -281,11 +287,9 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
     </style>
 </head>
 <body>
-    <h1><a href="https://github.com/
-{pr_info.get("owner", "")}/{pr_info.get("repo", "")}
-/pull/{pr_info["number"]}" target="_blank"
-        style="color: #58a6ff; text-decoration: none;">
-        PR #{pr_info["number"]}</a>
+    <h1><a href="{pr_url}" target="_blank"
+        style="color: #58a6ff; text-decoration: none;"
+        >PR #{pr_info["number"]}</a>
         — {escape(pr_info["title"])}</h1>
     <h2>{escape(pr_info["branch"])}</h2>
     <table>
@@ -403,7 +407,6 @@ def run(pr_number: int | None = None) -> None:
     pr_info["owner"] = owner
     pr_info["repo"] = repo
     comments = query_comments(db_path, pr_num)
-    comments = deduplicate_comments(comments)
 
     # TUI output
     print(format_tui_table(comments, pr_info))
@@ -426,7 +429,13 @@ def run(pr_number: int | None = None) -> None:
                     text=True,
                     timeout=5,
                 )
+                if port_result.returncode != 0 or not port_result.stdout.strip():
+                    print(f"\nHTML report saved: {html_path}")
+                    return
                 port = port_result.stdout.strip()
+                if not port.isdigit():
+                    print(f"\nHTML report saved: {html_path}")
+                    return
                 subprocess.Popen(
                     ["uv", "run", "python3", str(httpd), "--port", port, "--dir", str(html_path.parent)],
                     stdout=subprocess.DEVNULL,

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -2,7 +2,7 @@
 
 Outputs:
 1. TUI table to stdout
-2. HTML file saved to /tmp/pi-work/<project>/review-status.html
+2. HTML file saved to /tmp/pi-work/<project>/review-status-<pr>.html
 """
 
 import json
@@ -99,24 +99,44 @@ def query_comments(db_path: Path, pr_number: int) -> list[dict]:
         conn.close()
 
 
+def get_pr_repo_info(db_path: Path, pr_number: int) -> tuple[str, str]:
+    """Get owner/repo for a PR from the reviews DB."""
+    if not db_path.exists():
+        return ("", "")
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT owner, repo FROM reviews WHERE pr_number = ? LIMIT 1",
+            (pr_number,),
+        ).fetchone()
+        return (row[0], row[1]) if row else ("", "")
+    except sqlite3.Error:
+        return ("", "")
+    finally:
+        conn.close()
+
+
 def extract_summary(body: str, max_len: int = 60) -> str:
     """Extract a short summary from the comment body."""
     if not body:
         return ""
-    # Try to get the first meaningful line (skip HTML tags, empty lines)
-    for line in body.split("\n"):
+    # Strip ALL HTML tags from entire body first
+    cleaned_body = re.sub(r"<[^>]+>", "", body)
+    # Try to get the first meaningful line
+    for line in cleaned_body.split("\n"):
         line = line.strip()
-        if not line or line.startswith("<") or line.startswith("#"):
+        if not line or line.startswith("#"):
             continue
-        # Strip HTML tags and markdown bold/italic
-        line = re.sub(r"<[^>]+>", "", line)
+        # Strip markdown bold/italic/code
         clean = line.replace("**", "").replace("*", "").replace("`", "")
         # Strip leading numbering like "1\." or "2."
         if clean and clean[0].isdigit() and "." in clean[:4]:
             clean = clean.split(".", 1)[1].strip()
+        # Strip escaped backslashes from markdown
+        clean = clean.replace("\\", "")
         if clean:
             return clean[:max_len] + ("..." if len(clean) > max_len else "")
-    return body[:max_len].replace("\n", " ") + ("..." if len(body) > max_len else "")
+    return cleaned_body[:max_len].replace("\n", " ").strip() + ("..." if len(cleaned_body) > max_len else "")
 
 
 def deduplicate_comments(comments: list[dict]) -> list[dict]:
@@ -131,7 +151,7 @@ def deduplicate_comments(comments: list[dict]) -> list[dict]:
 
 
 def format_tui_table(comments: list[dict], pr_info: dict) -> str:
-    """Format comments as a TUI table."""
+    """Format comments as a clean TUI table."""
     lines = [f"PR #{pr_info['number']} ({pr_info['branch']}) — {pr_info['title']}"]
     lines.append("")
 
@@ -139,54 +159,61 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
         lines.append("No review comments stored.")
         return "\n".join(lines)
 
-    # Build table
-    headers = ["#", "Source", "File", "Line", "Summary", "Status", "Reply"]
-    rows = []
+    # Fixed column widths for clean alignment
+    col_widths = {
+        "#": 4,
+        "Source": 10,
+        "File": 25,
+        "Line": 5,
+        "Summary": 45,
+        "Status": 12,
+    }
+
+    def pad(text: str, width: int) -> str:
+        """Pad/truncate text to exact width."""
+        if len(text) > width:
+            return text[: width - 1] + "…"
+        return text.ljust(width)
+
+    # Header
+    header = (
+        f"  {'#':<{col_widths['#']}} "
+        f"{'Source':<{col_widths['Source']}} "
+        f"{'File':<{col_widths['File']}} "
+        f"{'Line':<{col_widths['Line']}} "
+        f"{'Summary':<{col_widths['Summary']}} "
+        f"{'Status':<{col_widths['Status']}}"
+    )
+    separator = "  " + "─" * (sum(col_widths.values()) + len(col_widths) - 1)
+
+    lines.append(header)
+    lines.append(separator)
+
+    # Rows
     for i, c in enumerate(comments, 1):
-        summary = extract_summary(c["body"])
-        reply = (c.get("reply") or c.get("skip_reason") or "")[:50]
-        if reply and len(c.get("reply") or c.get("skip_reason") or "") > 50:
-            reply += "..."
-        rows.append([
-            str(i),
-            c["source"],
-            (c.get("path") or "").split("/")[-1],  # basename only
-            str(c.get("line") or ""),
-            summary,
-            c.get("status") or "pending",
-            reply,
-        ])
+        summary = extract_summary(c["body"], col_widths["Summary"])
+        status = c.get("status") or "pending"
+        file_name = (c.get("path") or "").split("/")[-1]
+        line_num = str(c.get("line") or "")
 
-    # Calculate column widths
-    widths = [len(h) for h in headers]
-    for row in rows:
-        for j, cell in enumerate(row):
-            widths[j] = max(widths[j], len(cell))
-
-    # Cap widths
-    widths[4] = min(widths[4], 50)  # Summary
-    widths[6] = min(widths[6], 50)  # Reply
-
-    def fmt_row(cells: list[str]) -> str:
-        parts = []
-        for j, cell in enumerate(cells):
-            w = widths[j]
-            parts.append(cell[:w].ljust(w))
-        return "| " + " | ".join(parts) + " |"
-
-    lines.append(fmt_row(headers))
-    lines.append("|" + "|".join("-" * (w + 2) for w in widths) + "|")
-    for row in rows:
-        lines.append(fmt_row(row))
+        row = (
+            f"  {pad(str(i), col_widths['#'])} "
+            f"{pad(c['source'], col_widths['Source'])} "
+            f"{pad(file_name, col_widths['File'])} "
+            f"{pad(line_num, col_widths['Line'])} "
+            f"{pad(summary, col_widths['Summary'])} "
+            f"{pad(status, col_widths['Status'])}"
+        )
+        lines.append(row)
 
     # Summary counts
-    lines.append("")
+    lines.append(separator)
     status_counts: dict[str, int] = {}
     for c in comments:
         s = c.get("status") or "pending"
         status_counts[s] = status_counts.get(s, 0) + 1
     parts = [f"{v} {k}" for k, v in sorted(status_counts.items())]
-    lines.append(f"Total: {len(comments)} comments — {', '.join(parts)}")
+    lines.append(f"  Total: {len(comments)} — {', '.join(parts)}")
 
     return "\n".join(lines)
 
@@ -194,10 +221,16 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
 def generate_html(comments: list[dict], pr_info: dict) -> str:
     """Generate HTML report with styled table."""
     status_colors = {
-        "addressed": "#d4edda",
-        "skipped": "#fff3cd",
-        "not_addressed": "#f8d7da",
-        "pending": "#e2e3e5",
+        "addressed": "#1a3a2a",
+        "skipped": "#3a3520",
+        "not_addressed": "#3a1a1a",
+        "pending": "#2a2a2a",
+    }
+    status_text_colors = {
+        "addressed": "#3fb950",
+        "skipped": "#d29922",
+        "not_addressed": "#f85149",
+        "pending": "#8b949e",
     }
 
     rows_html = ""
@@ -214,7 +247,9 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
             <td title="{path}">{escape(path.split("/")[-1])}</td>
             <td>{c.get("line") or ""}</td>
             <td>{summary}</td>
-            <td style="background-color: {bg}; font-weight: bold;">{escape(status)}</td>
+            <td style="background-color: {bg}; font-weight: bold;
+                color: {status_text_colors.get(status, "#c9d1d9")};">
+                {escape(status)}</td>
             <td>{reply}</td>
         </tr>"""
 
@@ -231,20 +266,27 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Review Status — PR #{pr_info["number"]}</title>
     <style>
-        body {{ font-family: -apple-system, BlinkMacSystemFont,
-            'Segoe UI', Roboto, sans-serif; margin: 2rem;
-            background: #f8f9fa; color: #212529; }}
-        h1 {{ font-size: 1.5rem; margin-bottom: 0.25rem; }}
-        h2 {{ font-size: 1rem; color: #6c757d; font-weight: normal; margin-top: 0; }}
-        table {{ border-collapse: collapse; width: 100%; background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }}
-        th, td {{ padding: 8px 12px; text-align: left; border: 1px solid #dee2e6; font-size: 0.875rem; }}
-        th {{ background: #343a40; color: white; font-weight: 600; }}
-        tr:hover {{ background: #f1f3f5; }}
-        .summary {{ margin-top: 1rem; color: #6c757d; }}
+        body {{ font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 2rem; background: #0d1117; color: #c9d1d9; }}
+        h1 {{ font-size: 1.5rem; margin-bottom: 0.25rem; color: #f0f6fc; }}
+        h2 {{ font-size: 1rem; color: #8b949e; font-weight: normal; margin-top: 0; }}
+        table {{ border-collapse: collapse; width: 100%; background: #161b22;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.5); border-radius: 6px; overflow: hidden; }}
+        th, td {{ padding: 10px 14px; text-align: left; border: 1px solid #30363d;
+            font-size: 0.875rem; }}
+        th {{ background: #21262d; color: #f0f6fc; font-weight: 600; }}
+        tr:nth-child(even) {{ background: #1c2128; }}
+        tr:hover {{ background: #272d36; }}
+        .summary {{ margin-top: 1rem; color: #8b949e; }}
     </style>
 </head>
 <body>
-    <h1>PR #{pr_info["number"]} — {escape(pr_info["title"])}</h1>
+    <h1><a href="https://github.com/
+{pr_info.get("owner", "")}/{pr_info.get("repo", "")}
+/pull/{pr_info["number"]}" target="_blank"
+        style="color: #58a6ff; text-decoration: none;">
+        PR #{pr_info["number"]}</a>
+        — {escape(pr_info["title"])}</h1>
     <h2>{escape(pr_info["branch"])}</h2>
     <table>
         <thead>
@@ -267,16 +309,61 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
 </html>"""
 
 
-def save_html(html: str, project_name: str) -> Path:
+def save_html(html: str, project_name: str, pr_number: int) -> Path:
     """Save HTML to temp directory and return path."""
     tmp_dir = Path("/tmp/pi-work") / project_name
     tmp_dir.mkdir(parents=True, exist_ok=True)
-    html_path = tmp_dir / "review-status.html"
+    html_path = tmp_dir / f"review-status-{pr_number}.html"
     html_path.write_text(html, encoding="utf-8")
     return html_path
 
 
-def run() -> None:
+def list_prs_from_db(db_path: Path) -> None:
+    """List all PRs that have reviews stored in the database."""
+    if not db_path.exists():
+        print("No reviews database found.")
+        return
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.execute(
+            """
+            SELECT r.pr_number,
+                   COUNT(c.id) as total,
+                   SUM(CASE WHEN c.status = 'addressed' THEN 1 ELSE 0 END) as addressed,
+                   SUM(CASE WHEN c.status = 'skipped' THEN 1 ELSE 0 END) as skipped,
+                   SUM(CASE WHEN c.status = 'pending' THEN 1 ELSE 0 END) as pending,
+                   MIN(r.created_at) as first_review,
+                   MAX(r.created_at) as last_review
+            FROM reviews r
+            JOIN comments c ON c.review_id = r.id
+            GROUP BY r.pr_number
+            ORDER BY r.pr_number DESC
+            """,
+        )
+        rows = cursor.fetchall()
+    except sqlite3.Error as e:
+        print(f"Database error: {e}")
+        return
+    finally:
+        conn.close()
+
+    if not rows:
+        print("No reviews stored in the database.")
+        return
+
+    print("Available PRs in reviews database:\n")
+    print(f"  {'PR':<8} {'Total':<8} {'Addressed':<11} {'Skipped':<9} {'Pending':<9} {'Last Review'}")
+    print(f"  {'─' * 70}")
+    for row in rows:
+        pr, total, addressed, skipped, pending, _first, last = row
+        last_short = (last or "")[:10]
+        print(f"  #{pr:<7} {total:<8} {addressed:<11} {skipped:<9} {pending:<9} {last_short}")
+
+    print("\nUse: myk-pi-tools reviews status --pr <number>")
+
+
+def run(pr_number: int | None = None) -> None:
     """Main entry point for reviews status command."""
     project_root = get_project_root()
     project_name = project_root.name
@@ -286,12 +373,36 @@ def run() -> None:
         print("No reviews database found. Run /review-handler first.")
         sys.exit(0)
 
-    pr_info = get_current_pr()
-    if not pr_info or not pr_info.get("number"):
-        log("Error: Could not detect current PR. Check out a branch with an open PR.")
-        sys.exit(1)
+    if pr_number:
+        # Explicit PR number — build minimal pr_info
+        pr_info = {"number": pr_number, "title": f"PR #{pr_number}", "branch": ""}
+        # Try to get title from gh CLI
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "view", str(pr_number), "--json", "title,headRefName"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                data = json.loads(result.stdout)
+                pr_info["title"] = data.get("title", pr_info["title"])
+                pr_info["branch"] = data.get("headRefName", "")
+        except Exception:
+            pass  # Keep minimal info
+    else:
+        detected = get_current_pr()
+        if not detected or not detected.get("number"):
+            # List all PRs in the DB
+            list_prs_from_db(db_path)
+            sys.exit(0)
+        pr_info = detected
 
-    comments = query_comments(db_path, pr_info["number"])
+    pr_num = int(str(pr_info["number"]))
+    owner, repo = get_pr_repo_info(db_path, pr_num)
+    pr_info["owner"] = owner
+    pr_info["repo"] = repo
+    comments = query_comments(db_path, pr_num)
     comments = deduplicate_comments(comments)
 
     # TUI output
@@ -299,7 +410,7 @@ def run() -> None:
 
     # HTML output
     html = generate_html(comments, pr_info)
-    html_path = save_html(html, project_name)
+    html_path = save_html(html, project_name, pr_num)
 
     # Check if in container
     in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
@@ -322,7 +433,7 @@ def run() -> None:
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,
                 )
-                print(f"\nHTML report: http://localhost:{port}/review-status.html")
+                print(f"\nHTML report: http://localhost:{port}/{html_path.name}")
             except Exception as e:
                 print(f"\nHTML report saved: {html_path}")
                 log(f"Warning: Could not start HTTP server: {e}")

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -156,7 +156,7 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
     lines.append("")
 
     if not comments:
-        lines.append("No review comments stored.")
+        lines.append("No review comments found for this PR.")
         return "\n".join(lines)
 
     # Fixed column widths for clean alignment
@@ -166,7 +166,7 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
         "File": 25,
         "Line": 5,
         "Summary": 40,
-        "Status": 12,
+        "Status": 15,
         "Reply": 40,
     }
 
@@ -237,7 +237,15 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
         "pending": "#8b949e",
     }
 
-    pr_url = f"https://github.com/{pr_info.get('owner', '')}/{pr_info.get('repo', '')}/pull/{pr_info['number']}"
+    owner = pr_info.get("owner", "")
+    repo = pr_info.get("repo", "")
+    pr_url = f"https://github.com/{owner}/{repo}/pull/{pr_info['number']}" if owner and repo else ""
+    pr_link = (
+        f'<a href="{pr_url}" target="_blank" rel="noopener noreferrer"'
+        f' style="color: #58a6ff; text-decoration: none;">PR #{pr_info["number"]}</a>'
+        if pr_url
+        else f"PR #{pr_info['number']}"
+    )
 
     rows_html = ""
     for i, c in enumerate(comments, 1):
@@ -287,10 +295,7 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
     </style>
 </head>
 <body>
-    <h1><a href="{pr_url}" target="_blank"
-        style="color: #58a6ff; text-decoration: none;"
-        >PR #{pr_info["number"]}</a>
-        — {escape(pr_info["title"])}</h1>
+    <h1>{pr_link} — {escape(pr_info["title"])}</h1>
     <h2>{escape(pr_info["branch"])}</h2>
     <table>
         <thead>

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -1,0 +1,336 @@
+"""Review handler status — query reviews DB and display all comments for current PR.
+
+Outputs:
+1. TUI table to stdout
+2. HTML file saved to /tmp/pi-work/<project>/review-status.html
+"""
+
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from html import escape
+from pathlib import Path
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def get_project_root() -> Path:
+    """Get main project root (resolves through git worktrees)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            log(f"Error: git rev-parse failed: {result.stderr.strip()}")
+            sys.exit(1)
+        git_common = Path(result.stdout.strip()).resolve()
+        return git_common.parent
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        log(f"Error: {e}")
+        sys.exit(1)
+
+
+def get_current_pr() -> dict | None:
+    """Get current PR number and branch from git + gh CLI."""
+    try:
+        branch = subprocess.run(
+            ["git", "branch", "--show-current"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if branch.returncode != 0:
+            return None
+        branch_name = branch.stdout.strip()
+        if not branch_name or branch_name == "main":
+            return None
+
+        pr_info = subprocess.run(
+            ["gh", "pr", "view", "--json", "number,title,headRefName"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if pr_info.returncode != 0:
+            return None
+        data = json.loads(pr_info.stdout)
+        return {
+            "number": data.get("number"),
+            "title": data.get("title", ""),
+            "branch": data.get("headRefName", branch_name),
+        }
+    except Exception:
+        return None
+
+
+def query_comments(db_path: Path, pr_number: int) -> list[dict]:
+    """Query all comments for a PR from the reviews DB."""
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.execute(
+            """
+            SELECT c.source, c.path, c.line, c.body, c.status, c.reply,
+                   c.priority, c.skip_reason, c.type, c.quality_label,
+                   r.commit_sha, r.created_at
+            FROM comments c
+            JOIN reviews r ON c.review_id = r.id
+            WHERE r.pr_number = ?
+            ORDER BY r.created_at ASC, c.id ASC
+            """,
+            (pr_number,),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+    except sqlite3.Error as e:
+        log(f"Database error: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def extract_summary(body: str, max_len: int = 60) -> str:
+    """Extract a short summary from the comment body."""
+    if not body:
+        return ""
+    # Try to get the first meaningful line (skip HTML tags, empty lines)
+    for line in body.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("<") or line.startswith("#"):
+            continue
+        # Strip HTML tags and markdown bold/italic
+        line = re.sub(r"<[^>]+>", "", line)
+        clean = line.replace("**", "").replace("*", "").replace("`", "")
+        # Strip leading numbering like "1\." or "2."
+        if clean and clean[0].isdigit() and "." in clean[:4]:
+            clean = clean.split(".", 1)[1].strip()
+        if clean:
+            return clean[:max_len] + ("..." if len(clean) > max_len else "")
+    return body[:max_len].replace("\n", " ") + ("..." if len(body) > max_len else "")
+
+
+def deduplicate_comments(comments: list[dict]) -> list[dict]:
+    """Deduplicate comments — keep latest status for same path+line+source+summary."""
+    seen: dict[str, dict] = {}
+    for c in comments:
+        # Normalize summary for dedup: strip HTML, lowercase, first 30 chars
+        raw = re.sub(r"<[^>]+>", "", extract_summary(c["body"], 50)).lower().strip()
+        key = f"{c['source']}:{c['path']}:{c['line']}:{raw[:30]}"
+        seen[key] = c  # Last one wins (latest cycle)
+    return list(seen.values())
+
+
+def format_tui_table(comments: list[dict], pr_info: dict) -> str:
+    """Format comments as a TUI table."""
+    lines = [f"PR #{pr_info['number']} ({pr_info['branch']}) — {pr_info['title']}"]
+    lines.append("")
+
+    if not comments:
+        lines.append("No review comments stored.")
+        return "\n".join(lines)
+
+    # Build table
+    headers = ["#", "Source", "File", "Line", "Summary", "Status", "Reply"]
+    rows = []
+    for i, c in enumerate(comments, 1):
+        summary = extract_summary(c["body"])
+        reply = (c.get("reply") or c.get("skip_reason") or "")[:50]
+        if reply and len(c.get("reply") or c.get("skip_reason") or "") > 50:
+            reply += "..."
+        rows.append([
+            str(i),
+            c["source"],
+            (c.get("path") or "").split("/")[-1],  # basename only
+            str(c.get("line") or ""),
+            summary,
+            c.get("status") or "pending",
+            reply,
+        ])
+
+    # Calculate column widths
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for j, cell in enumerate(row):
+            widths[j] = max(widths[j], len(cell))
+
+    # Cap widths
+    widths[4] = min(widths[4], 50)  # Summary
+    widths[6] = min(widths[6], 50)  # Reply
+
+    def fmt_row(cells: list[str]) -> str:
+        parts = []
+        for j, cell in enumerate(cells):
+            w = widths[j]
+            parts.append(cell[:w].ljust(w))
+        return "| " + " | ".join(parts) + " |"
+
+    lines.append(fmt_row(headers))
+    lines.append("|" + "|".join("-" * (w + 2) for w in widths) + "|")
+    for row in rows:
+        lines.append(fmt_row(row))
+
+    # Summary counts
+    lines.append("")
+    status_counts: dict[str, int] = {}
+    for c in comments:
+        s = c.get("status") or "pending"
+        status_counts[s] = status_counts.get(s, 0) + 1
+    parts = [f"{v} {k}" for k, v in sorted(status_counts.items())]
+    lines.append(f"Total: {len(comments)} comments — {', '.join(parts)}")
+
+    return "\n".join(lines)
+
+
+def generate_html(comments: list[dict], pr_info: dict) -> str:
+    """Generate HTML report with styled table."""
+    status_colors = {
+        "addressed": "#d4edda",
+        "skipped": "#fff3cd",
+        "not_addressed": "#f8d7da",
+        "pending": "#e2e3e5",
+    }
+
+    rows_html = ""
+    for i, c in enumerate(comments, 1):
+        summary = escape(extract_summary(c["body"], 80))
+        reply = escape((c.get("reply") or c.get("skip_reason") or "")[:100])
+        status = c.get("status") or "pending"
+        bg = status_colors.get(status, "#e2e3e5")
+        path = escape(c.get("path") or "")
+        rows_html += f"""
+        <tr>
+            <td>{i}</td>
+            <td>{escape(c["source"])}</td>
+            <td title="{path}">{escape(path.split("/")[-1])}</td>
+            <td>{c.get("line") or ""}</td>
+            <td>{summary}</td>
+            <td style="background-color: {bg}; font-weight: bold;">{escape(status)}</td>
+            <td>{reply}</td>
+        </tr>"""
+
+    status_counts: dict[str, int] = {}
+    for c in comments:
+        s = c.get("status") or "pending"
+        status_counts[s] = status_counts.get(s, 0) + 1
+    summary_parts = [f"{v} {k}" for k, v in sorted(status_counts.items())]
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Review Status — PR #{pr_info["number"]}</title>
+    <style>
+        body {{ font-family: -apple-system, BlinkMacSystemFont,
+            'Segoe UI', Roboto, sans-serif; margin: 2rem;
+            background: #f8f9fa; color: #212529; }}
+        h1 {{ font-size: 1.5rem; margin-bottom: 0.25rem; }}
+        h2 {{ font-size: 1rem; color: #6c757d; font-weight: normal; margin-top: 0; }}
+        table {{ border-collapse: collapse; width: 100%; background: white; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }}
+        th, td {{ padding: 8px 12px; text-align: left; border: 1px solid #dee2e6; font-size: 0.875rem; }}
+        th {{ background: #343a40; color: white; font-weight: 600; }}
+        tr:hover {{ background: #f1f3f5; }}
+        .summary {{ margin-top: 1rem; color: #6c757d; }}
+    </style>
+</head>
+<body>
+    <h1>PR #{pr_info["number"]} — {escape(pr_info["title"])}</h1>
+    <h2>{escape(pr_info["branch"])}</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>#</th>
+                <th>Source</th>
+                <th>File</th>
+                <th>Line</th>
+                <th>Summary</th>
+                <th>Status</th>
+                <th>Reply</th>
+            </tr>
+        </thead>
+        <tbody>
+            {rows_html}
+        </tbody>
+    </table>
+    <p class="summary">Total: {len(comments)} comments — {", ".join(summary_parts)}</p>
+</body>
+</html>"""
+
+
+def save_html(html: str, project_name: str) -> Path:
+    """Save HTML to temp directory and return path."""
+    tmp_dir = Path("/tmp/pi-work") / project_name
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    html_path = tmp_dir / "review-status.html"
+    html_path.write_text(html, encoding="utf-8")
+    return html_path
+
+
+def run() -> None:
+    """Main entry point for reviews status command."""
+    project_root = get_project_root()
+    project_name = project_root.name
+    db_path = project_root / ".pi" / "data" / "reviews.db"
+
+    if not db_path.exists():
+        print("No reviews database found. Run /review-handler first.")
+        sys.exit(0)
+
+    pr_info = get_current_pr()
+    if not pr_info or not pr_info.get("number"):
+        log("Error: Could not detect current PR. Check out a branch with an open PR.")
+        sys.exit(1)
+
+    comments = query_comments(db_path, pr_info["number"])
+    comments = deduplicate_comments(comments)
+
+    # TUI output
+    print(format_tui_table(comments, pr_info))
+
+    # HTML output
+    html = generate_html(comments, pr_info)
+    html_path = save_html(html, project_name)
+
+    # Check if in container
+    in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
+
+    if in_container:
+        # Serve via httpd
+        httpd = project_root / "scripts" / "httpd.py"
+        if httpd.exists():
+            try:
+                port_result = subprocess.run(
+                    ["uv", "run", "python3", str(httpd), "--find-port"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+                port = port_result.stdout.strip()
+                subprocess.Popen(
+                    ["uv", "run", "python3", str(httpd), "--port", port, "--dir", str(html_path.parent)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    start_new_session=True,
+                )
+                print(f"\nHTML report: http://localhost:{port}/review-status.html")
+            except Exception as e:
+                print(f"\nHTML report saved: {html_path}")
+                log(f"Warning: Could not start HTTP server: {e}")
+        else:
+            print(f"\nHTML report saved: {html_path}")
+    else:
+        print(f"\nHTML report saved: {html_path}")
+
+
+if __name__ == "__main__":
+    run()

--- a/myk_pi_tools/reviews/store.py
+++ b/myk_pi_tools/reviews/store.py
@@ -60,10 +60,15 @@ def log(message: str) -> None:
 
 
 def get_project_root() -> Path:
-    """Detect project root using git rev-parse --show-toplevel."""
+    """Detect main project root (resolves through git worktrees).
+
+    Uses git-common-dir to always return the main repo root,
+    not the worktree root. This ensures .pi/data/reviews.db
+    is shared across all worktrees.
+    """
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "--show-toplevel"],
+            ["git", "rev-parse", "--git-common-dir"],
             capture_output=True,
             text=True,
             timeout=5,
@@ -71,7 +76,8 @@ def get_project_root() -> Path:
         if result.returncode != 0:
             log(f"Error: git rev-parse failed: {result.stderr.strip()}")
             sys.exit(1)
-        return Path(result.stdout.strip())
+        git_common = Path(result.stdout.strip()).resolve()
+        return git_common.parent
     except subprocess.TimeoutExpired:
         log("Error: git command timed out")
         sys.exit(1)

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -159,8 +159,16 @@ Returns JSON with:
 >       update the GitHub issue to match the actual design. Use `gh issue edit` to fix the spec.
 >       Then reply to Qodo referencing the updated spec.
 >
->    **There is no third option. "Already addressed", "by design", "not applicable" are FORBIDDEN.**
->    **Posting the same reply multiple times without a code fix or spec update is a HARD VIOLATION.**
+>    **Bare assertions without proof are FORBIDDEN:**
+>    - ❌ "Already addressed" (without citing commit SHA or diff link)
+>    - ❌ "By design" (without citing updated issue spec)
+>    - ❌ "Not applicable" (without explaining why AND updating spec if needed)
+>  
+>    **WITH proof, these are allowed:**
+>    - ✅ "Already addressed in commit abc123 — see diff" (links to specific change)
+>    - ✅ "By design per updated issue #N spec" (issue was actually updated)
+>  
+>    **Posting the same reply multiple times without a NEW code fix or spec update is a HARD VIOLATION.**
 >
 >    **If a Qodo sticky comment keeps re-appearing after your reply:**
 >    - The spec does not match the code — FIX THE SPEC (gh issue edit)

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -1,6 +1,6 @@
 ---
 description: Process ALL review sources (human, Qodo, CodeRabbit) from current PR
-argument-hint: "[--autorabbit] [--autoqodo] [status]"
+argument-hint: "[--autorabbit] [--autoqodo] [status [PR#]]"
 ---
 
 ## Raw Arguments
@@ -64,6 +64,7 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 - `/review-handler` - Process reviews from current PR
 - `/review-handler https://github.com/owner/repo/pull/123#pullrequestreview-456` - With specific review URL
 - `/review-handler status` - Show all review comments from DB for current PR
+- `/review-handler status 413` - Show review comments for specific PR number
 - `/review-handler --autorabbit` - Auto-fix CodeRabbit comments in a loop
 - `/review-handler --autoqodo` - Auto-fix Qodo comments in a loop
 - `/review-handler --autorabbit --autoqodo` - Auto-fix both CodeRabbit and Qodo comments
@@ -80,7 +81,9 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 Read the **Raw Arguments** section above. Parse as follows:
 
 1. Check if `status` appears in the raw arguments
-   - If YES: run `myk-pi-tools reviews status` and return the output. Skip all other phases.
+   - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
+   - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
+   - Return the output to the user. **STOP HERE — skip ALL other phases. Do not proceed.**
 2. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text
    - If NO: autorabbit mode = OFF

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -1,6 +1,6 @@
 ---
 description: Process ALL review sources (human, Qodo, CodeRabbit) from current PR
-argument-hint: "[--autorabbit] [--autoqodo]"
+argument-hint: "[--autorabbit] [--autoqodo] [status]"
 ---
 
 ## Raw Arguments
@@ -63,6 +63,7 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 - `/review-handler` - Process reviews from current PR
 - `/review-handler https://github.com/owner/repo/pull/123#pullrequestreview-456` - With specific review URL
+- `/review-handler status` - Show all review comments from DB for current PR
 - `/review-handler --autorabbit` - Auto-fix CodeRabbit comments in a loop
 - `/review-handler --autoqodo` - Auto-fix Qodo comments in a loop
 - `/review-handler --autorabbit --autoqodo` - Auto-fix both CodeRabbit and Qodo comments
@@ -78,15 +79,17 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 Read the **Raw Arguments** section above. Parse as follows:
 
-1. Check if `--autorabbit` appears in the raw arguments
+1. Check if `status` appears in the raw arguments
+   - If YES: run `myk-pi-tools reviews status` and return the output. Skip all other phases.
+2. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text
    - If NO: autorabbit mode = OFF
-2. Check if `--autoqodo` appears in the (remaining) raw arguments
+3. Check if `--autoqodo` appears in the (remaining) raw arguments
    - If YES: set autoqodo mode = ON, remove `--autoqodo` from the text
    - If NO: autoqodo mode = OFF
-3. The remaining text is the cleaned arguments — pass these through to the CLI
-4. `--autorabbit` and `--autoqodo` are **command-level flags** — NEVER pass them to the CLI
-5. Both flags can be active simultaneously
+4. The remaining text is the cleaned arguments — pass these through to the CLI
+5. `--autorabbit` and `--autoqodo` are **command-level flags** — NEVER pass them to the CLI
+6. Both flags can be active simultaneously
 
 **Example:** Raw arguments = `--autorabbit --autoqodo`
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -151,8 +151,21 @@ Returns JSON with:
 >    - `qodo_finding` (other) → **MUST address.** Either fix the code OR update the issue requirements. No skip allowed.
 >
 >    **No finding type is optional. Every finding gets a code fix or an issue update.**
->    **"Not a realistic issue", "by design", or "not applicable" are NOT valid skip reasons**
->    **unless the issue has been updated to explicitly document that decision.**
+>    **"Not a realistic issue", "by design", or "not applicable" are NOT valid skip reasons.**
+>
+>    🚨 **STRICT ENFORCEMENT — EVERY QODO FINDING MUST RESULT IN ONE OF:**
+>    1. **Code fix** — change the code to address the finding. Commit and push.
+>    2. **Issue spec update** — if the finding is about a spec mismatch (code does X, spec says Y),
+>       update the GitHub issue to match the actual design. Use `gh issue edit` to fix the spec.
+>       Then reply to Qodo referencing the updated spec.
+>
+>    **There is no third option. "Already addressed", "by design", "not applicable" are FORBIDDEN.**
+>    **Posting the same reply multiple times without a code fix or spec update is a HARD VIOLATION.**
+>
+>    **If a Qodo sticky comment keeps re-appearing after your reply:**
+>    - The spec does not match the code — FIX THE SPEC (gh issue edit)
+>    - OR the code does not match the spec — FIX THE CODE
+>    - NEVER post the same reply again. That means you haven't actually addressed it.
 >
 > Combined behavior:
 >


### PR DESCRIPTION
## Summary

New `/review-handler status` command that queries the reviews SQLite DB and shows all comments across all review cycles.

## Usage

- `/review-handler status` — auto-detect PR from branch, show comments
- `/review-handler status 413` — show comments for specific PR
- `myk-pi-tools reviews status` — CLI equivalent (auto-detect)
- `myk-pi-tools reviews status --pr 413` — CLI with explicit PR

When no PR is detected (e.g., on main), lists all PRs in the DB:
```
Available PRs in reviews database:

  PR       Total    Addressed   Skipped   Pending   Last Review
  ──────────────────────────────────────────────────────────────────────
  #413     14       14          0         0         2026-06-01
  #405     4        4           0         0         2026-05-31
  ...

Use: myk-pi-tools reviews status --pr <number>
```

## Output

### TUI Table
```
PR #413 (feat/issue-411-memory-vector-search) — feat(memory): vector search...

  #    Source     File                      Line  Summary                                       Status
  ──────────────────────────────────────────────────────────────────────────────────────────────────────────
  1    qodo       AGENTS.md                 60    AGENTS.md missing vector-search docs          addressed
  2    qodo       memory-tools.ts           68    No tests for vector search                    addressed
  ...
  Total: 13 — 13 addressed
```

### HTML Report (dark theme)
- Dark GitHub-style theme, color-coded status cells
- Clickable PR link opens GitHub in new tab
- Per-PR filename: `review-status-413.html`
- Container: served via httpd.py with URL
- Native: file path to open in browser

## Bug Fix: Worktree DB Path

`store.py` now uses `git rev-parse --git-common-dir` to always resolve the main repo root. Previously, worktrees had isolated `.pi/data/reviews.db` files that were lost on worktree removal.

## Files

| File | Change |
|------|--------|
| `myk_pi_tools/reviews/status.py` | New — TUI table, HTML report, PR listing, dedup |
| `myk_pi_tools/reviews/commands.py` | Modified — added `status` command with `--pr` option |
| `myk_pi_tools/reviews/store.py` | Modified — worktree-safe DB path via git-common-dir |
| `prompts/review-handler.md` | Modified — status arg in Phase 0, PR number support |
| `extensions/orchestrator/extended-autocomplete.ts` | Modified — added status to autocomplete |

Fixes #415