### PR TITLE
feat: pr-review past comment tracking with --user, --include-resolved, pr-reviews.db (#472)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,7 @@ pi-config/
 │   ├── db/
 │   ├── memory/
 │   ├── pr/
+│   │   └── pr_review_store.py       # PR review comment tracking (pr-reviews.db)
 │   ├── release/
 │   └── reviews/
 ├── scripts/                         # Utility scripts
@@ -388,6 +389,11 @@ Clean-room TypeScript implementation under MIT — not a code translation.
 - Indexed on session shutdown from compaction summaries
 - Auto-injected in `before_agent_start` for relevant past sessions
 - Storage: `.pi/data/session-search.json`
+
+**PR Review Store** (`myk_pi_tools/pr/pr_review_store.py`):
+
+- Tracks PR review comments in a local SQLite database
+- Storage: `.pi/data/pr-reviews.db`
 
 **Capacity Signal** (`situation-report.ts`):
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Single extension that provides:
 | `/implement <task>` | scout → planner → worker |
 | `/scout-and-plan <task>` | scout → planner |
 | `/implement-and-review <task>` | worker → 3 reviewers → worker |
-| `/pr-review [number\|url]` | Fetch PR diff, review with guidelines, post comments |
+| `/pr-review [number\|url]` | Fetch PR diff, check past review comments, review with guidelines, post and track comments |
 | `/release [flags]` | Create GitHub release with changelog and version bumping |
 | `/review-local [branch]` | Review local uncommitted or branch changes |
 | `/review-handler [url] [--autorabbit] [--autoqodo]` | Process PR review comments, fix approved items |

--- a/myk_pi_tools/pr/commands.py
+++ b/myk_pi_tools/pr/commands.py
@@ -61,3 +61,23 @@ def pr_post_comment(owner_repo: str, pr_number: str, commit_sha: str, json_file:
     from myk_pi_tools.pr.post_comment import run
 
     run(owner_repo, pr_number, commit_sha, json_file)
+
+
+@pr.command("store-pr-review")
+@click.argument("json_file")
+def pr_store_review(json_file: str) -> None:
+    """Store posted PR review comments to pr-reviews.db.
+
+    JSON format:
+        {
+            "metadata": {"owner": "...", "repo": "...", "pr_number": 123},
+            "comments": [{"thread_id": "...", "comment_id": 123, "path": "file.py",
+                          "line": 42, "body": "...", "severity": "WARNING", "posted_at": "..."}]
+        }
+    """
+    import sys
+
+    from myk_pi_tools.pr.pr_review_store import run_store
+
+    exit_code = run_store(json_file)
+    sys.exit(exit_code)

--- a/myk_pi_tools/pr/pr_review_store.py
+++ b/myk_pi_tools/pr/pr_review_store.py
@@ -1,0 +1,269 @@
+"""Store and query outgoing PR review comments in SQLite.
+
+Separate from reviews.db (which handles incoming review-handler comments).
+This DB tracks comments posted by /pr-review and /refine-review prompts
+for past-cycle verification on subsequent runs.
+
+Database location: <git-root>/.pi/data/pr-reviews.db
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS pr_reviews (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    owner TEXT NOT NULL,
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    head_sha TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS pr_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    review_id INTEGER NOT NULL REFERENCES pr_reviews(id),
+    thread_id TEXT,
+    comment_id INTEGER,
+    path TEXT,
+    line INTEGER,
+    body TEXT,
+    severity TEXT,
+    posted_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_pr_comments_review_id ON pr_comments(review_id);
+CREATE INDEX IF NOT EXISTS idx_pr_reviews_pr ON pr_reviews(owner, repo, pr_number);
+"""
+
+
+def log(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def _get_project_root() -> Path:
+    """Detect main project root (resolves through git worktrees)."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            log(f"Error: git rev-parse failed: {result.stderr.strip()}")
+            sys.exit(1)
+        return Path(result.stdout.strip()).resolve().parent
+    except subprocess.TimeoutExpired:
+        log("Error: git command timed out")
+        sys.exit(1)
+    except FileNotFoundError:
+        log("Error: git command not found")
+        sys.exit(1)
+
+
+def _get_current_commit_sha(cwd: Path | None = None) -> str:
+    """Get the current git commit SHA."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd,
+        )
+        if result.returncode != 0:
+            return "unknown"
+        return result.stdout.strip() or "unknown"
+    except (subprocess.SubprocessError, OSError):
+        return "unknown"
+
+
+def _get_db_path() -> Path:
+    """Get the pr-reviews.db path."""
+    project_root = _get_project_root()
+    return project_root / ".pi" / "data" / "pr-reviews.db"
+
+
+def _ensure_db(db_path: Path) -> None:
+    """Create DB directory and tables if needed."""
+    db_dir = db_path.parent
+    if not db_dir.exists():
+        db_dir.mkdir(parents=True, mode=0o700)
+    else:
+        try:
+            db_dir.chmod(0o700)
+        except OSError:
+            pass
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(SCHEMA)
+    finally:
+        conn.close()
+
+
+def store_pr_review(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    comments: list[dict[str, Any]],
+) -> None:
+    """Store posted PR review comments to the database.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: PR number.
+        comments: List of comment dicts with keys: thread_id, comment_id,
+                  path, line, body, severity, posted_at.
+    """
+    project_root = _get_project_root()
+    db_path = project_root / ".pi" / "data" / "pr-reviews.db"
+    _ensure_db(db_path)
+
+    head_sha = _get_current_commit_sha(cwd=project_root)
+    created_at = datetime.now(UTC).isoformat()
+
+    log(f"Storing {len(comments)} PR review comment(s) for {owner}/{repo}#{pr_number}...")
+    log(f"Database: {db_path}")
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO pr_reviews (owner, repo, pr_number, head_sha, created_at) VALUES (?, ?, ?, ?, ?)",
+            (owner, repo, pr_number, head_sha, created_at),
+        )
+        review_id = cursor.lastrowid
+        if not review_id:
+            raise RuntimeError("Failed to insert pr_reviews record")
+
+        for comment in comments:
+            cursor.execute(
+                """
+                INSERT INTO pr_comments (
+                    review_id, thread_id, comment_id, path, line, body, severity, posted_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    review_id,
+                    comment.get("thread_id"),
+                    comment.get("comment_id"),
+                    comment.get("path"),
+                    comment.get("line"),
+                    comment.get("body"),
+                    comment.get("severity"),
+                    comment.get("posted_at"),
+                ),
+            )
+
+        conn.commit()
+        log(f"Stored {len(comments)} comment(s) (commit: {head_sha[:7]})")
+
+    except sqlite3.Error as e:
+        conn.rollback()
+        log(f"Database error: {e}")
+        sys.exit(1)
+    finally:
+        conn.close()
+
+
+def get_pr_review_comments(owner: str, repo: str, pr_number: int) -> list[dict[str, Any]]:
+    """Get all previously posted review comments for a PR.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: PR number.
+
+    Returns:
+        List of dicts with keys: thread_id, comment_id, path, line, body,
+        severity, posted_at, head_sha, review_created_at.
+    """
+    db_path = _get_db_path()
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT c.thread_id, c.comment_id, c.path, c.line, c.body,
+                   c.severity, c.posted_at, r.head_sha, r.created_at as review_created_at
+            FROM pr_comments c
+            JOIN pr_reviews r ON c.review_id = r.id
+            WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
+            ORDER BY c.posted_at DESC
+            """,
+            (owner, repo, pr_number),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+    except sqlite3.Error as e:
+        log(f"Database error: {e}")
+        return []
+    finally:
+        conn.close()
+
+
+def run_store(json_path: str) -> int:
+    """Store PR review comments from a JSON file.
+
+    The JSON file should have:
+    - metadata: {owner, repo, pr_number}
+    - comments: [{thread_id, comment_id, path, line, body, severity, posted_at}, ...]
+
+    Args:
+        json_path: Path to the JSON file.
+
+    Returns:
+        Exit code (0 for success, 1 for error).
+    """
+    path = Path(json_path).resolve()
+    if not path.exists():
+        log(f"Error: JSON file not found: {json_path}")
+        return 1
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError) as e:
+        log(f"Error reading JSON: {e}")
+        return 1
+
+    metadata = data.get("metadata", {})
+    owner = metadata.get("owner", "")
+    repo = metadata.get("repo", "")
+    pr_number_raw = metadata.get("pr_number", 0)
+
+    if not owner or not repo or not pr_number_raw:
+        log("Error: JSON missing required metadata (owner, repo, pr_number)")
+        return 1
+
+    try:
+        pr_number = int(pr_number_raw)
+    except (TypeError, ValueError):
+        log(f"Error: Invalid pr_number: {pr_number_raw}")
+        return 1
+
+    if pr_number <= 0:
+        log(f"Error: Invalid pr_number: {pr_number}")
+        return 1
+
+    comments = data.get("comments", [])
+    if not comments:
+        log("No comments to store")
+        return 0
+
+    store_pr_review(owner, repo, pr_number, comments)
+    return 0

--- a/myk_pi_tools/pr/pr_review_store.py
+++ b/myk_pi_tools/pr/pr_review_store.py
@@ -1,4 +1,4 @@
-"""Store and query outgoing PR review comments in SQLite.
+"""Store outgoing PR review comments in SQLite.
 
 Separate from reviews.db (which handles incoming review-handler comments).
 This DB tracks comments posted by /pr-review and /refine-review prompts
@@ -53,7 +53,10 @@ def _get_project_root() -> Path:
     """Detect main project root (resolves through git worktrees)."""
     from myk_pi_tools.reviews.store import get_project_root
 
-    return get_project_root()
+    try:
+        return get_project_root()
+    except SystemExit as e:
+        raise RuntimeError("Failed to detect project root — git not available or not in a repo") from e
 
 
 def _get_current_commit_sha(cwd: Path | None = None) -> str:
@@ -67,9 +70,11 @@ def _get_current_commit_sha(cwd: Path | None = None) -> str:
             cwd=cwd,
         )
         if result.returncode != 0:
+            log(f"Warning: Could not get commit SHA: {result.stderr.strip()}")
             return "unknown"
         return result.stdout.strip() or "unknown"
-    except (subprocess.SubprocessError, OSError):
+    except (subprocess.SubprocessError, OSError) as e:
+        log(f"Warning: Could not get commit SHA: {e}")
         return "unknown"
 
 
@@ -77,23 +82,6 @@ def _get_db_path() -> Path:
     """Get the pr-reviews.db path."""
     project_root = _get_project_root()
     return project_root / ".pi" / "data" / "pr-reviews.db"
-
-
-def _ensure_db(db_path: Path) -> None:
-    """Create DB directory and tables if needed."""
-    db_dir = db_path.parent
-    if not db_dir.exists():
-        db_dir.mkdir(parents=True, mode=0o700)
-    else:
-        try:
-            db_dir.chmod(0o700)
-        except OSError as exc:
-            log(f"Warning: could not chmod {db_dir}: {exc}")
-    conn = sqlite3.connect(str(db_path))
-    try:
-        conn.executescript(SCHEMA)
-    finally:
-        conn.close()
 
 
 def store_pr_review(
@@ -111,9 +99,19 @@ def store_pr_review(
         pr_number: PR number.
         comments: List of comment dicts with keys: thread_id, comment_id,
                   path, line, body, severity, posted_at.
+        head_sha: Git commit SHA for the reviewed code. Auto-detected
+                  from local git HEAD if not provided.
     """
     db_path = _get_db_path()
-    _ensure_db(db_path)
+    # Ensure directory exists
+    db_dir = db_path.parent
+    if not db_dir.exists():
+        db_dir.mkdir(parents=True, mode=0o700)
+    else:
+        try:
+            db_dir.chmod(0o700)
+        except OSError as exc:
+            log(f"Warning: could not chmod {db_dir}: {exc}")
 
     if not head_sha:
         project_root = _get_project_root()
@@ -125,6 +123,7 @@ def store_pr_review(
 
     conn = sqlite3.connect(str(db_path))
     try:
+        conn.executescript(SCHEMA)
         conn.execute("PRAGMA foreign_keys=ON")
 
         cursor = conn.cursor()

--- a/myk_pi_tools/pr/pr_review_store.py
+++ b/myk_pi_tools/pr/pr_review_store.py
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS pr_reviews (
 
 CREATE TABLE IF NOT EXISTS pr_comments (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    review_id INTEGER NOT NULL REFERENCES pr_reviews(id),
+    review_id INTEGER NOT NULL REFERENCES pr_reviews(id) ON DELETE CASCADE,
     thread_id TEXT,
     comment_id INTEGER,
     path TEXT,
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS pr_comments (
 
 CREATE INDEX IF NOT EXISTS idx_pr_comments_review_id ON pr_comments(review_id);
 CREATE INDEX IF NOT EXISTS idx_pr_reviews_pr ON pr_reviews(owner, repo, pr_number);
+CREATE INDEX IF NOT EXISTS idx_pr_comments_posted_at ON pr_comments(posted_at);
 """
 
 
@@ -50,23 +51,9 @@ def log(message: str) -> None:
 
 def _get_project_root() -> Path:
     """Detect main project root (resolves through git worktrees)."""
-    try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--git-common-dir"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            log(f"Error: git rev-parse failed: {result.stderr.strip()}")
-            sys.exit(1)
-        return Path(result.stdout.strip()).resolve().parent
-    except subprocess.TimeoutExpired:
-        log("Error: git command timed out")
-        sys.exit(1)
-    except FileNotFoundError:
-        log("Error: git command not found")
-        sys.exit(1)
+    from myk_pi_tools.reviews.store import get_project_root
+
+    return get_project_root()
 
 
 def _get_current_commit_sha(cwd: Path | None = None) -> str:
@@ -100,8 +87,8 @@ def _ensure_db(db_path: Path) -> None:
     else:
         try:
             db_dir.chmod(0o700)
-        except OSError:
-            pass
+        except OSError as exc:
+            log(f"Warning: could not chmod {db_dir}: {exc}")
     conn = sqlite3.connect(str(db_path))
     try:
         conn.executescript(SCHEMA)
@@ -114,6 +101,7 @@ def store_pr_review(
     repo: str,
     pr_number: int,
     comments: list[dict[str, Any]],
+    head_sha: str | None = None,
 ) -> None:
     """Store posted PR review comments to the database.
 
@@ -124,11 +112,12 @@ def store_pr_review(
         comments: List of comment dicts with keys: thread_id, comment_id,
                   path, line, body, severity, posted_at.
     """
-    project_root = _get_project_root()
-    db_path = project_root / ".pi" / "data" / "pr-reviews.db"
+    db_path = _get_db_path()
     _ensure_db(db_path)
 
-    head_sha = _get_current_commit_sha(cwd=project_root)
+    if not head_sha:
+        project_root = _get_project_root()
+        head_sha = _get_current_commit_sha(cwd=project_root)
     created_at = datetime.now(UTC).isoformat()
 
     log(f"Storing {len(comments)} PR review comment(s) for {owner}/{repo}#{pr_number}...")
@@ -171,47 +160,7 @@ def store_pr_review(
 
     except sqlite3.Error as e:
         conn.rollback()
-        log(f"Database error: {e}")
-        sys.exit(1)
-    finally:
-        conn.close()
-
-
-def get_pr_review_comments(owner: str, repo: str, pr_number: int) -> list[dict[str, Any]]:
-    """Get all previously posted review comments for a PR.
-
-    Args:
-        owner: Repository owner.
-        repo: Repository name.
-        pr_number: PR number.
-
-    Returns:
-        List of dicts with keys: thread_id, comment_id, path, line, body,
-        severity, posted_at, head_sha, review_created_at.
-    """
-    db_path = _get_db_path()
-    if not db_path.exists():
-        return []
-
-    conn = sqlite3.connect(str(db_path))
-    conn.row_factory = sqlite3.Row
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT c.thread_id, c.comment_id, c.path, c.line, c.body,
-                   c.severity, c.posted_at, r.head_sha, r.created_at as review_created_at
-            FROM pr_comments c
-            JOIN pr_reviews r ON c.review_id = r.id
-            WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
-            ORDER BY c.posted_at DESC
-            """,
-            (owner, repo, pr_number),
-        )
-        return [dict(row) for row in cursor.fetchall()]
-    except sqlite3.Error as e:
-        log(f"Database error: {e}")
-        return []
+        raise RuntimeError(f"Database error storing PR review: {e}") from e
     finally:
         conn.close()
 
@@ -265,5 +214,20 @@ def run_store(json_path: str) -> int:
         log("No comments to store")
         return 0
 
-    store_pr_review(owner, repo, pr_number, comments)
+    if not isinstance(comments, list):
+        log(f"Error: 'comments' must be a list, got {type(comments).__name__}")
+        return 1
+
+    for i, comment in enumerate(comments):
+        if not isinstance(comment, dict):
+            log(f"Error: comment[{i}] must be a dict, got {type(comment).__name__}")
+            return 1
+
+    head_sha = metadata.get("head_sha") or metadata.get("commit_sha")
+
+    try:
+        store_pr_review(owner, repo, pr_number, comments, head_sha=head_sha)
+    except RuntimeError as e:
+        log(f"Error: {e}")
+        return 1
     return 0

--- a/myk_pi_tools/reviews/commands.py
+++ b/myk_pi_tools/reviews/commands.py
@@ -12,10 +12,14 @@ def reviews() -> None:
 
 @reviews.command("fetch")
 @click.argument("review_url", required=False, default="")
-def reviews_fetch(review_url: str) -> None:
-    """Fetch unresolved review threads from current PR.
+@click.option(
+    "--include-resolved", is_flag=True, default=False, help="Include resolved threads (with is_resolved field)"
+)
+@click.option("--user", default=None, help="Filter threads by author username")
+def reviews_fetch(review_url: str, include_resolved: bool, user: str | None) -> None:
+    """Fetch review threads from current PR.
 
-    Fetches ALL unresolved review threads from the current branch's PR
+    Fetches review threads from the current branch's PR
     and categorizes them by source (human, qodo, coderabbit).
 
     Saves output to /tmp/pi-work/pr-<number>-reviews.json
@@ -25,7 +29,7 @@ def reviews_fetch(review_url: str) -> None:
     """
     from myk_pi_tools.reviews.fetch import run
 
-    exit_code = run(review_url)
+    exit_code = run(review_url, include_resolved=include_resolved, user=user)
     sys.exit(exit_code)
 
 

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1,6 +1,7 @@
-"""Fetch unresolved review threads from a PR.
+"""Fetch review threads from a PR.
 
-This module fetches ALL unresolved review threads from the current branch's PR
+This module fetches review threads from the current branch's PR
+(supports resolved/unresolved filtering and user filtering).
 and categorizes them by source (human, qodo, coderabbit).
 
 Output: JSON with metadata and categorized comments saved to /tmp/pi-work/pr-<number>-reviews.json
@@ -349,8 +350,22 @@ def run_gh_api(endpoint: str, *, paginate: bool = False) -> Any | None:
         return None
 
 
-def fetch_unresolved_threads(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
-    """Fetch all unresolved review threads using paginated GraphQL."""
+def fetch_unresolved_threads(
+    owner: str,
+    repo: str,
+    pr_number: str,
+    include_resolved: bool = False,
+    user: str | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch review threads using paginated GraphQL.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: PR number.
+        include_resolved: If True, include resolved threads (with is_resolved field).
+        user: If set, only return threads where the first comment author matches this username.
+    """
     all_threads: list[dict[str, Any]] = []
     cursor: str | None = None
     has_next_page = True
@@ -456,10 +471,11 @@ def fetch_unresolved_threads(owner: str, repo: str, pr_number: str) -> list[dict
     if page_count > 1:
         print_stderr(f"Fetched {page_count} pages of review threads")
 
-    # Filter unresolved threads and extract first comment details with replies
+    # Filter threads and extract first comment details with replies
     result = []
     for thread in all_threads:
-        if thread.get("isResolved", False):
+        is_resolved = thread.get("isResolved", False)
+        if is_resolved and not include_resolved:
             continue
 
         comments = thread.get("comments", {}).get("nodes") or []
@@ -471,6 +487,7 @@ def fetch_unresolved_threads(owner: str, repo: str, pr_number: str) -> list[dict
 
         thread_data = {
             "thread_id": thread.get("id"),
+            "is_resolved": is_resolved,
             "node_id": first_comment.get("id"),
             "comment_id": first_comment.get("databaseId"),
             "author": first_comment.get("author", {}).get("login") if first_comment.get("author") else None,
@@ -486,6 +503,10 @@ def fetch_unresolved_threads(owner: str, repo: str, pr_number: str) -> list[dict
                 for c in rest_comments
             ],
         }
+        # Filter by user if specified
+        if user and thread_data.get("author") != user:
+            continue
+
         result.append(thread_data)
 
     return result
@@ -1009,11 +1030,13 @@ def fetch_review_body(owner: str, repo: str, pr_number: str, review_id: str) -> 
     return result if isinstance(result, dict) else None
 
 
-def run(review_url: str = "") -> int:
+def run(review_url: str = "", include_resolved: bool = False, user: str | None = None) -> int:
     """Main entry point.
 
     Args:
         review_url: Optional specific review URL for context.
+        include_resolved: If True, include resolved threads with is_resolved field.
+        user: If set, only return threads where the first comment author matches.
 
     Returns:
         Exit code (0 for success, 1 for error).
@@ -1039,23 +1062,26 @@ def run(review_url: str = "") -> int:
         json_path = out_dir / f"pr-{pr_number}-reviews.json"
 
         # Fetch all unresolved threads
-        print_stderr("Fetching unresolved review threads...")
-        all_threads = fetch_unresolved_threads(owner, repo, pr_number)
-        print_stderr(f"Found {len(all_threads)} unresolved thread(s)")
+        label = "review" if include_resolved else "unresolved review"
+        print_stderr(f"Fetching {label} threads...")
+        all_threads = fetch_unresolved_threads(owner, repo, pr_number, include_resolved=include_resolved, user=user)
+        print_stderr(f"Found {len(all_threads)} {label} thread(s)")
 
-        # Fetch CodeRabbit body-embedded comments from review bodies
-        print_stderr("Fetching CodeRabbit body-embedded comments...")
-        body_comment_threads = fetch_coderabbit_body_comments(owner, repo, pr_number)
-        if body_comment_threads:
-            print_stderr(f"Found {len(body_comment_threads)} body-embedded comment(s)")
-            all_threads = merge_threads(all_threads, body_comment_threads)
+        # Skip bot comment fetching when filtering by specific user
+        if not user:
+            # Fetch CodeRabbit body-embedded comments from review bodies
+            print_stderr("Fetching CodeRabbit body-embedded comments...")
+            body_comment_threads = fetch_coderabbit_body_comments(owner, repo, pr_number)
+            if body_comment_threads:
+                print_stderr(f"Found {len(body_comment_threads)} body-embedded comment(s)")
+                all_threads = merge_threads(all_threads, body_comment_threads)
 
-        # Fetch Qodo sticky comment findings
-        print_stderr("Fetching Qodo sticky comment findings...")
-        qodo_sticky_findings = fetch_qodo_sticky_findings(owner, repo, pr_number)
-        if qodo_sticky_findings:
-            print_stderr(f"Found {len(qodo_sticky_findings)} unresolved Qodo sticky finding(s)")
-            all_threads = merge_threads(all_threads, qodo_sticky_findings)
+            # Fetch Qodo sticky comment findings
+            print_stderr("Fetching Qodo sticky comment findings...")
+            qodo_sticky_findings = fetch_qodo_sticky_findings(owner, repo, pr_number)
+            if qodo_sticky_findings:
+                print_stderr(f"Found {len(qodo_sticky_findings)} unresolved Qodo sticky finding(s)")
+                all_threads = merge_threads(all_threads, qodo_sticky_findings)
 
         # If review URL provided, also fetch specific thread(s)
         specific_threads: list[dict[str, Any]] = []

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -350,7 +350,7 @@ def run_gh_api(endpoint: str, *, paginate: bool = False) -> Any | None:
         return None
 
 
-def fetch_unresolved_threads(
+def fetch_review_threads(
     owner: str,
     repo: str,
     pr_number: str,
@@ -504,7 +504,7 @@ def fetch_unresolved_threads(
             ],
         }
         # Filter by user if specified
-        if user and thread_data.get("author") != user:
+        if user and (thread_data.get("author") or "").lower() != user.lower():
             continue
 
         result.append(thread_data)
@@ -1064,7 +1064,7 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         # Fetch all unresolved threads
         label = "review" if include_resolved else "unresolved review"
         print_stderr(f"Fetching {label} threads...")
-        all_threads = fetch_unresolved_threads(owner, repo, pr_number, include_resolved=include_resolved, user=user)
+        all_threads = fetch_review_threads(owner, repo, pr_number, include_resolved=include_resolved, user=user)
         print_stderr(f"Found {len(all_threads)} {label} thread(s)")
 
         # Skip bot comment fetching when filtering by specific user

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -487,7 +487,6 @@ def fetch_review_threads(
 
         thread_data = {
             "thread_id": thread.get("id"),
-            "is_resolved": is_resolved,
             "node_id": first_comment.get("id"),
             "comment_id": first_comment.get("databaseId"),
             "author": first_comment.get("author", {}).get("login") if first_comment.get("author") else None,
@@ -503,6 +502,8 @@ def fetch_review_threads(
                 for c in rest_comments
             ],
         }
+        if include_resolved:
+            thread_data["is_resolved"] = is_resolved
         # Filter by user if specified
         if user and (thread_data.get("author") or "").lower() != user.lower():
             continue

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -220,7 +220,7 @@ After posting comments, store them in the PR review database for future cycle tr
 ```bash
 cat > /tmp/pi-work/$(basename $PWD)/pr-review-store.json << 'EOF'
 {
-  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}},
+  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}"},
   "comments": [
     {
       "thread_id": null,

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -124,6 +124,42 @@ myk-pi-tools pr claude-md <raw_arguments>
 
 Store the output as `claude_md_content`.
 
+### Phase 1c: Check Past Review Comments (MANDATORY)
+
+Fetch ALL human review threads (resolved + unresolved) from the PR:
+
+```bash
+myk-pi-tools reviews fetch --user {current_github_user} --include-resolved
+```
+
+Where `{current_github_user}` is obtained from:
+
+```bash
+gh api user --jq '.login'
+```
+
+Parse the JSON output. For the `human` list, categorize each thread:
+
+**Unresolved threads:**
+
+- These are still open — the PR author hasn't addressed them yet.
+- Include them in the findings presented to the user in Phase 3.
+- Mark as "⚠️ UNRESOLVED from previous review"
+
+**Resolved threads:**
+
+- Read the full thread including ALL replies from the PR author.
+- Check the diff from Phase 1a — did the code at `path:line` change?
+  - **Code changed:** Review the changed code to verify the fix is correct. Don't trust blindly.
+    - Fix looks correct → mark as "✅ Resolved — fix verified"
+    - Fix looks wrong/incomplete → include in findings as "❌ Resolved but fix is incorrect"
+  - **Code NOT changed:** Read the PR author's response/reply.
+    - Valid response (by design, wrong assumption, clarification) → mark as "✅ Resolved — response accepted"
+    - Invalid/missing response → include in findings as "❌ Resolved without code change or valid response"
+
+**All past comment statuses are included in the combined findings in Phase 3 —
+not presented as a separate summary.**
+
 ### Phase 2: Code Analysis
 
 Delegate to ALL 3 review agents IN PARALLEL (single message with 3 Task tool calls):
@@ -142,7 +178,20 @@ Merge and deduplicate the findings from all 3 reviewers before proceeding.
 
 ### Phase 3: User Selection
 
-Present findings to user grouped by severity (CRITICAL, WARNING, SUGGESTION). Ask which to post:
+Present ALL findings to user in one combined list, grouped by severity (CRITICAL, WARNING, SUGGESTION).
+This includes:
+
+1. **Past review findings** from Phase 1c (unresolved, incorrectly resolved, or bad fixes)
+2. **New code review findings** from Phase 2
+
+Each finding shows its source:
+
+- `[PREV-UNRESOLVED]` — unresolved from previous review cycle
+- `[PREV-BAD-FIX]` — resolved but fix is incorrect
+- `[PREV-NO-FIX]` — resolved without code change or valid response
+- `[NEW]` — new finding from current code analysis
+
+Ask which to post:
 
 - 'all' = Post all
 - 'none' = Skip posting
@@ -161,6 +210,40 @@ Use the `owner`, `repo`, `pr_number`, and `head_sha` from Phase 0 or Phase 1a me
 ```bash
 myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} /tmp/pi-work/$(basename $PWD)/pr-review-comments.json
 ```
+
+### Phase 4b: Store Posted Comments (MANDATORY)
+
+After posting comments, store them in the PR review database for future cycle tracking:
+
+1. Write a JSON file with the posted comments:
+
+```bash
+cat > /tmp/pi-work/$(basename $PWD)/pr-review-store.json << 'EOF'
+{
+  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}},
+  "comments": [
+    {
+      "thread_id": null,
+      "comment_id": null,
+      "path": "file.py",
+      "line": 42,
+      "body": "Comment body as posted",
+      "severity": "WARNING",
+      "posted_at": "<ISO timestamp>"
+    }
+  ]
+}
+EOF
+```
+
+1. Store to database:
+
+```bash
+myk-pi-tools pr store-pr-review /tmp/pi-work/$(basename $PWD)/pr-review-store.json
+```
+
+**This step is MANDATORY — never skip it.** The database is used by future `/pr-review`
+runs to track which comments were posted and verify they were addressed.
 
 ### Phase 5: Summary
 

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -153,6 +153,41 @@ This updates accepted comment bodies on GitHub and submits the review when `--su
 
 If the command fails, display the error. If it reports a 404, inform the user their pending review may have been submitted or deleted externally.
 
+### Phase 7b: Store Posted Comments (MANDATORY)
+
+After submitting the review (Phase 7), store the comments in the PR review database
+for future `/pr-review` cycle tracking:
+
+1. Write a JSON file with the submitted comments:
+
+```bash
+cat > /tmp/pi-work/$(basename $PWD)/pr-review-store.json << 'EOF'
+{
+  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}},
+  "comments": [
+    {
+      "thread_id": null,
+      "comment_id": null,
+      "path": "file.py",
+      "line": 42,
+      "body": "Comment body as posted (refined or original)",
+      "severity": null,
+      "posted_at": "<ISO timestamp>"
+    }
+  ]
+}
+EOF
+```
+
+1. Store to database:
+
+```bash
+myk-pi-tools pr store-pr-review /tmp/pi-work/$(basename $PWD)/pr-review-store.json
+```
+
+**This step is MANDATORY — never skip it.** Only store if the review was actually
+submitted (user chose "Yes" in Phase 6). Skip if review was kept pending.
+
 ### Phase 8: Summary
 
 Display:

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -163,7 +163,7 @@ for future `/pr-review` cycle tracking:
 ```bash
 cat > /tmp/pi-work/$(basename $PWD)/pr-review-store.json << 'EOF'
 {
-  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}},
+  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}"},
   "comments": [
     {
       "thread_id": null,


### PR DESCRIPTION
## Problem

`/pr-review` doesn't track past review cycles. When run again on the same PR, there's no check if previous comments were addressed, no verification of resolved threads, and no awareness of PR author responses.

## Changes

### CLI
- `myk-pi-tools reviews fetch --user <username>` — filter threads by author (skips bot comment fetching)
- `myk-pi-tools reviews fetch --include-resolved` — include resolved threads with `is_resolved` field
- `myk-pi-tools pr store-pr-review <json>` — store posted review comments to `pr-reviews.db`

### New module
- `myk_pi_tools/pr/pr_review_store.py` — schema, store, query for `.pi/data/pr-reviews.db` (separate from `reviews.db`)

### Prompt updates
- `pr-review.md` — Phase 1c (check past review comments: unresolved, verify fixes, read responses) + Phase 4b (store posted comments)
- `refine-review.md` — Phase 7b (store submitted comments)

### Documentation
- `AGENTS.md` — updated structure + new PR Review Store section
- `README.md` — updated `/pr-review` description

Closes #472