### PR TITLE
fix: replace naive ][ replacement with json.JSONDecoder.raw_decode

### DIFF
--- a/myk_pi_tools/pr/diff.py
+++ b/myk_pi_tools/pr/diff.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from myk_pi_tools.pr.common import PRInfo
 from myk_pi_tools.pr.common import parse_args as _parse_args
+from myk_pi_tools.utils import merge_paginated_json
 
 
 def parse_args(args: list[str]) -> PRInfo:
@@ -149,13 +150,10 @@ def fetch_pr_files(pr_info: PRInfo) -> list[dict[str, Any]]:
             check=True,
             timeout=120,
         )
-        # --paginate returns concatenated JSON arrays, merge them
-        files_data = []
-        for item in json.loads(f"[{result.stdout.replace('][', ',')}]"):
-            if isinstance(item, list):
-                files_data.extend(item)
-            else:
-                files_data.append(item)
+        # --paginate returns concatenated JSON arrays, merge them safely.
+        # Cannot use naive '][' replacement — it corrupts bracket sequences
+        # inside patch content (e.g., dict["key1"]["key2"] → dict["key1","key2"]).
+        files_data = merge_paginated_json(result.stdout)
         # Extract relevant fields
         return [
             {
@@ -185,6 +183,12 @@ def fetch_pr_files(pr_info: PRInfo) -> list[dict[str, Any]]:
             file=sys.stderr,
         )
         print(e.stderr, file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(
+            f"Error: Failed to parse PR files response for {pr_info.repo_full_name}#{pr_info.pr_number}: {e}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -25,6 +25,7 @@ from bs4 import BeautifulSoup
 from myk_pi_tools.db.query import ReviewDB, _body_similarity
 from myk_pi_tools.reviews.coderabbit_parser import parse_review_body_comments
 from myk_pi_tools.reviews.qodo_parser import is_qodo_sticky_comment, parse_qodo_sticky_comment
+from myk_pi_tools.utils import merge_paginated_json
 
 # Map Qodo finding types to our type field
 _QODO_TYPE_MAP = {
@@ -336,14 +337,7 @@ def run_gh_api(endpoint: str, *, paginate: bool = False) -> Any | None:
     try:
         # --paginate returns concatenated JSON arrays, merge them
         if paginate:
-            data = json.loads(f"[{result.stdout.replace('][', ',')}]")
-            merged = []
-            for item in data:
-                if isinstance(item, list):
-                    merged.extend(item)
-                else:
-                    merged.append(item)
-            return merged
+            return merge_paginated_json(result.stdout)
         return json.loads(result.stdout)
     except json.JSONDecodeError as e:
         print_stderr(f"Error parsing JSON from gh api: {e}")

--- a/myk_pi_tools/utils.py
+++ b/myk_pi_tools/utils.py
@@ -1,0 +1,30 @@
+"""Shared utilities for myk_pi_tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def merge_paginated_json(text: str) -> list[Any]:
+    """Merge concatenated JSON arrays from gh api --paginate output.
+
+    gh --paginate returns concatenated JSON arrays like ``[...][...]``.
+    We use ``json.JSONDecoder.raw_decode`` to parse each array boundary
+    correctly without corrupting bracket sequences inside string values.
+    """
+    merged: list[Any] = []
+    decoder = json.JSONDecoder()
+    idx = 0
+    text = text.strip()
+    while idx < len(text):
+        obj, end = decoder.raw_decode(text, idx)
+        if isinstance(obj, list):
+            merged.extend(obj)
+        else:
+            merged.append(obj)
+        # Skip whitespace between arrays
+        idx = end
+        while idx < len(text) and text[idx] in " \t\n\r":
+            idx += 1
+    return merged


### PR DESCRIPTION
## Summary

Fix `myk-pi-tools pr diff` corrupting chained Python bracket access (`]["`) into commas (`,`) in its JSON output.

## Root Cause

`gh api --paginate` returns concatenated JSON arrays (`[...][...]`). The previous code merged them via `result.stdout.replace('][', ',')` which corrupted `][` sequences inside string values — e.g., turning `dict["key1"]["key2"]` into `dict["key1","key2"]` in patch content.

## Fix

- Use `json.JSONDecoder.raw_decode()` to parse each JSON array boundary correctly without touching content inside JSON strings
- Extract `merge_paginated_json()` to `myk_pi_tools/utils.py` (was duplicated in diff.py and fetch.py)
- Add `JSONDecodeError` handler to diff.py's `fetch_pr_files()`

## Verification

Tested against [RedHatQE/mtv-api-tests#552](https://github.com/RedHatQE/mtv-api-tests/pull/552) — all 9 `][` sequences in the diff are preserved correctly. No corruption.

Closes #483