### PR TITLE
feat: use ctx.mode and ctx.getSystemPromptOptions() from pi 0.78.1 (#455)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ pi-config/
 │   │   ├── project-settings.ts        # Project-level settings (.pi/pi-config-settings.json)
 │   │   ├── situation-report.ts        # Token-budgeted memory context for system prompts
 │   │   ├── subagent-tool.ts         # Subagent tool + runSingleAgent (async-only enforcement for reviewers)
-│   │   └── utils.ts                 # Shared utilities (getProjectTmpDir, etc.)
+│   │   └── utils.ts                 # Shared utilities (getProjectTmpDir, tryGetSystemPromptOptions, etc.)
 │   ├── coms/                        # Inter-agent communication extension (standalone)
 │   │   ├── index.ts                 # Entry point — registers coms and coms-net
 │   │   ├── coms.ts                  # P2P agent communication wrapper (on-demand /coms command)
@@ -229,6 +229,21 @@ Checks each agent's `parentPid` + `parentStartTime` against `/proc/PID/stat` fie
 Dead parent = zombie = delete.
 
 **Shared helper:** `getProjectTmpDir(cwd)` in `utils.ts` — creates dir if missing, returns path.
+
+### Mode-Aware Guards (`ctx.mode`)
+
+Pi runs in four modes: `"tui"` (interactive), `"rpc"` (programmatic), `"json"` (structured output), `"print"` (one-shot).
+Use `ctx.mode` to skip features that only make sense in interactive mode:
+
+| Feature | Guard | Reason |
+|---------|-------|--------|
+| Daemon connections (pidash, pidiff) | `ctx.mode === "tui"` | No UI to display |
+| Autocomplete providers | `ctx.mode === "tui"` | No editor input |
+| Cron scheduling | `ctx.mode !== "print" && ctx.mode !== "json"` | One-shot, no timers |
+| Dreaming (auto-dream timer) | `ctx.mode !== "print" && ctx.mode !== "json"` | One-shot, no background work |
+
+**Keep `ctx.hasUI`** for simple UI guard checks (`notify`, `select`, `confirm`) — these work in both TUI and RPC modes.
+**Use `ctx.mode`** when the distinction between interactive and one-shot matters.
 
 ### Adding an Extension Command
 

--- a/extensions/orchestrator/btw.ts
+++ b/extensions/orchestrator/btw.ts
@@ -4,6 +4,7 @@
 
 import { complete, type UserMessage } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { tryGetSystemPromptOptions } from "./utils.js";
 import {
   BorderedLoader,
   convertToLlm,
@@ -42,12 +43,24 @@ export function registerBtw(pi: ExtensionAPI): void {
         conversationText = serializeConversation(llmMessages);
       }
 
+      // Build context-aware system prompt using loaded resources
+      let projectContext = "";
+      const opts = tryGetSystemPromptOptions(ctx);
+      if (opts?.contextFiles?.length) {
+        const names = opts.contextFiles.map((f: any) => f.path?.split("/").pop() || f.path || "(unknown)").join(", ");
+        projectContext = `\n- Project context files loaded: ${names}`;
+      }
+      if (opts?.skills?.length) {
+        const names = opts.skills.map((s: any) => s.name || s).join(", ");
+        projectContext += `\n- Available skills: ${names}`;
+      }
+
       const systemPrompt = `You are answering a quick "by the way" side question during a coding session.
 
 Rules:
 - Answer concisely and directly based on the conversation context provided.
 - You have NO tool access — you cannot read files, run commands, or make changes.
-- Only answer based on information already present in the conversation.
+- Only answer based on the conversation and loaded project context.${projectContext}
 - Keep your response brief and to the point.
 - Use markdown formatting where helpful (code blocks, lists, bold).
 - If the conversation context doesn't contain enough information to answer, say so honestly.`;

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -194,6 +194,8 @@ export function registerCron(
     lastCtx = ctx;
     CRON_FILE = path.join(getProjectTmpDir(ctx.cwd), `cron-${process.pid}.json`);
     cleanupOrphanedCronFiles();
+    // Skip cron scheduling in one-shot modes
+    if (ctx.mode === "print" || ctx.mode === "json") return;
 
     // Restore from persistence (after /reload or /new)
     const restored = loadCrons();

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -270,6 +270,10 @@ export function registerCron(
       const action = params.action as string;
 
       if (action === "add") {
+        // Block scheduling in one-shot modes
+        if (lastCtx?.mode === "print" || lastCtx?.mode === "json") {
+          return { content: [{ type: "text", text: "Error: cron scheduling is not available in one-shot modes (print/json)" }] };
+        }
         if (!params.task) {
           return { content: [{ type: "text", text: "Error: 'task' is required for add action" }] };
         }

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -247,6 +247,8 @@ export function registerDreaming(
     lastCtx = ctx;
     if (activePollInterval) { clearInterval(activePollInterval); activePollInterval = null; }
     dreamInFlight = false; // Reset — previous session's dream state doesn't carry over
+    // Skip dreaming in one-shot modes (print/json)
+    if (ctx.mode === "print" || ctx.mode === "json") return;
     updateDreamStatus();
     if (enabled) startTimer(ctx.cwd);
   });

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -425,7 +425,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       }
     }
 
-    if (!ctx.hasUI) return;
+    if (ctx.mode !== "tui") return;
 
     ctx.ui.addAutocompleteProvider((current: AutocompleteProvider) => ({
       async getSuggestions(

--- a/extensions/orchestrator/github-autocomplete.ts
+++ b/extensions/orchestrator/github-autocomplete.ts
@@ -137,7 +137,7 @@ export function registerGithubAutocomplete(pi: ExtensionAPI): void {
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
 
   pi.on("session_start", async (_event, ctx) => {
-    if (!ctx.hasUI) return;
+    if (ctx.mode !== "tui") return;
 
     // Resolve GitHub repo from git remote
     const remoteResult = await pi.exec("git", ["remote", "-v"], {

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -10,7 +10,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { formatDuration } from "./async-agents.js";
-import { buildSituationReport, rebuildAndOrganize } from "./situation-report.js";
+import { buildSituationReport, estimateMemoryBudget, rebuildAndOrganize } from "./situation-report.js";
 
 /** Social closer gate — skip expensive vector search for trivial messages */
 const SOCIAL_CLOSERS = new Set([
@@ -142,7 +142,9 @@ export function registerRules(
     }
 
     // Project memories — situation report (scored, token-budgeted) injected BEFORE rules
-    const memories = loadMemoriesWithScoring(ctx.cwd, isSubagent);
+    // systemPrompt.length is chars; estimateMemoryBudget converts internally
+    const budget = estimateMemoryBudget(event.systemPrompt?.length ?? 0);
+    const memories = loadMemoriesWithScoring(ctx.cwd, isSubagent, budget);
 
     // Auto-inject contextually relevant memories via vector search (~2.5ms, in-process)
     const shouldSearch = !isSubagent && !!event.prompt && !isSocialCloser(event.prompt);
@@ -278,9 +280,9 @@ export function registerRules(
 }
 
 // Loads memories using situation report (scored, token-budgeted) from topic files
-function loadMemoriesWithScoring(cwd: string, isSubagent: boolean): string {
+function loadMemoriesWithScoring(cwd: string, isSubagent: boolean, tokenBudget?: number): string {
   try {
-    const report = buildSituationReport(cwd);
+    const report = buildSituationReport(cwd, tokenBudget);
     if (report) {
       let result = "\n" + report + "\n";
       if (isSubagent) {

--- a/extensions/orchestrator/situation-report.ts
+++ b/extensions/orchestrator/situation-report.ts
@@ -263,6 +263,21 @@ export function buildSituationReport(
   return reportSections.join("\n");
 }
 
+/** Approximate total token budget for the system prompt (rules + context + memory). */
+const SYSTEM_PROMPT_TOKEN_BUDGET = 8000;
+
+/**
+ * Estimate available token budget for memory based on system prompt size.
+ * Shrinks memory budget when the system prompt is already large.
+ */
+export function estimateMemoryBudget(systemPromptLength: number, totalBudget: number = SYSTEM_PROMPT_TOKEN_BUDGET): number {
+  // Memory competes with rules, context files, skills, etc.
+  const systemPromptTokens = Math.ceil(systemPromptLength / CHARS_PER_TOKEN);
+  const remaining = totalBudget - systemPromptTokens;
+  // Clamp between 500 (minimum useful) and DEFAULT_TOKEN_BUDGET (maximum)
+  return Math.max(500, Math.min(DEFAULT_TOKEN_BUDGET, remaining));
+}
+
 // ── Formatting ─────────────────────────────────────────────────────────────
 
 function formatSection(name: string, entries: MemoryEntryWithText[]): string {

--- a/extensions/orchestrator/situation-report.ts
+++ b/extensions/orchestrator/situation-report.ts
@@ -274,8 +274,10 @@ export function estimateMemoryBudget(systemPromptLength: number, totalBudget: nu
   // Memory competes with rules, context files, skills, etc.
   const systemPromptTokens = Math.ceil(systemPromptLength / CHARS_PER_TOKEN);
   const remaining = totalBudget - systemPromptTokens;
-  // Clamp between 500 (minimum useful) and DEFAULT_TOKEN_BUDGET (maximum)
-  return Math.max(500, Math.min(DEFAULT_TOKEN_BUDGET, remaining));
+  // No budget left — skip memory injection entirely
+  if (remaining <= 0) return 0;
+  // Clamp to DEFAULT_TOKEN_BUDGET maximum
+  return Math.min(DEFAULT_TOKEN_BUDGET, remaining);
 }
 
 // ── Formatting ─────────────────────────────────────────────────────────────

--- a/extensions/orchestrator/status.ts
+++ b/extensions/orchestrator/status.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { tryGetSystemPromptOptions } from "./utils.js";
 import type { AsyncJob } from "./async-agents.js";
 import type { CronTask } from "./cron.js";
 import { getCurrentBranch, runGit } from "./git-helpers.js";
@@ -89,6 +90,18 @@ export function registerStatus(
       // ── Container ──────────────────────────────────────────────────
       if (inContainer) {
         lines.push("📦 Running in container");
+      }
+
+      // ── System prompt resources ────────────────────────────────────
+      const opts = tryGetSystemPromptOptions(ctx);
+      if (opts) {
+        const contextFiles = opts.contextFiles?.length ?? 0;
+        const skills = opts.skills?.length ?? 0;
+        const tools = opts.selectedTools?.length ?? 0;
+        const guidelines = opts.promptGuidelines?.length ?? 0;
+        if (contextFiles + skills + tools + guidelines > 0) {
+          lines.push(`📋 Loaded: ${contextFiles} context files, ${skills} skills, ${tools} tools, ${guidelines} guidelines`);
+        }
       }
 
       ctx.ui.notify(lines.join("\n"), "info");

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -76,3 +76,13 @@ export function getProjectTmpDir(cwd: string): string {
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   return dir;
 }
+
+/** Safely call ctx.getSystemPromptOptions() — returns null if unavailable. */
+export function tryGetSystemPromptOptions(ctx: any): { contextFiles?: any[]; skills?: any[]; selectedTools?: any[]; promptGuidelines?: any[] } | null {
+  try {
+    return ctx.getSystemPromptOptions?.() ?? null;
+  } catch (e: any) {
+    console.debug("[utils] getSystemPromptOptions failed:", e?.message);
+    return null;
+  }
+}

--- a/extensions/pidash/pidash.ts
+++ b/extensions/pidash/pidash.ts
@@ -693,7 +693,7 @@ export function registerPidash(
     // when the user types their first prompt (via before_agent_start triggering
     // the input pipeline). For now, this at least initializes the connection.
     // Session switching requires the user to have typed at least one slash command.
-    if (!connected) {
+    if (!connected && ctx.mode === "tui") {
       connect(ctx);
     } else if (ws) {
       // Already connected — session switched (e.g., /resume, /new)
@@ -711,7 +711,7 @@ export function registerPidash(
 
   // Fallback for /reload — connect on first tool_result if not connected
   pi.on("tool_result", (_event, ctx) => {
-    if (!connected && !shuttingDown) connect(ctx);
+    if (!connected && !shuttingDown && ctx.mode === "tui") connect(ctx);
   });
 
   // Periodic reconnect — ensures sessions that started before the daemon still connect
@@ -719,7 +719,7 @@ export function registerPidash(
     isConnected: () => connected,
     isConnecting: () => connecting,
     isShuttingDown: () => shuttingDown,
-    connect: () => { if (lastCtx) connect(lastCtx); },
+    connect: () => { if (lastCtx?.mode === "tui") connect(lastCtx); },
   });
 
   // ── Command execution from browser ────────────────────────────────

--- a/extensions/pidiff/pidiff.ts
+++ b/extensions/pidiff/pidiff.ts
@@ -272,7 +272,7 @@ export function registerPidiff(pi: ExtensionAPI): void {
   pi.on("session_start", async (_event, ctx) => {
     lastCtx = ctx;
     if (!isGitRepo(ctx.cwd)) return;
-    if (!connected) connect(ctx);
+    if (!connected && ctx.mode === "tui") connect(ctx);
   });
 
   pi.on("agent_end", (_event, ctx) => {
@@ -281,14 +281,14 @@ export function registerPidiff(pi: ExtensionAPI): void {
   });
 
   pi.on("tool_result", (_event, ctx) => {
-    if (!connected && !shuttingDown) connect(ctx);
+    if (!connected && !shuttingDown && ctx.mode === "tui") connect(ctx);
   });
 
   const cleanupReconnect = setupReconnectPoller({
     isConnected: () => connected,
     isConnecting: () => connecting,
     isShuttingDown: () => shuttingDown,
-    connect: () => { if (lastCtx) connect(lastCtx); },
+    connect: () => { if (lastCtx?.mode === "tui") connect(lastCtx); },
   });
 
   pi.on("session_shutdown", () => {


### PR DESCRIPTION
Closes #455

## Changes

### ctx.mode guards — skip features in non-interactive modes

| Feature | Guard | Effect |
|---------|-------|--------|
| pidash daemon spawn + reconnect poller | `ctx.mode === "tui"` | No daemon in print/json/rpc |
| pidiff daemon spawn + reconnect poller | `ctx.mode === "tui"` | No daemon in print/json/rpc |
| Extended autocomplete | `ctx.mode === "tui"` | No autocomplete in non-TUI |
| GitHub # autocomplete | `ctx.mode === "tui"` | No autocomplete in non-TUI |
| Cron scheduling | skip in `print`/`json` | No timers in one-shot modes |
| Dreaming (auto-dream timer) | skip in `print`/`json` | No background dreaming in one-shot modes |

Keeps `ctx.hasUI` for simple notification/dialog guards (works in both TUI and RPC).

### ctx.getSystemPromptOptions() usage

- **`/status`** — shows loaded context files, skills, tools, guidelines count
- **`/btw`** — enriches side-question prompt with project context (loaded files, skills)
- **`estimateMemoryBudget()`** — dynamically shrinks memory token budget based on actual system prompt size
- **`tryGetSystemPromptOptions()`** — shared null-safe helper in `utils.ts`

### Documentation

- **AGENTS.md** — new "Mode-Aware Guards" section documenting `ctx.mode` vs `ctx.hasUI` usage, utils.ts description updated