### PR TITLE
fix: never auto-skip Qodo sticky comments (#465)

### DIFF
--- a/myk_pi_tools/reviews/coderabbit_parser.py
+++ b/myk_pi_tools/reviews/coderabbit_parser.py
@@ -2,7 +2,9 @@
 
 CodeRabbit embeds certain comments directly in the review body text
 (not as inline threads). This module extracts those comments into
-structured data. Five kinds of body-embedded sections are supported:
+structured data using BeautifulSoup for HTML structure parsing and
+regex for markdown-level patterns. Five kinds of body-embedded
+sections are supported:
 
 - **Outside diff range** comments (code outside the PR diff range)
 - **Major** comments (significant issues requiring attention)
@@ -20,39 +22,23 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from bs4 import BeautifulSoup, Tag
+
 # ---------------------------------------------------------------------------
-# Compiled patterns
+# Section keyword mapping
 # ---------------------------------------------------------------------------
 
-# Matches the start of the outer "Outside diff range comments" section.
-_OUTSIDE_SECTION_START_RE = re.compile(
-    r"<summary>\s*(?:\S+\s+)*?Outside diff range comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
-)
+_SECTION_KEYWORDS: dict[str, str] = {
+    "outside_diff": "Outside diff range",
+    "major": "Major",
+    "minor": "Minor",
+    "nitpick": "Nitpick",
+    "duplicate": "Duplicate",
+}
 
-# Matches the start of the outer "Major comments" section.
-_MAJOR_SECTION_START_RE = re.compile(
-    r"<summary>\s*(?:\S+\s+)*?Major comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
-)
-
-# Matches the start of the outer "Minor comments" section.
-_MINOR_SECTION_START_RE = re.compile(
-    r"<summary>\s*(?:\S+\s+)*?Minor comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
-)
-
-# Matches the start of the outer "Nitpick comments" section.
-_NITPICK_SECTION_START_RE = re.compile(
-    r"<summary>\s*(?:\S+\s+)*?Nitpick comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
-)
-
-# Matches the start of the outer "Duplicate comments" section.
-_DUPLICATE_SECTION_START_RE = re.compile(
-    r"<summary>\s*(?:\S+\s+)*?Duplicate comments?\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
-)
-
-# Matches the start of a file-level <details> block with path and count.
-_FILE_SUMMARY_RE = re.compile(
-    r"<details>\s*\n?\s*<summary>\s*(?P<path>.+?)\s*(?:\(\d+\))?\s*</summary>\s*<blockquote>",
-)
+# ---------------------------------------------------------------------------
+# Compiled patterns (markdown-level — NOT HTML)
+# ---------------------------------------------------------------------------
 
 # Matches the backtick line-range pattern at the start of a comment.
 # Handles both range (`552-572`) and single-line (`42`) formats.
@@ -72,11 +58,13 @@ _TITLE_RE = re.compile(
     re.MULTILINE,
 )
 
-# Matches the "Prompt for AI Agents" details block (to be excluded).
-_AI_PROMPT_RE = re.compile(
-    r"<details>\s*\n?\s*<summary>\s*\S*\s*Prompt for AI Agents\s*</summary>.*?</details>",
-    re.DOTALL,
-)
+# Strips trailing count like " (2)" from file summary text.
+_FILE_PATH_COUNT_RE = re.compile(r"\s*\(\d+\)\s*$")
+
+
+# ---------------------------------------------------------------------------
+# BeautifulSoup helpers
+# ---------------------------------------------------------------------------
 
 
 def _strip_blockquote_prefix(text: str) -> str:
@@ -95,40 +83,77 @@ def _strip_blockquote_prefix(text: str) -> str:
     return "\n".join(lines)
 
 
-def _extract_blockquote_content(text: str, start: int) -> str | None:
-    """Extract blockquote content by tracking nesting depth from a given position.
+def _remove_ai_prompts(soup: BeautifulSoup) -> None:
+    """Remove all 'Prompt for AI Agents' details blocks from the soup.
+
+    Collects targets first to avoid modifying the tree during iteration.
+    """
+    to_remove: list[Tag] = []
+    for details in soup.find_all("details"):
+        summary = details.find("summary", recursive=False)
+        if summary and "Prompt for AI Agents" in summary.get_text():
+            to_remove.append(details)
+    for details in to_remove:
+        details.decompose()
+
+
+def _find_sections(soup: BeautifulSoup, keyword: str) -> list[Tag]:
+    """Find all ``<details>`` tags whose ``<summary>`` text contains *keyword*.
 
     Args:
-        text: The full text.
-        start: Position immediately after the opening ``<blockquote>`` tag.
+        soup: Parsed HTML tree.
+        keyword: Text to search for in ``<summary>`` content (e.g. ``"Major"``).
 
     Returns:
-        The content between the opening and its matching closing
-        ``</blockquote>`` tag, or ``None`` if no matching close is found.
+        List of matching ``<details>`` :class:`Tag` objects.
     """
-    depth = 1
-    pos = start
-    bq_open_tag = "<blockquote>"
-    bq_close_tag = "</blockquote>"
+    results: list[Tag] = []
+    for details in soup.find_all("details"):
+        summary = details.find("summary", recursive=False)
+        if summary and keyword in summary.get_text():
+            results.append(details)
+    return results
 
-    while depth > 0 and pos < len(text):
-        next_open = text.find(bq_open_tag, pos)
-        next_close = text.find(bq_close_tag, pos)
 
-        if next_close == -1:
-            # No closing tag found at all
-            break
+def _find_file_blocks(section_bq: Tag) -> list[tuple[str, Tag]]:
+    """Find file-level ``<details>`` blocks inside a section's ``<blockquote>``.
 
-        if next_open != -1 and next_open < next_close:
-            depth += 1
-            pos = next_open + len(bq_open_tag)
-        else:
-            depth -= 1
-            if depth == 0:
-                return text[start:next_close]
-            pos = next_close + len(bq_close_tag)
+    Each file block is expected to have a ``<summary>`` with the file path
+    (optionally followed by a count in parentheses) and a ``<blockquote>``
+    containing the individual comments.
 
-    return None
+    Args:
+        section_bq: The ``<blockquote>`` tag of a section-level ``<details>``.
+
+    Returns:
+        List of ``(path, blockquote_tag)`` tuples.
+    """
+    results: list[tuple[str, Tag]] = []
+    for details in section_bq.find_all("details", recursive=False):
+        summary = details.find("summary", recursive=False)
+        if summary:
+            path = _FILE_PATH_COUNT_RE.sub("", summary.get_text()).strip()
+            bq = details.find("blockquote", recursive=False)
+            if bq and path:
+                results.append((path, bq))
+    return results
+
+
+def _prepare_soup(body: str) -> BeautifulSoup:
+    """Prepare a :class:`BeautifulSoup` tree from a review body string.
+
+    Strips markdown blockquote ``>`` prefixes, parses the HTML, and removes
+    any "Prompt for AI Agents" ``<details>`` blocks.
+    """
+    cleaned = _strip_blockquote_prefix(body)
+    soup = BeautifulSoup(cleaned, "html.parser")
+    _remove_ai_prompts(soup)
+    return soup
+
+
+# ---------------------------------------------------------------------------
+# Comment parsing
+# ---------------------------------------------------------------------------
 
 
 def _parse_single_comment(raw: str) -> dict[str, Any] | None:
@@ -171,14 +196,11 @@ def _parse_single_comment(raw: str) -> dict[str, Any] | None:
         title = title_match.group("title").strip()
 
     # --- Body ---
-    # Body starts after the title line. We keep everything except the
-    # "Prompt for AI Agents" details block.
+    # Body starts after the title line. AI prompt sections have already
+    # been removed from the soup before text extraction.
     body_text = text
     if title_match:
         body_text = text[title_match.end() :].strip()
-
-    # Remove AI prompt sections
-    body_text = _AI_PROMPT_RE.sub("", body_text).strip()
 
     # Build the full body: title + remaining body
     body_parts: list[str] = []
@@ -199,18 +221,16 @@ def _parse_single_comment(raw: str) -> dict[str, Any] | None:
     }
 
 
-def _parse_section_comments(cleaned: str, section_re: re.Pattern[str]) -> list[dict[str, Any]]:
-    """Extract and parse comments from a single section of a cleaned review body.
+def _parse_section_comments(soup: BeautifulSoup, keyword: str) -> list[dict[str, Any]]:
+    """Extract and parse comments from sections matching *keyword*.
 
-    This is the shared logic for "outside diff range", "major", "minor", "nitpick", and "duplicate"
-    sections. The caller is responsible for cleaning the text first (stripping
-    blockquote prefixes and trailing AI prompt blocks).
+    Finds all ``<details>`` blocks whose ``<summary>`` contains *keyword*,
+    then iterates their file-level sub-blocks and parses individual
+    comments separated by ``---`` dividers.
 
     Args:
-        cleaned: The review body text after blockquote-prefix and AI-prompt
-            stripping.
-        section_re: Compiled regex that matches the section's ``<summary>``
-            header (up to and including the opening ``<blockquote>`` tag).
+        soup: Parsed and AI-prompt-cleaned HTML tree.
+        keyword: Section keyword (e.g. ``"Major"``).
 
     Returns:
         List of dicts, each with keys:
@@ -223,19 +243,13 @@ def _parse_section_comments(cleaned: str, section_re: re.Pattern[str]) -> list[d
     """
     results: list[dict[str, Any]] = []
 
-    for section_start_match in section_re.finditer(cleaned):
-        section_content = _extract_blockquote_content(cleaned, section_start_match.end())
-        if section_content is None:
+    for section in _find_sections(soup, keyword):
+        section_bq = section.find("blockquote", recursive=False)
+        if section_bq is None:
             continue
 
-        # Extract each file-level block using nesting-aware extraction.
-        for file_match in _FILE_SUMMARY_RE.finditer(section_content):
-            file_path = file_match.group("path").strip()
-            file_content = _extract_blockquote_content(section_content, file_match.end())
-            if file_content is None:
-                continue
-
-            file_content = file_content.strip()
+        for file_path, file_bq in _find_file_blocks(section_bq):
+            file_content = file_bq.decode_contents().strip()
 
             # Split individual comments on --- separators
             comment_blocks = re.split(r"\r?\n---\s*\r?\n", file_content)
@@ -247,6 +261,11 @@ def _parse_section_comments(cleaned: str, section_re: re.Pattern[str]) -> list[d
                     results.append(parsed)
 
     return results
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def parse_outside_diff_comments(body: str) -> list[dict[str, Any]]:
@@ -267,14 +286,7 @@ def parse_outside_diff_comments(body: str) -> list[dict[str, Any]]:
     if not body:
         return []
 
-    # Strip blockquote prefixes so we can parse clean HTML
-    cleaned = _strip_blockquote_prefix(body)
-
-    # Also strip a trailing AI prompt section that may appear outside the
-    # blockquote at the very end of the review body.
-    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
-
-    return _parse_section_comments(cleaned, _OUTSIDE_SECTION_START_RE)
+    return _parse_section_comments(_prepare_soup(body), _SECTION_KEYWORDS["outside_diff"])
 
 
 def parse_major_comments(body: str) -> list[dict[str, Any]]:
@@ -295,14 +307,7 @@ def parse_major_comments(body: str) -> list[dict[str, Any]]:
     if not body:
         return []
 
-    # Strip blockquote prefixes so we can parse clean HTML
-    cleaned = _strip_blockquote_prefix(body)
-
-    # Also strip a trailing AI prompt section that may appear outside the
-    # blockquote at the very end of the review body.
-    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
-
-    return _parse_section_comments(cleaned, _MAJOR_SECTION_START_RE)
+    return _parse_section_comments(_prepare_soup(body), _SECTION_KEYWORDS["major"])
 
 
 def parse_minor_comments(body: str) -> list[dict[str, Any]]:
@@ -323,14 +328,7 @@ def parse_minor_comments(body: str) -> list[dict[str, Any]]:
     if not body:
         return []
 
-    # Strip blockquote prefixes so we can parse clean HTML
-    cleaned = _strip_blockquote_prefix(body)
-
-    # Also strip a trailing AI prompt section that may appear outside the
-    # blockquote at the very end of the review body.
-    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
-
-    return _parse_section_comments(cleaned, _MINOR_SECTION_START_RE)
+    return _parse_section_comments(_prepare_soup(body), _SECTION_KEYWORDS["minor"])
 
 
 def parse_nitpick_comments(body: str) -> list[dict[str, Any]]:
@@ -351,14 +349,7 @@ def parse_nitpick_comments(body: str) -> list[dict[str, Any]]:
     if not body:
         return []
 
-    # Strip blockquote prefixes so we can parse clean HTML
-    cleaned = _strip_blockquote_prefix(body)
-
-    # Also strip a trailing AI prompt section that may appear outside the
-    # blockquote at the very end of the review body.
-    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
-
-    return _parse_section_comments(cleaned, _NITPICK_SECTION_START_RE)
+    return _parse_section_comments(_prepare_soup(body), _SECTION_KEYWORDS["nitpick"])
 
 
 def parse_duplicate_comments(body: str) -> list[dict[str, Any]]:
@@ -379,14 +370,7 @@ def parse_duplicate_comments(body: str) -> list[dict[str, Any]]:
     if not body:
         return []
 
-    # Strip blockquote prefixes so we can parse clean HTML
-    cleaned = _strip_blockquote_prefix(body)
-
-    # Also strip a trailing AI prompt section that may appear outside the
-    # blockquote at the very end of the review body.
-    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
-
-    return _parse_section_comments(cleaned, _DUPLICATE_SECTION_START_RE)
+    return _parse_section_comments(_prepare_soup(body), _SECTION_KEYWORDS["duplicate"])
 
 
 def parse_review_body_comments(body: str) -> dict[str, list[dict[str, Any]]]:
@@ -394,19 +378,12 @@ def parse_review_body_comments(body: str) -> dict[str, list[dict[str, Any]]]:
 
     Returns:
         Dict with keys ``'outside_diff'``, ``'major'``, ``'minor'``,
-        ``'major'``, ``'minor'``, ``'nitpick'``, and ``'duplicate'``, each containing a list of
+        ``'nitpick'``, and ``'duplicate'``, each containing a list of
         parsed comment dicts.
     """
     if not body:
         return {"outside_diff": [], "major": [], "minor": [], "nitpick": [], "duplicate": []}
 
-    cleaned = _strip_blockquote_prefix(body)
-    cleaned = _AI_PROMPT_RE.sub("", cleaned).strip()
+    soup = _prepare_soup(body)
 
-    return {
-        "outside_diff": _parse_section_comments(cleaned, _OUTSIDE_SECTION_START_RE),
-        "major": _parse_section_comments(cleaned, _MAJOR_SECTION_START_RE),
-        "minor": _parse_section_comments(cleaned, _MINOR_SECTION_START_RE),
-        "nitpick": _parse_section_comments(cleaned, _NITPICK_SECTION_START_RE),
-        "duplicate": _parse_section_comments(cleaned, _DUPLICATE_SECTION_START_RE),
-    }
+    return {key: _parse_section_comments(soup, keyword) for key, keyword in _SECTION_KEYWORDS.items()}

--- a/myk_pi_tools/reviews/coderabbit_parser.py
+++ b/myk_pi_tools/reviews/coderabbit_parser.py
@@ -110,7 +110,7 @@ def _find_sections(soup: BeautifulSoup, keyword: str) -> list[Tag]:
     results: list[Tag] = []
     for details in soup.find_all("details"):
         summary = details.find("summary", recursive=False)
-        if summary and keyword in summary.get_text():
+        if summary and keyword.lower() + " comment" in summary.get_text().lower():
             results.append(details)
     return results
 

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -748,7 +748,7 @@ def process_and_categorize(threads: list[dict[str, Any]], owner: str, repo: str)
         author = thread.get("author")
         body = thread.get("body")
 
-        source = detect_source(author)
+        source = thread.get("source") or detect_source(author)
 
         # Preserve pre-computed priority (e.g., from Qodo sticky findings)
         existing_priority = thread.get("priority")

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -19,6 +19,8 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from bs4 import BeautifulSoup
+
 from myk_pi_tools.db.query import ReviewDB, _body_similarity
 from myk_pi_tools.reviews.coderabbit_parser import parse_review_body_comments
 from myk_pi_tools.reviews.qodo_parser import is_qodo_sticky_comment, parse_qodo_sticky_comment
@@ -853,7 +855,7 @@ def _extract_sticky_title(body: str) -> str:
         return m.group(1).strip().lower()
     # Fallback: first non-empty line, stripped of HTML/markdown
     for line in body.split("\n"):
-        clean = re.sub(r"<[^>]+>", "", line).strip()
+        clean = BeautifulSoup(line, "html.parser").get_text().strip()
         clean = clean.replace("**", "").replace("*", "").replace("`", "").strip()
         if clean and len(clean) > 5:
             return clean[:60].lower()

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -854,8 +854,10 @@ def _extract_sticky_title(body: str) -> str:
     if m:
         return m.group(1).strip().lower()
     # Fallback: first non-empty line, stripped of HTML/markdown
-    for line in body.split("\n"):
-        clean = BeautifulSoup(line, "html.parser").get_text().strip()
+    # Strip HTML once, then scan lines
+    plain = BeautifulSoup(body, "html.parser").get_text()
+    for line in plain.split("\n"):
+        clean = line.strip()
         clean = clean.replace("**", "").replace("*", "").replace("`", "").strip()
         if clean and len(clean) > 5:
             return clean[:60].lower()

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -761,7 +761,13 @@ def process_and_categorize(threads: list[dict[str, Any]], owner: str, repo: str)
         }
 
         # Check for previously dismissed similar comment (only if status is pending)
-        if (dismissed_by_path or dismissed_by_comment_id or dismissed_by_key) and enriched.get("status") == "pending":
+        # Qodo sticky findings are never auto-skipped — they persist intentionally
+        # until properly resolved and must always be re-evaluated.
+        if (
+            source != "qodo"
+            and (dismissed_by_path or dismissed_by_comment_id or dismissed_by_key)
+            and enriched.get("status") == "pending"
+        ):
             # Fast path: exact match by thread key (works for sticky findings)
             thread_key = get_thread_key(enriched)
             if thread_key and thread_key in dismissed_by_key:

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -685,6 +685,10 @@ def fetch_qodo_sticky_findings(owner: str, repo: str, pr_number: str) -> list[di
                 else "MEDIUM",
                 "reply": None,
                 "status": "pending",
+                "code_diff": finding.get("code_diff", ""),
+                "evidence": finding.get("evidence", ""),
+                "evidence_refs": finding.get("evidence_refs", []),
+                "agent_prompt": finding.get("agent_prompt", ""),
             }
             results.append(thread_data)
 

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -8,15 +8,9 @@ This module parses that comment to extract unresolved findings.
 from __future__ import annotations
 
 import re
-import sys
 from typing import Any
 
 from bs4 import BeautifulSoup, Tag
-
-
-def _log(msg: str) -> None:
-    print(msg, file=sys.stderr)
-
 
 # Header that identifies a Qodo sticky comment
 QODO_STICKY_HEADER = "Code Review by Qodo"
@@ -50,6 +44,25 @@ _FENCED_DIFF_RE = re.compile(r"```diff\n(.*?)```", re.DOTALL)
 # Pattern to extract fenced code blocks (``` ... ```)
 _FENCED_CODE_RE = re.compile(r"```(?!\w)\n(.*?)```", re.DOTALL)
 
+# Finding type keywords from Qodo sticky <code> tags
+_FINDING_TYPES = (
+    "Bug",
+    "Rule violation",
+    "Requirement gap",
+    "UX issue",
+    "Cross-repo conflict",
+)
+
+# Finding category keywords from Qodo sticky <code> tags
+_FINDING_CATEGORIES = (
+    "Correctness",
+    "Security",
+    "Reliability",
+    "Performance",
+    "Maintainability",
+    "Observability",
+)
+
 
 def _strip_blockquote_prefix(text: str) -> str:
     """Strip leading `> ` or `>` markdown blockquote prefix from each line."""
@@ -72,16 +85,8 @@ def _find_inner_section(soup: BeautifulSoup | Tag, section_name: str) -> Tag | N
     return None
 
 
-def _extract_description(section: Tag) -> str:
-    """Extract description from a Description section's <pre> block, preserving HTML."""
-    pre = section.find("pre")
-    if not pre:
-        return ""
-    return pre.decode_contents().strip()
-
-
-def _extract_evidence(section: Tag) -> str:
-    """Extract evidence text from an Evidence section's <pre> block, preserving HTML."""
+def _extract_pre_content(section: Tag) -> str:
+    """Extract text from a section's <pre> block, preserving HTML."""
     pre = section.find("pre")
     if not pre:
         return ""
@@ -174,28 +179,13 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
             codes_soup = BeautifulSoup(codes_str, "html.parser")
             for code_tag in codes_soup.find_all("code"):
                 text = code_tag.get_text()
-                _types = (
-                    "Bug",
-                    "Rule violation",
-                    "Requirement gap",
-                    "UX issue",
-                    "Cross-repo conflict",
-                )
-                _cats = (
-                    "Correctness",
-                    "Security",
-                    "Reliability",
-                    "Performance",
-                    "Maintainability",
-                    "Observability",
-                )
                 if "Resolved" in text:
                     is_resolved = True
                 elif "Dismissed" in text:
                     is_dismissed = True
-                elif any(t in text for t in _types):
+                elif any(t in text for t in _FINDING_TYPES):
                     finding_type = re.sub(r"[^\w\s-]", "", text).strip()
-                elif any(c in text for c in _cats):
+                elif any(c in text for c in _FINDING_CATEGORIES):
                     category = re.sub(r"[^\w\s]", "", text).strip()
 
         if strikethrough_title is not None:
@@ -206,7 +196,7 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
             title = plain_title or ""
 
         # Strip HTML from title
-        title = re.sub(r"<[^>]+>", "", title).strip()
+        title = BeautifulSoup(title, "html.parser").get_text().strip()
 
         if is_resolved or is_dismissed:
             continue
@@ -230,7 +220,7 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
         description = ""
         desc_section = _find_inner_section(soup, "Description")
         if desc_section:
-            description = _extract_description(desc_section)
+            description = _extract_pre_content(desc_section)
 
         # Extract code diff from Code section
         code_diff = ""
@@ -247,7 +237,7 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
         evidence_refs: list[str] = []
         evidence_section = _find_inner_section(soup, "Evidence")
         if evidence_section:
-            evidence = _extract_evidence(evidence_section)
+            evidence = _extract_pre_content(evidence_section)
             evidence_refs = _extract_evidence_refs(evidence_section)
 
         # Extract agent prompt

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -11,6 +11,8 @@ import re
 import sys
 from typing import Any
 
+from bs4 import BeautifulSoup, Tag
+
 
 def _log(msg: str) -> None:
     print(msg, file=sys.stderr)
@@ -19,7 +21,14 @@ def _log(msg: str) -> None:
 # Header that identifies a Qodo sticky comment
 QODO_STICKY_HEADER = "Code Review by Qodo"
 
-# Pattern matching individual findings in the sticky comment
+# Boundary marking previous review iterations (duplicates of current findings)
+# Match the real fold marker — must be on its own line (not inside backtick quotes).
+_PREVIOUS_RESULTS_RE = re.compile(
+    r"^\s*<!-- FOLDED_SECTION_START -->\s*$",
+    re.MULTILINE,
+)
+
+# Pattern matching individual finding summary lines
 # Captures: number, optional strikethrough, title, codes (type, category)
 _FINDING_SUMMARY_RE = re.compile(
     r"<summary>\s*(\d+)\.\s+"  # number
@@ -29,31 +38,84 @@ _FINDING_SUMMARY_RE = re.compile(
     re.DOTALL,
 )
 
-# Pattern for resolved/dismissed markers
-_RESOLVED_RE = re.compile(r"<code>[^<]*Resolved[^<]*</code>")
-_DISMISSED_RE = re.compile(r"<code>[^<]*Dismissed[^<]*</code>")
-
 # Pattern for code references like [file[R28-52]](url) or [file[28-52]](url)
 _CODE_REF_RE = re.compile(
     r"\[([^\[\]]+)\[R?(\d+)(?:-(?:R)?(\d+))?\]\]"  # file[R28-52] or file[28-52]
     r"\(([^)]+)\)"  # (url)
 )
 
-# Pattern for description in <pre> tags
-_DESCRIPTION_RE = re.compile(r"<pre>(.*?)</pre>", re.DOTALL)
+# Pattern to extract fenced diff blocks (```diff ... ```)
+_FENCED_DIFF_RE = re.compile(r"```diff\n(.*?)```", re.DOTALL)
 
-# Pattern for severity/type code tags
-_TYPE_RE = re.compile(r"<code>([^<]*(?:Bug|Rule violation|Requirement gap|UX issue|Cross-repo conflict)[^<]*)</code>")
-_CATEGORY_RE = re.compile(r"<code>([^<]*(?:Correctness|Security|Reliability|Performance|Maintainability)[^<]*)</code>")
+# Pattern to extract fenced code blocks (``` ... ```)
+_FENCED_CODE_RE = re.compile(r"```(?!\w)\n(.*?)```", re.DOTALL)
 
-# Boundary marking previous review iterations (duplicates of current findings)
-# Match the real fold marker — must be on its own line (not inside backtick quotes).
-# The marker appears as: \n<!-- FOLDED_SECTION_START -->\n
-# Inside code quotes it appears as: `<!-- FOLDED_SECTION_START -->`
-_PREVIOUS_RESULTS_RE = re.compile(
-    r"^\s*<!-- FOLDED_SECTION_START -->\s*$",
-    re.MULTILINE,
-)
+
+def _strip_blockquote_prefix(text: str) -> str:
+    """Strip leading `> ` or `>` markdown blockquote prefix from each line."""
+    lines = []
+    for line in text.splitlines():
+        if line.startswith(">"):
+            line = line[1:]
+            if line.startswith(" "):
+                line = line[1:]
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _find_inner_section(soup: BeautifulSoup | Tag, section_name: str) -> Tag | None:
+    """Find a nested <details> whose <summary> text matches *section_name*."""
+    for details in soup.find_all("details"):
+        summary = details.find("summary")
+        if summary and summary.get_text(strip=True) == section_name:
+            return details
+    return None
+
+
+def _extract_description(section: Tag) -> str:
+    """Extract description from a Description section's <pre> block, preserving HTML."""
+    pre = section.find("pre")
+    if not pre:
+        return ""
+    return pre.decode_contents().strip()
+
+
+def _extract_evidence(section: Tag) -> str:
+    """Extract evidence text from an Evidence section's <pre> block, preserving HTML."""
+    pre = section.find("pre")
+    if not pre:
+        return ""
+    return pre.decode_contents().strip()
+
+
+def _extract_evidence_refs(section: Tag) -> list[str]:
+    """Extract <code> tags from Evidence section that are OUTSIDE any <pre> block."""
+    # Get all <pre> tags to identify which <code> tags are inside them
+    pre_tags = set()
+    for pre in section.find_all("pre"):
+        for code in pre.find_all("code"):
+            pre_tags.add(id(code))
+
+    refs = []
+    for code in section.find_all("code"):
+        if id(code) in pre_tags:
+            continue
+        text = code.get_text(strip=True)
+        if text:
+            refs.append(text)
+    return refs
+
+
+def _extract_agent_prompt(raw_section: str) -> str:
+    """Extract agent prompt from fenced code block, excluding trailing copy-hint line."""
+    match = _FENCED_CODE_RE.search(raw_section)
+    if not match:
+        return ""
+    content = match.group(1).strip()
+    lines = content.splitlines()
+    while lines and "ⓘ Copy this prompt" in lines[-1]:
+        lines.pop()
+    return "\n".join(lines).strip()
 
 
 def is_qodo_sticky_comment(body: str) -> bool:
@@ -70,10 +132,14 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
     - path: str (file path from first code reference)
     - line: int (start line from first code reference)
     - end_line: int | None
-    - description: str (from <pre> block)
+    - description: str (from Description section <pre> block, HTML preserved)
     - finding_type: str (Bug, Rule violation, Requirement gap)
     - category: str (Correctness, Security, etc.)
-    - status: str ("open", "resolved", "dismissed")
+    - status: str ("open")
+    - code_diff: str (diff content from Code section)
+    - evidence: str (reasoning text from Evidence section <pre> block, HTML preserved)
+    - evidence_refs: list[str] (reference lines from Evidence section <code> tags)
+    - agent_prompt: str (prompt text from Agent prompt section)
     """
     if not is_qodo_sticky_comment(body):
         return []
@@ -86,8 +152,7 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
 
     # Split into individual <details> blocks for each finding
-    # Each finding is a <details><summary>...</summary>...</details> block
-    details_blocks = re.split(r"<details>\s*\n?", body)
+    details_blocks = re.split(r"^<details>\s*\n?", body, flags=re.MULTILINE)
 
     for block in details_blocks:
         summary_match = _FINDING_SUMMARY_RE.search(block)
@@ -95,18 +160,47 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
             continue
 
         index = int(summary_match.group(1))
-        strikethrough_title = summary_match.group(2)  # if in <s> tags
-        plain_title = summary_match.group(3)  # if not in <s> tags
+        strikethrough_title = summary_match.group(2)
+        plain_title = summary_match.group(3)
         codes_str = summary_match.group(4)
 
-        # Determine status
-        is_resolved = _RESOLVED_RE.search(codes_str) is not None if codes_str else False
-        is_dismissed = _DISMISSED_RE.search(codes_str) is not None if codes_str else False
+        # Parse code tags with BeautifulSoup to determine status, type, category
+        is_resolved = False
+        is_dismissed = False
+        finding_type = ""
+        category = ""
+
+        if codes_str:
+            codes_soup = BeautifulSoup(codes_str, "html.parser")
+            for code_tag in codes_soup.find_all("code"):
+                text = code_tag.get_text()
+                _types = (
+                    "Bug",
+                    "Rule violation",
+                    "Requirement gap",
+                    "UX issue",
+                    "Cross-repo conflict",
+                )
+                _cats = (
+                    "Correctness",
+                    "Security",
+                    "Reliability",
+                    "Performance",
+                    "Maintainability",
+                    "Observability",
+                )
+                if "Resolved" in text:
+                    is_resolved = True
+                elif "Dismissed" in text:
+                    is_dismissed = True
+                elif any(t in text for t in _types):
+                    finding_type = re.sub(r"[^\w\s-]", "", text).strip()
+                elif any(c in text for c in _cats):
+                    category = re.sub(r"[^\w\s]", "", text).strip()
 
         if strikethrough_title is not None:
             title = strikethrough_title
             if not is_resolved and not is_dismissed:
-                # Has strikethrough but no explicit marker — treat as resolved
                 is_resolved = True
         else:
             title = plain_title or ""
@@ -115,20 +209,9 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
         title = re.sub(r"<[^>]+>", "", title).strip()
 
         if is_resolved or is_dismissed:
-            continue  # Skip resolved/dismissed
+            continue
 
-        # Extract type and category from code tags
-        finding_type = ""
-        category = ""
-        if codes_str:
-            type_match = _TYPE_RE.search(codes_str)
-            if type_match:
-                finding_type = re.sub(r"[^\w\s-]", "", type_match.group(1)).strip()
-            cat_match = _CATEGORY_RE.search(codes_str)
-            if cat_match:
-                category = re.sub(r"[^\w\s]", "", cat_match.group(1)).strip()
-
-        # Extract first code reference (file + lines)
+        # Extract first code reference from raw block (markdown construct)
         path = ""
         line = None
         end_line = None
@@ -139,13 +222,39 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
             if code_ref.group(3):
                 end_line = int(code_ref.group(3))
 
+        # Strip blockquote prefixes and parse inner sections with BeautifulSoup
+        stripped_block = _strip_blockquote_prefix(block)
+        soup = BeautifulSoup(stripped_block, "html.parser")
+
         # Extract description
         description = ""
-        desc_match = _DESCRIPTION_RE.search(block)
-        if desc_match:
-            desc_text = desc_match.group(1).strip()
-            # Strip HTML tags from description
-            description = re.sub(r"<[^>]+>", "", desc_text).strip()
+        desc_section = _find_inner_section(soup, "Description")
+        if desc_section:
+            description = _extract_description(desc_section)
+
+        # Extract code diff from Code section
+        code_diff = ""
+        code_section = _find_inner_section(soup, "Code")
+        if code_section:
+            # Use raw stripped text for fenced diff extraction (markdown)
+            code_section_str = str(code_section)
+            diff_match = _FENCED_DIFF_RE.search(code_section_str)
+            if diff_match:
+                code_diff = diff_match.group(1).strip()
+
+        # Extract evidence and evidence refs
+        evidence = ""
+        evidence_refs: list[str] = []
+        evidence_section = _find_inner_section(soup, "Evidence")
+        if evidence_section:
+            evidence = _extract_evidence(evidence_section)
+            evidence_refs = _extract_evidence_refs(evidence_section)
+
+        # Extract agent prompt
+        agent_prompt = ""
+        prompt_section = _find_inner_section(soup, "Agent prompt")
+        if prompt_section:
+            agent_prompt = _extract_agent_prompt(str(prompt_section))
 
         results.append({
             "index": index,
@@ -157,6 +266,10 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
             "finding_type": finding_type,
             "category": category,
             "status": "open",
+            "code_diff": code_diff,
+            "evidence": evidence,
+            "evidence_refs": evidence_refs,
+            "agent_prompt": agent_prompt,
         })
 
     return results

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -77,9 +77,9 @@ def _strip_blockquote_prefix(text: str) -> str:
 
 
 def _find_inner_section(soup: BeautifulSoup | Tag, section_name: str) -> Tag | None:
-    """Find a nested <details> whose <summary> text matches *section_name*."""
-    for details in soup.find_all("details"):
-        summary = details.find("summary")
+    """Find a direct-child <details> whose <summary> text matches *section_name*."""
+    for details in soup.find_all("details", recursive=False):
+        summary = details.find("summary", recursive=False)
         if summary and summary.get_text(strip=True) == section_name:
             return details
     return None
@@ -95,15 +95,9 @@ def _extract_pre_content(section: Tag) -> str:
 
 def _extract_evidence_refs(section: Tag) -> list[str]:
     """Extract <code> tags from Evidence section that are OUTSIDE any <pre> block."""
-    # Get all <pre> tags to identify which <code> tags are inside them
-    pre_tags = set()
-    for pre in section.find_all("pre"):
-        for code in pre.find_all("code"):
-            pre_tags.add(id(code))
-
     refs = []
     for code in section.find_all("code"):
-        if id(code) in pre_tags:
+        if code.find_parent("pre"):
             continue
         text = code.get_text(strip=True)
         if text:

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -123,7 +123,7 @@ def extract_summary(body: str, max_len: int = 60) -> str:
     if not body:
         return ""
     # Strip ALL HTML tags from entire body first
-    cleaned_body = BeautifulSoup(body, "html.parser").get_text()
+    cleaned_body = BeautifulSoup(body, "html.parser").get_text() if "<" in body else body
     # Try to get the first meaningful line
     for line in cleaned_body.split("\n"):
         line = line.strip()

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -7,13 +7,14 @@ Outputs:
 
 import json
 import os
-import re
 import sqlite3
 import subprocess
 import sys
 from html import escape
 from pathlib import Path
 from urllib.parse import quote
+
+from bs4 import BeautifulSoup
 
 
 def log(message: str) -> None:
@@ -122,7 +123,7 @@ def extract_summary(body: str, max_len: int = 60) -> str:
     if not body:
         return ""
     # Strip ALL HTML tags from entire body first
-    cleaned_body = re.sub(r"<[^>]+>", "", body)
+    cleaned_body = BeautifulSoup(body, "html.parser").get_text()
     # Try to get the first meaningful line
     for line in cleaned_body.split("\n"):
         line = line.strip()
@@ -145,7 +146,7 @@ def deduplicate_comments(comments: list[dict]) -> list[dict]:
     seen: dict[str, dict] = {}
     for c in comments:
         # Normalize summary for dedup: strip HTML, lowercase, first 30 chars
-        raw = re.sub(r"<[^>]+>", "", extract_summary(c["body"], 50)).lower().strip()
+        raw = BeautifulSoup(extract_summary(c["body"], 50), "html.parser").get_text().lower().strip()
         key = f"{c['source']}:{c['path']}:{c['line']}:{raw[:30]}"
         seen[key] = c  # Last one wins (latest cycle)
     return list(seen.values())

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -7,6 +7,7 @@ Outputs:
 
 import json
 import os
+import re
 import sqlite3
 import subprocess
 import sys
@@ -123,7 +124,7 @@ def extract_summary(body: str, max_len: int = 60) -> str:
     if not body:
         return ""
     # Strip ALL HTML tags from entire body first
-    cleaned_body = BeautifulSoup(body, "html.parser").get_text() if "<" in body else body
+    cleaned_body = BeautifulSoup(body, "html.parser").get_text() if re.search(r"<[a-zA-Z/]", body) else body
     # Try to get the first meaningful line
     for line in cleaned_body.split("\n"):
         line = line.strip()

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -146,7 +146,7 @@ def deduplicate_comments(comments: list[dict]) -> list[dict]:
     seen: dict[str, dict] = {}
     for c in comments:
         # Normalize summary for dedup: strip HTML, lowercase, first 30 chars
-        raw = BeautifulSoup(extract_summary(c["body"], 50), "html.parser").get_text().lower().strip()
+        raw = extract_summary(c["body"], 50).lower().strip()
         key = f"{c['source']}:{c['path']}:{c['line']}:{raw[:30]}"
         seen[key] = c  # Last one wins (latest cycle)
     return list(seen.values())

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -138,6 +138,11 @@ Returns JSON with:
 >
 > If autoqodo mode is ON:
 >
+> **Qodo sticky findings are NEVER auto-skipped.** Unlike CodeRabbit, Qodo sticky
+> findings persist intentionally until resolved. Even if a finding was previously
+> addressed or dismissed, it must be re-evaluated and fixed again. The `is_auto_skipped`
+> flag does not apply to Qodo sources.
+>
 > 1. **Qodo comments → auto-approved based on finding type:**
 >    - `qodo_bug` → **MUST address.** Fix the code. No skip allowed.
 >    - `qodo_rule_violation` → **MUST address.** Fix the code. No skip allowed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,12 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
 ]
-dependencies = ["click>=8.0.0", "tomli>=2.0.0; python_version < '3.11'", "ai-cli-runner>=0.4.0"]
+dependencies = [
+    "click>=8.0.0",
+    "tomli>=2.0.0; python_version < '3.11'",
+    "ai-cli-runner>=0.4.0",
+    "beautifulsoup4>=4.15.0",
+]
 
 [project.scripts]
 myk-pi-tools = "myk_pi_tools.cli:main"

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -70,7 +70,7 @@ Generate the exact commands the user needs to run. For each peer:
 
 ```text
 Open a new pi terminal and run:
-/coms start --name <peer-name> --purpose "<brief purpose>"
+/coms start --cname <peer-name> --purpose "<brief purpose>"
 ```
 
 Repeat for each peer. Then:

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -70,7 +70,7 @@ Generate the exact commands the user needs to run. For each peer:
 
 ```text
 Open a new pi terminal and run:
-/coms start --cname <peer-name> --purpose "<brief purpose>"
+/coms start --name <peer-name> --purpose "<brief purpose>"
 ```
 
 Repeat for each peer. Then:

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -128,6 +141,7 @@ version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-cli-runner" },
+    { name = "beautifulsoup4" },
     { name = "click" },
 ]
 
@@ -139,6 +153,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "ai-cli-runner", specifier = ">=0.4.0" },
+    { name = "beautifulsoup4", specifier = ">=4.15.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
 ]
@@ -197,6 +212,15 @@ dependencies = [
     { name = "colorlog" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f1/5b/e97b2209a7de9763c50ef073620630aff8ffc546206e519f1d4330293f9c/python_simple_logger-2.0.19.tar.gz", hash = "sha256:1a26cf71da4bea84ac3093a90a2476555a8dde5cce69c8271143eea7675ca9e1", size = 9953, upload-time = "2026-02-26T09:36:04.764Z" }
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Problem

Qodo sticky comments were being auto-skipped when they matched previously dismissed comments (by path/body similarity or thread key). This caused the poll loop to see them as non-actionable, skipping them instead of surfacing for re-evaluation.

Qodo sticky findings are persistent and intentionally re-appear until properly resolved — auto-skipping defeats their purpose.

## Changes

- **`myk_pi_tools/reviews/fetch.py`** — Added `source != "qodo"` guard to the auto-skip dismissal matching condition. Qodo comments always stay `pending`.
- **`prompts/review-handler.md`** — Added explicit paragraph reinforcing that Qodo sticky findings are never auto-skipped.

Closes #465