### PR TITLE
fix: robust writable gitignore handling in container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,10 +38,9 @@ register_pi_pkg pi-tasks @tintinweb/pi-tasks
 
 
 # Fix host-specific paths in mounted .gitconfig (read-only mount, can't write in-place)
-cp "$HOME/.gitconfig" "$HOME/.gitconfig-local" 2>/dev/null || true
-if [ -f "$HOME/.gitconfig-local" ]; then
-    export GIT_CONFIG_GLOBAL="$HOME/.gitconfig-local"
-fi
+# Always create a writable local copy so git config --global never writes to a read-only mount
+cp "$HOME/.gitconfig" "$HOME/.gitconfig-local" 2>/dev/null || touch "$HOME/.gitconfig-local"
+export GIT_CONFIG_GLOBAL="$HOME/.gitconfig-local"
 
 # Ensure gitignore is writable (host file may be read-only mounted)
 # Resolve source: normalize ~ prefix, try configured path then known defaults
@@ -68,7 +67,7 @@ export GIT_SSH_COMMAND="ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -
 
 # Ensure required entries are in global gitignore
 add_to_gitignore() {
-    if ! grep -qF "$1" "$GITIGNORE_LOCAL" 2>/dev/null; then
+    if ! grep -qxF "$1" "$GITIGNORE_LOCAL" 2>/dev/null; then
         echo "$1" >> "$GITIGNORE_LOCAL"
     fi
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,12 +41,24 @@ register_pi_pkg pi-tasks @tintinweb/pi-tasks
 cp "$HOME/.gitconfig" "$HOME/.gitconfig-local" 2>/dev/null || true
 if [ -f "$HOME/.gitconfig-local" ]; then
     export GIT_CONFIG_GLOBAL="$HOME/.gitconfig-local"
-    # Copy gitignore to writable location (host file may be read-only mounted)
-    GITIGNORE_SRC="$(git config --global core.excludesFile 2>/dev/null || echo "$HOME/.gitignore-global")"
-    GITIGNORE_LOCAL="$HOME/.gitignore-local"
-    cp "$GITIGNORE_SRC" "$GITIGNORE_LOCAL" 2>/dev/null || touch "$GITIGNORE_LOCAL"
-    git config --global core.excludesFile "$GITIGNORE_LOCAL"
 fi
+
+# Ensure gitignore is writable (host file may be read-only mounted)
+# Resolve source: normalize ~ prefix, try configured path then known defaults
+GITIGNORE_SRC="$(git config --global core.excludesFile 2>/dev/null || true)"
+case "$GITIGNORE_SRC" in ~/*)  GITIGNORE_SRC="$HOME/${GITIGNORE_SRC#\~/}" ;; esac
+if [ -z "$GITIGNORE_SRC" ] || [ ! -r "$GITIGNORE_SRC" ]; then
+    for candidate in "$HOME/.gitignore-global" "$HOME/.config/git/ignore"; do
+        if [ -r "$candidate" ]; then GITIGNORE_SRC="$candidate"; break; fi
+    done
+fi
+GITIGNORE_LOCAL="$HOME/.gitignore-local"
+if [ -n "$GITIGNORE_SRC" ] && [ -r "$GITIGNORE_SRC" ]; then
+    cp "$GITIGNORE_SRC" "$GITIGNORE_LOCAL"
+else
+    touch "$GITIGNORE_LOCAL"
+fi
+git config --global core.excludesFile "$GITIGNORE_LOCAL"
 
 # SSH timeout — detect dead connections during git fetch/push/pull
 # ServerAliveInterval: send keepalive every 15s
@@ -54,17 +66,14 @@ fi
 # ConnectTimeout: fail if can't connect within 10s
 export GIT_SSH_COMMAND="ssh -o ServerAliveInterval=15 -o ServerAliveCountMax=3 -o ConnectTimeout=10"
 
-# Ensure .pi/memory/ is in global gitignore (memory DB must not be committed)
-GITIGNORE_FILE="$(git config --global core.excludesFile 2>/dev/null || echo "$HOME/.gitignore-global")"
-if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.pi/memory/' "$GITIGNORE_FILE" 2>/dev/null; then
-    echo '.pi/memory/' >> "$GITIGNORE_FILE"
-fi
-if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.worktrees/' "$GITIGNORE_FILE" 2>/dev/null; then
-    echo '.worktrees/' >> "$GITIGNORE_FILE"
-fi
-if [ -n "$GITIGNORE_FILE" ] && ! grep -qF '.pi/tasks/' "$GITIGNORE_FILE" 2>/dev/null; then
-    echo '.pi/tasks/' >> "$GITIGNORE_FILE"
-fi
+# Ensure required entries are in global gitignore
+add_to_gitignore() {
+    if ! grep -qF "$1" "$GITIGNORE_LOCAL" 2>/dev/null; then
+        echo "$1" >> "$GITIGNORE_LOCAL"
+    fi
+}
+add_to_gitignore '.pi/'
+add_to_gitignore '.worktrees/'
 
 
 exec pi "$@"

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -293,8 +293,10 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
     pi_inst = wt_inst = False
     try:
         content = Path(gi).read_text()
-        pi_inst = ".pi/" in content
-        wt_inst = ".worktrees/" in content
+        # Exact line match — ".pi/memory/" should not count as ".pi/" being present
+        lines = content.splitlines()
+        pi_inst = ".pi/" in lines
+        wt_inst = ".worktrees/" in lines
     except Exception:
         pass
 

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -290,12 +290,11 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
     # ── Step 6: Environment Setup ────────────────────────────────────────
     gd = "" if has["git"] else "requires git"
     gi = _gitignore_path()
-    mem_inst = wt_inst = tasks_inst = False
+    pi_inst = wt_inst = False
     try:
         content = Path(gi).read_text()
-        mem_inst = ".pi/memory/" in content
+        pi_inst = ".pi/" in content
         wt_inst = ".worktrees/" in content
-        tasks_inst = ".pi/tasks/" in content
     except Exception:
         pass
 
@@ -320,11 +319,11 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
         "Git configuration for pi-config",
         [
             Tool(
-                ".pi/memory/ in gitignore",
-                "Prevent memory files from being committed",
-                installed=mem_inst,
+                ".pi/ in gitignore",
+                "Prevent pi data files from being committed",
+                installed=pi_inst,
                 disabled=gd,
-                install_fn=lambda: _add_to_gitignore(".pi/memory/"),
+                install_fn=lambda: _add_to_gitignore(".pi/"),
                 installed_label="configured",
             ),
             Tool(
@@ -333,14 +332,6 @@ def build_steps(prereqs: dict[str, bool]) -> list[Step]:
                 installed=wt_inst,
                 disabled=gd,
                 install_fn=lambda: _add_to_gitignore(".worktrees/"),
-                installed_label="configured",
-            ),
-            Tool(
-                ".pi/tasks/ in gitignore",
-                "Prevent task state files from being committed",
-                installed=tasks_inst,
-                disabled=gd,
-                install_fn=lambda: _add_to_gitignore(".pi/tasks/"),
                 installed_label="configured",
             ),
         ],


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix container startup by making global gitignore writable
<code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Fixes the read-only gitignore error on container startup.

## Changes

### entrypoint.sh
- Decouple gitignore writable copy from `.gitconfig-local` existence — gitignore is always made writable regardless of whether `.gitconfig` was copied
- Normalize `~` prefix in `core.excludesFile` path before using it
- Try known fallback locations (`~/.gitignore-global`, `~/.config/git/ignore`) when configured path is unreadable
- Only overwrite `core.excludesFile` after successful copy — never silently lose existing patterns
- Use `.pi/` instead of separate `.pi/memory/` and `.pi/tasks/` entries (`.pi/` covers all subdirs)
- DRY: `add_to_gitignore` helper function

### scripts/install.py
- Simplify gitignore step: single `.pi/` entry replaces `.pi/memory/` + `.pi/tasks/`

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Copy global gitignore to a writable local file to avoid read-only mount failures.
• Resolve <b><i>core.excludesFile</i></b> reliably (normalize <b><i>~</i></b>, try fallback locations).
• Standardize ignore patterns to <b><i>.pi/</i></b> and <b><i>.worktrees/</i></b> across startup and installer.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  Start((Container start)) --> EP["entrypoint.sh"] --> Resolve["Resolve excludesFile src"] --> Local["Create ~/.gitignore-local"] --> Set["Set core.excludesFile"] --> Add["Add .pi/ + .worktrees/"]
  Install["scripts/install.py"] --> Ensure["Ensure ignore entries"] --> Set
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Only switch excludesFile when a readable source exists</b></summary>

- ➕ Avoids overwriting an existing (but unreadable) excludes file with an empty local file
- ➕ Preserves user ignore patterns in edge cases where no fallback is readable
- ➖ May reintroduce startup failure if the existing excludesFile is read-only mounted and Git attempts to lock/write it
- ➖ Adds a decision branch that needs clear logging/behavior definition

</details>

<details>
<summary><b>2. Standardize on XDG path and avoid probing multiple candidates</b></summary>

- ➕ Simpler mental model: always use ~/.config/git/ignore (or $XDG_CONFIG_HOME)
- ➕ Aligns with modern Git defaults on many platforms
- ➖ May be a behavior change for users relying on a custom core.excludesFile path
- ➖ Still requires rewriting core.excludesFile to point to the chosen path

</details>

<details>
<summary><b>3. Use repo-local excludes instead of global excludesFile</b></summary>

- ➕ Does not modify user/global Git configuration
- ➕ Avoids interacting with read-only mounted home directories
- ➖ Does not apply to arbitrary repos without iterating and updating each repo’s .git/info/exclude
- ➖ Harder to ensure consistent behavior across multiple workspaces in the container

</details>

**Recommendation:** The PR’s approach (copy to a writable ~/.gitignore-local and repoint core.excludesFile) is the most reliable way to prevent container startup failures caused by read-only mounts while keeping Git behavior consistent. Consider a small follow-up safeguard: if neither configured path nor fallbacks are readable, log a warning and/or avoid switching excludesFile to an empty local file unless necessary for startup stability.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>entrypoint.sh</strong> <code>Always route core.excludesFile to a writable ~/.gitignore-local</code> <code>+25/-16</code></summary>

<br/>

>Always route core.excludesFile to a writable ~/.gitignore-local
>
><pre>
>• Moves gitignore handling out of the .gitconfig-local guard and makes it unconditional. Resolves &#x27;core.excludesFile&#x27; with &#x27;~&#x27; normalization plus fallback locations, then copies (or creates) &#x27;~/.gitignore-local&#x27; and points Git to it. Replaces repeated grep/echo blocks with an &#x27;add_to_gitignore&#x27; helper and consolidates ignore rules to &#x27;.pi/&#x27; + &#x27;.worktrees/&#x27;.
></pre>
>
><a href='https://github.com/myk-org/pi-config/pull/460/files#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2'>entrypoint.sh</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>install.py</strong> <code>Consolidate installer gitignore checks to &#x27;.pi/&#x27; + &#x27;.worktrees/&#x27;</code> <code>+6/-15</code></summary>

<br/>

>Consolidate installer gitignore checks to &#x27;.pi/&#x27; + &#x27;.worktrees/&#x27;
>
><pre>
>• Updates the environment setup step to check for a single &#x27;.pi/&#x27; entry instead of separate &#x27;.pi/memory/&#x27; and &#x27;.pi/tasks/&#x27; entries. Removes the extra tool item for tasks and adjusts the installation function to add &#x27;.pi/&#x27;.
></pre>
>
><a href='https://github.com/myk-org/pi-config/pull/460/files#diff-aea06381e5b0018003a3e1e9a05c66b4171729c1cb06653ac45dcb568800addf'>scripts/install.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>