### PR TITLE
fix: copy gitignore to writable location in container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,7 +41,11 @@ register_pi_pkg pi-tasks @tintinweb/pi-tasks
 cp "$HOME/.gitconfig" "$HOME/.gitconfig-local" 2>/dev/null || true
 if [ -f "$HOME/.gitconfig-local" ]; then
     export GIT_CONFIG_GLOBAL="$HOME/.gitconfig-local"
-    git config --global core.excludesFile "$HOME/.gitignore-global"
+    # Copy gitignore to writable location (host file may be read-only mounted)
+    GITIGNORE_SRC="$(git config --global core.excludesFile 2>/dev/null || echo "$HOME/.gitignore-global")"
+    GITIGNORE_LOCAL="$HOME/.gitignore-local"
+    cp "$GITIGNORE_SRC" "$GITIGNORE_LOCAL" 2>/dev/null || touch "$GITIGNORE_LOCAL"
+    git config --global core.excludesFile "$GITIGNORE_LOCAL"
 fi
 
 # SSH timeout — detect dead connections during git fetch/push/pull


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix container startup: use writable .gitignore-local for global excludes
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Host `.gitignore-global` is read-only mounted in container. Copy to `.gitignore-local` (same pattern as `.gitconfig-local`) before appending entries like `.pi/tasks/`, `.pi/memory/`, `.worktrees/`.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Detect read-only mounted global gitignore and copy it to a writable local file.
• Point Git’s global excludesFile to .gitignore-local before appending ignore entries.
• Preserve existing behavior of using .gitconfig-local as the effective global config.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["entrypoint.sh"] --> B["Use .gitconfig-local"] --> C["Read excludesFile"] --> D["Copy/touch .gitignore-local"] --> E["Set core.excludesFile"] --> F["Git operations"]

  subgraph Legend
    direction LR
    _file["File/Script"] ~~~ _step["Step"]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Append to a separate ignore file (without copying) and include it</b></summary>

- ➕ Avoids duplicating the base ignore content
- ➕ Keeps host-managed ignore file untouched
- ➖ Git global excludesFile supports only a single path; would require overwriting or user includes (not supported) or switching to templateDir/hooks
- ➖ More complexity than a simple copy for a container entrypoint

</details>

<details>
<summary><b>2. Detect read-only mount and only copy when needed (stat/test write)</b></summary>

- ➕ Avoids an extra copy on every startup when the file is already writable
- ➖ More branching and portability concerns across environments (busybox/stat flags)
- ➖ Current approach is already safe and simple

</details>

**Recommendation:** The PR’s approach (copy configured excludes file to .gitignore-local and repoint core.excludesFile) is the most robust and simplest way to guarantee writability in containers where host mounts may be read-only. The always-copy behavior is acceptable given the small file size and startup-only impact.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>entrypoint.sh</strong> <code>Copy global gitignore to writable .gitignore-local and repoint excludesFile</code> <code>+5/-1</code></summary>

<br/>

>Copy global gitignore to writable .gitignore-local and repoint excludesFile
>
><pre>
>• Replaces the hardcoded core.excludesFile target with logic that resolves the current configured excludes file (falling back to ~/.gitignore-global), copies it to ~/.gitignore-local (or creates it if missing), and sets Git to use the local writable file.
></pre>
>
><a href='https://github.com/myk-org/pi-config/pull/459/files#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2'>entrypoint.sh</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>