### PR TITLE
fix: ensure /tmp/pi-work and /tmp/pi-data are owned by node in container

### DIFF
--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -97,9 +97,12 @@ for d in /tmp/pi-work /tmp/pi-data; do
     # Refuse to operate on symlinks — prevents chown escape
     if [ -L "$d" ]; then
         echo "WARNING: $d is a symlink — removing to prevent chown escape" >&2
-        rm -f "$d"
+        rm -f "$d" || true
     fi
-    mkdir -p "$d"
+    if ! mkdir -p "$d" 2>/dev/null; then
+        echo "WARNING: failed to create $d — temp files may fail" >&2
+        continue
+    fi
     if ! chown node:node "$d" 2>/dev/null; then
         echo "WARNING: could not chown $d — temp file writes may fail on mounted volumes" >&2
     fi

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -83,5 +83,9 @@ if [ -S "$DOCKER_SOCK" ]; then
     fi
 fi
 
+# Ensure temp dirs exist and are owned by node (not root)
+mkdir -p /tmp/pi-work /tmp/pi-data
+chown node:node /tmp/pi-work /tmp/pi-data
+
 # Drop to node permanently — runuser replaces the process
 exec runuser -m -u node -- entrypoint.sh "$@"

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -13,10 +13,10 @@ if [ "$(id -u)" != "0" ]; then
     for d in /tmp/pi-work /tmp/pi-data; do
         if ! mkdir -p "$d" 2>/dev/null; then
             echo "WARNING: failed to create $d — temp files may fail. Fix with: sudo mkdir -p $d && sudo chown $(id -u):$(id -g) $d" >&2
-        elif ! touch "$d/.write-test" 2>/dev/null; then
+        elif _probe="$d/.pi-probe-$$" && ! touch "$_probe" 2>/dev/null; then
             echo "WARNING: $d is not writable by $(whoami) — temp files may fail. Fix with: sudo chown $(id -u):$(id -g) $d" >&2
         else
-            rm -f "$d/.write-test" 2>/dev/null
+            rm -f "$_probe" 2>/dev/null
         fi
     done
     exec entrypoint.sh "$@"
@@ -93,10 +93,17 @@ if [ -S "$DOCKER_SOCK" ]; then
 fi
 
 # Ensure temp dirs exist and are owned by node (not root)
-mkdir -p /tmp/pi-work /tmp/pi-data
-if ! chown node:node /tmp/pi-work /tmp/pi-data 2>/dev/null; then
-    echo "WARNING: could not chown /tmp/pi-work or /tmp/pi-data — temp file writes may fail on mounted volumes" >&2
-fi
+for d in /tmp/pi-work /tmp/pi-data; do
+    # Refuse to operate on symlinks — prevents chown escape
+    if [ -L "$d" ]; then
+        echo "WARNING: $d is a symlink — removing to prevent chown escape" >&2
+        rm -f "$d"
+    fi
+    mkdir -p "$d"
+    if ! chown node:node "$d" 2>/dev/null; then
+        echo "WARNING: could not chown $d — temp file writes may fail on mounted volumes" >&2
+    fi
+done
 
 # Drop to node permanently — runuser replaces the process
 exec runuser -m -u node -- entrypoint.sh "$@"

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -10,6 +10,7 @@ if [ "$(id -u)" != "0" ]; then
         exec sudo --preserve-env "$0" "$@"
     fi
     # No PI_HOST_USER and no docker socket — skip root setup, run entrypoint directly as node
+    mkdir -p /tmp/pi-work /tmp/pi-data
     exec entrypoint.sh "$@"
 fi
 

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -10,11 +10,11 @@ if [ "$(id -u)" != "0" ]; then
         exec sudo --preserve-env "$0" "$@"
     fi
     # No PI_HOST_USER and no docker socket — skip root setup, run entrypoint directly as node
-    mkdir -p /tmp/pi-work /tmp/pi-data 2>/dev/null || true
-    # Warn if dirs exist but aren't writable (e.g., root-owned from previous run)
     for d in /tmp/pi-work /tmp/pi-data; do
-        if [ -d "$d" ] && ! touch "$d/.write-test" 2>/dev/null; then
-            echo "WARNING: $d is not writable by $(whoami) — temp files may fail. Fix with: sudo chown -R $(id -u):$(id -g) $d" >&2
+        if ! mkdir -p "$d" 2>/dev/null; then
+            echo "WARNING: failed to create $d — temp files may fail. Fix with: sudo mkdir -p $d && sudo chown $(id -u):$(id -g) $d" >&2
+        elif ! touch "$d/.write-test" 2>/dev/null; then
+            echo "WARNING: $d is not writable by $(whoami) — temp files may fail. Fix with: sudo chown $(id -u):$(id -g) $d" >&2
         else
             rm -f "$d/.write-test" 2>/dev/null
         fi
@@ -94,7 +94,9 @@ fi
 
 # Ensure temp dirs exist and are owned by node (not root)
 mkdir -p /tmp/pi-work /tmp/pi-data
-chown -R node:node /tmp/pi-work /tmp/pi-data 2>/dev/null || true
+if ! chown node:node /tmp/pi-work /tmp/pi-data 2>/dev/null; then
+    echo "WARNING: could not chown /tmp/pi-work or /tmp/pi-data — temp file writes may fail on mounted volumes" >&2
+fi
 
 # Drop to node permanently — runuser replaces the process
 exec runuser -m -u node -- entrypoint.sh "$@"

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -10,7 +10,15 @@ if [ "$(id -u)" != "0" ]; then
         exec sudo --preserve-env "$0" "$@"
     fi
     # No PI_HOST_USER and no docker socket — skip root setup, run entrypoint directly as node
-    mkdir -p /tmp/pi-work /tmp/pi-data
+    mkdir -p /tmp/pi-work /tmp/pi-data 2>/dev/null || true
+    # Warn if dirs exist but aren't writable (e.g., root-owned from previous run)
+    for d in /tmp/pi-work /tmp/pi-data; do
+        if [ -d "$d" ] && ! touch "$d/.write-test" 2>/dev/null; then
+            echo "WARNING: $d is not writable by $(whoami) — temp files may fail. Fix with: sudo chown -R $(id -u):$(id -g) $d" >&2
+        else
+            rm -f "$d/.write-test" 2>/dev/null
+        fi
+    done
     exec entrypoint.sh "$@"
 fi
 
@@ -86,7 +94,7 @@ fi
 
 # Ensure temp dirs exist and are owned by node (not root)
 mkdir -p /tmp/pi-work /tmp/pi-data
-chown node:node /tmp/pi-work /tmp/pi-data
+chown -R node:node /tmp/pi-work /tmp/pi-data 2>/dev/null || true
 
 # Drop to node permanently — runuser replaces the process
 exec runuser -m -u node -- entrypoint.sh "$@"


### PR DESCRIPTION
## Problem

In the container, `/tmp/pi-work` and `/tmp/pi-data` are created as root-owned because `init-entrypoint.sh` runs as root before dropping to the `node` user. When pi extensions try to create files in these directories, they fail or create root-owned subdirectories.

- `/tmp/pi-work` — used for temp files, git clones, baseline test comparisons
- `/tmp/pi-data` — used for async agent working dirs, cron state, debug logs, session data

## Fix

Add `mkdir -p` + `chown node:node` for both directories in `init-entrypoint.sh`, right before the `exec runuser` drop to `node`.

## Done

- [x] Create `/tmp/pi-work` and `/tmp/pi-data` owned by `node:node` in init-entrypoint.sh