### PR TITLE
rules: enforce code investigation before issue creation

### DIFF
--- a/rules/00-orchestrator-core.md
+++ b/rules/00-orchestrator-core.md
@@ -44,7 +44,7 @@ Before ANY code changes, run the pre-implementation checklist:
 
 → **See the "Pre-Implementation Checklist" section below** - Do NOT skip this step.
 
-**Quick check** (when issue-first workflow applies — see skip conditions below):
+**Quick check** (when issue-first workflow applies — see `rules/05-issue-first-workflow.md` for skip conditions):
 
 - [ ] Root cause investigated? (read relevant code, understand the problem)
 - [ ] GitHub issue created?

--- a/rules/00-orchestrator-core.md
+++ b/rules/00-orchestrator-core.md
@@ -46,5 +46,6 @@ Before ANY code changes, run the pre-implementation checklist:
 
 **Quick check:**
 
+- [ ] Root cause investigated? (read relevant code, understand the problem)
 - [ ] GitHub issue created?
 - [ ] On issue branch (`feat/issue-N-...` or `fix/issue-N-...`)?

--- a/rules/00-orchestrator-core.md
+++ b/rules/00-orchestrator-core.md
@@ -44,7 +44,7 @@ Before ANY code changes, run the pre-implementation checklist:
 
 → **See the "Pre-Implementation Checklist" section below** - Do NOT skip this step.
 
-**Quick check:**
+**Quick check** (when issue-first workflow applies — see skip conditions below):
 
 - [ ] Root cause investigated? (read relevant code, understand the problem)
 - [ ] GitHub issue created?

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -20,7 +20,7 @@ Before ANY code changes, complete this checklist:
    - Understand the current behavior and why it happens
    - Know what the fix looks like (at least conceptually)
    - If the user's request is based on a misunderstanding, clarify before proceeding
-   - NO → Investigate first. Use read tool and delegate exploration to `scout`.
+   - NO → Investigate first. Use read tool and delegate search/grep to `scout`.
    - YES → Continue
 
 3. **GitHub issue created?**

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -20,7 +20,7 @@ Before ANY code changes, complete this checklist:
    - Understand the current behavior and why it happens
    - Know what the fix looks like (at least conceptually)
    - If the user's request is based on a misunderstanding, clarify before proceeding
-   - NO → Investigate first. Use read/bash/grep to understand the code.
+   - NO → Investigate first. Use read tool and delegate exploration to worker agent.
    - YES → Continue
 
 3. **GitHub issue created?**
@@ -78,9 +78,17 @@ Should skip workflow? ──YES──→ Do it directly (skip workflow)
      │
     NO
      ↓
+Investigate root cause:
+  - Read relevant source code
+  - Identify affected files/functions
+  - Understand current behavior
+  - Form conceptual fix approach
+     ↓
 Delegate to github-expert to create issue with:
   - Type (fix/feat/refactor/docs)
   - Problem/feature description
+  - Root cause analysis (affected files, functions, why)
+  - Proposed fix approach
   - Requirements
   - Deliverables checklist
      ↓

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -15,17 +15,35 @@ Before ANY code changes, complete this checklist:
    - YES → Do directly, skip remaining steps
    - NO → Continue checklist
 
-2. **GitHub issue created?**
+2. **Root cause investigated?**
+   - Read the relevant source code — identify files, functions, and lines involved
+   - Understand the current behavior and why it happens
+   - Know what the fix looks like (at least conceptually)
+   - If the user's request is based on a misunderstanding, clarify before proceeding
+   - NO → Investigate first. Use read/bash/grep to understand the code.
+   - YES → Continue
+
+3. **GitHub issue created?**
    - NO → Create issue first (delegate to `github-expert`)
    - YES → Continue
 
-3. **On correct branch?** (`feat/issue-N-...` or `fix/issue-N-...`)
+4. **On correct branch?** (`feat/issue-N-...` or `fix/issue-N-...`)
    - NO → Create branch from origin/main (delegate to `git-expert`)
    - YES → Continue
 
-4. **User confirmed "work on it now"?**
+5. **User confirmed "work on it now"?**
    - NO → Ask user
    - YES → Proceed with implementation
+
+🚨 **NEVER create issues blindly from user requests.** Before creating ANY issue:
+
+- Read and understand the relevant code
+- Verify the problem exists (don't take the user's word — check the code)
+- Know what files/functions are involved
+- Have a conceptual fix in mind
+- If a fix PR already exists, link to it instead of creating a duplicate issue
+
+An issue without root cause analysis is a TODO, not a useful issue.
 
 ---
 
@@ -106,6 +124,8 @@ The `github-expert` agent handles issue formatting. When delegating issue creati
 
 - Type (fix/feat/refactor/docs)
 - Problem/feature description
+- Root cause analysis (for bugs) — affected files, functions, and why it happens
+- Proposed fix approach
 - Requirements list
 - **Deliverables checklist (MANDATORY)** — every issue MUST have a `## Done` section with checkboxes
 

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -20,7 +20,7 @@ Before ANY code changes, complete this checklist:
    - Understand the current behavior and why it happens
    - Know what the fix looks like (at least conceptually)
    - If the user's request is based on a misunderstanding, clarify before proceeding
-   - NO → Investigate first. Use read tool and delegate exploration to scout agent.
+   - NO → Investigate first. Use read tool and delegate exploration to `scout`.
    - YES → Continue
 
 3. **GitHub issue created?**
@@ -132,7 +132,7 @@ The `github-expert` agent handles issue formatting. When delegating issue creati
 
 - Type (fix/feat/refactor/docs)
 - Problem/feature description
-- Root cause analysis (for bugs/fixes) — affected files, functions, and why it happens
+- Root cause analysis (for bugs/fixes) — affected files, functions, lines, and why it happens
 - Proposed fix approach
 - Requirements list
 - **Deliverables checklist (MANDATORY)** — every issue MUST have a `## Done` section with checkboxes

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -20,7 +20,7 @@ Before ANY code changes, complete this checklist:
    - Understand the current behavior and why it happens
    - Know what the fix looks like (at least conceptually)
    - If the user's request is based on a misunderstanding, clarify before proceeding
-   - NO → Investigate first. Use read tool and delegate search/grep to `scout`.
+   - NO → Investigate first.
    - YES → Continue
 
 3. **GitHub issue created?**

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -20,7 +20,7 @@ Before ANY code changes, complete this checklist:
    - Understand the current behavior and why it happens
    - Know what the fix looks like (at least conceptually)
    - If the user's request is based on a misunderstanding, clarify before proceeding
-   - NO → Investigate first. Use read tool and delegate exploration to worker agent.
+   - NO → Investigate first. Use read tool and delegate exploration to scout agent.
    - YES → Continue
 
 3. **GitHub issue created?**
@@ -87,7 +87,7 @@ Investigate root cause:
 Delegate to github-expert to create issue with:
   - Type (fix/feat/refactor/docs)
   - Problem/feature description
-  - Root cause analysis (affected files, functions, why)
+  - Root cause analysis (for bugs/fixes — affected files, functions, why)
   - Proposed fix approach
   - Requirements
   - Deliverables checklist
@@ -132,7 +132,7 @@ The `github-expert` agent handles issue formatting. When delegating issue creati
 
 - Type (fix/feat/refactor/docs)
 - Problem/feature description
-- Root cause analysis (for bugs) — affected files, functions, and why it happens
+- Root cause analysis (for bugs/fixes) — affected files, functions, and why it happens
 - Proposed fix approach
 - Requirements list
 - **Deliverables checklist (MANDATORY)** — every issue MUST have a `## Done` section with checkboxes


### PR DESCRIPTION
## Summary

Closes #447 — Adds a mandatory investigation step to the issue-first workflow to prevent blindly creating issues from user requests.

## Changes

In `rules/05-issue-first-workflow.md`:

- **New step 2**: "Root cause investigated?" — requires reading source code, understanding the problem, identifying affected files/functions, and knowing what the fix looks like before creating an issue
- **Updated issue format**: Issue creation delegation now requires root cause analysis and proposed fix approach
- **New callout**: "NEVER create issues blindly" with concrete requirements (verify problem exists, check for existing fix PRs, etc.)

## Why

The orchestrator was opening issues based on user requests without investigating the codebase, leading to vague descriptions, duplicate issues for already-fixed problems, and misidentified root causes.