### PR TITLE
fix: review-handler status — extract table as text + serve HTML report via httpd

### DIFF
--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -84,16 +84,22 @@ Read the **Raw Arguments** section above. Parse as follows:
    - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
    - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
    - Extract the table from the CLI output and present it as formatted text in your response (not as raw bash output)
-   - If the output includes an HTML report path, serve it using the file preview httpd:
+   - If the output includes an HTML report path (`HTML_PATH`), make it accessible:
+     - **Container** (check if `/.dockerenv` or `/.containerenv` exists): serve via httpd:
 
-     ```bash
-     HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
-     PORT=$(uv run python3 $HTTPD --find-port)
-     nohup uv run python3 $HTTPD --port $PORT --dir $(dirname $HTML_PATH) > /tmp/pi-work/$(basename $PWD)/httpd-$PORT.log 2>&1 &
-     disown
-     ```
+       ```bash
+       HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
+       PORT=$(uv run python3 $HTTPD --find-port)
+       LOGDIR=/tmp/pi-work/pi-config
+       mkdir -p $LOGDIR
+       nohup uv run python3 $HTTPD --port $PORT --dir $(dirname $HTML_PATH) > $LOGDIR/httpd-$PORT.log 2>&1 &
+       disown
+       sleep 0.5
+       if ! kill -0 $! 2>/dev/null; then echo "Server failed:"; cat $LOGDIR/httpd-$PORT.log; fi
+       ```
 
-     Then tell the user: "Report: `http://localhost:$PORT/$(basename $HTML_PATH)`"
+       Then tell the user: "Report: `http://localhost:$PORT/$(basename $HTML_PATH)`"
+     - **Native** (no container markers): tell the user: "Report: `file://$HTML_PATH`"
    - **STOP HERE — skip ALL other phases. Do not proceed.**
 2. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -83,29 +83,11 @@ Read the **Raw Arguments** section above. Parse as follows:
 1. Check if `status` appears in the raw arguments
    - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
    - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
-   - Extract the table from the CLI output and present it as formatted text in your response (not as raw bash output)
-   - If the output includes an HTML report path, extract it from the CLI output line
-     `HTML report saved: <path>`. Then make it accessible:
-     - **Container** (check if `/.dockerenv` or `/run/.containerenv` exists): serve via httpd:
-
-       ```bash
-       # HTML_PATH extracted from CLI output above
-       HTTPD=$(find ~/.pi/agent -name httpd.py -path "*/scripts/*" 2>/dev/null | head -1)
-       if [ -z "$HTTPD" ]; then echo "httpd.py not found"; exit 1; fi
-       PORT=$(uv run python3 "$HTTPD" --find-port)
-       LOGDIR=$(dirname "$HTML_PATH")
-       nohup uv run python3 "$HTTPD" --port "$PORT" --dir "$LOGDIR" > "$LOGDIR/httpd-$PORT.log" 2>&1 &
-       disown
-       sleep 0.5
-       if ! kill -0 $! 2>/dev/null; then echo "Server failed:"; cat "$LOGDIR/httpd-$PORT.log"; fi
-       ```
-
-       Then tell the user the URL (without backticks so it's clickable):
-       <!-- markdownlint-disable-next-line MD034 -->
-       Report: http://localhost:PORT/FILENAME
-     - **Native** (no container markers): tell the user the extracted path (without backticks):
-       <!-- markdownlint-disable-next-line MD034 -->
-       Report: file:///path/to/report.html
+   - Extract the table from the CLI output and present it as formatted text in your response
+     (not as raw bash output — the user should see the table directly)
+   - If the CLI output contains `HTML report saved:`, extract the full path after it.
+     Serve the report using the file preview rule (see `rules/45-file-preview.md`).
+     The file preview rule handles httpd startup, port allocation, and container detection.
    - **STOP HERE — skip ALL other phases. Do not proceed.**
 2. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -83,7 +83,18 @@ Read the **Raw Arguments** section above. Parse as follows:
 1. Check if `status` appears in the raw arguments
    - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
    - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
-   - Return the output to the user. **STOP HERE — skip ALL other phases. Do not proceed.**
+   - Extract the table from the CLI output and present it as formatted text in your response (not as raw bash output)
+   - If the output includes an HTML report path, serve it using the file preview httpd:
+
+     ```bash
+     HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
+     PORT=$(uv run python3 $HTTPD --find-port)
+     nohup uv run python3 $HTTPD --port $PORT --dir $(dirname $HTML_PATH) > /tmp/pi-work/$(basename $PWD)/httpd-$PORT.log 2>&1 &
+     disown
+     ```
+
+     Then tell the user: "Report: `http://localhost:$PORT/$(basename $HTML_PATH)`"
+   - **STOP HERE — skip ALL other phases. Do not proceed.**
 2. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text
    - If NO: autorabbit mode = OFF

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -83,9 +83,8 @@ Read the **Raw Arguments** section above. Parse as follows:
 1. Check if `status` appears in the raw arguments
    - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
    - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
-   - Present the CLI output as formatted text in your response (not as raw bash output).
-     If the output contains a table, show it directly. If it contains diagnostics or errors,
-     show those instead.
+   - Present the full CLI output as formatted text in your response (not as raw bash output).
+     Show everything: table, diagnostics, errors — include all of it.
    - If the CLI output contains `HTML report saved:`, extract the full path after it.
      Serve the report using the file preview rule (see `rules/45-file-preview.md`).
      The file preview rule handles httpd startup, port allocation, and container detection.

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -83,8 +83,9 @@ Read the **Raw Arguments** section above. Parse as follows:
 1. Check if `status` appears in the raw arguments
    - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
    - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
-   - Extract the table from the CLI output and present it as formatted text in your response
-     (not as raw bash output — the user should see the table directly)
+   - Present the CLI output as formatted text in your response (not as raw bash output).
+     If the output contains a table, show it directly. If it contains diagnostics or errors,
+     show those instead.
    - If the CLI output contains `HTML report saved:`, extract the full path after it.
      Serve the report using the file preview rule (see `rules/45-file-preview.md`).
      The file preview rule handles httpd startup, port allocation, and container detection.

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -84,22 +84,27 @@ Read the **Raw Arguments** section above. Parse as follows:
    - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
    - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
    - Extract the table from the CLI output and present it as formatted text in your response (not as raw bash output)
-   - If the output includes an HTML report path (`HTML_PATH`), make it accessible:
-     - **Container** (check if `/.dockerenv` or `/.containerenv` exists): serve via httpd:
+   - If the output includes an HTML report path, make it accessible:
+     - **Container** (check if `/.dockerenv` or `/run/.containerenv` exists): serve via httpd:
 
        ```bash
+       HTML_PATH="/tmp/pi-work/pi-config/review-status-NNN.html"  # from CLI output
        HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
        PORT=$(uv run python3 $HTTPD --find-port)
        LOGDIR=/tmp/pi-work/pi-config
-       mkdir -p $LOGDIR
-       nohup uv run python3 $HTTPD --port $PORT --dir $(dirname $HTML_PATH) > $LOGDIR/httpd-$PORT.log 2>&1 &
+       mkdir -p "$LOGDIR"
+       nohup uv run python3 $HTTPD --port "$PORT" --dir "$(dirname "$HTML_PATH")" > "$LOGDIR/httpd-$PORT.log" 2>&1 &
        disown
        sleep 0.5
-       if ! kill -0 $! 2>/dev/null; then echo "Server failed:"; cat $LOGDIR/httpd-$PORT.log; fi
+       if ! kill -0 $! 2>/dev/null; then echo "Server failed:"; cat "$LOGDIR/httpd-$PORT.log"; fi
        ```
 
-       Then tell the user: "Report: `http://localhost:$PORT/$(basename $HTML_PATH)`"
-     - **Native** (no container markers): tell the user: "Report: `file://$HTML_PATH`"
+       Then tell the user the URL (without backticks so it's clickable):
+       <!-- markdownlint-disable-next-line MD034 -->
+       Report: http://localhost:PORT/review-status-NNN.html
+     - **Native** (no container markers): tell the user the path (without backticks):
+       <!-- markdownlint-disable-next-line MD034 -->
+       Report: file:///tmp/pi-work/pi-config/review-status-NNN.html
    - **STOP HERE — skip ALL other phases. Do not proceed.**
 2. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -84,16 +84,17 @@ Read the **Raw Arguments** section above. Parse as follows:
    - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
    - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
    - Extract the table from the CLI output and present it as formatted text in your response (not as raw bash output)
-   - If the output includes an HTML report path, make it accessible:
+   - If the output includes an HTML report path, extract it from the CLI output line
+     `HTML report saved: <path>`. Then make it accessible:
      - **Container** (check if `/.dockerenv` or `/run/.containerenv` exists): serve via httpd:
 
        ```bash
-       HTML_PATH="/tmp/pi-work/pi-config/review-status-NNN.html"  # from CLI output
-       HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
-       PORT=$(uv run python3 $HTTPD --find-port)
-       LOGDIR=/tmp/pi-work/pi-config
-       mkdir -p "$LOGDIR"
-       nohup uv run python3 $HTTPD --port "$PORT" --dir "$(dirname "$HTML_PATH")" > "$LOGDIR/httpd-$PORT.log" 2>&1 &
+       # HTML_PATH extracted from CLI output above
+       HTTPD=$(find ~/.pi/agent -name httpd.py -path "*/scripts/*" 2>/dev/null | head -1)
+       if [ -z "$HTTPD" ]; then echo "httpd.py not found"; exit 1; fi
+       PORT=$(uv run python3 "$HTTPD" --find-port)
+       LOGDIR=$(dirname "$HTML_PATH")
+       nohup uv run python3 "$HTTPD" --port "$PORT" --dir "$LOGDIR" > "$LOGDIR/httpd-$PORT.log" 2>&1 &
        disown
        sleep 0.5
        if ! kill -0 $! 2>/dev/null; then echo "Server failed:"; cat "$LOGDIR/httpd-$PORT.log"; fi
@@ -101,10 +102,10 @@ Read the **Raw Arguments** section above. Parse as follows:
 
        Then tell the user the URL (without backticks so it's clickable):
        <!-- markdownlint-disable-next-line MD034 -->
-       Report: http://localhost:PORT/review-status-NNN.html
-     - **Native** (no container markers): tell the user the path (without backticks):
+       Report: http://localhost:PORT/FILENAME
+     - **Native** (no container markers): tell the user the extracted path (without backticks):
        <!-- markdownlint-disable-next-line MD034 -->
-       Report: file:///tmp/pi-work/pi-config/review-status-NNN.html
+       Report: file:///path/to/report.html
    - **STOP HERE — skip ALL other phases. Do not proceed.**
 2. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text


### PR DESCRIPTION
## Summary

Fixes `/review-handler status` output to be user-friendly:

1. **TUI table** — Extract the status table from CLI output and present as formatted text instead of raw bash output (which pi collapses behind "ctrl+o to expand")
2. **HTML report link** — Serve the HTML report via httpd and provide a clickable `http://localhost:<port>/` link

## Changes

- `prompts/review-handler.md` — Updated Phase 0 status handling instructions

Closes #421