### PR TITLE
fix: project-scoped temp dirs under /tmp/pi-data/ + zombie cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ pi-config/
 │   │   ├── project-settings.ts        # Project-level settings (.pi/pi-config-settings.json)
 │   │   ├── situation-report.ts        # Token-budgeted memory context for system prompts
 │   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent (async-only enforcement for reviewers)
-│   │   └── utils.ts                 # Shared utilities
+│   │   └── utils.ts                 # Shared utilities (getProjectTmpDir, etc.)
 │   ├── coms/                        # Inter-agent communication extension (standalone)
 │   │   ├── index.ts                 # Entry point — registers coms and coms-net
 │   │   ├── coms.ts                  # P2P agent communication wrapper (on-demand /coms command)
@@ -196,6 +196,35 @@ waiting for long-running agents.
 
 1. Edit the `ASYNC_ONLY_AGENTS` set in `extensions/orchestrator/subagent-tool.ts`
 2. Update this section in `AGENTS.md`
+
+### Project-Scoped Temp Directories
+
+All async agent temp files live under project-scoped subdirectories:
+
+```text
+/tmp/pi-data/<project>/
+├── debug.log                    # Async debug log
+├── cron-<pid>.json              # Cron task state
+├── .repeat-<pid>.json           # Repeat command detection
+├── nvim-<pid>-<ts>.lua          # Nvim integration (ephemeral)
+├── nvim-qf-<pid>-<ts>.json      # Nvim quickfix data (ephemeral)
+├── async-cfg-<id>.json          # Async runner config (ephemeral)
+├── subagent-<random>/           # Subagent prompt temp dir (ephemeral)
+├── async-results-pid-<pid>/     # Async agent completion results (picked up by poller)
+└── worker-<id>/                 # Async agent working dir
+    ├── status.json              # Agent state (running/complete/failed)
+    ├── session.json             # Parent PID + starttime for zombie detection
+    ├── output.log               # Agent output
+    └── system-prompt.md         # Agent system prompt
+```
+
+**Project name format:** cwd with `/` replaced by `__` (e.g., `home__myakove__git__pi-config`).
+
+**Zombie cleanup:** On `session_start`, scans project dir for dead agents.
+Checks each agent's `parentPid` + `parentStartTime` against `/proc/PID/stat` field 22.
+Dead parent = zombie = delete.
+
+**Shared helper:** `getProjectTmpDir(cwd)` in `utils.ts` — creates dir if missing, returns path.
 
 ### Adding an Extension Command
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -379,7 +379,7 @@ export function registerAsyncAgents(
     // Zombie cleanup: scan project dir for dead agents
     try {
       for (const entry of fs.readdirSync(PROJECT_TMP_DIR)) {
-        if (!entry.startsWith("worker-")) continue;
+        if (entry.startsWith("async-results-") || entry.startsWith("cron-") || entry.startsWith("subagent-") || entry.startsWith(".") || entry.endsWith(".json") || entry.endsWith(".log")) continue;
         const jobDir = path.join(PROJECT_TMP_DIR, entry);
         try {
           const markerPath = path.join(jobDir, "session.json");
@@ -389,12 +389,8 @@ export function registerAsyncAgents(
           if (marker.resultsDir === ASYNC_RESULTS_DIR) continue;
           const parentPid = marker.parentPid;
           const parentStartTime = marker.parentStartTime;
-          if (!parentPid) {
-            // Legacy entry without parentPid — check process directly
-            const status = readAsyncStatus(jobDir);
-            if (status?.pid) {
-              try { process.kill(status.pid, 0); continue; } catch {} // dead
-            }
+          if (!parentPid || !parentStartTime) {
+            // Missing identity — can't verify, remove as stale
             try { fs.rmSync(jobDir, { recursive: true, force: true }); } catch {}
             continue;
           }

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -379,10 +379,11 @@ export function registerAsyncAgents(
     // Zombie cleanup: scan project dir for dead agents
     try {
       for (const entry of fs.readdirSync(PROJECT_TMP_DIR)) {
-        if (entry.startsWith("async-results-") || entry.startsWith("cron-") || entry.startsWith("subagent-") || entry.startsWith(".") || entry.endsWith(".json") || entry.endsWith(".log")) continue;
         const jobDir = path.join(PROJECT_TMP_DIR, entry);
+        if (!fs.statSync(jobDir).isDirectory()) continue;
         try {
           const markerPath = path.join(jobDir, "session.json");
+          // Only process dirs that have session.json (agent dirs)
           if (!fs.existsSync(markerPath)) continue;
           const marker = JSON.parse(fs.readFileSync(markerPath, "utf-8"));
           // Skip our own session's agents

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -255,10 +255,16 @@ export function registerAsyncAgents(
     fs.mkdirSync(ASYNC_RESULTS_DIR, { recursive: true, mode: 0o700 });
 
     // Write session marker so restore can match jobs to sessions
-    const parentStartTime = (() => {
-      try { return fs.readFileSync(`/proc/${process.pid}/stat`, "utf-8").split(" ")[21]; }
-      catch { return ""; }
-    })();
+    let parentStartTime = "";
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        parentStartTime = fs.readFileSync(`/proc/${process.pid}/stat`, "utf-8").split(" ")[21] || "";
+        if (parentStartTime) break;
+      } catch { /* retry */ }
+    }
+    if (!parentStartTime) {
+      console.debug("[async-agents] WARNING: could not read /proc/self/stat starttime after 3 attempts");
+    }
     fs.writeFileSync(path.join(workerDir, "session.json"), JSON.stringify({
       resultsDir: ASYNC_RESULTS_DIR,
       fireAndForget: options?.fireAndForget || false,
@@ -391,8 +397,7 @@ export function registerAsyncAgents(
           const parentPid = marker.parentPid;
           const parentStartTime = marker.parentStartTime;
           if (!parentPid || !parentStartTime) {
-            // Missing identity — can't verify, remove as stale
-            try { fs.rmSync(jobDir, { recursive: true, force: true }); } catch {}
+            // Missing identity — can't safely verify, skip
             continue;
           }
           // Check if parent pi process is alive via /proc/PID/stat starttime

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -13,11 +13,12 @@ const require = createRequire(import.meta.url);
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentConfig } from "./agents.js";
-import { getPiInvocation } from "./utils.js";
+import { getPiInvocation, getProjectTmpDir, PI_TMP_BASE_DIR } from "./utils.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
-const ASYNC_BASE_DIR = path.join(os.tmpdir(), "pi-async-agents");
+
+
 const ASYNC_POLL_INTERVAL_MS = 3000;
 
 // ── Interfaces ───────────────────────────────────────────────────────────
@@ -28,7 +29,7 @@ export interface AsyncJob {
   name?: string;
   task: string;
   status: "queued" | "running" | "complete" | "failed";
-  asyncDir: string;
+  workerDir: string;
   startedAt: number;
   updatedAt: number;
   output?: string;
@@ -47,19 +48,16 @@ interface AsyncState {
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
-function readAsyncStatus(asyncDir: string): any | null {
+function readAsyncStatus(workerDir: string): any | null {
   try {
-    const statusPath = path.join(asyncDir, "status.json");
+    const statusPath = path.join(workerDir, "status.json");
     return JSON.parse(fs.readFileSync(statusPath, "utf-8"));
   } catch { return null; }
 }
 
 /** Derive a stable directory name from a session file path. */
-function sessionDirName(sessionFile: string): string {
-  if (!sessionFile) return `pid-${process.pid}`;
-  const { createHash } = require("node:crypto");
-  const normalized = path.resolve(sessionFile);
-  return `session-${createHash("sha256").update(normalized).digest("hex").slice(0, 12)}`;
+function sessionResultsDirName(): string {
+  return `async-results-pid-${process.pid}`;
 }
 
 export function formatDuration(ms: number): string {
@@ -80,14 +78,15 @@ export function registerAsyncAgents(
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
   getAsyncJobs: () => Array<{ id: string; agent: string; name?: string; task: string; status: string; startedAt: number }>;
 } {
-  const ASYNC_DIR = ASYNC_BASE_DIR;
-  let ASYNC_RESULTS_DIR = path.join(ASYNC_BASE_DIR, `pid-${process.pid}`);
+  let PROJECT_TMP_DIR = PI_TMP_BASE_DIR; // Updated to project-scoped dir on session_start
+  let ASYNC_RESULTS_DIR = ""; // Set on session_start to project-scoped dir
 
   const ASYNC_DEBUG = !!process.env.PI_ASYNC_DEBUG;
-  const ASYNC_LOG = path.join(os.tmpdir(), "pi-async-debug.log");
+  const EARLY_LOG_PATH = ASYNC_DEBUG ? path.join(PI_TMP_BASE_DIR, `early-debug-${process.pid}.log`) : "";
+  let DEBUG_LOG_PATH = EARLY_LOG_PATH; // Starts with early log, moved to project dir on session_start
   function asyncLog(msg: string) {
-    if (!ASYNC_DEBUG) return;
-    try { fs.appendFileSync(ASYNC_LOG, `${new Date().toISOString()} ${msg}\n`); } catch {}
+    if (!ASYNC_DEBUG || !DEBUG_LOG_PATH) return;
+    try { fs.appendFileSync(DEBUG_LOG_PATH, `${new Date().toISOString()} ${msg}\n`); } catch {}
   }
 
   const asyncState: AsyncState = {
@@ -143,7 +142,7 @@ export function registerAsyncAgents(
 
       for (const job of asyncState.jobs.values()) {
         if (job.status === "complete" || job.status === "failed") continue;
-        const status = readAsyncStatus(job.asyncDir);
+        const status = readAsyncStatus(job.workerDir);
         if (status) {
           job.status = status.state;
           job.updatedAt = status.lastUpdate ?? Date.now();
@@ -249,14 +248,23 @@ export function registerAsyncAgents(
     if (!agent) return { id: "", error: `Unknown agent: "${agentName}"` };
 
     const id = `${agentName}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-    const asyncDir = path.join(ASYNC_DIR, id);
+    const workerDir = path.join(PROJECT_TMP_DIR, id);
     const resultPath = path.join(ASYNC_RESULTS_DIR, `${id}.json`);
 
-    fs.mkdirSync(asyncDir, { recursive: true });
+    fs.mkdirSync(workerDir, { recursive: true });
     fs.mkdirSync(ASYNC_RESULTS_DIR, { recursive: true, mode: 0o700 });
 
     // Write session marker so restore can match jobs to sessions
-    fs.writeFileSync(path.join(asyncDir, "session.json"), JSON.stringify({ resultsDir: ASYNC_RESULTS_DIR, fireAndForget: options?.fireAndForget || false }), { mode: 0o600 });
+    const parentStartTime = (() => {
+      try { return fs.readFileSync(`/proc/${process.pid}/stat`, "utf-8").split(" ")[21]; }
+      catch { return ""; }
+    })();
+    fs.writeFileSync(path.join(workerDir, "session.json"), JSON.stringify({
+      resultsDir: ASYNC_RESULTS_DIR,
+      fireAndForget: options?.fireAndForget || false,
+      parentPid: process.pid,
+      parentStartTime,
+    }), { mode: 0o600 });
 
     // Build pi args
     const piArgs: string[] = ["--mode", "json", "-p", "--no-session", "-nc"];
@@ -265,7 +273,7 @@ export function registerAsyncAgents(
     if (agent.tools?.length) piArgs.push("--tools", agent.tools.join(","));
 
     if (agent.systemPrompt?.trim()) {
-      const promptPath = path.join(asyncDir, "system-prompt.md");
+      const promptPath = path.join(workerDir, "system-prompt.md");
       fs.writeFileSync(promptPath, agent.systemPrompt, { mode: 0o600 });
       piArgs.push("--append-system-prompt", promptPath);
     }
@@ -275,7 +283,7 @@ export function registerAsyncAgents(
     const inv = getPiInvocation(piArgs);
 
     // Write config for the runner
-    const configPath = path.join(os.tmpdir(), `pi-async-cfg-${id}.json`);
+    const configPath = path.join(PROJECT_TMP_DIR, `async-cfg-${id}.json`);
     fs.writeFileSync(configPath, JSON.stringify({
       id,
       agent: agentName,
@@ -283,7 +291,7 @@ export function registerAsyncAgents(
       cwd,
       model: effectiveModel,
       resultPath,
-      asyncDir,
+      workerDir,
       sessionId: `${process.pid}:${process.cwd()}`,
       piCommand: inv.command,
       piArgs: inv.args,
@@ -336,7 +344,7 @@ export function registerAsyncAgents(
       name: options?.name,
       task: task.slice(0, 200),
       status: "queued",
-      asyncDir,
+      workerDir,
       startedAt: Date.now(),
       updatedAt: Date.now(),
       fireAndForget: options?.fireAndForget,
@@ -353,30 +361,62 @@ export function registerAsyncAgents(
   pi.on("session_start", (_event, ctx) => {
     asyncState.lastCtx = ctx;
 
-    // Set results dir based on session file — stable across reload/resume/--continue
-    const sessionFile = ctx.sessionManager?.getSessionFile?.() || (ctx as any).sessionFile || "";
-    ASYNC_RESULTS_DIR = path.join(ASYNC_BASE_DIR, sessionDirName(sessionFile));
-    asyncLog(`session_start: sessionFile=${sessionFile.slice(-40)} resultsDir=${path.basename(ASYNC_RESULTS_DIR)}`);
+    // Set project-scoped dir first (getProjectTmpDir creates it if missing)
+    PROJECT_TMP_DIR = getProjectTmpDir(ctx.cwd);
 
-    // Clean up legacy PID-based results directories only if their process is dead
+    // Set results dir — PID-scoped under project dir
+    ASYNC_RESULTS_DIR = path.join(PROJECT_TMP_DIR, sessionResultsDirName());
+    const projectLogPath = path.join(PROJECT_TMP_DIR, "debug.log");
+    // Move early startup logs to project dir
+    if (EARLY_LOG_PATH && fs.existsSync(EARLY_LOG_PATH)) {
+      try {
+        fs.appendFileSync(projectLogPath, fs.readFileSync(EARLY_LOG_PATH, "utf-8"));
+        fs.unlinkSync(EARLY_LOG_PATH);
+      } catch {}
+    }
+    DEBUG_LOG_PATH = projectLogPath;
+
+    // Zombie cleanup: scan project dir for dead agents
     try {
-      for (const entry of fs.readdirSync(ASYNC_BASE_DIR)) {
-        const m = entry.match(/^(?:results|pid)-(\d+)$/);
-        if (m) {
-          const pid = +m[1];
-          try { process.kill(pid, 0); } catch {
-            // Process dead — safe to clean up
-            try { fs.rmSync(path.join(ASYNC_BASE_DIR, entry), { recursive: true, force: true }); } catch {}
+      for (const entry of fs.readdirSync(PROJECT_TMP_DIR)) {
+        if (!entry.startsWith("worker-")) continue;
+        const jobDir = path.join(PROJECT_TMP_DIR, entry);
+        try {
+          const markerPath = path.join(jobDir, "session.json");
+          if (!fs.existsSync(markerPath)) continue;
+          const marker = JSON.parse(fs.readFileSync(markerPath, "utf-8"));
+          // Skip our own session's agents
+          if (marker.resultsDir === ASYNC_RESULTS_DIR) continue;
+          const parentPid = marker.parentPid;
+          const parentStartTime = marker.parentStartTime;
+          if (!parentPid) {
+            // Legacy entry without parentPid — check process directly
+            const status = readAsyncStatus(jobDir);
+            if (status?.pid) {
+              try { process.kill(status.pid, 0); continue; } catch {} // dead
+            }
+            try { fs.rmSync(jobDir, { recursive: true, force: true }); } catch {}
+            continue;
           }
-        }
+          // Check if parent pi process is alive via /proc/PID/stat starttime
+          try {
+            const stat = fs.readFileSync(`/proc/${parentPid}/stat`, "utf-8");
+            const currentStartTime = stat.split(" ")[21];
+            if (currentStartTime === parentStartTime) continue; // alive, same process
+          } catch {} // /proc not found = dead
+          // Parent dead or PID reused — zombie, delete
+          try { fs.rmSync(jobDir, { recursive: true, force: true }); } catch {}
+        } catch {} // skip unreadable dirs
       }
-    } catch (e: any) { console.debug("[async-agents] orphan cleanup failed:", e?.message || e); }
+    } catch (e: any) { console.debug("[async-agents] zombie cleanup failed:", e?.message?.slice(0, 100)); }
 
-    // Restore jobs from status files in ASYNC_DIR that belong to this session
+    asyncLog(`session_start: resultsDir=${path.basename(ASYNC_RESULTS_DIR)}`);
+
+    // Restore jobs from status files in PROJECT_TMP_DIR that belong to this session
     try {
-      for (const entry of fs.readdirSync(ASYNC_DIR)) {
+      for (const entry of fs.readdirSync(PROJECT_TMP_DIR)) {
         if (entry.startsWith("session-") || entry.startsWith("pid-")) continue;
-        const jobDir = path.join(ASYNC_DIR, entry);
+        const jobDir = path.join(PROJECT_TMP_DIR, entry);
         const status = readAsyncStatus(jobDir);
         if (!status) continue;
         // Check if this job belongs to our session
@@ -398,7 +438,7 @@ export function registerAsyncAgents(
             agent: status.agent || "unknown",
             task: (status.task || "").slice(0, 200),
             status: isComplete ? status.state : "running",
-            asyncDir: path.join(ASYNC_DIR, entry),
+            workerDir: path.join(PROJECT_TMP_DIR, entry),
             startedAt: status.startedAt || Date.now(),
             updatedAt: status.lastUpdate || Date.now(),
             exitCode: status.exitCode,
@@ -468,7 +508,7 @@ export function registerAsyncAgents(
       if (idx < 0) return;
 
       const job = running[idx];
-      const outputPath = path.join(job.asyncDir, "output.log");
+      const outputPath = path.join(job.workerDir, "output.log");
 
       // Create a live output viewer as an overlay
       await ctx.ui.custom<void>((tui, _theme, _kb, done) => {
@@ -597,7 +637,7 @@ export function registerAsyncAgents(
 
             const headerWidth = width - 2;
             const dur = formatDuration(Date.now() - job.startedAt);
-            const status = readAsyncStatus(job.asyncDir);
+            const status = readAsyncStatus(job.workerDir);
             const state = status?.state || job.status;
             const stateIcon = state === "complete" ? "✅" : state === "failed" ? "❌" : "⏳";
             const header = truncateToWidth(`${stateIcon} ${job.name || job.agent} — ${dur} — ${job.task.slice(0, 40)}`, headerWidth);
@@ -668,7 +708,7 @@ export function registerAsyncAgents(
     }
 
     for (const job of targets) {
-      const status = readAsyncStatus(job.asyncDir);
+      const status = readAsyncStatus(job.workerDir);
       if (status?.pid) {
         try {
           const tree = execFileSync("pstree", ["-p", String(status.pid)], { encoding: "utf-8", timeout: 3000 });
@@ -736,7 +776,7 @@ export function registerAsyncAgents(
       const job = running[idx];
 
       // Kill entire process tree
-      const status = readAsyncStatus(job.asyncDir);
+      const status = readAsyncStatus(job.workerDir);
       if (status?.pid) {
         const killLog: string[] = [];
         try {
@@ -753,7 +793,7 @@ export function registerAsyncAgents(
           try { process.kill(status.pid, "SIGKILL"); killLog.push(`killed runner ${status.pid}`); } catch {}
           if (status.childPid) try { process.kill(status.childPid, "SIGKILL"); killLog.push(`killed child ${status.childPid}`); } catch {}
         }
-        const logPath = path.join(job.asyncDir, "kill.log");
+        const logPath = path.join(job.workerDir, "kill.log");
         fs.writeFileSync(logPath, killLog.join("\n"), "utf-8");
       }
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -380,8 +380,8 @@ export function registerAsyncAgents(
     try {
       for (const entry of fs.readdirSync(PROJECT_TMP_DIR)) {
         const jobDir = path.join(PROJECT_TMP_DIR, entry);
-        if (!fs.statSync(jobDir).isDirectory()) continue;
         try {
+          if (!fs.statSync(jobDir).isDirectory()) continue;
           const markerPath = path.join(jobDir, "session.json");
           // Only process dirs that have session.json (agent dirs)
           if (!fs.existsSync(markerPath)) continue;

--- a/extensions/orchestrator/async-runner.ts
+++ b/extensions/orchestrator/async-runner.ts
@@ -18,7 +18,7 @@ interface RunConfig {
   tools?: string[];
   systemPrompt?: string;
   resultPath: string;
-  asyncDir: string;
+  workerDir: string;
   sessionId?: string;
   piCommand: string;
   piArgs: string[];
@@ -52,8 +52,8 @@ function writeJson(filePath: string, data: object): void {
 }
 
 async function run(config: RunConfig): Promise<void> {
-  const statusPath = path.join(config.asyncDir, "status.json");
-  const outputPath = path.join(config.asyncDir, "output.log");
+  const statusPath = path.join(config.workerDir, "status.json");
+  const outputPath = path.join(config.workerDir, "output.log");
   const startedAt = Date.now();
 
   const status: StatusPayload = {
@@ -74,7 +74,7 @@ async function run(config: RunConfig): Promise<void> {
   // Connect to pidash server to stream events
   const pidashPort = parseInt(process.env.PI_PIDASH_PORT || "", 10) || 19190;
   let pidashWs: any = null;
-  const pidashLog = path.join(config.asyncDir, "pidash-ws.log");
+  const pidashLog = path.join(config.workerDir, "pidash-ws.log");
   fs.writeFileSync(pidashLog, `START port=${pidashPort} id=${config.id}\n`);
   try {
     const _require = createRequire(import.meta.url);
@@ -221,7 +221,7 @@ async function run(config: RunConfig): Promise<void> {
     durationMs: endedAt - startedAt,
     cwd: config.cwd,
     sessionId: config.sessionId,
-    asyncDir: config.asyncDir,
+    workerDir: config.workerDir,
   });
 }
 

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -17,6 +17,7 @@ import * as path from "node:path";
 import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { discoverAgents } from "./agents.js";
+import { getProjectTmpDir } from "./utils.js";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -34,7 +35,7 @@ export interface CronTask {
 
 // ── Persistence ──────────────────────────────────────────────────────
 
-const CRON_FILE = path.join(os.tmpdir(), `pi-cron-${process.pid}.json`);
+let CRON_FILE = ""; // Set on session_start to project-scoped dir
 
 function saveCrons(tasks: CronTask[]): void {
   try {
@@ -53,9 +54,10 @@ function loadCrons(): CronTask[] {
 
 function cleanupOrphanedCronFiles(): void {
   try {
-    const dir = os.tmpdir();
+    // Clean up project-scoped cron files
+    const dir = path.dirname(CRON_FILE);
     for (const f of fs.readdirSync(dir)) {
-      const m = f.match(/^pi-cron-(\d+)\.json$/);
+      const m = f.match(/^cron-(\d+)\.json$/);
       if (m && +m[1] !== process.pid) {
         try { process.kill(+m[1], 0); } catch {
           try { fs.unlinkSync(path.join(dir, f)); } catch {}
@@ -63,6 +65,7 @@ function cleanupOrphanedCronFiles(): void {
       }
     }
   } catch (e: any) { console.debug("[cron] cleanup orphaned cron files failed:", e?.message || e); }
+
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -184,6 +187,7 @@ export function registerCron(
   pi.on("session_start", (_event, ctx) => {
     lastCwd = ctx.cwd;
     lastCtx = ctx;
+    CRON_FILE = path.join(getProjectTmpDir(ctx.cwd), `cron-${process.pid}.json`);
     cleanupOrphanedCronFiles();
 
     // Restore from persistence (after /reload or /new)
@@ -310,9 +314,9 @@ export function registerCron(
       if (action === "list-all") {
         const sections: string[] = [];
         try {
-          const dir = os.tmpdir();
+          const dir = path.dirname(CRON_FILE);
           for (const f of fs.readdirSync(dir)) {
-            const m = f.match(/^pi-cron-(\d+)\.json$/);
+            const m = f.match(/^cron-(\d+)\.json$/);
             if (!m) continue;
             const pid = +m[1];
             const isMe = pid === process.pid;
@@ -385,9 +389,9 @@ export function registerCron(
       if (sub === "list-all") {
         const sections: string[] = [];
         try {
-          const dir = os.tmpdir();
+          const dir = path.dirname(CRON_FILE);
           for (const f of fs.readdirSync(dir)) {
-            const m = f.match(/^pi-cron-(\d+)\.json$/);
+            const m = f.match(/^cron-(\d+)\.json$/);
             if (!m) continue;
             const pid = +m[1];
             const isMe = pid === process.pid;

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -37,6 +37,9 @@ export interface CronTask {
 
 let CRON_FILE = ""; // Set on session_start to project-scoped dir
 
+/** Get current cron file path — used by autocomplete */
+export function getCronFilePath(): string { return CRON_FILE; }
+
 function saveCrons(tasks: CronTask[]): void {
   try {
     fs.writeFileSync(CRON_FILE, JSON.stringify(tasks), { mode: 0o600 });

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -41,12 +41,14 @@ let CRON_FILE = ""; // Set on session_start to project-scoped dir
 export function getCronFilePath(): string { return CRON_FILE; }
 
 function saveCrons(tasks: CronTask[]): void {
+  if (!CRON_FILE) return;
   try {
     fs.writeFileSync(CRON_FILE, JSON.stringify(tasks), { mode: 0o600 });
   } catch (e: any) { console.debug("[cron] save crons failed:", e?.message || e); }
 }
 
 function loadCrons(): CronTask[] {
+  if (!CRON_FILE) return [];
   try {
     const data = JSON.parse(fs.readFileSync(CRON_FILE, "utf-8"));
     return Array.isArray(data) ? data : [];

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -19,6 +19,7 @@ import { getSetting } from "./project-settings.js";
 import { discoverAgents } from "./agents.js";
 import { ICON_DREAM } from "./icons.js";
 import { rebuildAndOrganize } from "./situation-report.js";
+import { getProjectTmpDir } from "./utils.js";
 
 // Default: 3 hours. Override with PI_DREAM_INTERVAL_HOURS env var (0.5–24).
 const _rawHours = parseFloat(process.env.PI_DREAM_INTERVAL_HOURS || "3");
@@ -112,7 +113,9 @@ export function registerDreaming(
     );
     // Poll the async agent status file until dream completes
     if (id) {
-      const statusPath = path.join(os.tmpdir(), "pi-async-agents", id, "status.json");
+      // Scan project dir for the worker's status file
+      const projectDir = getProjectTmpDir(cwd);
+      const statusPath = path.join(projectDir, id, "status.json");
       const pollStart = Date.now();
       const POLL_TIMEOUT_MS = 30 * 60 * 1000; // 30 min max
       if (activePollInterval) clearInterval(activePollInterval);

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -8,6 +8,7 @@ import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getSetting } from "./project-settings.js";
+import { getProjectTmpDir } from "./utils.js";
 import {
   DANGEROUS,
   getCurrentBranch,
@@ -35,7 +36,6 @@ let REPEAT_FILE = "";
 
 function ensureRepeatFile(cwd: string): void {
   if (!REPEAT_FILE) {
-    const { getProjectTmpDir } = require("./utils.js");
     REPEAT_FILE = join(getProjectTmpDir(cwd), `.repeat-${process.pid}.json`);
   }
 }

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -30,9 +30,18 @@ function normalizeForRepeatCheck(command: string): string {
 }
 
 // Repeat detection via temp file — immune to module reload / closure issues
-const REPEAT_FILE = `/tmp/.pi-repeat-${process.pid}.json`;
+// Repeat detection file — set to project dir on first use
+let REPEAT_FILE = "";
+
+function ensureRepeatFile(cwd: string): void {
+  if (!REPEAT_FILE) {
+    const { getProjectTmpDir } = require("./utils.js");
+    REPEAT_FILE = join(getProjectTmpDir(cwd), `.repeat-${process.pid}.json`);
+  }
+}
 
 function readRepeatState(): { lastCmd: string; count: number } {
+  if (!REPEAT_FILE) return { lastCmd: "", count: 0 };
   try {
     return JSON.parse(readFileSync(REPEAT_FILE, "utf-8"));
   } catch {
@@ -41,6 +50,7 @@ function readRepeatState(): { lastCmd: string; count: number } {
 }
 
 function writeRepeatState(state: { lastCmd: string; count: number }): void {
+  if (!REPEAT_FILE) return;
   try {
     writeFileSync(REPEAT_FILE, JSON.stringify(state));
   } catch (e: any) { console.debug("[enforcement] write repeat state failed:", e?.message || e); }
@@ -75,6 +85,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     // Block repeated identical commands (polling-by-spam) — orchestrator only
     if (process.env.PI_SUBAGENT_CHILD !== "1") {
+      ensureRepeatFile(ctx.cwd);
       const normalized = normalizeForRepeatCheck(command);
       const rs = readRepeatState();
       if (normalized === rs.lastCmd) {

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -23,8 +23,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from "@earendil-works/pi-tui";
 import { fuzzyFilter } from "@earendil-works/pi-tui";
 import * as fs from "node:fs";
-import * as path from "node:path";
-import { getProjectTmpDir } from "./utils.js";
+import { getCronFilePath } from "./cron.js";
 
 // ── Cache infrastructure ────────────────────────────────────────────
 
@@ -355,7 +354,8 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       // After "remove" — show task IDs (supports multi-select)
       if (sub === "remove" || sub === "rm" || sub === "delete" || sub === "kill") {
         try {
-          const cronFile = path.join(getProjectTmpDir(process.cwd()), `cron-${process.pid}.json`);
+          const cronFile = getCronFilePath();
+          if (!cronFile) return null;
           const cronTasks = JSON.parse(fs.readFileSync(cronFile, "utf-8"));
           if (Array.isArray(cronTasks)) {
             const alreadySelected = new Set(parts.slice(1).filter(p => p !== lastPart));

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -352,7 +352,8 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       // After "remove" — show task IDs (supports multi-select)
       if (sub === "remove" || sub === "rm" || sub === "delete" || sub === "kill") {
         try {
-          const cronFile = require("node:path").join(require("node:os").tmpdir(), `pi-cron-${process.pid}.json`);
+          const { getProjectTmpDir } = require("./utils.js");
+          const cronFile = require("node:path").join(getProjectTmpDir(process.cwd()), `cron-${process.pid}.json`);
           const cronTasks = JSON.parse(require("node:fs").readFileSync(cronFile, "utf-8"));
           if (Array.isArray(cronTasks)) {
             const alreadySelected = new Set(parts.slice(1).filter(p => p !== lastPart));

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -22,6 +22,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from "@earendil-works/pi-tui";
 import { fuzzyFilter } from "@earendil-works/pi-tui";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { getProjectTmpDir } from "./utils.js";
 
 // ── Cache infrastructure ────────────────────────────────────────────
 
@@ -352,9 +355,8 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       // After "remove" — show task IDs (supports multi-select)
       if (sub === "remove" || sub === "rm" || sub === "delete" || sub === "kill") {
         try {
-          const { getProjectTmpDir } = require("./utils.js");
-          const cronFile = require("node:path").join(getProjectTmpDir(process.cwd()), `cron-${process.pid}.json`);
-          const cronTasks = JSON.parse(require("node:fs").readFileSync(cronFile, "utf-8"));
+          const cronFile = path.join(getProjectTmpDir(process.cwd()), `cron-${process.pid}.json`);
+          const cronTasks = JSON.parse(fs.readFileSync(cronFile, "utf-8"));
           if (Array.isArray(cronTasks)) {
             const alreadySelected = new Set(parts.slice(1).filter(p => p !== lastPart));
             return filter(cronTasks.filter((t: any) => !alreadySelected.has(String(t.id))).map((t: any) => ({

--- a/extensions/orchestrator/nvim.ts
+++ b/extensions/orchestrator/nvim.ts
@@ -9,6 +9,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { runGit } from "./git-helpers.js";
+import { getProjectTmpDir } from "./utils.js";
 
 const NVIM_SOCKET = process.env.NVIM;
 
@@ -23,10 +24,10 @@ export function isInsideNvim(): boolean {
  * Execute a lua file in the parent nvim instance via --remote-expr.
  * Returns the JSON-parsed result, or null on failure.
  */
-function nvimExecLua(luaCode: string): any | null {
+function nvimExecLua(luaCode: string, cwd?: string): any | null {
   if (!NVIM_SOCKET) return null;
 
-  const tmpFile = path.join(os.tmpdir(), `pi-nvim-${process.pid}-${Date.now()}.lua`);
+  const tmpFile = path.join(getProjectTmpDir(cwd || process.cwd()), `nvim-${process.pid}-${Date.now()}.lua`);
   try {
     fs.writeFileSync(tmpFile, luaCode, "utf-8");
     const result = execFileSync(
@@ -48,10 +49,10 @@ function nvimExecLua(luaCode: string): any | null {
  * Send a quickfix list to nvim and open the quickfix window.
  * Each entry: { filename, lnum?, col?, text }
  */
-function nvimSetQuickfix(entries: Array<{ filename: string; lnum?: number; col?: number; text?: string }>, title?: string): boolean {
+function nvimSetQuickfix(entries: Array<{ filename: string; lnum?: number; col?: number; text?: string }>, title?: string, cwd?: string): boolean {
   if (!NVIM_SOCKET || entries.length === 0) return false;
 
-  const dataFile = path.join(os.tmpdir(), `pi-nvim-qf-${process.pid}-${Date.now()}.json`);
+  const dataFile = path.join(getProjectTmpDir(cwd || process.cwd()), `nvim-qf-${process.pid}-${Date.now()}.json`);
   try {
     fs.writeFileSync(dataFile, JSON.stringify(entries), "utf-8");
 
@@ -79,7 +80,7 @@ vim.cmd("copen")
 return vim.fn.json_encode({status = "ok", count = #items})
 `;
 
-    const result = nvimExecLua(lua);
+    const result = nvimExecLua(lua, cwd);
     // Clean up data file if lua didn't remove it (nvim unreachable)
     if (result?.status !== "ok") {
       try { fs.unlinkSync(dataFile); } catch {}
@@ -156,7 +157,7 @@ export function registerNvim(pi: ExtensionAPI): void {
         text: f.status,
       }));
 
-      const ok = nvimSetQuickfix(entries, "pi: changed files");
+      const ok = nvimSetQuickfix(entries, "pi: changed files", ctx.cwd);
       if (ok) {
         ctx.ui.notify(`Sent ${entries.length} changed file(s) to nvim quickfix.`, "info");
       } else {

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -27,7 +27,7 @@ import {
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
-import { clockHHMM, getPiInvocation } from "./utils.js";
+import { clockHHMM, getPiInvocation, getProjectTmpDir } from "./utils.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -304,8 +304,11 @@ async function mapWithConcurrency<I, O>(
 async function writePromptFile(
   name: string,
   prompt: string,
+  cwd?: string,
 ): Promise<{ dir: string; filePath: string }> {
-  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pi-subagent-"));
+  let dir: string;
+  const projectDir = getProjectTmpDir(cwd || process.cwd());
+  dir = await fs.promises.mkdtemp(path.join(projectDir, "subagent-"));
   const filePath = path.join(
     dir,
     `prompt-${name.replace(/[^\w.-]+/g, "_")}.md`,
@@ -404,7 +407,7 @@ export async function runSingleAgent(
 
   try {
     if (agent.systemPrompt.trim()) {
-      const tmp = await writePromptFile(agent.name, agent.systemPrompt);
+      const tmp = await writePromptFile(agent.name, agent.systemPrompt, cwd);
       tmpDir = tmp.dir;
       tmpFile = tmp.filePath;
       args.push("--append-system-prompt", tmpFile);

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -4,6 +4,7 @@
 
 import { execFile } from "node:child_process";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 
 /** Whether notify-send is available (false = ENOENT, never retry) */
@@ -63,4 +64,15 @@ export function getPiInvocation(args: string[]): { command: string; args: string
   if (!/^(node|bun)(\.exe)?$/.test(e))
     return { command: process.execPath, args };
   return { command: "pi", args };
+}
+
+/** Base temp dir for all pi data */
+export const PI_TMP_BASE_DIR = path.join(os.tmpdir(), "pi-data");
+
+/** Get project-scoped temp dir under /tmp/pi-data/<project>/ */
+export function getProjectTmpDir(cwd: string): string {
+  const projectName = cwd.replace(/^[\\/]/, "").replace(/[\\/]/g, "__");
+  const dir = path.join(PI_TMP_BASE_DIR, projectName);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  return dir;
 }


### PR DESCRIPTION
## Summary

All pi temp files now live under `/tmp/pi-data/<project>/` instead of flat `/tmp/`. Adds zombie agent cleanup on session_start using `/proc/PID/stat` starttime.

## Directory structure

```
/tmp/pi-data/home__myakove__git__pi-config/
├── debug.log
├── cron-<pid>.json
├── .repeat-<pid>.json
├── async-results-pid-<pid>/
├── worker-<id>/
│   ├── status.json
│   ├── session.json (parentPid + parentStartTime)
│   ├── output.log
│   └── system-prompt.md
├── subagent-<random>/
└── nvim-*, async-cfg-* (ephemeral)
```

## Changes (9 files)

- `utils.ts` — `PI_TMP_BASE_DIR` constant + `getProjectTmpDir()` helper
- `async-agents.ts` — project-scoped dirs, parentPid tracking, zombie cleanup
- `dreaming.ts` — project-scoped status path
- `cron.ts` — project-scoped cron file
- `nvim.ts` — project-scoped temp files
- `subagent-tool.ts` — project-scoped mkdtemp
- `enforcement.ts` — project-scoped repeat file
- `extended-autocomplete.ts` — project-scoped cron reference
- `AGENTS.md` — documented directory structure

## Zombie cleanup

On session_start, scans project dir for dead agents:
1. Read session.json → parentPid + parentStartTime
2. Check /proc/PID/stat field 22
3. Dead parent or PID reused → delete worker dir

Closes #437