### PR TITLE
feat: support Qodo UX issue and Cross-repo conflict finding types

### DIFF
--- a/myk_pi_tools/db/query.py
+++ b/myk_pi_tools/db/query.py
@@ -232,7 +232,8 @@ class ReviewDB:
           ``outside_diff_comment``, ``major_comment``, ``minor_comment``,
           ``nitpick_comment``, ``duplicate_comment``, ``qodo_bug``,
           ``qodo_rule_violation``, ``qodo_requirement_gap``, or
-          ``qodo_finding``.  These types lack a GitHub review thread
+          ``qodo_finding``, ``qodo_ux_issue``, or ``qodo_cross_repo``.
+          These types lack a GitHub review thread
           that can be resolved, so the database is the only mechanism to
           auto-skip them on subsequent fetches.  Normal
           inline thread comments rely on GitHub's ``isResolved`` filter in
@@ -275,7 +276,8 @@ class ReviewDB:
                               'minor_comment', 'nitpick_comment',
                               'duplicate_comment',
                               'qodo_bug', 'qodo_rule_violation',
-                              'qodo_requirement_gap', 'qodo_finding'))
+                              'qodo_requirement_gap', 'qodo_finding',
+                              'qodo_ux_issue', 'qodo_cross_repo'))
                   )
                 ORDER BY c.path, c.line
                 """,

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -856,7 +856,14 @@ def get_thread_key(thread: dict[str, Any]) -> str | None:
     # Line number excluded — shifts after rebases, causing false mismatches
     # Type included — prevents cross-type collisions on same file+title
     qodo_type = thread.get("type")
-    if qodo_type in ("qodo_bug", "qodo_rule_violation", "qodo_requirement_gap", "qodo_finding"):
+    if qodo_type in (
+        "qodo_bug",
+        "qodo_rule_violation",
+        "qodo_requirement_gap",
+        "qodo_finding",
+        "qodo_ux_issue",
+        "qodo_cross_repo",
+    ):
         path = thread.get("path")
         title = _extract_sticky_title(thread.get("body", ""))
         if path and title:

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -28,6 +28,8 @@ _QODO_TYPE_MAP = {
     "Bug": "qodo_bug",
     "Rule violation": "qodo_rule_violation",
     "Requirement gap": "qodo_requirement_gap",
+    "UX issue": "qodo_ux_issue",
+    "Cross-repo conflict": "qodo_cross_repo",
 }
 
 # Known AI reviewer usernames
@@ -678,7 +680,9 @@ def fetch_qodo_sticky_findings(owner: str, repo: str, pr_number: str) -> list[di
                 "quality_label": finding.get("category", ""),
                 "type": _QODO_TYPE_MAP.get(finding.get("finding_type", ""), "qodo_finding"),
                 "source": "qodo",
-                "priority": "HIGH" if finding.get("finding_type") in ("Bug", "Rule violation") else "MEDIUM",
+                "priority": "HIGH"
+                if finding.get("finding_type") in ("Bug", "Rule violation", "Cross-repo conflict")
+                else "MEDIUM",
                 "reply": None,
                 "status": "pending",
             }

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -553,6 +553,8 @@ def run(json_path: str) -> None:
                 "qodo_rule_violation",
                 "qodo_requirement_gap",
                 "qodo_finding",
+                "qodo_ux_issue",
+                "qodo_cross_repo",
             ):
                 if status == "pending":
                     pending_count += 1
@@ -719,7 +721,14 @@ def run(json_path: str) -> None:
                 nitpick_count += 1
             elif comment_type == "duplicate_comment":
                 duplicate_count += 1
-            elif comment_type in ("qodo_bug", "qodo_rule_violation", "qodo_requirement_gap", "qodo_finding"):
+            elif comment_type in (
+                "qodo_bug",
+                "qodo_rule_violation",
+                "qodo_requirement_gap",
+                "qodo_finding",
+                "qodo_ux_issue",
+                "qodo_cross_repo",
+            ):
                 qodo_sticky_count += 1
 
         body_comment_failed = total_body - len(body_updates)

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -43,7 +43,7 @@ _CODE_REF_RE = re.compile(
 _DESCRIPTION_RE = re.compile(r"<pre>(.*?)</pre>", re.DOTALL)
 
 # Pattern for severity/type code tags
-_TYPE_RE = re.compile(r"<code>([^<]*(?:Bug|Rule violation|Requirement gap)[^<]*)</code>")
+_TYPE_RE = re.compile(r"<code>([^<]*(?:Bug|Rule violation|Requirement gap|UX issue|Cross-repo conflict)[^<]*)</code>")
 _CATEGORY_RE = re.compile(r"<code>([^<]*(?:Correctness|Security|Reliability|Performance|Maintainability)[^<]*)</code>")
 
 # Boundary marking previous review iterations (duplicates of current findings)

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -123,7 +123,7 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
         if codes_str:
             type_match = _TYPE_RE.search(codes_str)
             if type_match:
-                finding_type = re.sub(r"[^\w\s]", "", type_match.group(1)).strip()
+                finding_type = re.sub(r"[^\w\s-]", "", type_match.group(1)).strip()
             cat_match = _CATEGORY_RE.search(codes_str)
             if cat_match:
                 category = re.sub(r"[^\w\s]", "", cat_match.group(1)).strip()

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -142,6 +142,8 @@ Returns JSON with:
 >    - `qodo_bug` → **MUST address.** Fix the code. No skip allowed.
 >    - `qodo_rule_violation` → **MUST address.** Fix the code. No skip allowed.
 >    - `qodo_requirement_gap` → **MUST address.** Either fix the code OR update the issue requirements to document the design decision. No skip allowed.
+>    - `qodo_ux_issue` → **MUST address.** Either fix the UX concern OR update the issue requirements to document the design decision. No skip allowed.
+>    - `qodo_cross_repo` → **MUST address.** Fix the code to avoid cross-repo breakage. No skip allowed.
 >    - `qodo_finding` (other) → **MUST address.** Either fix the code OR update the issue requirements. No skip allowed.
 >
 >    **No finding type is optional. Every finding gets a code fix or an issue update.**


### PR DESCRIPTION
## Summary

Closes #446 — Qodo now emits two additional finding types that were falling through to `qodo_finding`.

## Changes

- **qodo_parser.py**: Added `UX issue|Cross-repo conflict` to `_TYPE_RE` regex
- **fetch.py**: Added `qodo_ux_issue` and `qodo_cross_repo` to `_QODO_TYPE_MAP`; Cross-repo conflicts are HIGH priority
- **post.py**: Added new types to type lists and elif checks
- **review-handler.md**: Added handling rules for new types in autoqodo section

## Testing

- 57 tests pass
- Pre-commit all green