### PR TITLE
feat: add @tintinweb/pi-tasks for structured task tracking (#453)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,9 @@ pi-config/
 │   ├── 35-memory.md
 │   ├── 40-critical-rules.md
 │   ├── 45-file-preview.md
-│   └── 50-agent-bug-reporting.md
+│   ├── 50-agent-bug-reporting.md
+│   ├── 55-coms-protocol.md
+│   └── 60-task-tracking.md
 ├── myk_pi_tools/                    # Python CLI tooling package
 │   ├── __init__.py
 │   ├── ai_cli/
@@ -184,8 +186,8 @@ pi-config/
 
 ### Async-Only Agents
 
-Some agents are enforced to only run with `async: true` — sync calls are rejected
-by `subagent-tool.ts` with an error. This prevents the LLM from blocking the session
+Some agents are enforced to only run with `async: true` — sync calls are automatically
+promoted to async by `subagent-tool.ts`. This prevents the LLM from blocking the session
 waiting for long-running agents.
 
 **Currently enforced:**
@@ -394,6 +396,15 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 Resolution: project file → env var → default.
 
 Module: `extensions/orchestrator/project-settings.ts`
+
+## Companion Packages
+
+These npm packages are installed alongside pi-config (via Dockerfile + `entrypoint.sh` for containers, `scripts/install.py` for native):
+
+| Package | Purpose |
+|---------|--------|
+| [`pi-web-access`](https://github.com/pinkpixel/pi-web-access) | Web search, fetch, librarian skills |
+| [`@tintinweb/pi-tasks`](https://github.com/tintinweb/pi-tasks) | Task tracking for multi-step workflows — live widget, reminder cadence, dependency management |
 
 ## Docker / Dockerfile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,9 +72,9 @@ RUN DOCKER_VERSION=$(curl -fsSL https://download.docker.com/linux/static/stable/
 # Copy docker-safe wrapper
 COPY --chmod=755 scripts/docker-safe /usr/local/bin/docker-safe
 
-# Install acpx, agent-browser, pi-web-access, gemini-cli (pi itself is installed at runtime in entrypoint.sh)
+# Install acpx, agent-browser, pi-web-access, gemini-cli, pi-tasks (pi itself is installed at runtime in entrypoint.sh)
 RUN --mount=type=cache,target=/root/.npm,sharing=locked \
-  npm install -g acpx agent-browser pi-web-access @google/gemini-cli
+  npm install -g acpx agent-browser pi-web-access @google/gemini-cli @tintinweb/pi-tasks
 
 
 # Switch to non-root user (node:22 ships with user 'node' at UID 1000)

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Single extension that provides:
 | **Pidiff viewer** | Standalone diff viewer with review comments — branch diffs, file tree, inline comments |
 | **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains topic-based memory |
 | **Upgrade changelog** | Shows release notes on session start after pi-config version upgrade |
+| **Task tracking** | Structured task lists for multi-step workflows — live widget, progress tracking, reminder nudges ([@tintinweb/pi-tasks](https://github.com/tintinweb/pi-tasks)) |
 | **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |
 | **Inter-agent communication** | P2P (`/coms`) and networked (`/coms-net`) agent communication — on-demand activation via slash commands |
 | **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status`, `/status`, `/dream`, `/remember`, `/coms`, `/coms-net` — with autocomplete argument hints |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,11 +24,16 @@ else
     pi update git:github.com/myk-org/pi-vertex-claude
 fi
 
-# pi-web-access: register in pi settings if not already present
-# (installed globally in Docker image, just needs pi to know about it)
-if ! grep -q 'pi-web-access' "$HOME/.pi/agent/settings.json" 2>/dev/null; then
-    pi install npm:pi-web-access 2>/dev/null || true
-fi
+# Register pi packages if not already present
+# (installed globally in Docker image, just need pi to know about them)
+register_pi_pkg() {
+    local name="$1" source="$2"
+    if ! grep -q "$name" "$HOME/.pi/agent/settings.json" 2>/dev/null; then
+        pi install "npm:$source" 2>/dev/null || true
+    fi
+}
+register_pi_pkg pi-web-access pi-web-access
+register_pi_pkg pi-tasks @tintinweb/pi-tasks
 
 
 
@@ -52,6 +57,9 @@ if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.pi/memory/' "$GITIGNORE_FILE" 2>/dev
 fi
 if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.worktrees/' "$GITIGNORE_FILE" 2>/dev/null; then
     echo '.worktrees/' >> "$GITIGNORE_FILE"
+fi
+if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.pi/tasks/' "$GITIGNORE_FILE" 2>/dev/null; then
+    echo '.pi/tasks/' >> "$GITIGNORE_FILE"
 fi
 
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -193,10 +193,9 @@ export function registerAsyncAgents(
       if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
         const output = (data.output || "").slice(0, 3000);
-        const RESUME_REMINDER = "\n\n---\n⚠️ **Resume check:** Were you in the middle of a workflow before this result arrived? If yes, handle this result and then resume the workflow from the next pending step.";
         pi.sendMessage({
           customType: "async-agent-result",
-          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${RESUME_REMINDER}`,
+          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}`,
           display: true,
         }, { triggerTurn: true, deliverAs: "followUp" });
       }

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -47,9 +47,6 @@ const ASYNC_ONLY_AGENTS = new Set([
   "code-reviewer-guidelines",
   "code-reviewer-security",
 ]);
-const ASYNC_ONLY_ERROR = (names: string[]) =>
-  `These agents MUST use async: true: ${names.join(", ")}. Review agents run in the background — never block the session waiting for them.`;
-
 // ── Schemas ──────────────────────────────────────────────────────────────
 
 const TaskItem = Type.Object({
@@ -603,11 +600,7 @@ export function registerSubagentTool(
             };
           }
           if (params.async !== true) {
-            return {
-              content: [{ type: "text", text: ASYNC_ONLY_ERROR(violators) }],
-              details: mkd("single")([]),
-              isError: true,
-            };
+            params.async = true;
           }
         }
       }

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -601,6 +601,15 @@ export function registerSubagentTool(
           }
           if (params.async !== true) {
             params.async = true;
+            // Set default name(s) for async display — async path requires names
+            if (params.agent && !params.name) {
+              params.name = params.agent;
+            }
+            if (params.tasks) {
+              for (const t of params.tasks) {
+                if (!(t as any).name) (t as any).name = t.agent;
+              }
+            }
           }
         }
       }

--- a/rules/60-task-tracking.md
+++ b/rules/60-task-tracking.md
@@ -1,0 +1,95 @@
+# Task Tracking (MANDATORY)
+
+## Scope
+
+> **If you are a SPECIALIST AGENT:**
+> IGNORE this rule. This is for the ORCHESTRATOR only.
+
+---
+
+## When to Create Tasks
+
+**BEFORE starting any multi-step workflow (3+ steps)**, use `TaskCreate` to list ALL steps first.
+
+**Use tasks for:**
+
+- Feature implementation (investigate → issue → branch → implement → review → commit → push → PR)
+- Bug fixes with multiple files or steps
+- Any workflow from `rules/05-issue-first-workflow.md` or `rules/20-code-review-loop.md`
+- Refactoring across multiple files
+- Any work the user requests that involves more than 2 actions
+
+**Skip tasks for:**
+
+- Single-step actions (one edit, one command)
+- Questions or explanations (no code changes)
+- `/btw` side questions
+- Trivial fixes (typos, single-line changes)
+
+---
+
+## Task Granularity
+
+Tasks MUST be **detailed and specific** — not high-level summaries.
+
+❌ **BAD** (too vague):
+
+```text
+- Implement the fix
+- Review code
+- Create PR
+```
+
+✅ **GOOD** (specific and actionable):
+
+```text
+- Investigate root cause in extensions/orchestrator/utils.ts
+- Create GitHub issue with root cause analysis
+- Create branch fix/issue-N-description from origin/main
+- Edit extensions/orchestrator/utils.ts — add timeout parameter to fetchData()
+- Run code review loop (3 async reviewers)
+- Fix review findings (if any)
+- Run test-automator
+- Commit changes (git add specific files, commit with message)
+- Push branch to origin
+- Create PR with description
+```
+
+---
+
+## Task Lifecycle (MANDATORY)
+
+1. **Create all tasks BEFORE starting work** — use `TaskCreate` for each step
+2. **Mark `in_progress`** via `TaskUpdate` BEFORE starting each task
+3. **Mark `completed`** via `TaskUpdate` IMMEDIATELY after finishing each task
+4. **Do NOT skip tasks** — work through them in order
+5. **Do NOT start new work** while unchecked tasks exist (unless user explicitly pivots)
+
+---
+
+## Side Questions During Workflow
+
+When the user asks a side question while tasks are active:
+
+1. Answer the question
+2. **Resume the next unchecked task immediately** — the task list tells you exactly where you left off
+
+This is the entire point of task tracking — you cannot "forget" what you were doing because the tasks are persistent and injected into every turn.
+
+---
+
+## Integration with Existing Rules
+
+Task tracking works alongside — not instead of — existing workflow rules:
+
+- **Issue-first workflow** (`05-issue-first-workflow.md`): Create tasks for the full issue workflow
+- **Code review loop** (`20-code-review-loop.md`): Include review steps as individual tasks
+- **Documentation updates** (`25-documentation-updates.md`): Include doc updates as tasks when applicable
+
+---
+
+## Key Rules
+
+- **Tasks are code-enforced** — the extension injects reminders if you ignore tasks for 4+ turns
+- **Never abandon tasks** — if scope changes, use `TaskUpdate` with `status: "deleted"` to remove obsolete tasks
+- **The task list is your contract** — complete every task or explicitly remove it

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -166,7 +166,7 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
     def _is_pi_pkg_installed(name: str) -> bool:
         try:
             return name in (HOME / ".pi/agent/settings.json").read_text()
-        except (FileNotFoundError, OSError):
+        except (FileNotFoundError, OSError, UnicodeDecodeError, ValueError):
             return False
 
     pi_web = _is_pi_pkg_installed("pi-web-access")
@@ -290,11 +290,12 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
     # ── Step 6: Environment Setup ────────────────────────────────────────
     gd = "" if has["git"] else "requires git"
     gi = _gitignore_path()
-    mem_inst = wt_inst = False
+    mem_inst = wt_inst = tasks_inst = False
     try:
         content = Path(gi).read_text()
         mem_inst = ".pi/memory/" in content
         wt_inst = ".worktrees/" in content
+        tasks_inst = ".pi/tasks/" in content
     except Exception:
         pass
 
@@ -332,6 +333,14 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
                 installed=wt_inst,
                 disabled=gd,
                 install_fn=lambda: _add_to_gitignore(".worktrees/"),
+                installed_label="configured",
+            ),
+            Tool(
+                ".pi/tasks/ in gitignore",
+                "Prevent task state files from being committed",
+                installed=tasks_inst,
+                disabled=gd,
+                install_fn=lambda: _add_to_gitignore(".pi/tasks/"),
                 installed_label="configured",
             ),
         ],

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -162,11 +162,15 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
     pi_dis = "" if has["pi"] else "requires pi"
     pi_cfg = (HOME / ".pi/agent/git/github.com/myk-org/pi-config").exists()
     pi_vtx = (HOME / ".pi/agent/git/github.com/myk-org/pi-vertex-claude").exists()
-    pi_web = False
-    try:
-        pi_web = "pi-web-access" in (HOME / ".pi/agent/settings.json").read_text()
-    except Exception:
-        pass
+
+    def _is_pi_pkg_installed(name: str) -> bool:
+        try:
+            return name in (HOME / ".pi/agent/settings.json").read_text()
+        except (FileNotFoundError, OSError):
+            return False
+
+    pi_web = _is_pi_pkg_installed("pi-web-access")
+    pi_tasks = _is_pi_pkg_installed("pi-tasks")
 
     step1 = Step(
         "📦",
@@ -193,6 +197,13 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
                 installed=pi_web,
                 disabled=pi_dis,
                 install_cmd="pi install npm:pi-web-access",
+            ),
+            Tool(
+                "pi-tasks",
+                "Task tracking for multi-step workflows",
+                installed=pi_tasks,
+                disabled=pi_dis,
+                install_cmd="pi install npm:@tintinweb/pi-tasks",
             ),
             Tool(
                 "myk-pi-tools",
@@ -386,9 +397,11 @@ def run_step(step_idx: int, step: Step) -> list[Tool]:
         print(f"  {DIM}Cancelled.{RESET}")
         sys.exit(1)
 
-    # Map selected labels back to Tool objects
+    # Map selected labels back to Tool objects (skip already installed/disabled)
     selected: list[Tool] = []
     for tool in step.tools:
+        if tool.installed or tool.disabled:
+            continue
         label = f"{tool.name} — {tool.description}"
 
         if label in result:
@@ -472,6 +485,37 @@ def install_all(selections: list[Tool]) -> tuple[int, int, list[Tool]]:
     return installed, failed, failed_tools
 
 
+# ── Update ─────────────────────────────────────────────────────────────────
+
+
+def update_pi(prereqs: dict[str, bool]) -> None:
+    """Run pi update to update pi itself and all installed packages."""
+    if not prereqs.get("pi"):
+        return
+
+    print()
+    print("  ⏳ Updating pi and packages...", end="", flush=True)
+    try:
+        result = subprocess.run(
+            "pi update",
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if result.returncode == 0:
+            print(f"\r\033[2K  {GREEN}✓{RESET} pi and packages updated")
+        else:
+            print(f"\r\033[2K  {RED}✗{RESET} pi update failed")
+            if result.stderr:
+                for line in result.stderr.strip().splitlines()[-2:]:
+                    print(f"    {DIM}{line}{RESET}")
+    except subprocess.TimeoutExpired:
+        print(f"\r\033[2K  {RED}✗{RESET} pi update timed out (5m)")
+    except Exception as exc:
+        print(f"\r\033[2K  {RED}✗{RESET} pi update — {exc}")
+
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 
@@ -535,6 +579,8 @@ def main() -> None:
     if not selections:
         print()
         print("  Nothing to install.")
+        # Still update pi and existing packages
+        update_pi(prereqs)
         print()
         return
 
@@ -549,12 +595,12 @@ def main() -> None:
             print(f"  {DIM}Cancelled.{RESET}")
             sys.exit(1)
 
-    # Count skipped (installed+disabled that weren't selected)
-    total_tools = sum(len(step.tools) for step in steps)
-    skipped = total_tools - len(selections)
-
     # Install
+    total_tools = sum(len(step.tools) for step in steps)
     installed, failed, failed_tools = install_all(selections)
+
+    # Update pi and all packages
+    update_pi(prereqs)
 
     # Adjust skipped to account for failures
     skipped = total_tools - installed - failed


### PR DESCRIPTION
Closes #453

## Changes

### @tintinweb/pi-tasks integration (3 install channels)
- **Dockerfile** — added to `npm install -g` line
- **entrypoint.sh** — `register_pi_pkg()` helper for package registration (DRY refactor)
- **scripts/install.py** — added to Step 1 Pi Packages with `_is_pi_pkg_installed()` helper

### New rule: `rules/60-task-tracking.md`
- MANDATORY task creation for multi-step workflows (3+ steps)
- Detailed granularity required (not high-level summaries)
- Task lifecycle: create all → mark in_progress → mark completed
- Works with the extension's built-in 4-turn reminder cadence (code enforcement)

### Async-only agent auto-promotion (`subagent-tool.ts`)
- Async-only agents (reviewers) now silently promote to `async: true` instead of erroring
- Removed dead `ASYNC_ONLY_ERROR` const
- Chain mode still correctly errors (async doesn't support chains)

### Removed resume check reminder (`async-agents.ts`)
- Removed the "⚠️ Resume check" text injected into async agent results — replaced by pi-tasks task tracking

### install.py fixes
- **Bug fix**: installed tools no longer appear in installation plan (skip `installed/disabled` in selection mapping)
- **`pi update` final step**: runs after all installations (also runs when nothing to install)

### Documentation
- **README.md** — task tracking row in features table
- **AGENTS.md** — Companion Packages section, rule tree update (added `55-coms-protocol.md` + `60-task-tracking.md`), updated async-only description