### PR TITLE
fix: group release changelog entries by PR number, collapse fix-up commits (#475)

### DIFF
--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -79,6 +79,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
 
   // Caches (populated lazily on first Tab)
   const prCache = createCache<AutocompleteItem[]>();
+  let prUrlMap = new Map<string, string>();
   const branchCache = createCache<AutocompleteItem[]>();
   const tagCache = createCache<AutocompleteItem[]>();
   const modelCaches = new Map<string, Cache<AutocompleteItem[]>>();
@@ -91,17 +92,19 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
     prCache.loading = true;
     try {
       const result = await pi.exec(
-        "gh", ["pr", "list", "--state", "open", "--limit", "50", "--json", "number,title"],
+        "gh", ["pr", "list", "--state", "open", "--limit", "50", "--json", "number,title,url"],
         { cwd, timeout: 10_000 },
       );
       if (result.code === 0) {
-        const prs = JSON.parse(result.stdout) as Array<{ number: number; title: string }>;
+        const prs = JSON.parse(result.stdout) as Array<{ number: number; title: string; url: string }>;
         prCache.data = prs.map((pr) => ({
           value: String(pr.number),
           label: `#${pr.number}`,
           description: pr.title,
         }));
         prCache.timestamp = Date.now();
+        // URL-keyed version for pr-review (uses URL as completion value)
+        prUrlMap = new Map(prs.map((pr) => [String(pr.number), pr.url || String(pr.number)]));
       }
     } catch (e: any) { console.debug("[autocomplete] PR fetch failed:", e?.message || e); }
     prCache.loading = false;
@@ -263,7 +266,9 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
 
     "pr-review": (prefix: string) => {
       void fetchOpenPRs(lastCwd);
-      return prCache.data ? filter(prCache.data, prefix.replace(/^#/, "")) : null;
+      if (!prCache.data) return null;
+      const filtered = filter(prCache.data, prefix.replace(/^#/, ""));
+      return filtered ? filtered.map((item) => ({ ...item, value: prUrlMap.get(item.value) || item.value })) : null;
     },
 
     "coderabbit-rate-limit": (prefix: string) => {

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -86,7 +86,22 @@ If the raw arguments are empty:
 
 4. Use `{pr_number}` for subsequent CLI commands
 
-If the raw arguments contain a PR number or URL, use it directly.
+If the raw arguments contain a PR number or URL:
+
+1. Parse the PR number from the arguments (extract number from URL if needed)
+2. Get `owner` and `repo` from the current repository context:
+
+   ```bash
+   gh repo view --json owner,name
+   ```
+
+3. Get `head_sha`:
+
+   ```bash
+   gh pr view {pr_number} --json headRefOid --jq '.headRefOid'
+   ```
+
+4. Store `owner`, `repo`, `pr_number`, and `head_sha` — these are used by Phase 1c and Phase 4.
 
 ### Phase 1a: Data Fetching
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -88,20 +88,29 @@ If the raw arguments are empty:
 
 If the raw arguments contain a PR number or URL:
 
-1. Parse the PR number from the arguments (extract number from URL if needed)
-2. Get `owner` and `repo` from the current repository context:
+1. If the argument is a URL (contains `github.com`):
+   - Extract `owner`, `repo`, and `pr_number` directly from the URL pattern
+     `https://github.com/{owner}/{repo}/pull/{pr_number}`
+   - Get `head_sha`:
 
-   ```bash
-   gh repo view --json owner,name
-   ```
+     ```bash
+     gh pr view {pr_number} --repo {owner}/{repo} --json headRefOid --jq '.headRefOid'
+     ```
 
-3. Get `head_sha`:
+1. If the argument is a bare PR number:
+   - Get `owner` and `repo` from the current repository context:
 
-   ```bash
-   gh pr view {pr_number} --json headRefOid --jq '.headRefOid'
-   ```
+     ```bash
+     gh repo view --json owner,name
+     ```
 
-4. Store `owner`, `repo`, `pr_number`, and `head_sha` — these are used by Phase 1c and Phase 4.
+   - Get `head_sha`:
+
+     ```bash
+     gh pr view {pr_number} --json headRefOid --jq '.headRefOid'
+     ```
+
+1. Store `owner`, `repo`, `pr_number`, and `head_sha` — these are used by Phase 1c and Phase 4.
 
 ### Phase 1a: Data Fetching
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -128,8 +128,16 @@ Store the output as `claude_md_content`.
 
 Fetch ALL human review threads (resolved + unresolved) from the PR:
 
+If PR was auto-detected (no arguments):
+
 ```bash
 myk-pi-tools reviews fetch --user {current_github_user} --include-resolved
+```
+
+Otherwise:
+
+```bash
+myk-pi-tools reviews fetch --user {current_github_user} --include-resolved <raw_arguments>
 ```
 
 Where `{current_github_user}` is obtained from:

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -128,16 +128,10 @@ Store the output as `claude_md_content`.
 
 Fetch ALL human review threads (resolved + unresolved) from the PR:
 
-If PR was auto-detected (no arguments):
+Use the `owner`, `repo`, and `pr_number` from Phase 0 to construct the PR URL:
 
 ```bash
-myk-pi-tools reviews fetch --user {current_github_user} --include-resolved
-```
-
-Otherwise:
-
-```bash
-myk-pi-tools reviews fetch --user {current_github_user} --include-resolved <raw_arguments>
+myk-pi-tools reviews fetch --user {current_github_user} --include-resolved https://github.com/{owner}/{repo}/pull/{pr_number}
 ```
 
 Where `{current_github_user}` is obtained from:

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -88,14 +88,18 @@ Store the detect-versions JSON output for use in Phase 4. The key fields are:
 
 **Group commits by PR number first, then categorize.**
 
-1. Extract the PR number from each commit subject (the `(#NNN)` suffix)
+1. Extract the PR number from each commit — check ALL of these locations:
+   - Subject suffix: `(#NNN)`
+   - Merge commit subject: `Merge pull request #NNN`
+   - Commit body: any `(#NNN)` or `#NNN` reference
 2. Group all commits that share the same PR number
-3. For each PR group, create ONE changelog entry — use the most descriptive commit
-   (prefer `feat:` over `fix:`, prefer the first commit over fix-up iterations)
+3. For each PR group, create ONE changelog entry — use the commit with the
+   highest-priority type (`feat:` > `fix:` > `refactor:` > `docs:` > `chore:`)
+   as the changelog entry. Do NOT use fix-up commits as the entry.
 4. Internal fix-up commits within the same PR (e.g., `fix: address review findings (#472)`,
    `fix: review cycle 2 (#472)`) are NOT separate entries — they are implementation
    iterations within the parent PR
-5. Only commits WITHOUT a PR reference (direct pushes to main) get their own entries
+5. Only commits WITHOUT a PR reference anywhere (subject or body) get their own entries
 
 Categorize each PR entry by the highest-priority commit type in its group:
 

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -91,11 +91,12 @@ Store the detect-versions JSON output for use in Phase 4. The key fields are:
 1. Extract the PR number from each commit — check ALL of these locations:
    - Subject suffix: `(#NNN)`
    - Merge commit subject: `Merge pull request #NNN`
-   - Commit body: any `(#NNN)` or `#NNN` reference
+   - Commit body: `(#NNN)` pattern (parenthesized only — bare `#NNN` may be an issue reference, not a PR)
 2. Group all commits that share the same PR number
 3. For each PR group, create ONE changelog entry — use the commit with the
    highest-priority type (`feat:` > `fix:` > `refactor:` > `docs:` > `chore:`)
-   as the changelog entry. Do NOT use fix-up commits as the entry.
+   as the changelog entry. If multiple commits share the same type, use the one
+   with the most descriptive subject. Do NOT use fix-up commits as the entry.
 4. Internal fix-up commits within the same PR (e.g., `fix: address review findings (#472)`,
    `fix: review cycle 2 (#472)`) are NOT separate entries — they are implementation
    iterations within the parent PR

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -86,11 +86,24 @@ Store the detect-versions JSON output for use in Phase 4. The key fields are:
 
 ### Phase 3: Changelog Analysis & Version
 
-Parse commits from Phase 1 output and categorize by conventional commit type:
+**Group commits by PR number first, then categorize.**
+
+1. Extract the PR number from each commit subject (the `(#NNN)` suffix)
+2. Group all commits that share the same PR number
+3. For each PR group, create ONE changelog entry — use the most descriptive commit
+   (prefer `feat:` over `fix:`, prefer the first commit over fix-up iterations)
+4. Internal fix-up commits within the same PR (e.g., `fix: address review findings (#472)`,
+   `fix: review cycle 2 (#472)`) are NOT separate entries — they are implementation
+   iterations within the parent PR
+5. Only commits WITHOUT a PR reference (direct pushes to main) get their own entries
+
+Categorize each PR entry by the highest-priority commit type in its group:
 
 - Breaking Changes → MAJOR
 - Features (`feat:`) → MINOR
 - Bug Fixes (`fix:`), Docs (`docs:`), Maintenance (`chore:`, `refactor:`, `test:`, `ci:`) → PATCH
+
+If a PR group contains both `feat:` and `fix:` commits, categorize as `feat:` (highest priority wins).
 
 **Changelog formatting rules (MANDATORY):**
 


### PR DESCRIPTION
## Problem

The `/release` prompt generates a separate changelog entry for every commit. Internal fix-up commits within a PR (e.g., `fix: address review findings (#472)`) appear as separate bug fix entries alongside the actual feature.

## Fix

Updated Phase 3 of `prompts/release.md` to group commits by PR number first. Each PR gets ONE changelog entry using the most descriptive commit. Fix-up iterations within the same PR are collapsed.

Closes #475