### PR TITLE
feat: project-level settings (.pi/pi-config-settings.json)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ pi-config/
 │   │   ├── memory-embeddings.ts         # Vector embedding support for semantic memory search (fastembed)
 │   │   ├── memory-tree.ts             # Hierarchical topic-based memory organization
 │   │   ├── preference-extractor.ts    # Auto-extract user preferences from conversation
+│   │   ├── project-settings.ts        # Project-level settings (.pi/pi-config-settings.json)
 │   │   ├── situation-report.ts        # Token-budgeted memory context for system prompts
 │   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent (async-only enforcement for reviewers)
 │   │   └── utils.ts                 # Shared utilities
@@ -137,6 +138,7 @@ pi-config/
 ├── entrypoint.sh                    # Container entrypoint
 ├── README.md                        # Project README
 ├── AGENTS.md                        # This file
+├── pi-config-settings.example.json    # Example project settings file
 ├── package.json                     # Node.js dependencies (extensions)
 └── pyproject.toml                   # Python project config (myk_pi_tools)
 ```
@@ -347,6 +349,20 @@ Clean-room TypeScript implementation under MIT — not a code translation.
 - Detects "I prefer...", "always use...", "never..." in user messages
 - Auto-adds to memory with explicit cue weight
 - Reinforces existing preferences on repetition
+
+### Project-Level Settings
+
+Settings file: `.pi/pi-config-settings.json` — per-project configuration overriding global env vars.
+
+| Setting | Type | Default | Env var | Description |
+|---|---|---|---|---|
+| `co_author` | boolean | disabled | `PI_CO_AUTHOR` | Co-author trailer in commits |
+| `use_worktrees` | boolean | disabled | `PI_USE_WORKTREES` | Force worktree-only workflow |
+| `dream_interval_hours` | number | 3 | `PI_DREAM_INTERVAL_HOURS` | Dream frequency |
+
+Resolution: project file → env var → default.
+
+Module: `extensions/orchestrator/project-settings.ts`
 
 ## Docker / Dockerfile
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ Loops until all approve, then runs tests.
 
 ## Customization
 
+### Project Settings
+
+Create `.pi/pi-config-settings.json` in your project to override global defaults:
+
+```json
+{
+  "co_author": true,
+  "use_worktrees": true,
+  "dream_interval_hours": 6
+}
+```
+
+Resolution order: project file → env var → default.
+
 ### Override agents
 
 Place a `.md` file with the same `name` frontmatter in `~/.pi/agent/agents/` (user) or `.pi/agents/` (project) to override a bundled agent.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ Create `.pi/pi-config-settings.json` in your project to override global defaults
 
 Resolution order: project file → env var → default.
 
+Global env vars: `PI_CO_AUTHOR`, `PI_USE_WORKTREES`, `PI_DREAM_INTERVAL_HOURS`
+
 ### Override agents
 
 Place a `.md` file with the same `name` frontmatter in `~/.pi/agent/agents/` (user) or `.pi/agents/` (project) to override a bundled agent.

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -148,17 +148,22 @@ export function registerDreaming(
 
   let rebuildTimer: ReturnType<typeof setInterval> | null = null;
 
+  let currentIntervalMs = 0;
+
   function startTimer(cwd: string) {
     lastCwd = cwd;
-    if (dreamTimer) return;
 
-    // Override dream interval from project settings if available
-    // getSetting already resolves project > env > default(3), just clamp range
+    // Resolve dream interval from project settings
     const projectHours = getSetting(cwd, "dream_interval_hours");
     const clampedHours = Math.max(0.5, Math.min(24, projectHours));
     const effectiveMs = clampedHours * 60 * 60 * 1000;
 
-    // LLM dreaming — every 3h (expensive, spawns worker agent)
+    // Restart timer if interval changed (or first start)
+    if (dreamTimer && currentIntervalMs === effectiveMs) return;
+    if (dreamTimer) clearInterval(dreamTimer);
+    currentIntervalMs = effectiveMs;
+
+    // LLM dreaming
     dreamTimer = setInterval(() => {
       if (enabled && lastCwd) runDreamAsync(lastCwd);
     }, effectiveMs);

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -153,9 +153,10 @@ export function registerDreaming(
     if (dreamTimer) return;
 
     // Override dream interval from project settings if available
+    // getSetting already resolves project > env > default(3), just clamp range
     const projectHours = getSetting(cwd, "dream_interval_hours");
-    const effectiveMs = (Number.isFinite(projectHours) && projectHours >= 0.5 && projectHours <= 24
-      ? projectHours : DREAM_INTERVAL_HOURS) * 60 * 60 * 1000;
+    const clampedHours = Math.max(0.5, Math.min(24, projectHours));
+    const effectiveMs = clampedHours * 60 * 60 * 1000;
 
     // LLM dreaming — every 3h (expensive, spawns worker agent)
     dreamTimer = setInterval(() => {

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { getSetting } from "./project-settings.js";
 import { discoverAgents } from "./agents.js";
 import { ICON_DREAM } from "./icons.js";
 import { rebuildAndOrganize } from "./situation-report.js";
@@ -151,10 +152,15 @@ export function registerDreaming(
     lastCwd = cwd;
     if (dreamTimer) return;
 
+    // Override dream interval from project settings if available
+    const projectHours = getSetting(cwd, "dream_interval_hours");
+    const effectiveMs = (Number.isFinite(projectHours) && projectHours >= 0.5 && projectHours <= 24
+      ? projectHours : DREAM_INTERVAL_HOURS) * 60 * 60 * 1000;
+
     // LLM dreaming — every 3h (expensive, spawns worker agent)
     dreamTimer = setInterval(() => {
       if (enabled && lastCwd) runDreamAsync(lastCwd);
-    }, DREAM_INTERVAL_MS);
+    }, effectiveMs);
     if (dreamTimer.unref) dreamTimer.unref();
 
     // Scoring rebuild — every 30 min (cheap, no LLM, just rescores + reorganizes topics)

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -190,7 +190,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       if (getSetting(ctx.cwd, "use_worktrees")) {
         const mb = getMainBranch(gitCwd) || "main";
         const hint = `Use: git worktree add .worktrees/<name> -b <branch> ${mb}`;
-        if (hasGitSub(command, "checkout") && !command.includes("--")) {
+        if (hasGitSub(command, "checkout") && !/\bgit\b.*\bcheckout\b\s+--\s/.test(command)) {
           return { block: true, reason: `⛔ git checkout blocked — use_worktrees is enabled. ${hint}` };
         }
         if (hasGitSub(command, "switch")) {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -187,7 +187,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     const gitCwd = resolveEffectiveCwd(command, ctx.cwd);
     if (isGitRepo(gitCwd)) {
       // Block branch switching when use_worktrees is enabled
-      if (getSetting(gitCwd, "use_worktrees")) {
+      if (getSetting(ctx.cwd, "use_worktrees")) {
         if (hasGitSub(command, "checkout") && /\bgit\b.*\bcheckout\b\s+(-b|-B)\b/.test(command)) {
           return {
             block: true,
@@ -281,7 +281,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
           };
 
         // Co-author trailer injection
-        if (getSetting(gitCwd, "co_author")) {
+        if (getSetting(ctx.cwd, "co_author")) {
           const model = (ctx as any).model;
           if (model?.id && !command.includes("Co-authored-by:")) {
             // Pattern A: echo "..." | git commit -F -

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -186,18 +186,18 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     // Git protection
     const gitCwd = resolveEffectiveCwd(command, ctx.cwd);
     if (isGitRepo(gitCwd)) {
-      // Block branch switching when use_worktrees is enabled
+      // Block branch creation AND switching when use_worktrees is enabled
       if (getSetting(ctx.cwd, "use_worktrees")) {
-        if (hasGitSub(command, "checkout") && /\bgit\b.*\bcheckout\b\s+(-b|-B)\b/.test(command)) {
+        if (hasGitSub(command, "checkout") && !command.includes("--")) {
           return {
             block: true,
-            reason: "⛔ Branch creation via checkout blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
+            reason: "⛔ git checkout blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
           };
         }
-        if (hasGitSub(command, "switch") && /\bgit\b.*\bswitch\b\s+(-c|-C)\b/.test(command)) {
+        if (hasGitSub(command, "switch")) {
           return {
             block: true,
-            reason: "⛔ Branch creation via switch blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
+            reason: "⛔ git switch blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
           };
         }
       }

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -190,7 +190,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       if (getSetting(ctx.cwd, "use_worktrees")) {
         const mb = getMainBranch(gitCwd) || "main";
         const hint = `Use: git worktree add .worktrees/<name> -b <branch> ${mb}`;
-        if (hasGitSub(command, "checkout") && !/\bgit\b.*\bcheckout\b\s+--\s/.test(command)) {
+        if (hasGitSub(command, "checkout") && !/\bgit\b.*\bcheckout\b.*\s--\s/.test(command)) {
           return { block: true, reason: `⛔ git checkout blocked — use_worktrees is enabled. ${hint}` };
         }
         if (hasGitSub(command, "switch")) {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -188,17 +188,13 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     if (isGitRepo(gitCwd)) {
       // Block branch creation AND switching when use_worktrees is enabled
       if (getSetting(ctx.cwd, "use_worktrees")) {
+        const mb = getMainBranch(gitCwd) || "main";
+        const hint = `Use: git worktree add .worktrees/<name> -b <branch> ${mb}`;
         if (hasGitSub(command, "checkout") && !command.includes("--")) {
-          return {
-            block: true,
-            reason: "⛔ git checkout blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
-          };
+          return { block: true, reason: `⛔ git checkout blocked — use_worktrees is enabled. ${hint}` };
         }
         if (hasGitSub(command, "switch")) {
-          return {
-            block: true,
-            reason: "⛔ git switch blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
-          };
+          return { block: true, reason: `⛔ git switch blocked — use_worktrees is enabled. ${hint}` };
         }
       }
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -7,6 +7,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { getSetting } from "./project-settings.js";
 import {
   DANGEROUS,
   getCurrentBranch,
@@ -185,6 +186,22 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     // Git protection
     const gitCwd = resolveEffectiveCwd(command, ctx.cwd);
     if (isGitRepo(gitCwd)) {
+      // Block branch switching when use_worktrees is enabled
+      if (getSetting(gitCwd, "use_worktrees")) {
+        if (hasGitSub(command, "checkout") && /\bgit\b.*\bcheckout\b\s+(-b|-B)\b/.test(command)) {
+          return {
+            block: true,
+            reason: "⛔ Branch creation via checkout blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
+          };
+        }
+        if (hasGitSub(command, "switch") && /\bgit\b.*\bswitch\b\s+(-c|-C)\b/.test(command)) {
+          return {
+            block: true,
+            reason: "⛔ Branch creation via switch blocked — use_worktrees is enabled. Use: git worktree add .worktrees/<name> -b <branch> origin/main",
+          };
+        }
+      }
+
       // Block git add . / git add -A
       if (
         hasGitSub(command, "add") &&
@@ -264,7 +281,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
           };
 
         // Co-author trailer injection
-        if (existsSync(join(gitCwd, ".pi-co-author"))) {
+        if (getSetting(gitCwd, "co_author")) {
           const model = (ctx as any).model;
           if (model?.id && !command.includes("Co-authored-by:")) {
             // Pattern A: echo "..." | git commit -F -

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -19,6 +19,7 @@ import { registerAsyncAgents } from "./async-agents.js";
 import { registerBtw } from "./btw.js";
 import { registerDreaming } from "./dreaming.js";
 import { registerEnforcement } from "./enforcement.js";
+import { registerProjectSettings } from "./project-settings.js";
 import { registerRules } from "./rules.js";
 import { registerSessionValidation } from "./session-validation.js";
 import { registerStatusLine } from "./status-line.js";
@@ -79,6 +80,7 @@ export default function (pi: ExtensionAPI) {
   registerAskUser(pi, terminalNotify);
   const { spawnAsyncAgent, killAsyncAgent, getAsyncJobs } = registerAsyncAgents(pi, terminalNotify);
   registerSubagentTool(pi, spawnAsyncAgent, killAsyncAgent);
+  registerProjectSettings(pi);
   registerEnforcement(pi, IN_CONTAINER);
   registerRules(pi, getAsyncJobs);
 

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -1,0 +1,138 @@
+/**
+ * Project-level settings — loads .pi/pi-config-settings.json with env var fallback.
+ *
+ * Resolution order:
+ * 1. Project .pi/pi-config-settings.json (wins if set)
+ * 2. Global env var (PI_CO_AUTHOR, PI_USE_WORKTREES, PI_DREAM_INTERVAL_HOURS)
+ * 3. Default (only dream_interval_hours has a default of 3)
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { join, dirname } from "node:path";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+interface ProjectSettings {
+  co_author?: boolean;
+  use_worktrees?: boolean;
+  dream_interval_hours?: number;
+}
+
+const SETTINGS_FILENAME = "pi-config-settings.json";
+
+function getSettingsPath(cwd: string): string {
+  return join(cwd, ".pi", SETTINGS_FILENAME);
+}
+
+function loadProjectSettings(cwd: string): ProjectSettings {
+  const settingsPath = getSettingsPath(cwd);
+  if (!existsSync(settingsPath)) return {};
+  try {
+    return JSON.parse(readFileSync(settingsPath, "utf-8")) as ProjectSettings;
+  } catch {
+    return {};
+  }
+}
+
+function saveProjectSettings(cwd: string, settings: ProjectSettings): void {
+  const settingsPath = getSettingsPath(cwd);
+  const dir = dirname(settingsPath);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
+}
+
+function parseBoolEnv(name: string): boolean | undefined {
+  const val = process.env[name];
+  if (val === undefined || val === "") return undefined;
+  return ["true", "1", "yes", "on"].includes(val.toLowerCase());
+}
+
+function parseNumEnv(name: string): number | undefined {
+  const val = process.env[name];
+  if (val === undefined || val === "") return undefined;
+  const n = parseFloat(val);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/** Cached settings per cwd */
+let cachedCwd = "";
+let cachedSettings: ProjectSettings = {};
+
+function getSettings(cwd: string): ProjectSettings {
+  if (cwd === cachedCwd) return cachedSettings;
+  cachedSettings = loadProjectSettings(cwd);
+  cachedCwd = cwd;
+  return cachedSettings;
+}
+
+/** Clear cache — call after migration or manual edits */
+export function clearSettingsCache(): void {
+  cachedCwd = "";
+  cachedSettings = {};
+}
+
+/**
+ * Get a setting value. Resolution: project file → env var → default.
+ */
+export function getSetting(cwd: string, key: "co_author"): boolean;
+export function getSetting(cwd: string, key: "use_worktrees"): boolean;
+export function getSetting(cwd: string, key: "dream_interval_hours"): number;
+export function getSetting(cwd: string, key: string): boolean | number {
+  const settings = getSettings(cwd);
+
+  switch (key) {
+    case "co_author": {
+      if (settings.co_author !== undefined) return settings.co_author;
+      const env = parseBoolEnv("PI_CO_AUTHOR");
+      if (env !== undefined) return env;
+      return false; // default: disabled
+    }
+    case "use_worktrees": {
+      if (settings.use_worktrees !== undefined) return settings.use_worktrees;
+      const env = parseBoolEnv("PI_USE_WORKTREES");
+      if (env !== undefined) return env;
+      return false; // default: disabled
+    }
+    case "dream_interval_hours": {
+      if (settings.dream_interval_hours !== undefined) return settings.dream_interval_hours;
+      const env = parseNumEnv("PI_DREAM_INTERVAL_HOURS");
+      if (env !== undefined) return env;
+      return 3; // default: 3 hours
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * One-time migration: .pi-co-author file → pi-config-settings.json
+ * Call on session_start. If .pi-co-author exists, migrate and delete it.
+ */
+export function migrateCoAuthorFile(cwd: string): void {
+  const legacyPath = join(cwd, ".pi-co-author");
+  if (!existsSync(legacyPath)) return;
+
+  try {
+    const settings = loadProjectSettings(cwd);
+    if (settings.co_author === undefined) {
+      settings.co_author = true;
+    }
+    saveProjectSettings(cwd, settings);
+    unlinkSync(legacyPath);
+    console.debug("[project-settings] Migrated .pi-co-author → pi-config-settings.json");
+    clearSettingsCache();
+  } catch (e: any) {
+    console.debug("[project-settings] migration failed:", e?.message?.slice(0, 100));
+  }
+}
+
+/**
+ * Register project settings — runs migration on session_start.
+ */
+export function registerProjectSettings(pi: ExtensionAPI): void {
+  if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
+  pi.on("session_start", (_event, ctx) => {
+    migrateCoAuthorFile(ctx.cwd);
+    clearSettingsCache();
+  });
+}

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -7,7 +7,7 @@
  * 3. Default (only dream_interval_hours has a default of 3)
  */
 
-import { existsSync, lstatSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { existsSync, lstatSync, statSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
@@ -76,7 +76,7 @@ function getSettings(cwd: string): ProjectSettings {
     cachedCwd = cwd;
     try {
       const settingsPath = getSettingsPath(cwd);
-      cachedMtime = existsSync(settingsPath) ? lstatSync(settingsPath).mtimeMs : 0;
+      cachedMtime = existsSync(settingsPath) ? statSync(settingsPath).mtimeMs : 0;
     } catch { cachedMtime = 0; }
     lastMtimeCheck = now;
     return cachedSettings;
@@ -86,7 +86,7 @@ function getSettings(cwd: string): ProjectSettings {
   lastMtimeCheck = now;
   const settingsPath = getSettingsPath(cwd);
   let mtime = 0;
-  try { if (existsSync(settingsPath)) mtime = lstatSync(settingsPath).mtimeMs; } catch {}
+  try { if (existsSync(settingsPath)) mtime = statSync(settingsPath).mtimeMs; } catch {}
   if (mtime === cachedMtime) return cachedSettings;
   cachedSettings = loadProjectSettings(cwd);
   cachedMtime = mtime;

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -65,14 +65,30 @@ function parseNumEnv(name: string): number | undefined {
 let cachedCwd = "";
 let cachedSettings: ProjectSettings = {};
 let cachedMtime = 0;
+let lastMtimeCheck = 0;
+const MTIME_CHECK_INTERVAL_MS = 30_000; // Check file mtime at most every 30s
 
 function getSettings(cwd: string): ProjectSettings {
+  const now = Date.now();
+  // Different cwd — always reload
+  if (cwd !== cachedCwd) {
+    cachedSettings = loadProjectSettings(cwd);
+    cachedCwd = cwd;
+    try {
+      const settingsPath = getSettingsPath(cwd);
+      cachedMtime = existsSync(settingsPath) ? lstatSync(settingsPath).mtimeMs : 0;
+    } catch { cachedMtime = 0; }
+    lastMtimeCheck = now;
+    return cachedSettings;
+  }
+  // Same cwd — throttle mtime checks
+  if (now - lastMtimeCheck < MTIME_CHECK_INTERVAL_MS) return cachedSettings;
+  lastMtimeCheck = now;
   const settingsPath = getSettingsPath(cwd);
   let mtime = 0;
   try { if (existsSync(settingsPath)) mtime = lstatSync(settingsPath).mtimeMs; } catch {}
-  if (cwd === cachedCwd && mtime === cachedMtime) return cachedSettings;
+  if (mtime === cachedMtime) return cachedSettings;
   cachedSettings = loadProjectSettings(cwd);
-  cachedCwd = cwd;
   cachedMtime = mtime;
   return cachedSettings;
 }
@@ -129,11 +145,13 @@ export function migrateCoAuthorFile(cwd: string): void {
     const dir = dirname(settingsPath);
     // Guard against symlink attacks — skip migration if .pi or settings file is a symlink
     if (existsSync(dir) && lstatSync(dir).isSymbolicLink()) {
-      console.debug("[project-settings] .pi dir is a symlink — skipping migration");
+      console.debug("[project-settings] .pi dir is a symlink — skipping write, deleting legacy file");
+      try { unlinkSync(legacyPath); } catch {}
       return;
     }
     if (existsSync(settingsPath) && lstatSync(settingsPath).isSymbolicLink()) {
-      console.debug("[project-settings] settings file is a symlink — skipping migration");
+      console.debug("[project-settings] settings file is a symlink — skipping write, deleting legacy file");
+      try { unlinkSync(legacyPath); } catch {}
       return;
     }
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -120,11 +120,19 @@ export function migrateCoAuthorFile(cwd: string): void {
   if (!existsSync(legacyPath)) return;
 
   try {
-    const settings = loadProjectSettings(cwd);
-    if (settings.co_author === undefined) {
-      settings.co_author = true;
+    const settingsPath = getSettingsPath(cwd);
+    const dir = dirname(settingsPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    // Read raw JSON to preserve unknown keys
+    let raw: Record<string, unknown> = {};
+    if (existsSync(settingsPath)) {
+      try { raw = JSON.parse(readFileSync(settingsPath, "utf-8")); } catch {}
+      if (typeof raw !== "object" || raw === null || Array.isArray(raw)) raw = {};
     }
-    saveProjectSettings(cwd, settings);
+    if (raw.co_author === undefined) {
+      raw.co_author = true;
+    }
+    writeFileSync(settingsPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
     unlinkSync(legacyPath);
     console.debug("[project-settings] Migrated .pi-co-author → pi-config-settings.json");
     clearSettingsCache();

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -27,7 +27,15 @@ function loadProjectSettings(cwd: string): ProjectSettings {
   const settingsPath = getSettingsPath(cwd);
   if (!existsSync(settingsPath)) return {};
   try {
-    return JSON.parse(readFileSync(settingsPath, "utf-8")) as ProjectSettings;
+    const raw = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
+    const result: ProjectSettings = {};
+    if (typeof raw.co_author === "boolean") result.co_author = raw.co_author;
+    if (typeof raw.use_worktrees === "boolean") result.use_worktrees = raw.use_worktrees;
+    if (typeof raw.dream_interval_hours === "number" && Number.isFinite(raw.dream_interval_hours)) {
+      result.dream_interval_hours = raw.dream_interval_hours;
+    }
+    return result;
   } catch {
     return {};
   }

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -7,7 +7,7 @@
  * 3. Default (only dream_interval_hours has a default of 3)
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { join, dirname } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
@@ -64,11 +64,16 @@ function parseNumEnv(name: string): number | undefined {
 /** Cached settings per cwd */
 let cachedCwd = "";
 let cachedSettings: ProjectSettings = {};
+let cachedMtime = 0;
 
 function getSettings(cwd: string): ProjectSettings {
-  if (cwd === cachedCwd) return cachedSettings;
+  const settingsPath = getSettingsPath(cwd);
+  let mtime = 0;
+  try { if (existsSync(settingsPath)) mtime = lstatSync(settingsPath).mtimeMs; } catch {}
+  if (cwd === cachedCwd && mtime === cachedMtime) return cachedSettings;
   cachedSettings = loadProjectSettings(cwd);
   cachedCwd = cwd;
+  cachedMtime = mtime;
   return cachedSettings;
 }
 
@@ -122,6 +127,15 @@ export function migrateCoAuthorFile(cwd: string): void {
   try {
     const settingsPath = getSettingsPath(cwd);
     const dir = dirname(settingsPath);
+    // Guard against symlink attacks — skip migration if .pi or settings file is a symlink
+    if (existsSync(dir) && lstatSync(dir).isSymbolicLink()) {
+      console.debug("[project-settings] .pi dir is a symlink — skipping migration");
+      return;
+    }
+    if (existsSync(settingsPath) && lstatSync(settingsPath).isSymbolicLink()) {
+      console.debug("[project-settings] settings file is a symlink — skipping migration");
+      return;
+    }
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     // Read raw JSON to preserve unknown keys
     let raw: Record<string, unknown> = {};

--- a/pi-config-settings.example.json
+++ b/pi-config-settings.example.json
@@ -1,0 +1,5 @@
+{
+  "co_author": true,
+  "use_worktrees": false,
+  "dream_interval_hours": 3
+}


### PR DESCRIPTION
## Summary

Adds project-level settings via `.pi/pi-config-settings.json`. Project settings override global env vars.

## Settings

| Setting | Type | Default | Env var | Description |
|---|---|---|---|---|
| `co_author` | boolean | disabled | `PI_CO_AUTHOR` | Co-author trailer in commits |
| `use_worktrees` | boolean | disabled | `PI_USE_WORKTREES` | Force worktree-only workflow |
| `dream_interval_hours` | number | 3 | `PI_DREAM_INTERVAL_HOURS` | Dream frequency |

Resolution: project file → env var → default

## Changes

- **New** `extensions/orchestrator/project-settings.ts` — load/merge/typed getters/migration
- **Updated** `extensions/orchestrator/enforcement.ts` — co-author via getSetting + use_worktrees enforcement
- **Updated** `extensions/orchestrator/dreaming.ts` — dream interval via getSetting
- **Updated** `extensions/orchestrator/index.ts` — register before enforcement
- **New** `pi-config-settings.example.json` — example file

## Migration

`.pi-co-author` file is automatically migrated on startup:
1. Detects `.pi-co-author` exists
2. Creates/updates `.pi/pi-config-settings.json` with `co_author: true`
3. Deletes `.pi-co-author`

## Testing

All 3 resolution paths verified: no config → default, env var → env wins, project file → project wins.
Migration verified: `.pi-co-author` deleted after settings written.

Closes #427