### PR TITLE
fix: deduplicate already-replied Qodo sticky findings, detect mid-review (#469)

### DIFF
--- a/myk_pi_tools/db/query.py
+++ b/myk_pi_tools/db/query.py
@@ -203,8 +203,14 @@ class ReviewDB:
             try:
                 cursor = conn.execute("PRAGMA table_info(comments)")
                 columns = {row[1] for row in cursor.fetchall()}
+                needs_commit = False
                 if "type" not in columns:
                     conn.execute("ALTER TABLE comments ADD COLUMN type TEXT DEFAULT NULL")
+                    needs_commit = True
+                if "code_diff" not in columns:
+                    conn.execute("ALTER TABLE comments ADD COLUMN code_diff TEXT DEFAULT NULL")
+                    needs_commit = True
+                if needs_commit:
                     conn.commit()
             finally:
                 conn.close()
@@ -335,7 +341,7 @@ class ReviewDB:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                SELECT c.comment_id, c.body, c.status, c.reply, c.posted_at
+                SELECT c.comment_id, c.body, c.status, c.reply, c.posted_at, c.code_diff
                 FROM comments c
                 JOIN reviews r ON c.review_id = r.id
                 WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
@@ -355,6 +361,7 @@ class ReviewDB:
                     "status": row["status"],
                     "reply": row["reply"],
                     "posted_at": row["posted_at"],
+                    "code_diff": row["code_diff"],
                 })
             return results
         except sqlite3.Error as e:

--- a/myk_pi_tools/db/query.py
+++ b/myk_pi_tools/db/query.py
@@ -312,6 +312,9 @@ class ReviewDB:
         - Status is not 'pending' (i.e., was processed)
         - Has a comment_id (sticky findings use the issue comment ID)
 
+        Failed entries with posted_at set are included (consolidated reply was
+        posted even though per-item status stayed failed).
+
         Used for deduplication: if a sticky finding's comment_id + body
         exactly matches an entry here, it was already replied to.
 
@@ -337,7 +340,8 @@ class ReviewDB:
                 JOIN reviews r ON c.review_id = r.id
                 WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
                   AND c.source = 'qodo'
-                  AND c.status IN ('addressed', 'not_addressed', 'skipped')
+                  AND (c.status IN ('addressed', 'not_addressed', 'skipped')
+                       OR (c.status = 'failed' AND c.posted_at IS NOT NULL AND c.posted_at != ''))
                   AND c.comment_id IS NOT NULL
                 ORDER BY c.posted_at DESC
                 """,

--- a/myk_pi_tools/db/query.py
+++ b/myk_pi_tools/db/query.py
@@ -303,6 +303,62 @@ class ReviewDB:
         finally:
             conn.close()
 
+    def get_replied_sticky_findings(self, owner: str, repo: str, pr_number: int) -> list[dict[str, Any]]:
+        """Get Qodo sticky findings that were already replied to for a specific PR.
+
+        Returns comments from the DB where:
+        - Same owner/repo/pr_number
+        - Source is 'qodo'
+        - Status is not 'pending' (i.e., was processed)
+        - Has a comment_id (sticky findings use the issue comment ID)
+
+        Used for deduplication: if a sticky finding's comment_id + body
+        exactly matches an entry here, it was already replied to.
+
+        Args:
+            owner: GitHub repository owner.
+            repo: GitHub repository name.
+            pr_number: PR number.
+
+        Returns:
+            List of dicts with keys: comment_id, body, status, reply, posted_at.
+            Returns empty list if database doesn't exist or on error.
+        """
+        if not self.db_path.exists():
+            return []
+
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT c.comment_id, c.body, c.status, c.reply, c.posted_at
+                FROM comments c
+                JOIN reviews r ON c.review_id = r.id
+                WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
+                  AND c.source = 'qodo'
+                  AND c.status != 'pending'
+                  AND c.comment_id IS NOT NULL
+                ORDER BY c.posted_at DESC
+                """,
+                (owner, repo, pr_number),
+            )
+            results = []
+            for row in cursor.fetchall():
+                results.append({
+                    "comment_id": row["comment_id"],
+                    "body": row["body"],
+                    "status": row["status"],
+                    "reply": row["reply"],
+                    "posted_at": row["posted_at"],
+                })
+            return results
+        except sqlite3.Error as e:
+            log(f"Database error: {e}")
+            return []
+        finally:
+            conn.close()
+
     def find_similar_comment(
         self, owner: str, repo: str, path: str, body: str, threshold: float = 0.6
     ) -> dict[str, Any] | None:

--- a/myk_pi_tools/db/query.py
+++ b/myk_pi_tools/db/query.py
@@ -337,7 +337,7 @@ class ReviewDB:
                 JOIN reviews r ON c.review_id = r.id
                 WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
                   AND c.source = 'qodo'
-                  AND c.status != 'pending'
+                  AND c.status IN ('addressed', 'not_addressed', 'skipped')
                   AND c.comment_id IS NOT NULL
                 ORDER BY c.posted_at DESC
                 """,

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -747,14 +747,15 @@ def process_and_categorize(
             dismissed_by_key = {}
 
     # Preload already-replied Qodo sticky findings for dedup (exact match only)
-    replied_sticky: set[tuple[int, str]] = set()
+    replied_sticky: set[tuple[int, str, str]] = set()
     if db and pr_number:
         try:
             for c in db.get_replied_sticky_findings(owner, repo, pr_number):
                 cid = c.get("comment_id")
                 body = c.get("body") or ""
+                code_diff = c.get("code_diff") or ""
                 if cid is not None:
-                    replied_sticky.add((int(cid), body))
+                    replied_sticky.add((int(cid), body, code_diff))
         except Exception as e:
             print_stderr(f"Warning: Failed to preload replied sticky findings: {e}")
 
@@ -784,7 +785,8 @@ def process_and_categorize(
         if source == "qodo" and thread.get("thread_id") is None and replied_sticky:
             cid = thread.get("comment_id")
             thread_body = thread.get("body") or ""
-            if cid is not None and (int(cid), thread_body) in replied_sticky:
+            thread_code_diff = thread.get("code_diff") or ""
+            if cid is not None and (int(cid), thread_body, thread_code_diff) in replied_sticky:
                 enriched["already_replied"] = True
 
         # Check for previously dismissed similar comment (only if status is pending)

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -697,7 +697,9 @@ def fetch_qodo_sticky_findings(owner: str, repo: str, pr_number: str) -> list[di
     return results
 
 
-def process_and_categorize(threads: list[dict[str, Any]], owner: str, repo: str) -> dict[str, list[dict[str, Any]]]:
+def process_and_categorize(
+    threads: list[dict[str, Any]], owner: str, repo: str, pr_number: int | None = None
+) -> dict[str, list[dict[str, Any]]]:
     """Process threads: add source and priority, categorize, and auto-skip previously dismissed."""
     human: list[dict[str, Any]] = []
     qodo: list[dict[str, Any]] = []
@@ -744,6 +746,18 @@ def process_and_categorize(threads: list[dict[str, Any]], owner: str, repo: str)
             dismissed_by_comment_id = {}
             dismissed_by_key = {}
 
+    # Preload already-replied Qodo sticky findings for dedup (exact match only)
+    replied_sticky: set[tuple[int, str]] = set()
+    if db and pr_number:
+        try:
+            for c in db.get_replied_sticky_findings(owner, repo, pr_number):
+                cid = c.get("comment_id")
+                body = c.get("body") or ""
+                if cid is not None:
+                    replied_sticky.add((int(cid), body))
+        except Exception as e:
+            print_stderr(f"Warning: Failed to preload replied sticky findings: {e}")
+
     for thread in threads:
         author = thread.get("author")
         body = thread.get("body")
@@ -765,6 +779,13 @@ def process_and_categorize(threads: list[dict[str, Any]], owner: str, repo: str)
             "status": thread.get("status", "pending"),
             "quality_label": thread.get("quality_label"),
         }
+
+        # Check if this Qodo sticky finding was already replied to (exact match)
+        if source == "qodo" and thread.get("thread_id") is None and replied_sticky:
+            cid = thread.get("comment_id")
+            thread_body = thread.get("body") or ""
+            if cid is not None and (int(cid), thread_body) in replied_sticky:
+                enriched["already_replied"] = True
 
         # Check for previously dismissed similar comment (only if status is pending)
         # Qodo sticky findings are never auto-skipped — they persist intentionally
@@ -1097,7 +1118,7 @@ def run(review_url: str = "") -> int:
 
         # Process and categorize threads
         print_stderr("Categorizing threads by source...")
-        categorized = process_and_categorize(all_threads, owner, repo)
+        categorized = process_and_categorize(all_threads, owner, repo, pr_number=int(pr_number))
 
         # Build final output
         final_output = {

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -242,8 +242,15 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> dict | None:
                     rbody = r.get("body") or ""
                     if cid is not None:
                         key = (int(cid), rbody)
-                        if key not in replied_map:
+                        existing = replied_map.get(key)
+                        if existing is None:
                             replied_map[key] = r
+                        else:
+                            # Prefer records with meaningful replies over dedup artifacts
+                            existing_reply = existing.get("reply") or ""
+                            new_reply = r.get("reply") or ""
+                            if "Already replied" in existing_reply and "Already replied" not in new_reply and new_reply:
+                                replied_map[key] = r
 
                 # Check each unresolved finding
                 sticky_id = int(comment.get("id", 0))
@@ -386,20 +393,26 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
         # Step 2: Only check approval AFTER confirming 0 new comments
         # This prevents approving before processing new findings
         if fetch_result == 0:
-            print_stderr("[poll] Checking Qodo approval...")
-            approval = _is_qodo_approved(owner, repo, pr_number)
-            if approval:
-                reason = approval.get("reason", "unknown")
-                if reason == "all_resolved":
-                    print_stderr("[poll] Qodo approved — all findings resolved.")
-                elif reason == "stale_sticky":
-                    print_stderr("[poll] Qodo approved — stale sticky, all unresolved findings already replied to.")
-                else:
-                    print_stderr(f"[poll] Qodo approved — {reason}.")
-                # Print approval summary
-                _print_approval_summary(approval)
-                print('{"approved": true}')
-                return 0
+            # Don't check approval if Qodo is mid-review — sticky is about to change
+            if _is_qodo_reviewing(owner, repo, pr_number):
+                print_stderr(
+                    "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
+                )
+            else:
+                print_stderr("[poll] Checking Qodo approval...")
+                approval = _is_qodo_approved(owner, repo, pr_number)
+                if approval:
+                    reason = approval.get("reason", "unknown")
+                    if reason == "all_resolved":
+                        print_stderr("[poll] Qodo approved — all findings resolved.")
+                    elif reason == "stale_sticky":
+                        print_stderr("[poll] Qodo approved — stale sticky, all unresolved findings already replied to.")
+                    else:
+                        print_stderr(f"[poll] Qodo approved — {reason}.")
+                    # Print approval summary
+                    _print_approval_summary(approval)
+                    print('{"approved": true}')
+                    return 0
 
         # No actionable result — sleep and loop
         print_stderr(f"[poll] No new Qodo comments. Sleeping {_POLL_SLEEP_SECONDS}s before next cycle...")

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -119,7 +119,37 @@ def _has_actionable_qodo_comments(pr_number: str) -> bool:
         return True
 
     for comment in data.get("qodo", []):
-        if not comment.get("is_auto_skipped"):
+        if not comment.get("is_auto_skipped") and not comment.get("already_replied"):
+            return True
+
+    return False
+
+
+# Exact body Qodo posts while reviewing a PR (transient comment)
+_QODO_REVIEWING_BODY = (
+    "\n<h3>Looking for bugs?</h3>\nCheck back in a few minutes. An AI review agent is analyzing this pull request.\n"
+)
+
+
+def _is_qodo_reviewing(owner: str, repo: str, pr_number: str) -> bool:
+    """Check if Qodo is currently reviewing the PR.
+
+    Qodo posts a transient comment with exact body while reviewing.
+    If this comment exists, the sticky is about to be updated — we should wait.
+    Matches exact author (qodo-code-review[bot]) and exact body text.
+    """
+    endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+    comments = run_gh_api(endpoint, paginate=True)
+    if not comments or not isinstance(comments, list):
+        return False
+
+    for comment in comments:
+        author = comment.get("user", {}).get("login") if comment.get("user") else None
+        if author != "qodo-code-review[bot]":
+            continue
+        body = comment.get("body", "")
+        if body == _QODO_REVIEWING_BODY:
+            print_stderr("[poll] Qodo review in progress (Looking for bugs).")
             return True
 
     return False
@@ -161,16 +191,6 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> bool:
 
     QODO_USERS = {"qodo-code-review[bot]", "qodo-code-review"}
 
-    # Check if Qodo has a review-in-progress comment after our commit
-    for comment in comments:
-        author = comment.get("user", {}).get("login") if comment.get("user") else None
-        if author not in QODO_USERS:
-            continue
-        body = comment.get("body", "")
-        if "Looking for bugs" in body:
-            print_stderr("[poll] Qodo review in progress (Looking for bugs). Not approved yet.")
-            return False
-
     for comment in comments:
         author = comment.get("user", {}).get("login") if comment.get("user") else None
         if author not in QODO_USERS:
@@ -189,6 +209,38 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> bool:
         # Parse for unresolved findings
         unresolved = parse_qodo_sticky_comment(body)
         if len(unresolved) > 0:
+            # Check if all unresolved findings were already replied to (stale sticky)
+            try:
+                from myk_pi_tools.db.query import ReviewDB
+
+                db = ReviewDB(db_path=None)
+                replied = db.get_replied_sticky_findings(owner, repo, int(pr_number))
+                replied_set: set[tuple[int, str]] = set()
+                for r in replied:
+                    cid = r.get("comment_id")
+                    rbody = r.get("body") or ""
+                    if cid is not None:
+                        replied_set.add((int(cid), rbody))
+
+                # Build body for each unresolved finding to check against DB
+                sticky_id = int(comment.get("id", 0))
+                all_replied = True
+                for finding in unresolved:
+                    finding_body = f"**{finding.get('title', '')}**\n\n{finding.get('description', '')}"
+                    if (sticky_id, finding_body) not in replied_set:
+                        all_replied = False
+                        break
+
+                if all_replied:
+                    print_stderr(
+                        f"[poll] Sticky has {len(unresolved)} unresolved finding(s),"
+                        f" but all already replied to (stale sticky)."
+                    )
+                    print_stderr("[poll] Treating stale sticky as approved.")
+                    return True
+            except Exception as e:
+                print_stderr(f"[poll] Warning: Could not check replied sticky findings: {e}")
+
             print_stderr(f"[poll] Sticky has {len(unresolved)} unresolved finding(s).")
             return False
 
@@ -236,9 +288,17 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
             _print_poll_summary(pr_number)
             has_actionable = _has_actionable_qodo_comments(pr_number)
             if has_actionable:
-                print_stderr("[poll] Found actionable Qodo comments.")
-                return 0
-            print_stderr("[poll] No actionable Qodo comments (all auto-skipped or none found).")
+                # Before returning, check if Qodo is mid-review — if so, wait for it to finish
+                if _is_qodo_reviewing(owner, repo, pr_number):
+                    print_stderr(
+                        "[poll] Qodo is currently reviewing —"
+                        " waiting for review to complete before processing findings."
+                    )
+                else:
+                    print_stderr("[poll] Found actionable Qodo comments.")
+                    return 0
+            else:
+                print_stderr("[poll] No actionable Qodo comments (all auto-skipped or none found).")
         else:
             print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -11,7 +11,6 @@ on "no new comments" -- sleeps and retries.
 from __future__ import annotations
 
 import contextlib
-import re
 import sys
 import time
 from datetime import UTC, datetime
@@ -155,13 +154,23 @@ def _is_qodo_reviewing(owner: str, repo: str, pr_number: str) -> bool:
     return False
 
 
-def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> bool:
+def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> dict | None:
     """Check if Qodo has approved the PR.
 
+    Returns a summary dict if approved, None if not approved.
+
     Approved when:
-    1. Sticky comment has 0 unresolved findings
+    1. Sticky comment has 0 unresolved findings (or all unresolved are already replied to)
     2. Sticky has at least one resolved/dismissed finding (not empty)
     3. Sticky updated_at is AFTER PR head commit date (Qodo finished reviewing latest)
+
+    Returns dict with keys:
+    - approved: True
+    - reason: str ("all_resolved" or "stale_sticky")
+    - total_findings: int (total in sticky, resolved + unresolved)
+    - resolved_count: int (resolved/dismissed by Qodo)
+    - unresolved_count: int (still open in sticky)
+    - findings: list of dicts with title, status, reply (from DB for already-replied)
     """
     from myk_pi_tools.reviews.qodo_parser import is_qodo_sticky_comment, parse_qodo_sticky_comment
 
@@ -169,25 +178,25 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> bool:
     pr_endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}"
     pr_data = run_gh_api(pr_endpoint)
     if not isinstance(pr_data, dict):
-        return False
+        return None
     head_sha = pr_data.get("head", {}).get("sha", "")
     if not head_sha:
-        return False
+        return None
 
     # Get commit date for PR HEAD
     commit_endpoint = f"/repos/{owner}/{repo}/commits/{head_sha}"
     commit_data = run_gh_api(commit_endpoint)
     if not isinstance(commit_data, dict):
-        return False
+        return None
     commit_date = commit_data.get("commit", {}).get("committer", {}).get("date", "")
     if not commit_date:
-        return False
+        return None
 
     # Find the Qodo sticky comment
     endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
     comments = run_gh_api(endpoint, paginate=True)
     if not comments or not isinstance(comments, list):
-        return False
+        return None
 
     QODO_USERS = {"qodo-code-review[bot]", "qodo-code-review"}
 
@@ -204,10 +213,20 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> bool:
         sticky_updated = comment.get("updated_at", "")
         if not sticky_updated or sticky_updated < commit_date:
             print_stderr(f"[poll] Sticky updated {sticky_updated} but commit at {commit_date} — not yet reviewed.")
-            return False
+            return None
 
         # Parse for unresolved findings
         unresolved = parse_qodo_sticky_comment(body)
+
+        # Count resolved findings from the sticky body
+        import re as _re
+
+        _prev_re = _re.compile(r"^\s*<!-- FOLDED_SECTION_START -->\s*$", _re.MULTILINE)
+        _prev_match = _prev_re.search(body)
+        current_body = body[: _prev_match.start()] if _prev_match else body
+        resolved_count = current_body.count("✓ Resolved") + current_body.count("✗ Dismissed")
+        total_findings = resolved_count + len(unresolved)
+
         if len(unresolved) > 0:
             # Check if all unresolved findings were already replied to (stale sticky)
             try:
@@ -215,19 +234,33 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> bool:
 
                 db = ReviewDB(db_path=None)
                 replied = db.get_replied_sticky_findings(owner, repo, int(pr_number))
-                replied_set: set[tuple[int, str]] = set()
+
+                # Build lookup: (comment_id, body) -> DB record
+                replied_map: dict[tuple[int, str], dict] = {}
                 for r in replied:
                     cid = r.get("comment_id")
                     rbody = r.get("body") or ""
                     if cid is not None:
-                        replied_set.add((int(cid), rbody))
+                        key = (int(cid), rbody)
+                        if key not in replied_map:
+                            replied_map[key] = r
 
-                # Build body for each unresolved finding to check against DB
+                # Check each unresolved finding
                 sticky_id = int(comment.get("id", 0))
                 all_replied = True
+                findings_summary = []
                 for finding in unresolved:
                     finding_body = f"**{finding.get('title', '')}**\n\n{finding.get('description', '')}"
-                    if (sticky_id, finding_body) not in replied_set:
+                    key = (sticky_id, finding_body)
+                    db_record = replied_map.get(key)
+                    if db_record:
+                        findings_summary.append({
+                            "title": finding.get("title", ""),
+                            "finding_type": finding.get("finding_type", ""),
+                            "status": db_record.get("status", "unknown"),
+                            "reply": db_record.get("reply", ""),
+                        })
+                    else:
                         all_replied = False
                         break
 
@@ -237,32 +270,80 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> bool:
                         f" but all already replied to (stale sticky)."
                     )
                     print_stderr("[poll] Treating stale sticky as approved.")
-                    return True
+                    return {
+                        "approved": True,
+                        "reason": "stale_sticky",
+                        "total_findings": total_findings,
+                        "resolved_count": resolved_count,
+                        "unresolved_count": len(unresolved),
+                        "findings": findings_summary,
+                    }
             except Exception as e:
                 print_stderr(f"[poll] Warning: Could not check replied sticky findings: {e}")
 
             print_stderr(f"[poll] Sticky has {len(unresolved)} unresolved finding(s).")
-            return False
+            return None
 
         # Check at least one resolved/dismissed finding exists
-        _prev_re = re.compile(r"^\s*<!-- FOLDED_SECTION_START -->\s*$", re.MULTILINE)
-        _prev_match = _prev_re.search(body)
-        current_body = body[: _prev_match.start()] if _prev_match else body
         has_resolved = (
-            "\u2713 Resolved" in current_body
+            "✓ Resolved" in current_body
             or "Resolved</code>" in current_body
-            or "\u2717 Dismissed" in current_body
+            or "✗ Dismissed" in current_body
             or "Dismissed</code>" in current_body
         )
         if not has_resolved:
             print_stderr("[poll] Sticky has no resolved findings — empty review.")
-            return False
+            return None
 
-        # All checks passed
-        return True
+        # All checks passed — fully approved by Qodo
+        return {
+            "approved": True,
+            "reason": "all_resolved",
+            "total_findings": total_findings,
+            "resolved_count": resolved_count,
+            "unresolved_count": 0,
+            "findings": [],
+        }
 
     # No sticky comment found
-    return False
+    return None
+
+
+def _print_approval_summary(approval: dict) -> None:
+    """Print a summary of the Qodo approval status."""
+    reason = approval.get("reason", "unknown")
+    total = approval.get("total_findings", 0)
+    resolved = approval.get("resolved_count", 0)
+    unresolved = approval.get("unresolved_count", 0)
+    findings = approval.get("findings", [])
+
+    print_stderr("")
+    print_stderr("[poll] === Qodo Approval Summary ===")
+    print_stderr(f"  Total findings: {total} ({resolved} resolved by Qodo, {unresolved} still in sticky)")
+
+    if reason == "all_resolved":
+        print_stderr("  Status: All findings resolved/dismissed by Qodo ✅")
+    elif reason == "stale_sticky":
+        print_stderr("  Status: Stale sticky — all unresolved findings already replied to")
+        if findings:
+            print_stderr("")
+            print_stderr("  Unresolved findings (already replied):")
+            for i, f in enumerate(findings, 1):
+                title = f.get("title", "unknown")
+                status = f.get("status", "unknown")
+                finding_type = f.get("finding_type", "")
+                reply = f.get("reply", "")
+                status_icon = {"addressed": "✅", "not_addressed": "⚠️", "skipped": "⏭️"}.get(status, "❓")
+                type_tag = f" [{finding_type}]" if finding_type else ""
+                print_stderr(f"    {i}. {status_icon} [{status}]{type_tag} {title}")
+                if reply:
+                    # Show first line of reply, truncated
+                    reason_line = reply.split("\n")[0].strip()
+                    if len(reason_line) > 100:
+                        reason_line = reason_line[:97] + "..."
+                    print_stderr(f"       Reply: {reason_line}")
+
+    print_stderr("")
 
 
 def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> int:
@@ -306,8 +387,11 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
         # This prevents approving before processing new findings
         if fetch_result == 0:
             print_stderr("[poll] Checking Qodo approval...")
-            if _is_qodo_approved(owner, repo, pr_number):
+            approval = _is_qodo_approved(owner, repo, pr_number)
+            if approval:
                 print_stderr("[poll] Qodo approved — all findings resolved.")
+                # Print approval summary
+                _print_approval_summary(approval)
                 print('{"approved": true}')
                 return 0
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -224,7 +224,7 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> dict | None:
         _prev_re = _re.compile(r"^\s*<!-- FOLDED_SECTION_START -->\s*$", _re.MULTILINE)
         _prev_match = _prev_re.search(body)
         current_body = body[: _prev_match.start()] if _prev_match else body
-        resolved_count = current_body.count("✓ Resolved") + current_body.count("✗ Dismissed")
+        resolved_count = current_body.count("Resolved</code>") + current_body.count("Dismissed</code>")
         total_findings = resolved_count + len(unresolved)
 
         if len(unresolved) > 0:
@@ -389,7 +389,13 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
             print_stderr("[poll] Checking Qodo approval...")
             approval = _is_qodo_approved(owner, repo, pr_number)
             if approval:
-                print_stderr("[poll] Qodo approved — all findings resolved.")
+                reason = approval.get("reason", "unknown")
+                if reason == "all_resolved":
+                    print_stderr("[poll] Qodo approved — all findings resolved.")
+                elif reason == "stale_sticky":
+                    print_stderr("[poll] Qodo approved — stale sticky, all unresolved findings already replied to.")
+                else:
+                    print_stderr(f"[poll] Qodo approved — {reason}.")
                 # Print approval summary
                 _print_approval_summary(approval)
                 print('{"approved": true}')

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -235,13 +235,14 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> dict | None:
                 db = ReviewDB(db_path=None)
                 replied = db.get_replied_sticky_findings(owner, repo, int(pr_number))
 
-                # Build lookup: (comment_id, body) -> DB record
-                replied_map: dict[tuple[int, str], dict] = {}
+                # Build lookup: (comment_id, body, code_diff) -> DB record
+                replied_map: dict[tuple[int, str, str], dict] = {}
                 for r in replied:
                     cid = r.get("comment_id")
                     rbody = r.get("body") or ""
+                    rcode_diff = r.get("code_diff") or ""
                     if cid is not None:
-                        key = (int(cid), rbody)
+                        key = (int(cid), rbody, rcode_diff)
                         existing = replied_map.get(key)
                         if existing is None:
                             replied_map[key] = r
@@ -258,7 +259,8 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> dict | None:
                 findings_summary = []
                 for finding in unresolved:
                     finding_body = f"**{finding.get('title', '')}**\n\n{finding.get('description', '')}"
-                    key = (sticky_id, finding_body)
+                    finding_code_diff = finding.get("code_diff") or ""
+                    key = (sticky_id, finding_body, finding_code_diff)
                     db_record = replied_map.get(key)
                     if db_record:
                         findings_summary.append({

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -130,15 +130,16 @@ _QODO_REVIEWING_BODY = (
 )
 
 
-def _is_qodo_reviewing(owner: str, repo: str, pr_number: str) -> bool:
+def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | None = None) -> bool:
     """Check if Qodo is currently reviewing the PR.
 
     Qodo posts a transient comment with exact body while reviewing.
     If this comment exists, the sticky is about to be updated — we should wait.
     Matches exact author (qodo-code-review[bot]) and exact body text.
     """
-    endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
-    comments = run_gh_api(endpoint, paginate=True)
+    if comments is None:
+        endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+        comments = run_gh_api(endpoint, paginate=True)
     if not comments or not isinstance(comments, list):
         return False
 
@@ -154,7 +155,7 @@ def _is_qodo_reviewing(owner: str, repo: str, pr_number: str) -> bool:
     return False
 
 
-def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> dict | None:
+def _is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | None = None) -> dict | None:
     """Check if Qodo has approved the PR.
 
     Returns a summary dict if approved, None if not approved.
@@ -193,8 +194,9 @@ def _is_qodo_approved(owner: str, repo: str, pr_number: str) -> dict | None:
         return None
 
     # Find the Qodo sticky comment
-    endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
-    comments = run_gh_api(endpoint, paginate=True)
+    if comments is None:
+        endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+        comments = run_gh_api(endpoint, paginate=True)
     if not comments or not isinstance(comments, list):
         return None
 
@@ -379,7 +381,9 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
             has_actionable = _has_actionable_qodo_comments(pr_number)
             if has_actionable:
                 # Before returning, check if Qodo is mid-review — if so, wait for it to finish
-                if _is_qodo_reviewing(owner, repo, pr_number):
+                _comments_endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+                _pr_comments = run_gh_api(_comments_endpoint, paginate=True)
+                if _is_qodo_reviewing(owner, repo, pr_number, comments=_pr_comments):
                     print_stderr(
                         "[poll] Qodo is currently reviewing —"
                         " waiting for review to complete before processing findings."
@@ -395,14 +399,17 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
         # Step 2: Only check approval AFTER confirming 0 new comments
         # This prevents approving before processing new findings
         if fetch_result == 0:
+            # Fetch PR comments once — reused by mid-review and approval checks
+            _comments_endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+            _pr_comments = run_gh_api(_comments_endpoint, paginate=True)
             # Don't check approval if Qodo is mid-review — sticky is about to change
-            if _is_qodo_reviewing(owner, repo, pr_number):
+            if _is_qodo_reviewing(owner, repo, pr_number, comments=_pr_comments):
                 print_stderr(
                     "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
                 )
             else:
                 print_stderr("[poll] Checking Qodo approval...")
-                approval = _is_qodo_approved(owner, repo, pr_number)
+                approval = _is_qodo_approved(owner, repo, pr_number, comments=_pr_comments)
                 if approval:
                     reason = approval.get("reason", "unknown")
                     if reason == "all_resolved":

--- a/myk_pi_tools/reviews/store.py
+++ b/myk_pi_tools/reviews/store.py
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS comments (
     posted_at TEXT,
     resolved_at TEXT,
     type TEXT DEFAULT NULL,
-    quality_label TEXT DEFAULT NULL
+    quality_label TEXT DEFAULT NULL,
+    code_diff TEXT DEFAULT NULL
 );
 
 CREATE INDEX IF NOT EXISTS idx_comments_review_id ON comments(review_id);
@@ -111,6 +112,8 @@ def create_tables(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE comments ADD COLUMN type TEXT DEFAULT NULL")
     if "quality_label" not in columns:
         conn.execute("ALTER TABLE comments ADD COLUMN quality_label TEXT DEFAULT NULL")
+    if "code_diff" not in columns:
+        conn.execute("ALTER TABLE comments ADD COLUMN code_diff TEXT DEFAULT NULL")
 
 
 def get_current_commit_sha(cwd: Path | None = None) -> str:
@@ -163,8 +166,8 @@ def insert_comment(conn: sqlite3.Connection, review_id: int, source: str, commen
         INSERT INTO comments (
             review_id, source, thread_id, node_id, comment_id, author,
             path, line, body, priority, status, reply, skip_reason,
-            posted_at, resolved_at, type, quality_label
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            posted_at, resolved_at, type, quality_label, code_diff
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             review_id,
@@ -184,6 +187,7 @@ def insert_comment(conn: sqlite3.Connection, review_id: int, source: str, commen
             comment.get("resolved_at"),
             comment.get("type"),
             comment.get("quality_label"),
+            comment.get("code_diff"),
         ),
     )
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -321,7 +321,7 @@ Update each JSON entry with `status` and `reply` fields before posting.
 **Mapping from user decisions (Phase 2):**
 
 - User said **yes** and code was changed → `addressed`
-- User said **yes** but change was not implemented → `not_addressed`
+- User said **yes** but fix attempt failed (code change didn't work) → `not_addressed`
 - User said **no** → `skipped` (include the user's skip reason in `reply`)
 - User said **all** → same as **yes** for each remaining comment
 - User said **skip \<source\>** → `skipped` for all remaining from that source

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -344,7 +344,7 @@ refactoring, new module, etc.).** The AI does NOT decide what is too much work �
 If a finding requires a code change, make the code change. If you genuinely believe a finding
 is wrong or not applicable, set status to `skipped` with a technical reason — but "too much work",
 "requires migration", "will add later", or "deferred to follow-up" are NEVER valid reasons to skip.
-Fix it now or ask the user.
+Fix it now. In auto mode (--autoqodo / --autorabbit), there is NO user interaction — fix the code.
 
 ### Phase 6: Testing
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -339,6 +339,13 @@ Update each JSON entry with `status` and `reply` fields before posting.
 🚨 **`addressed` means code was changed. If no code was changed, the status MUST be `skipped`.**
 `not_addressed` means "we wanted to fix it but couldn't" — do NOT use it for "by design" findings.
 
+🚨 **NEVER defer or skip a finding because the fix "requires too much work" (schema migration,
+refactoring, new module, etc.).** The AI does NOT decide what is too much work — the user does.
+If a finding requires a code change, make the code change. If you genuinely believe a finding
+is wrong or not applicable, set status to `skipped` with a technical reason — but "too much work",
+"requires migration", "will add later", or "deferred to follow-up" are NEVER valid reasons to skip.
+Fix it now or ask the user.
+
 ### Phase 6: Testing
 
 Run tests with coverage.

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -329,6 +329,16 @@ Update each JSON entry with `status` and `reply` fields before posting.
 - User said **skip ai** → `skipped` for all remaining AI sources
   (include the user's skip reason in `reply`)
 
+**Autoqodo status rules (MANDATORY):**
+
+- Code was changed to fix the finding → `addressed`
+- No code changed, finding is by design / won't fix / not applicable → `skipped` (with reason)
+- No code changed, deferred to follow-up → `skipped` (with reason)
+- Issue spec was updated (no code change) → `skipped` (with reason referencing the spec update)
+
+🚨 **`addressed` means code was changed. If no code was changed, the status MUST be `skipped`.**
+`not_addressed` means "we wanted to fix it but couldn't" — do NOT use it for "by design" findings.
+
 ### Phase 6: Testing
 
 Run tests with coverage.


### PR DESCRIPTION
## Problem

The `--autoqodo` polling loop re-posts the same consolidated reply to Qodo sticky findings every cycle, even when findings haven't changed. Creates excessive PR comment spam (10+ duplicate replies on PR #1109).

Additionally, when Qodo is mid-review (transient "Looking for bugs?" comment), the loop processes stale findings instead of waiting.

## Changes

- **`myk_pi_tools/db/query.py`** — New `get_replied_sticky_findings()` method to query DB for already-replied sticky findings by PR
- **`myk_pi_tools/reviews/fetch.py`** — Add `already_replied` field to Qodo sticky findings that exactly match (comment_id + body) in the DB
- **`myk_pi_tools/reviews/poll.py`** — Exclude `already_replied` findings from actionable count, treat all-replied stale sticky as approved, detect Qodo mid-review and sleep instead of returning stale findings

## Key design decisions

- **Exact match only** — `comment_id` (integer) + `body` (exact string, character for character). No fuzzy matching, no hashing. Zero tolerance for false positives.
- **`already_replied` is NOT `is_auto_skipped`** — auto-skip is about dismissed comments from old PRs. `already_replied` is same-PR dedup for sticky findings we already posted a reply to.
- **Mid-review detection** — exact match on Qodo's transient "Looking for bugs?" comment body + author

Closes #469