### PR TITLE
refactor: extract /review-handler-status into own prompt

### DIFF
--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -316,8 +316,6 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       const tokens = prefix.trim().split(/\s+/).filter(Boolean);
       const selected = new Set(tokens);
       const lastPart = prefix.endsWith(" ") ? "" : (tokens[tokens.length - 1] || "");
-      // status and --auto flags are mutually exclusive
-      const hasAutoFlag = tokens.some(t => t.startsWith("--auto"));
       const all = [
         { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
         { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -317,19 +317,11 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       const selected = new Set(tokens);
       const lastPart = prefix.endsWith(" ") ? "" : (tokens[tokens.length - 1] || "");
       // status and --auto flags are mutually exclusive
-      const hasStatus = tokens.includes("status");
       const hasAutoFlag = tokens.some(t => t.startsWith("--auto"));
-      if (hasStatus) return null; // status is standalone, no more suggestions
-      const all = hasAutoFlag
-        ? [ // Only show remaining --auto flags (status excluded)
-            { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
-            { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
-          ]
-        : [ // Show all options
-            { value: "status", label: "status", description: "Show all review comments from DB for current PR" },
-            { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
-            { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
-          ];
+      const all = [
+        { value: "--autorabbit", label: "--autorabbit", description: "Auto-fix CodeRabbit comments in a loop" },
+        { value: "--autoqodo", label: "--autoqodo", description: "Auto-fix Qodo comments in a loop" },
+      ];
       const available = all.filter(item => !selected.has(item.value));
       return filter(available, lastPart);
     },

--- a/prompts/review-handler-status.md
+++ b/prompts/review-handler-status.md
@@ -6,12 +6,12 @@ description: "Show live status of running review-handler agents — /review-hand
 
 $ARGUMENTS
 
+## Review Handler Status
+
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
 > while executing this command — DO NOT work around it silently. Ask the user:
 > "Should I create a GitHub issue for this?" Route to `myk-org/pi-config` for prompt/extension issues,
 > or to the relevant tool's repository for CLI issues.
-
-## Review Handler Status
 
 Show the live state of running autoqodo/autorabbit review-handler agents.
 
@@ -20,10 +20,11 @@ Show the live state of running autoqodo/autorabbit review-handler agents.
 1. **Check if any review-handler agents are running:**
    Run the `/async-status` command. Look at the output for agents whose task contains `reviews poll`.
    If none found, tell the user:
-   "No review handler agents running — nothing to show." **STOP HERE.**
-   Extract the PR number from the agent's task or worktree cwd.
+   "No review handler agents running — nothing to show."
+   Do not proceed to step 2.
 
 2. **If agents ARE running**, for each PR being handled:
+   - Extract the PR number from the agent's task or worktree cwd
    - Run `myk-pi-tools reviews status --pr <number>` to generate the HTML report
    - Extract the HTML report path from the CLI output line `HTML report saved: <path>`
    - **Container** (check `/.dockerenv` or `/run/.containerenv`): serve via file preview rule (`rules/45-file-preview.md`)

--- a/prompts/review-handler-status.md
+++ b/prompts/review-handler-status.md
@@ -1,0 +1,30 @@
+---
+description: "Show live status of running review-handler agents — /review-handler-status"
+---
+
+## Raw Arguments
+
+$ARGUMENTS
+
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to `myk-org/pi-config` for prompt/extension issues,
+> or to the relevant tool's repository for CLI issues.
+
+## Review Handler Status
+
+Show the live state of running autoqodo/autorabbit review-handler agents.
+
+### Steps
+
+1. **Check if any review-handler agents are running:**
+   Run the `/async-status` command. Look at the output for agents whose task contains `reviews poll`.
+   If none found, tell the user:
+   "No review handler agents running — nothing to show." **STOP HERE.**
+   Extract the PR number from the agent's task or worktree cwd.
+
+2. **If agents ARE running**, for each PR being handled:
+   - Run `myk-pi-tools reviews status --pr <number>` to generate the HTML report
+   - Extract the HTML report path from the CLI output line `HTML report saved: <path>`
+   - **Container** (check `/.dockerenv` or `/run/.containerenv`): serve via file preview rule (`rules/45-file-preview.md`)
+   - **Native** (not in container): show `file://<path>` as a clickable link

--- a/prompts/review-handler-status.md
+++ b/prompts/review-handler-status.md
@@ -17,15 +17,11 @@ Show the live state of running autoqodo/autorabbit review-handler agents.
 
 ### Steps
 
-1. **Check if any review-handler agents are running:**
-   Run the `/async-status` command. Look at the output for agents whose task contains `reviews poll`.
-   If none found, tell the user:
-   "No review handler agents running — nothing to show."
-   Do not proceed to step 2.
+1. Run `/async-status`. Look for agents whose task contains `reviews poll`.
+   If none found → "No review handler agents running — nothing to show."
 
-2. **If agents ARE running**, for each PR being handled:
-   - Extract the PR number from the agent's task or worktree cwd
-   - Run `myk-pi-tools reviews status --pr <number>` to generate the HTML report
-   - Extract the HTML report path from the CLI output line `HTML report saved: <path>`
-   - **Container** (check `/.dockerenv` or `/run/.containerenv`): serve via file preview rule (`rules/45-file-preview.md`)
-   - **Native** (not in container): show `file://<path>` as a clickable link
+2. For each running review agent, extract the PR number from the agent's task or worktree cwd.
+   Run `myk-pi-tools reviews status --pr <number>` to generate the HTML report.
+   Extract the path from `HTML report saved: <path>` in the output.
+   - **Container** (`/.dockerenv` or `/run/.containerenv` exists): serve via file preview rule (`rules/45-file-preview.md`)
+   - **Native**: show `file://<path>`

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -1,6 +1,6 @@
 ---
 description: Process ALL review sources (human, Qodo, CodeRabbit) from current PR
-argument-hint: "[--autorabbit] [--autoqodo] [status [PR#]]"
+argument-hint: "[--autorabbit] [--autoqodo]"
 ---
 
 ## Raw Arguments
@@ -63,8 +63,6 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 - `/review-handler` - Process reviews from current PR
 - `/review-handler https://github.com/owner/repo/pull/123#pullrequestreview-456` - With specific review URL
-- `/review-handler status` - Show all review comments from DB for current PR
-- `/review-handler status 413` - Show review comments for specific PR number
 - `/review-handler --autorabbit` - Auto-fix CodeRabbit comments in a loop
 - `/review-handler --autoqodo` - Auto-fix Qodo comments in a loop
 - `/review-handler --autorabbit --autoqodo` - Auto-fix both CodeRabbit and Qodo comments
@@ -80,24 +78,15 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 Read the **Raw Arguments** section above. Parse as follows:
 
-1. Check if `status` appears in the raw arguments
-   - If YES: extract optional PR number after `status` (e.g., `status 413` → PR 413)
-   - Run `myk-pi-tools reviews status` (or `myk-pi-tools reviews status --pr 413` if PR number given)
-   - Present the full CLI output as formatted text in your response (not as raw bash output).
-     Show everything: table, diagnostics, errors — include all of it.
-   - If the CLI output contains `HTML report saved:`, extract the full path after it.
-     Serve the report using the file preview rule (see `rules/45-file-preview.md`).
-     The file preview rule handles httpd startup, port allocation, and container detection.
-   - **STOP HERE — skip ALL other phases. Do not proceed.**
-2. Check if `--autorabbit` appears in the raw arguments
+1. Check if `--autorabbit` appears in the raw arguments
    - If YES: set autorabbit mode = ON, remove `--autorabbit` from the text
    - If NO: autorabbit mode = OFF
-3. Check if `--autoqodo` appears in the (remaining) raw arguments
+2. Check if `--autoqodo` appears in the (remaining) raw arguments
    - If YES: set autoqodo mode = ON, remove `--autoqodo` from the text
    - If NO: autoqodo mode = OFF
-4. The remaining text is the cleaned arguments — pass these through to the CLI
-5. `--autorabbit` and `--autoqodo` are **command-level flags** — NEVER pass them to the CLI
-6. Both flags can be active simultaneously
+3. The remaining text is the cleaned arguments — pass these through to the CLI
+4. `--autorabbit` and `--autoqodo` are **command-level flags** — NEVER pass them to the CLI
+5. Both flags can be active simultaneously
 
 **Example:** Raw arguments = `--autorabbit --autoqodo`
 


### PR DESCRIPTION
## Summary

Separates `/review-handler-status` from the review-handler prompt into its own command.

## What it does

1. Checks running async agents for `reviews poll` tasks
2. If none running → "No review handler agents running"
3. If running → queries DB for each PR, generates HTML report, shows file:// link (native) or serves via httpd (container)

## Changes

- **New** `prompts/review-handler-status.md`
- **Updated** `prompts/review-handler.md` — removed status from Phase 0
- **Updated** `extensions/orchestrator/extended-autocomplete.ts` — removed status from review-handler autocomplete

Closes #436