### PR TITLE
fix(urgent): migrate @xenova/transformers → @huggingface/transformers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,12 +310,12 @@ Clean-room TypeScript implementation under MIT — not a code translation.
 
 **Layer 4 — Vector Embeddings** (`memory-embeddings.ts`):
 
-- Model: `Xenova/bge-small-en-v1.5` (384 dims, runs locally via @xenova/transformers ONNX)
+- Model: `Xenova/bge-small-en-v1.5` (384 dims, runs locally via @huggingface/transformers ONNX)
 - Storage: `.pi/memory/embeddings.json`
 - Embed on write: `memory_add` embeds each entry immediately
 - Semantic search: `memory_search` embeds query, cosine similarity against stored vectors
 - Hybrid results: union of vector + keyword matches, deduplicated
-- Fallback: keyword-only search when @xenova/transformers is unavailable
+- Fallback: keyword-only search when @huggingface/transformers is unavailable
 - Migration: first `memory_search` call embeds all existing entries missing from store
 - No API keys needed — runs entirely locally
 

--- a/extensions/orchestrator/memory-embeddings.ts
+++ b/extensions/orchestrator/memory-embeddings.ts
@@ -2,7 +2,7 @@
  * memory-embeddings.ts — Vector embedding support for memory search
  *
  * Embeds memory entries and search queries using Xenova/bge-small-en-v1.5 via
- * @xenova/transformers (in-process ONNX, no Python, no subprocess).
+ * @huggingface/transformers (in-process ONNX, no Python, no subprocess).
  * Stores embeddings in .pi/memory/embeddings.json.
  *
  * Falls back gracefully when the model is unavailable — callers always get a
@@ -75,7 +75,7 @@ async function getPipeline(): Promise<any> {
 
   pipelineLoading = (async () => {
     try {
-      const { pipeline } = await import("@xenova/transformers");
+      const { pipeline } = await import("@huggingface/transformers");
       const extractor = await pipeline("feature-extraction", "Xenova/bge-small-en-v1.5", {
         quantized: true,
       });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@xenova/transformers": "^2.17.0",
+    "@huggingface/transformers": "^4.2.0",
     "acpx": "^0.8.0",
     "chokidar": "^5.0.0",
     "discord.js": "^14.0.0",


### PR DESCRIPTION
## Summary

`@xenova/transformers` is deprecated and pulls in `protobufjs` with 9 CVEs (including critical arbitrary code execution). Migrated to `@huggingface/transformers` — the official successor with identical API.

## Changes

- `package.json` — `@xenova/transformers` → `@huggingface/transformers@^4.2.0`
- `extensions/orchestrator/memory-embeddings.ts` — updated import path

## Results

- `npm audit`: **0 vulnerabilities** (was 4: 3 high, 1 critical)
- No `prebuild-install` deprecation warning
- Same model (`Xenova/bge-small-en-v1.5`), same API (`pipeline`, `feature-extraction`)

Closes #431