### PR TITLE
fix(dreaming): create skills in .pi/skills/ with required frontmatter

### DIFF
--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -76,7 +76,12 @@ export function registerDreaming(
       `   - [category] summary *(pinned)*    (if pinned)\n` +
       `   - [category] summary               (if not pinned)\n` +
       `6. Auto-generate skills: if you notice a multi-step workflow pattern across entries,\n` +
-      `   create a skill file at ~/.agents/skills/<name>/SKILL.md with the steps.\n` +
+      `   create a skill file at .pi/skills/<name>/SKILL.md (project-level, NOT global ~/.agents/).\n` +
+      `   The SKILL.md MUST start with YAML frontmatter:\n` +
+      `   ---\n` +
+      `   name: <name>\n` +
+      `   description: "What this skill does and when to use it"\n` +
+      `   ---\n` +
       `   Only create skills for workflows with 3+ steps that are likely to recur.\n` +
       `7. Write the current timestamp to ${topicsDir}/../.dream-watermark to track progress.\n` +
       `8. Memory rules: one line per entry, max ~100 chars, specific and actionable, no fluff.`,

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -314,6 +314,8 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
 
     "review-handler": (prefix: string) => {
       const tokens = prefix.trim().split(/\s+/).filter(Boolean);
+      // If 'status' is already selected, no further suggestions (status is standalone)
+      if (tokens.includes("status")) return null;
       const selected = new Set(tokens);
       const lastPart = prefix.endsWith(" ") ? "" : (tokens[tokens.length - 1] || "");
       const all = [

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -313,11 +313,16 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
 
 
     "review-handler": (prefix: string) => {
-      return filter([
+      const tokens = prefix.trim().split(/\s+/).filter(Boolean);
+      const selected = new Set(tokens.filter(p => p.startsWith("--")));
+      const lastPart = prefix.endsWith(" ") ? "" : (tokens[tokens.length - 1] || "");
+      const all = [
         { value: "status", label: "status", description: "Show all review comments from DB for current PR" },
         { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
         { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
-      ], prefix);
+      ];
+      const available = all.filter(item => !selected.has(item.value));
+      return filter(available, lastPart);
     },
 
     "dream-auto": (prefix: string) => {

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -314,7 +314,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
 
     "review-handler": (prefix: string) => {
       const tokens = prefix.trim().split(/\s+/).filter(Boolean);
-      const selected = new Set(tokens.filter(p => p.startsWith("--")));
+      const selected = new Set(tokens);
       const lastPart = prefix.endsWith(" ") ? "" : (tokens[tokens.length - 1] || "");
       const all = [
         { value: "status", label: "status", description: "Show all review comments from DB for current PR" },

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -314,15 +314,22 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
 
     "review-handler": (prefix: string) => {
       const tokens = prefix.trim().split(/\s+/).filter(Boolean);
-      // If 'status' is already selected, no further suggestions (status is standalone)
-      if (tokens.includes("status")) return null;
       const selected = new Set(tokens);
       const lastPart = prefix.endsWith(" ") ? "" : (tokens[tokens.length - 1] || "");
-      const all = [
-        { value: "status", label: "status", description: "Show all review comments from DB for current PR" },
-        { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
-        { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
-      ];
+      // status and --auto flags are mutually exclusive
+      const hasStatus = tokens.includes("status");
+      const hasAutoFlag = tokens.some(t => t.startsWith("--auto"));
+      if (hasStatus) return null; // status is standalone, no more suggestions
+      const all = hasAutoFlag
+        ? [ // Only show remaining --auto flags (status excluded)
+            { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
+            { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
+          ]
+        : [ // Show all options
+            { value: "status", label: "status", description: "Show all review comments from DB for current PR" },
+            { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
+            { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
+          ];
       const available = all.filter(item => !selected.has(item.value));
       return filter(available, lastPart);
     },

--- a/prompts/create-skill.md
+++ b/prompts/create-skill.md
@@ -21,7 +21,7 @@ Save a successful workflow as a reusable pi skill.
 ## Usage
 
 - `/create-skill <name>` — Create a skill with the given name from the current conversation
-- `/create-skill` — Prompt for a name
+- `/create-skill` — Prompt for a name and scope
 
 ## Workflow
 
@@ -41,6 +41,19 @@ Validate the name:
 - No spaces, underscores, or special characters
 - If invalid, ask the user to provide a valid name
 
+### Step 1.5: Determine Skill Scope
+
+Ask the user where to create the skill:
+
+> Where should this skill be created?
+>
+> - **Global** (`~/.agents/skills/`) — available in all projects
+> - **Project** (`.pi/skills/`) — available only in this project
+
+Use `ask_user` with options: `["Global (~/.agents/skills/)", "Project (.pi/skills/)"]`
+
+Store the chosen path prefix for Step 3.
+
 ### Step 2: Extract the Workflow
 
 Review the current conversation and identify:
@@ -53,10 +66,13 @@ Review the current conversation and identify:
 
 ### Step 3: Write the SKILL.md
 
-Create the skill file at `~/.agents/skills/<name>/SKILL.md`:
+Create the skill file at the chosen location from Step 1.5:
+
+- **Global:** `~/.agents/skills/<name>/SKILL.md`
+- **Project:** `.pi/skills/<name>/SKILL.md`
 
 ```bash
-mkdir -p ~/.agents/skills/<name>
+mkdir -p <chosen-path>/<name>
 ```
 
 The SKILL.md must follow this exact format:
@@ -101,6 +117,7 @@ like `<API_KEY>` or `$ENV_VAR`. Skills are stored in plain text.
 
 Tell the user:
 
-> ✅ Skill `<name>` created at `~/.agents/skills/<name>/SKILL.md`
+> ✅ Skill `<name>` created at `<chosen-path>/<name>/SKILL.md`
 >
-> It will be available in the next pi session. Reload pi to use it immediately.
+> **Global skills** are available in all projects. **Project skills** are available only in this project.
+> Reload pi to use it immediately.

--- a/prompts/create-skill.md
+++ b/prompts/create-skill.md
@@ -50,9 +50,14 @@ Ask the user where to create the skill:
 > - **Global** (`~/.agents/skills/`) — available in all projects
 > - **Project** (`.pi/skills/`) — available only in this project
 
-Use `ask_user` with options: `["Global (~/.agents/skills/)", "Project (.pi/skills/)"]`
+Use `ask_user` with options: `["Global", "Project"]`
 
-Store the chosen path prefix for Step 3.
+Map the response to the path:
+
+- "Global" → `~/.agents/skills/`
+- "Project" → `.pi/skills/`
+
+Store the resolved path for Step 3.
 
 ### Step 2: Extract the Workflow
 


### PR DESCRIPTION
## Summary

Fix two issues with auto-generated skills from dreaming:

1. **Wrong location** — Skills were created at `~/.agents/skills/` (global) instead of `.pi/skills/` (project-level)
2. **Missing frontmatter** — Skills were created without required YAML frontmatter (`name` + `description`), causing pi skill validation warnings

## Change

`extensions/orchestrator/dreaming.ts` — updated the dreaming task instructions to:
- Use `.pi/skills/<name>/SKILL.md` (project-level)
- Include YAML frontmatter template with `name` and `description` fields