### PR TITLE
fix(prompts,agents): task-oriented review prompts + self-sufficient reviewers

### DIFF
--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -40,7 +40,7 @@ Check these locations in order — use the first `AGENTS.md` found, fall back to
 1. `CLAUDE.md` (repository root)
 2. `.claude/CLAUDE.md`
 
-Read ALL matching files found (a project may have both root and nested).
+If multiple AGENTS.md files exist (e.g., both root and `.agents/`), read and merge ALL of them.
 Use the guidelines to inform your review — flag violations of project-specific
 conventions, patterns, or rules as findings.
 

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -29,8 +29,8 @@ You are a code review specialist focused on **project guidelines and style adher
 
 Before reviewing any code, check for and read the project's guidelines files:
 
-1. Check for `AGENTS.md` in the repository root — read it if present
-2. Check for `CLAUDE.md` in the repository root — read it if present
+1. Check for `AGENTS.md` in the repository root — if present, read it and use it
+2. Only if `AGENTS.md` does NOT exist, check for `CLAUDE.md` as a fallback
 3. Review the changed files against those rules
 4. **Check if AGENTS.md or README.md need updating** based on the changes — missing doc updates are `[CRITICAL]`
 5. Check consistency with existing codebase patterns

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -14,7 +14,7 @@ You are a code review specialist focused on **project guidelines and style adher
 
 ## Review Focus
 
-- AGENTS.md compliance (read the project's AGENTS.md first!)
+- AGENTS.md / CLAUDE.md compliance
 - **Documentation updates (MANDATORY)** — if code was added/changed/removed, check that AGENTS.md and README.md are updated.
   Flag missing docs as `[CRITICAL]`. See the Documentation Updates table in AGENTS.md.
 - Project-specific coding standards
@@ -25,13 +25,18 @@ You are a code review specialist focused on **project guidelines and style adher
 - Import ordering and grouping
 - Configuration file formats
 
-## Approach
+## Project Guidelines (MANDATORY — read before reviewing)
 
-1. First read AGENTS.md to understand project rules
-2. Review the changed files against those rules
-3. **Check if AGENTS.md or README.md need updating** based on the changes — missing doc updates are `[CRITICAL]`
-4. Check consistency with existing codebase patterns
-5. Report deviations
+Before reviewing any code, check for and read the project's guidelines files:
+
+1. Check for `AGENTS.md` in the repository root — read it if present
+2. Check for `CLAUDE.md` in the repository root — read it if present
+3. Review the changed files against those rules
+4. **Check if AGENTS.md or README.md need updating** based on the changes — missing doc updates are `[CRITICAL]`
+5. Check consistency with existing codebase patterns
+6. Report deviations
+
+Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
 ## Output Format
 

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -27,10 +27,24 @@ You are a code review specialist focused on **project guidelines and style adher
 
 ## Project Guidelines (MANDATORY — read before reviewing)
 
-Before reviewing any code, check for and read the project's guidelines files:
+Before reviewing any code, find and read the project's guidelines files.
+Check these locations in order — use the first `AGENTS.md` found, fall back to `CLAUDE.md` only if no `AGENTS.md` exists anywhere:
 
-1. Check for `AGENTS.md` in the repository root — if present, read it and use it
-2. Only if `AGENTS.md` does NOT exist, check for `CLAUDE.md` as a fallback
+**AGENTS.md locations (check in order):**
+
+1. `AGENTS.md` (repository root)
+2. `.agents/AGENTS.md`
+
+**CLAUDE.md fallback (only if no AGENTS.md found):**
+
+1. `CLAUDE.md` (repository root)
+2. `.claude/CLAUDE.md`
+
+Read ALL matching files found (a project may have both root and nested).
+Use the guidelines to inform your review — flag violations of project-specific
+conventions, patterns, or rules as findings.
+
+Additionally:
 3. Review the changed files against those rules
 4. **Check if AGENTS.md or README.md need updating** based on the changes — missing doc updates are `[CRITICAL]`
 5. Check consistency with existing codebase patterns

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -27,7 +27,7 @@ Check these locations in order — use the first `AGENTS.md` found, fall back to
 1. `CLAUDE.md` (repository root)
 2. `.claude/CLAUDE.md`
 
-Read ALL matching files found (a project may have both root and nested).
+If multiple AGENTS.md files exist (e.g., both root and `.agents/`), read and merge ALL of them.
 Use the guidelines to inform your review — flag violations of project-specific
 conventions, patterns, or rules as findings.
 

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -14,12 +14,22 @@ You are a code review specialist focused on **general code quality and maintaina
 
 ## Project Guidelines (MANDATORY — read before reviewing)
 
-Before reviewing any code, check for and read the project's guidelines files:
+Before reviewing any code, find and read the project's guidelines files.
+Check these locations in order — use the first `AGENTS.md` found, fall back to `CLAUDE.md` only if no `AGENTS.md` exists anywhere:
 
-1. Check for `AGENTS.md` in the repository root — if present, read it and use it
-2. Only if `AGENTS.md` does NOT exist, check for `CLAUDE.md` as a fallback
-3. Use the guidelines to inform your review — flag violations of project-specific
-   conventions, patterns, or rules as findings
+**AGENTS.md locations (check in order):**
+
+1. `AGENTS.md` (repository root)
+2. `.agents/AGENTS.md`
+
+**CLAUDE.md fallback (only if no AGENTS.md found):**
+
+1. `CLAUDE.md` (repository root)
+2. `.claude/CLAUDE.md`
+
+Read ALL matching files found (a project may have both root and nested).
+Use the guidelines to inform your review — flag violations of project-specific
+conventions, patterns, or rules as findings.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -12,6 +12,17 @@ You are a code review specialist focused on **general code quality and maintaina
 - Do NOT modify files — only review and report findings
 - If a task falls outside your domain, report it and hand off
 
+## Project Guidelines (MANDATORY — read before reviewing)
+
+Before reviewing any code, check for and read the project's guidelines files:
+
+1. Check for `AGENTS.md` in the repository root — read it if present
+2. Check for `CLAUDE.md` in the repository root — read it if present
+3. Use the guidelines to inform your review — flag violations of project-specific
+   conventions, patterns, or rules as findings
+
+Do NOT rely on the calling prompt to provide these files — always read them yourself.
+
 ## Review Focus
 
 - Code readability and clarity

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -16,8 +16,8 @@ You are a code review specialist focused on **general code quality and maintaina
 
 Before reviewing any code, check for and read the project's guidelines files:
 
-1. Check for `AGENTS.md` in the repository root — read it if present
-2. Check for `CLAUDE.md` in the repository root — read it if present
+1. Check for `AGENTS.md` in the repository root — if present, read it and use it
+2. Only if `AGENTS.md` does NOT exist, check for `CLAUDE.md` as a fallback
 3. Use the guidelines to inform your review — flag violations of project-specific
    conventions, patterns, or rules as findings
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -26,13 +26,25 @@ You are a code review specialist focused on **bugs, logic errors, and security v
 - Resource leaks (unclosed connections/files)
 - Edge cases and boundary conditions
 
+## Project Guidelines (MANDATORY — read before reviewing)
+
+Before reviewing any code, check for and read the project's guidelines files:
+
+1. Check for `AGENTS.md` in the repository root — read it if present
+2. Check for `CLAUDE.md` in the repository root — read it if present
+3. Use the guidelines to understand project-specific security patterns, trust boundaries,
+   and conventions
+
+Do NOT rely on the calling prompt to provide these files — always read them yourself.
+
 ## Approach
 
-1. Trace data flow through changed code
-2. Identify trust boundaries
-3. Check error paths and edge cases
-4. Look for implicit assumptions
-5. Verify input validation
+1. Read project guidelines (see above)
+2. Trace data flow through changed code
+3. Identify trust boundaries
+4. Check error paths and edge cases
+5. Look for implicit assumptions
+6. Verify input validation
 
 ## Output Format
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -41,7 +41,7 @@ Check these locations in order — use the first `AGENTS.md` found, fall back to
 1. `CLAUDE.md` (repository root)
 2. `.claude/CLAUDE.md`
 
-Read ALL matching files found (a project may have both root and nested).
+If multiple AGENTS.md files exist (e.g., both root and `.agents/`), read and merge ALL of them.
 Use the guidelines to inform your review — flag violations of project-specific
 conventions, patterns, or rules as findings.
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -30,8 +30,8 @@ You are a code review specialist focused on **bugs, logic errors, and security v
 
 Before reviewing any code, check for and read the project's guidelines files:
 
-1. Check for `AGENTS.md` in the repository root — read it if present
-2. Check for `CLAUDE.md` in the repository root — read it if present
+1. Check for `AGENTS.md` in the repository root — if present, read it and use it
+2. Only if `AGENTS.md` does NOT exist, check for `CLAUDE.md` as a fallback
 3. Use the guidelines to understand project-specific security patterns, trust boundaries,
    and conventions
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -28,12 +28,25 @@ You are a code review specialist focused on **bugs, logic errors, and security v
 
 ## Project Guidelines (MANDATORY — read before reviewing)
 
-Before reviewing any code, check for and read the project's guidelines files:
+Before reviewing any code, find and read the project's guidelines files.
+Check these locations in order — use the first `AGENTS.md` found, fall back to `CLAUDE.md` only if no `AGENTS.md` exists anywhere:
 
-1. Check for `AGENTS.md` in the repository root — if present, read it and use it
-2. Only if `AGENTS.md` does NOT exist, check for `CLAUDE.md` as a fallback
-3. Use the guidelines to understand project-specific security patterns, trust boundaries,
-   and conventions
+**AGENTS.md locations (check in order):**
+
+1. `AGENTS.md` (repository root)
+2. `.agents/AGENTS.md`
+
+**CLAUDE.md fallback (only if no AGENTS.md found):**
+
+1. `CLAUDE.md` (repository root)
+2. `.claude/CLAUDE.md`
+
+Read ALL matching files found (a project may have both root and nested).
+Use the guidelines to inform your review — flag violations of project-specific
+conventions, patterns, or rules as findings.
+
+Use the guidelines to understand project-specific security patterns, trust boundaries,
+and conventions.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -24,6 +24,9 @@ let TaskStoreClass: any = null;
       if (mod.TaskStore) { TaskStoreClass = mod.TaskStore; break; }
     } catch { continue; }
   }
+  if (!TaskStoreClass) {
+    console.debug("[async-agents] WARNING: TaskStore not found — task auto-completion disabled");
+  }
 })();
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -92,34 +95,21 @@ function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): bool
   if (!taskId || taskId === "-1" || !TaskStoreClass) return false;
 
   const tasksDir = path.join(cwd, ".pi", "tasks");
-  // Determine the store path — prefer session-scoped, fall back to project-scoped
-  let storePath: string | undefined;
-  if (sessionId) {
-    const sessionFile = path.join(tasksDir, `tasks-${sessionId}.json`);
-    if (fs.existsSync(sessionFile)) storePath = sessionFile;
-  }
-  if (!storePath) {
-    const projectFile = path.join(tasksDir, "tasks.json");
-    if (fs.existsSync(projectFile)) storePath = projectFile;
-  }
-  if (!storePath) {
-    // Try to find any session-scoped file
-    try {
-      const files = fs.readdirSync(tasksDir).filter(f => f.startsWith("tasks") && f.endsWith(".json"));
-      if (files.length > 0) storePath = path.join(tasksDir, files[0]);
-    } catch { /* dir doesn't exist */ }
-  }
-  if (!storePath) return false;
+  const candidates: string[] = [];
+  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+  candidates.push(path.join(tasksDir, "tasks.json"));
 
-  try {
-    const store = new TaskStoreClass(storePath);
-    const task = store.get(taskId);
-    if (!task || task.status === "completed") return false;
-    store.update(taskId, { status: "completed" });
-    return true;
-  } catch {
-    return false;
+  for (const storePath of candidates) {
+    try {
+      const store = new TaskStoreClass(storePath);
+      const task = store.get(taskId);
+      if (task && task.status !== "completed") {
+        store.update(taskId, { status: "completed" });
+        return true;
+      }
+    } catch { continue; }
   }
+  return false;
 }
 
 // ── Registration ─────────────────────────────────────────────────────────

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -10,6 +10,12 @@ import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
+// Import TaskStore for direct task auto-completion (bypasses AI)
+let TaskStoreClass: any = null;
+try {
+  TaskStoreClass = require("@tintinweb/pi-tasks/dist/task-store.js").TaskStore;
+} catch {}
+
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentConfig } from "./agents.js";
@@ -71,50 +77,39 @@ export function formatDuration(ms: number): string {
   return `${m}m${s}s`;
 }
 
-/** Directly update a task's status in the pi-tasks store file. */
-function autoCompleteTask(taskId: string, cwd: string): boolean {
-  if (!taskId || taskId === "-1") return false;
+/** Auto-complete a task via pi-tasks TaskStore (in-process, no AI involvement). */
+function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): boolean {
+  if (!taskId || taskId === "-1" || !TaskStoreClass) return false;
 
   const tasksDir = path.join(cwd, ".pi", "tasks");
-  // Try all possible store files
-  let files: string[];
+  // Determine the store path — prefer session-scoped, fall back to project-scoped
+  let storePath: string | undefined;
+  if (sessionId) {
+    const sessionFile = path.join(tasksDir, `tasks-${sessionId}.json`);
+    if (fs.existsSync(sessionFile)) storePath = sessionFile;
+  }
+  if (!storePath) {
+    const projectFile = path.join(tasksDir, "tasks.json");
+    if (fs.existsSync(projectFile)) storePath = projectFile;
+  }
+  if (!storePath) {
+    // Try to find any session-scoped file
+    try {
+      const files = fs.readdirSync(tasksDir).filter(f => f.startsWith("tasks") && f.endsWith(".json"));
+      if (files.length > 0) storePath = path.join(tasksDir, files[0]);
+    } catch { /* dir doesn't exist */ }
+  }
+  if (!storePath) return false;
+
   try {
-    files = fs.readdirSync(tasksDir)
-      .filter(f => f.startsWith("tasks") && f.endsWith(".json"))
-      .sort((a, b) => {
-        // Session-scoped files (tasks-<uuid>.json) before project-scoped (tasks.json)
-        const aSession = a !== "tasks.json" ? 1 : 0;
-        const bSession = b !== "tasks.json" ? 1 : 0;
-        return bSession - aSession;
-      });
+    const store = new TaskStoreClass(storePath);
+    const task = store.get(taskId);
+    if (!task || task.status === "completed") return false;
+    store.update(taskId, { status: "completed" });
+    return true;
   } catch {
     return false;
   }
-
-  for (const file of files) {
-    const filePath = path.join(tasksDir, file);
-    try {
-      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-      const tasks: any[] = data.tasks || [];
-      const task = tasks.find((t: any) => t.id === taskId);
-      if (task) {
-        // Check all blockedBy deps are completed
-        const allDepsCompleted = (task.blockedBy || []).every((depId: string) => {
-          const dep = tasks.find((t: any) => t.id === depId);
-          return dep && dep.status === "completed";
-        });
-        if (!allDepsCompleted) return false;
-
-        task.status = "completed";
-        task.updatedAt = Date.now();
-        fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
-        return true;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return false;
 }
 
 // ── Registration ─────────────────────────────────────────────────────────
@@ -272,7 +267,8 @@ export function registerAsyncAgents(
       const output = (j.output || "").slice(0, 3000);
       // Auto-complete linked task directly in the store file (no AI involvement)
       if (j.taskId && j.taskId !== "-1" && j.status === "complete" && j.cwd) {
-        const completed = autoCompleteTask(j.taskId, j.cwd);
+        const sessionId = asyncState.lastCtx?.sessionManager?.getSessionId?.();
+        const completed = autoCompleteTask(j.taskId, j.cwd, sessionId);
         asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
       }
       const taskHint = "";
@@ -343,7 +339,8 @@ export function registerAsyncAgents(
         const output = (data.output || "").slice(0, 3000);
         // Auto-complete linked task directly in the store file (no AI involvement)
         if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
-          const completed = autoCompleteTask(job.taskId, job.cwd);
+          const sessionId = asyncState.lastCtx?.sessionManager?.getSessionId?.();
+          const completed = autoCompleteTask(job.taskId, job.cwd, sessionId);
           asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
         }
         const taskHint = "";

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -232,7 +232,13 @@ export function registerAsyncAgents(
   }
 
   /** Deliver all results from a completed group as a single combined message. */
+  let groupDeliveryInProgress = new Set<string>();
   async function deliverGroupResults(groupJobs: AsyncJob[]) {
+    // Guard against duplicate concurrent invocations
+    const gid = groupJobs[0]?.groupId;
+    if (gid && groupDeliveryInProgress.has(gid)) return;
+    if (gid) groupDeliveryInProgress.add(gid);
+    try {
     if (!asyncState.lastCtx) return;
 
     // Ingest any unprocessed result files — zombie/kill paths may trigger delivery
@@ -295,6 +301,9 @@ export function registerAsyncAgents(
       const rp = path.join(ASYNC_RESULTS_DIR, `${j.id}.json`);
       try { fs.unlinkSync(rp); } catch (e: any) { asyncLog(`unlink failed ${rp}: ${e?.message}`); }
     }
+    } finally {
+      if (gid) groupDeliveryInProgress.delete(gid);
+    }
   }
 
   async function processResultFile(resultPath: string) {
@@ -342,7 +351,6 @@ export function registerAsyncAgents(
       // Non-grouped job: deliver immediately (existing behavior)
       if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
-        const output = (data.output || "").slice(0, 3000);
         let autoCompleteError = "";
         // Auto-complete linked task directly in the store file (no AI involvement)
         if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
@@ -354,6 +362,8 @@ export function registerAsyncAgents(
             asyncLog(`auto-complete failed for task #${job.taskId}: ${e?.message}`);
           }
         }
+        const maxOutput = 3000 - autoCompleteError.length;
+        const output = (data.output || "").slice(0, Math.max(maxOutput, 500));
         pi.sendMessage({
           customType: "async-agent-result",
           content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${autoCompleteError}`,

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -357,6 +357,7 @@ export function registerAsyncAgents(
       fireAndForget: options?.fireAndForget || false,
       parentPid: process.pid,
       parentStartTime,
+      taskId: options?.taskId || null,
     }), { mode: 0o600 });
 
     // Build pi args

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -13,8 +13,7 @@ const require = createRequire(import.meta.url);
 
 // Import TaskStore for direct task auto-completion (bypasses AI)
 let TaskStoreClass: any = null;
-(async () => {
-  // Try multiple resolution strategies
+const taskStoreReady: Promise<void> = (async () => {
   const candidates = [
     "@tintinweb/pi-tasks/dist/task-store.js",
     pathToFileURL(path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js")).href,
@@ -93,8 +92,9 @@ export function formatDuration(ms: number): string {
 }
 
 /** Auto-complete a task via pi-tasks TaskStore (in-process, no AI involvement). */
-function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): boolean {
+async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
   if (!taskId || taskId === "-1") return false;
+  await taskStoreReady;
 
   const tasksDir = path.join(cwd, ".pi", "tasks");
   const candidates: string[] = [];
@@ -232,7 +232,7 @@ export function registerAsyncAgents(
   }
 
   /** Deliver all results from a completed group as a single combined message. */
-  function deliverGroupResults(groupJobs: AsyncJob[]) {
+  async function deliverGroupResults(groupJobs: AsyncJob[]) {
     if (!asyncState.lastCtx) return;
 
     // Ingest any unprocessed result files — zombie/kill paths may trigger delivery
@@ -269,7 +269,7 @@ export function registerAsyncAgents(
       const output = (j.output || "").slice(0, 3000);
       // Auto-complete linked task directly in the store file (no AI involvement)
       if (j.taskId && j.taskId !== "-1" && j.status === "complete" && j.cwd) {
-        const completed = autoCompleteTask(j.taskId, j.cwd, j.sessionId);
+        const completed = await autoCompleteTask(j.taskId, j.cwd, j.sessionId);
         asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
       }
       const taskHint = "";
@@ -292,7 +292,7 @@ export function registerAsyncAgents(
     }
   }
 
-  function processResultFile(resultPath: string) {
+  async function processResultFile(resultPath: string) {
     try {
       const data = JSON.parse(fs.readFileSync(resultPath, "utf-8"));
       const job = asyncState.jobs.get(data.id);
@@ -340,7 +340,7 @@ export function registerAsyncAgents(
         const output = (data.output || "").slice(0, 3000);
         // Auto-complete linked task directly in the store file (no AI involvement)
         if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
-          const completed = autoCompleteTask(job.taskId, job.cwd, job.sessionId);
+          const completed = await autoCompleteTask(job.taskId, job.cwd, job.sessionId);
           asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
         }
         const taskHint = "";

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -223,7 +223,7 @@ export function registerAsyncAgents(
       const resultStatus = j.status === "complete" ? "✅ completed" : "❌ failed";
       const displayName = j.name || j.agent;
       const output = (j.output || "").slice(0, 3000);
-      const taskHint = j.taskId ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${j.taskId}", status="${j.status === "complete" ? "completed" : "in_progress"}")\` now.` : "";
+      const taskHint = j.taskId && j.taskId !== "-1" ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${j.taskId}", status="${j.status === "complete" ? "completed" : "in_progress"}")\` now.` : "";
       sections.push(`## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${j.task}\nDuration: ${formatDuration(j.durationMs || 0)}\n\n${output}${taskHint}`);
       j.delivered = true;
     }
@@ -289,7 +289,7 @@ export function registerAsyncAgents(
       if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
         const output = (data.output || "").slice(0, 3000);
-        const taskHint = job.taskId ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${job.taskId}", status="${data.success ? "completed" : "in_progress"}")\` now.` : "";
+        const taskHint = job.taskId && job.taskId !== "-1" ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${job.taskId}", status="${data.success ? "completed" : "in_progress"}")\` now.` : "";
         pi.sendMessage({
           customType: "async-agent-result",
           content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${taskHint}`,

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -267,17 +267,18 @@ export function registerAsyncAgents(
       const resultStatus = j.status === "complete" ? "✅ completed" : "❌ failed";
       const displayName = j.name || j.agent;
       const output = (j.output || "").slice(0, 3000);
+      let autoCompleteError = "";
       // Auto-complete linked task directly in the store file (no AI involvement)
       if (j.taskId && j.taskId !== "-1" && j.status === "complete" && j.cwd) {
         try {
           const completed = await autoCompleteTask(j.taskId, j.cwd, j.sessionId);
           asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
         } catch (e: any) {
+          autoCompleteError = `\n\n⚠️ Failed to auto-complete task #${j.taskId}: ${e?.message}. Run TaskUpdate(taskId="${j.taskId}", status="completed") manually.`;
           asyncLog(`auto-complete failed for task #${j.taskId}: ${e?.message}`);
         }
       }
-      const taskHint = "";
-      sections.push(`## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${j.task}\nDuration: ${formatDuration(j.durationMs || 0)}\n\n${output}${taskHint}`);
+      sections.push(`## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${j.task}\nDuration: ${formatDuration(j.durationMs || 0)}\n\n${output}${autoCompleteError}`);
       j.delivered = true;
     }
 
@@ -342,19 +343,20 @@ export function registerAsyncAgents(
       if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
         const output = (data.output || "").slice(0, 3000);
+        let autoCompleteError = "";
         // Auto-complete linked task directly in the store file (no AI involvement)
         if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
           try {
             const completed = await autoCompleteTask(job.taskId, job.cwd, job.sessionId);
             asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
           } catch (e: any) {
+            autoCompleteError = `\n\n⚠️ Failed to auto-complete task #${job.taskId}: ${e?.message}. Run TaskUpdate(taskId="${job.taskId}", status="completed") manually.`;
             asyncLog(`auto-complete failed for task #${job.taskId}: ${e?.message}`);
           }
         }
-        const taskHint = "";
         pi.sendMessage({
           customType: "async-agent-result",
-          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${taskHint}`,
+          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${autoCompleteError}`,
           display: true,
         }, { triggerTurn: true, deliverAs: "followUp" });
       }

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -12,9 +12,19 @@ const require = createRequire(import.meta.url);
 
 // Import TaskStore for direct task auto-completion (bypasses AI)
 let TaskStoreClass: any = null;
-import("@tintinweb/pi-tasks/dist/task-store.js")
-  .then(mod => { TaskStoreClass = mod.TaskStore; })
-  .catch(() => {});
+(async () => {
+  // Try multiple resolution strategies
+  const candidates = [
+    "@tintinweb/pi-tasks/dist/task-store.js",
+    path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js"),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const mod = await import(candidate);
+      if (mod.TaskStore) { TaskStoreClass = mod.TaskStore; break; }
+    } catch { continue; }
+  }
+})();
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -25,7 +25,7 @@ let TaskStoreClass: any = null;
     } catch { continue; }
   }
   if (!TaskStoreClass) {
-    console.debug("[async-agents] WARNING: TaskStore not found — task auto-completion disabled");
+    throw new Error("[async-agents] FATAL: TaskStore not found — @tintinweb/pi-tasks is required but failed to load");
   }
 })();
 
@@ -92,7 +92,7 @@ export function formatDuration(ms: number): string {
 
 /** Auto-complete a task via pi-tasks TaskStore (in-process, no AI involvement). */
 function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): boolean {
-  if (!taskId || taskId === "-1" || !TaskStoreClass) return false;
+  if (!taskId || taskId === "-1") return false;
 
   const tasksDir = path.join(cwd, ".pi", "tasks");
   const candidates: string[] = [];

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -38,6 +38,7 @@ export interface AsyncJob {
   delivered?: boolean;
   fireAndForget?: boolean;
   groupId?: string;
+  taskId?: string;
 }
 
 interface AsyncState {
@@ -75,7 +76,7 @@ export function registerAsyncAgents(
   pi: ExtensionAPI,
   terminalNotify: (title: string, body: string) => void,
 ): {
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string }) => { id: string; error?: string; model?: string };
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string; taskId?: string }) => { id: string; error?: string; model?: string };
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
   getAsyncJobs: () => Array<{ id: string; agent: string; name?: string; task: string; status: string; startedAt: number }>;
 } {
@@ -222,7 +223,8 @@ export function registerAsyncAgents(
       const resultStatus = j.status === "complete" ? "✅ completed" : "❌ failed";
       const displayName = j.name || j.agent;
       const output = (j.output || "").slice(0, 3000);
-      sections.push(`## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${j.task}\nDuration: ${formatDuration(j.durationMs || 0)}\n\n${output}`);
+      const taskHint = j.taskId ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${j.taskId}", status="${j.status === "complete" ? "completed" : "in_progress"}")\` now.` : "";
+      sections.push(`## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${j.task}\nDuration: ${formatDuration(j.durationMs || 0)}\n\n${output}${taskHint}`);
       j.delivered = true;
     }
 
@@ -287,9 +289,10 @@ export function registerAsyncAgents(
       if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
         const output = (data.output || "").slice(0, 3000);
+        const taskHint = job.taskId ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${job.taskId}", status="${data.success ? "completed" : "in_progress"}")\` now.` : "";
         pi.sendMessage({
           customType: "async-agent-result",
-          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}`,
+          content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${taskHint}`,
           display: true,
         }, { triggerTurn: true, deliverAs: "followUp" });
       }
@@ -326,7 +329,7 @@ export function registerAsyncAgents(
     task: string,
     cwd: string,
     agents: AgentConfig[],
-    options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string },
+    options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string; taskId?: string },
   ): { id: string; error?: string; model?: string } {
     const agent = agents.find(a => a.name === agentName);
     if (!agent) return { id: "", error: `Unknown agent: "${agentName}"` };
@@ -441,6 +444,7 @@ export function registerAsyncAgents(
       updatedAt: Date.now(),
       fireAndForget: options?.fireAndForget,
       groupId: options?.groupId,
+      taskId: options?.taskId,
     };
     asyncState.jobs.set(id, job);
     updateAsyncWidget();

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -6,6 +6,7 @@ import { execFileSync, execSync, spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
@@ -16,7 +17,7 @@ let TaskStoreClass: any = null;
   // Try multiple resolution strategies
   const candidates = [
     "@tintinweb/pi-tasks/dist/task-store.js",
-    path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js"),
+    pathToFileURL(path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js")).href,
   ];
   for (const candidate of candidates) {
     try {
@@ -59,6 +60,7 @@ export interface AsyncJob {
   groupId?: string;
   taskId?: string;
   cwd?: string;
+  sessionId?: string;
 }
 
 interface AsyncState {
@@ -267,8 +269,7 @@ export function registerAsyncAgents(
       const output = (j.output || "").slice(0, 3000);
       // Auto-complete linked task directly in the store file (no AI involvement)
       if (j.taskId && j.taskId !== "-1" && j.status === "complete" && j.cwd) {
-        const sessionId = asyncState.lastCtx?.sessionManager?.getSessionId?.();
-        const completed = autoCompleteTask(j.taskId, j.cwd, sessionId);
+        const completed = autoCompleteTask(j.taskId, j.cwd, j.sessionId);
         asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
       }
       const taskHint = "";
@@ -339,8 +340,7 @@ export function registerAsyncAgents(
         const output = (data.output || "").slice(0, 3000);
         // Auto-complete linked task directly in the store file (no AI involvement)
         if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
-          const sessionId = asyncState.lastCtx?.sessionManager?.getSessionId?.();
-          const completed = autoCompleteTask(job.taskId, job.cwd, sessionId);
+          const completed = autoCompleteTask(job.taskId, job.cwd, job.sessionId);
           asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
         }
         const taskHint = "";
@@ -413,6 +413,7 @@ export function registerAsyncAgents(
       parentStartTime,
       taskId: options?.taskId || null,
       cwd,
+      sessionId: asyncState.lastCtx?.sessionManager?.getSessionId?.() || null,
     }), { mode: 0o600 });
 
     // Build pi args
@@ -502,6 +503,7 @@ export function registerAsyncAgents(
       groupId: options?.groupId,
       taskId: options?.taskId,
       cwd,
+      sessionId: asyncState.lastCtx?.sessionManager?.getSessionId?.(),
     };
     asyncState.jobs.set(id, job);
     updateAsyncWidget();
@@ -596,6 +598,7 @@ export function registerAsyncAgents(
             fireAndForget: marker.fireAndForget || false,
             taskId: marker.taskId || undefined,
             cwd: marker.cwd || undefined,
+            sessionId: marker.sessionId || undefined,
           };
           asyncState.jobs.set(id, job);
           asyncLog(`restored job: ${id} state=${job.status}`);

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -39,6 +39,7 @@ export interface AsyncJob {
   fireAndForget?: boolean;
   groupId?: string;
   taskId?: string;
+  cwd?: string;
 }
 
 interface AsyncState {
@@ -68,6 +69,45 @@ export function formatDuration(ms: number): string {
   const m = Math.floor(ms / 60000);
   const s = Math.floor((ms % 60000) / 1000);
   return `${m}m${s}s`;
+}
+
+/** Directly update a task's status in the pi-tasks store file. */
+function autoCompleteTask(taskId: string, cwd: string): boolean {
+  if (!taskId || taskId === "-1") return false;
+
+  const tasksDir = path.join(cwd, ".pi", "tasks");
+  // Try all possible store files
+  let files: string[];
+  try {
+    files = fs.readdirSync(tasksDir).filter(f => f.startsWith("tasks") && f.endsWith(".json"));
+  } catch {
+    return false;
+  }
+
+  for (const file of files) {
+    const filePath = path.join(tasksDir, file);
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      const tasks: any[] = data.tasks || [];
+      const task = tasks.find((t: any) => t.id === taskId);
+      if (task) {
+        // Check all blockedBy deps are completed
+        const allDepsCompleted = (task.blockedBy || []).every((depId: string) => {
+          const dep = tasks.find((t: any) => t.id === depId);
+          return dep && dep.status === "completed";
+        });
+        if (!allDepsCompleted) return false;
+
+        task.status = "completed";
+        task.updatedAt = Date.now();
+        fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+        return true;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return false;
 }
 
 // ── Registration ─────────────────────────────────────────────────────────
@@ -223,7 +263,12 @@ export function registerAsyncAgents(
       const resultStatus = j.status === "complete" ? "✅ completed" : "❌ failed";
       const displayName = j.name || j.agent;
       const output = (j.output || "").slice(0, 3000);
-      const taskHint = j.taskId && j.taskId !== "-1" ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${j.taskId}", status="${j.status === "complete" ? "completed" : "in_progress"}")\` now.` : "";
+      // Auto-complete linked task directly in the store file (no AI involvement)
+      if (j.taskId && j.taskId !== "-1" && j.status === "complete" && j.cwd) {
+        const completed = autoCompleteTask(j.taskId, j.cwd);
+        asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
+      }
+      const taskHint = "";
       sections.push(`## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${j.task}\nDuration: ${formatDuration(j.durationMs || 0)}\n\n${output}${taskHint}`);
       j.delivered = true;
     }
@@ -289,7 +334,12 @@ export function registerAsyncAgents(
       if (asyncState.lastCtx && !job.fireAndForget) {
         const resultStatus = data.success ? "✅ completed" : "❌ failed";
         const output = (data.output || "").slice(0, 3000);
-        const taskHint = job.taskId && job.taskId !== "-1" ? `\n\n**Auto-complete:** Run \`TaskUpdate(taskId="${job.taskId}", status="${data.success ? "completed" : "in_progress"}")\` now.` : "";
+        // Auto-complete linked task directly in the store file (no AI involvement)
+        if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
+          const completed = autoCompleteTask(job.taskId, job.cwd);
+          asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
+        }
+        const taskHint = "";
         pi.sendMessage({
           customType: "async-agent-result",
           content: `## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${data.task}\nDuration: ${formatDuration(data.durationMs)}\n\n${output}${taskHint}`,
@@ -446,6 +496,7 @@ export function registerAsyncAgents(
       fireAndForget: options?.fireAndForget,
       groupId: options?.groupId,
       taskId: options?.taskId,
+      cwd,
     };
     asyncState.jobs.set(id, job);
     updateAsyncWidget();

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -79,7 +79,14 @@ function autoCompleteTask(taskId: string, cwd: string): boolean {
   // Try all possible store files
   let files: string[];
   try {
-    files = fs.readdirSync(tasksDir).filter(f => f.startsWith("tasks") && f.endsWith(".json"));
+    files = fs.readdirSync(tasksDir)
+      .filter(f => f.startsWith("tasks") && f.endsWith(".json"))
+      .sort((a, b) => {
+        // Session-scoped files (tasks-<uuid>.json) before project-scoped (tasks.json)
+        const aSession = a !== "tasks.json" ? 1 : 0;
+        const bSession = b !== "tasks.json" ? 1 : 0;
+        return bSession - aSession;
+      });
   } catch {
     return false;
   }
@@ -408,6 +415,7 @@ export function registerAsyncAgents(
       parentPid: process.pid,
       parentStartTime,
       taskId: options?.taskId || null,
+      cwd,
     }), { mode: 0o600 });
 
     // Build pi args
@@ -589,6 +597,8 @@ export function registerAsyncAgents(
             exitCode: status.exitCode,
             durationMs: status.endedAt ? status.endedAt - status.startedAt : undefined,
             fireAndForget: marker.fireAndForget || false,
+            taskId: marker.taskId || undefined,
+            cwd: marker.cwd || undefined,
           };
           asyncState.jobs.set(id, job);
           asyncLog(`restored job: ${id} state=${job.status}`);

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -269,8 +269,12 @@ export function registerAsyncAgents(
       const output = (j.output || "").slice(0, 3000);
       // Auto-complete linked task directly in the store file (no AI involvement)
       if (j.taskId && j.taskId !== "-1" && j.status === "complete" && j.cwd) {
-        const completed = await autoCompleteTask(j.taskId, j.cwd, j.sessionId);
-        asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
+        try {
+          const completed = await autoCompleteTask(j.taskId, j.cwd, j.sessionId);
+          asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
+        } catch (e: any) {
+          asyncLog(`auto-complete failed for task #${j.taskId}: ${e?.message}`);
+        }
       }
       const taskHint = "";
       sections.push(`## Async Agent Result: ${displayName} ${resultStatus}\n\nTask: ${j.task}\nDuration: ${formatDuration(j.durationMs || 0)}\n\n${output}${taskHint}`);
@@ -340,8 +344,12 @@ export function registerAsyncAgents(
         const output = (data.output || "").slice(0, 3000);
         // Auto-complete linked task directly in the store file (no AI involvement)
         if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
-          const completed = await autoCompleteTask(job.taskId, job.cwd, job.sessionId);
-          asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
+          try {
+            const completed = await autoCompleteTask(job.taskId, job.cwd, job.sessionId);
+            asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
+          } catch (e: any) {
+            asyncLog(`auto-complete failed for task #${job.taskId}: ${e?.message}`);
+          }
         }
         const taskHint = "";
         pi.sendMessage({

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -12,9 +12,9 @@ const require = createRequire(import.meta.url);
 
 // Import TaskStore for direct task auto-completion (bypasses AI)
 let TaskStoreClass: any = null;
-try {
-  TaskStoreClass = require("@tintinweb/pi-tasks/dist/task-store.js").TaskStore;
-} catch {}
+import("@tintinweb/pi-tasks/dist/task-store.js")
+  .then(mod => { TaskStoreClass = mod.TaskStore; })
+  .catch(() => {});
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -511,7 +511,7 @@ export async function runSingleAgent(
 
 export function registerSubagentTool(
   pi: ExtensionAPI,
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; taskId?: string }) => { id: string; error?: string; model?: string },
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string; taskId?: string }) => { id: string; error?: string; model?: string },
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] },
 ): void {
   // Only the orchestrator (top-level pi) can spawn subagents.

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -526,18 +526,22 @@ export async function runSingleAgent(
 function validateTaskId(taskId: string, cwd: string, sessionId?: string): string | null {
   if (taskId === "-1") return null;
 
-  if (TaskStoreClass) {
-    // Use TaskStore API — no raw file reads
-    const tasksDir = path.join(cwd, ".pi", "tasks");
-    const paths: string[] = [];
-    if (sessionId) paths.push(path.join(tasksDir, `tasks-${sessionId}.json`));
-    paths.push(path.join(tasksDir, "tasks.json"));
-    for (const p of paths) {
-      try {
+  const tasksDir = path.join(cwd, ".pi", "tasks");
+  const paths: string[] = [];
+  if (sessionId) paths.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+  paths.push(path.join(tasksDir, "tasks.json"));
+
+  for (const p of paths) {
+    try {
+      if (TaskStoreClass) {
         const store = new TaskStoreClass(p);
         if (store.get(taskId)) return null;
-      } catch { continue; }
-    }
+      } else {
+        // Fallback: raw file read when TaskStore hasn't loaded yet (async init race)
+        const data = JSON.parse(fs.readFileSync(p, "utf-8"));
+        if ((data.tasks || []).some((t: any) => t.id === taskId)) return null;
+      }
+    } catch { continue; }
   }
 
   return `Task #${taskId} not found. Verify the task ID exists (use TaskList to check), or pass taskId: "-1" if not linked to a task.`;

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -27,6 +27,21 @@ import {
 } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./agents.js";
+
+// Import TaskStore for taskId validation (bypasses raw file reads)
+let TaskStoreClass: any = null;
+(async () => {
+  const candidates = [
+    "@tintinweb/pi-tasks/dist/task-store.js",
+    path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js"),
+  ];
+  for (const c of candidates) {
+    try { const mod = await import(c); if (mod.TaskStore) { TaskStoreClass = mod.TaskStore; break; } } catch { continue; }
+  }
+  if (!TaskStoreClass) {
+    console.debug("[subagent] WARNING: TaskStore not found — taskId validation falls back to file reads");
+  }
+})();
 import { clockHHMM, getPiInvocation, getProjectTmpDir } from "./utils.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
@@ -509,23 +524,22 @@ export async function runSingleAgent(
 
 /** Validate that a taskId references an existing task in the pi-tasks store. */
 function validateTaskId(taskId: string, cwd: string, sessionId?: string): string | null {
-  if (taskId === "-1") return null; // -1 means "not linked"
+  if (taskId === "-1") return null;
 
-  // Try session-scoped file first, then project-scoped
-  const tasksDir = path.join(cwd, ".pi", "tasks");
-  const candidates: string[] = [];
-  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
-  candidates.push(path.join(tasksDir, "tasks.json"));
-
-  for (const filePath of candidates) {
-    try {
-      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
-      const tasks: any[] = data.tasks || [];
-      if (tasks.some((t: any) => t.id === taskId)) return null; // Found
-    } catch {
-      continue; // File doesn't exist or parse error
+  if (TaskStoreClass) {
+    // Use TaskStore API — no raw file reads
+    const tasksDir = path.join(cwd, ".pi", "tasks");
+    const paths: string[] = [];
+    if (sessionId) paths.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+    paths.push(path.join(tasksDir, "tasks.json"));
+    for (const p of paths) {
+      try {
+        const store = new TaskStoreClass(p);
+        if (store.get(taskId)) return null;
+      } catch { continue; }
     }
   }
+
   return `Task #${taskId} not found. Verify the task ID exists (use TaskList to check), or pass taskId: "-1" if not linked to a task.`;
 }
 

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -507,6 +507,28 @@ export async function runSingleAgent(
   }
 }
 
+/** Validate that a taskId references an existing task in the pi-tasks store. */
+function validateTaskId(taskId: string, cwd: string, sessionId?: string): string | null {
+  if (taskId === "-1") return null; // -1 means "not linked"
+
+  // Try session-scoped file first, then project-scoped
+  const tasksDir = path.join(cwd, ".pi", "tasks");
+  const candidates: string[] = [];
+  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+  candidates.push(path.join(tasksDir, "tasks.json"));
+
+  for (const filePath of candidates) {
+    try {
+      const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+      const tasks: any[] = data.tasks || [];
+      if (tasks.some((t: any) => t.id === taskId)) return null; // Found
+    } catch {
+      continue; // File doesn't exist or parse error
+    }
+  }
+  return `Task #${taskId} not found. Verify the task ID exists (use TaskList to check), or pass taskId: "-1" if not linked to a task.`;
+}
+
 // ── Registration ─────────────────────────────────────────────────────────
 
 export function registerSubagentTool(
@@ -694,6 +716,17 @@ export function registerSubagentTool(
               isError: true,
             };
           }
+          for (const t of params.tasks) {
+            const tid = (t as any).taskId as string;
+            const taskErr = validateTaskId(tid, t.cwd, ctx.sessionManager?.getSessionId?.());
+            if (taskErr) {
+              return {
+                content: [{ type: "text", text: `${taskErr} (agent: ${t.agent})` }],
+                details: mkd("single")([]),
+                isError: true,
+              };
+            }
+          }
           const results: string[] = [];
           const errors: string[] = [];
           // Group parallel async tasks so results are delivered together
@@ -755,6 +788,16 @@ export function registerSubagentTool(
             details: mkd("single")([]),
             isError: true,
           };
+        }
+        {
+          const taskErr = validateTaskId(params.taskId, params.cwd, ctx.sessionManager?.getSessionId?.());
+          if (taskErr) {
+            return {
+              content: [{ type: "text", text: taskErr }],
+              details: mkd("single")([]),
+              isError: true,
+            };
+          }
         }
         const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents, { fireAndForget: params.fireAndForget, name: params.name, parentModelId, parentProvider, taskId: params.taskId });
         if (result.error) {

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -39,7 +39,7 @@ let TaskStoreClass: any = null;
     try { const mod = await import(c); if (mod.TaskStore) { TaskStoreClass = mod.TaskStore; break; } } catch { continue; }
   }
   if (!TaskStoreClass) {
-    console.debug("[subagent] WARNING: TaskStore not found — taskId validation falls back to file reads");
+    throw new Error("[subagent] FATAL: TaskStore not found — @tintinweb/pi-tasks is required but failed to load");
   }
 })();
 import { clockHHMM, getPiInvocation, getProjectTmpDir } from "./utils.js";

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -55,6 +55,7 @@ const TaskItem = Type.Object({
   cwd: Type.String({ description: "Working directory" }),
   name: Type.Optional(Type.String({ description: "Display name for async status" })),
   estimatedSeconds: Type.Optional(Type.Number({ description: "Estimated task duration in seconds. Required for sync parallel tasks." })),
+  taskId: Type.Optional(Type.String({ description: "Task ID to auto-complete when this async agent finishes" })),
 });
 const ChainItem = Type.Object({
   agent: Type.String({ description: "Agent name" }),
@@ -104,6 +105,9 @@ const SubagentParams = Type.Object({
   ),
   name: Type.Optional(
     Type.String({ description: "Display name for async agents in status line and notifications (e.g., 'Dream', 'Code Review'). Defaults to agent name." }),
+  ),
+  taskId: Type.Optional(
+    Type.String({ description: "Task ID to auto-complete when this async agent finishes. Only works with async: true." }),
   ),
   asyncKill: Type.Optional(
     Type.String({ description: "Kill async agent(s) by name, id prefix, or 'all'. Returns which agents were killed." }),
@@ -507,7 +511,7 @@ export async function runSingleAgent(
 
 export function registerSubagentTool(
   pi: ExtensionAPI,
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string }) => { id: string; error?: string; model?: string },
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; taskId?: string }) => { id: string; error?: string; model?: string },
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] },
 ): void {
   // Only the orchestrator (top-level pi) can spawn subagents.
@@ -695,6 +699,7 @@ export function registerSubagentTool(
               parentModelId,
               parentProvider,
               groupId,
+              taskId: (t as any).taskId,
             });
             if (r.error) {
               errors.push(`${t.agent}: ${r.error}`);
@@ -736,7 +741,7 @@ export function registerSubagentTool(
             isError: true,
           };
         }
-        const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents, { fireAndForget: params.fireAndForget, name: params.name, parentModelId, parentProvider });
+        const result = spawnAsyncAgent(params.agent, params.task, params.cwd, agents, { fireAndForget: params.fireAndForget, name: params.name, parentModelId, parentProvider, taskId: params.taskId });
         if (result.error) {
           return {
             content: [{ type: "text", text: result.error }],

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -107,7 +107,7 @@ const SubagentParams = Type.Object({
     Type.String({ description: "Display name for async agents in status line and notifications (e.g., 'Dream', 'Code Review'). Defaults to agent name." }),
   ),
   taskId: Type.Optional(
-    Type.String({ description: "Task ID to auto-complete when this async agent finishes. Only works with async: true." }),
+    Type.String({ description: "Task ID to auto-complete when this async agent finishes. Required for async agents — pass \"-1\" if not linked to any task." }),
   ),
   asyncKill: Type.Optional(
     Type.String({ description: "Kill async agent(s) by name, id prefix, or 'all'. Returns which agents were killed." }),
@@ -686,6 +686,14 @@ export function registerSubagentTool(
               isError: true,
             };
           }
+          const noTaskId = params.tasks.filter(t => (t as any).taskId == null);
+          if (noTaskId.length > 0) {
+            return {
+              content: [{ type: "text", text: `Missing required parameter: taskId. Every async agent MUST have a taskId.\n\nMissing taskId for: ${noTaskId.map(t => t.agent).join(", ")}\n\nIf an agent is working on a task: pass the task ID (e.g., taskId: "5")\nIf an agent is NOT linked to any task: pass taskId: "-1"` }],
+              details: mkd("single")([]),
+              isError: true,
+            };
+          }
           const results: string[] = [];
           const errors: string[] = [];
           // Group parallel async tasks so results are delivered together
@@ -737,6 +745,13 @@ export function registerSubagentTool(
         if (!params.name) {
           return {
             content: [{ type: "text", text: "Async agents require a name for display in status line (e.g., 'Dream', 'Code Review', 'PR #42')." }],
+            details: mkd("single")([]),
+            isError: true,
+          };
+        }
+        if (params.taskId == null) {
+          return {
+            content: [{ type: "text", text: `Missing required parameter: taskId. Every async agent MUST have a taskId.\n\nIf this agent is working on a task: pass the task ID (e.g., taskId: "5")\nIf this agent is NOT linked to any task: pass taskId: "-1"\n\nExample: subagent(agent="${params.agent}", task="...", async=true, name="${params.name}", taskId="-1")` }],
             details: mkd("single")([]),
             isError: true,
           };

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -6,6 +6,7 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { createRequire } from "node:module";
 
@@ -33,7 +34,7 @@ let TaskStoreClass: any = null;
 (async () => {
   const candidates = [
     "@tintinweb/pi-tasks/dist/task-store.js",
-    path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js"),
+    pathToFileURL(path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js")).href,
   ];
   for (const c of candidates) {
     try { const mod = await import(c); if (mod.TaskStore) { TaskStoreClass = mod.TaskStore; break; } } catch { continue; }
@@ -541,7 +542,11 @@ function validateTaskId(taskId: string, cwd: string, sessionId?: string): string
         const data = JSON.parse(fs.readFileSync(p, "utf-8"));
         if ((data.tasks || []).some((t: any) => t.id === taskId)) return null;
       }
-    } catch { continue; }
+    } catch (e: any) {
+      // Only continue silently for missing files; report other errors
+      if (e?.code === "ENOENT" || e?.message?.includes("ENOENT")) continue;
+      return `Task store error for ${path.basename(p)}: ${e?.message || e}. Fix the task store or pass taskId: "-1".`;
+    }
   }
 
   return `Task #${taskId} not found. Verify the task ID exists (use TaskList to check), or pass taskId: "-1" if not linked to a task.`;

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -710,8 +710,15 @@ export function registerSubagentTool(
           }
           const noTaskId = params.tasks.filter(t => (t as any).taskId == null);
           if (noTaskId.length > 0) {
+            const errorMsg = `Missing required parameter: taskId. Every async agent MUST have a taskId.\n\nMissing taskId for: ${noTaskId.map(t => t.agent).join(", ")}\n\nIf an agent is working on a task: pass the task ID (e.g., taskId: "5")\nIf an agent is NOT linked to any task: pass taskId: "-1"`;
+            // Force a follow-up turn so the AI MUST deal with this error
+            pi.sendMessage({
+              customType: "subagent-taskid-error",
+              content: `🚨 CRITICAL: Async subagent call was REJECTED — missing taskId for: ${noTaskId.map(t => t.agent).join(", ")}. NO agents were spawned. You MUST retry with taskId for each agent. Use TaskList to find task IDs, or pass taskId: "-1" if not linked.`,
+              display: true,
+            }, { triggerTurn: true, deliverAs: "followUp" });
             return {
-              content: [{ type: "text", text: `Missing required parameter: taskId. Every async agent MUST have a taskId.\n\nMissing taskId for: ${noTaskId.map(t => t.agent).join(", ")}\n\nIf an agent is working on a task: pass the task ID (e.g., taskId: "5")\nIf an agent is NOT linked to any task: pass taskId: "-1"` }],
+              content: [{ type: "text", text: errorMsg }],
               details: mkd("single")([]),
               isError: true,
             };
@@ -720,6 +727,11 @@ export function registerSubagentTool(
             const tid = (t as any).taskId as string;
             const taskErr = validateTaskId(tid, t.cwd, ctx.sessionManager?.getSessionId?.());
             if (taskErr) {
+              pi.sendMessage({
+                customType: "subagent-taskid-error",
+                content: `🚨 CRITICAL: ${taskErr} (agent: ${t.agent}). NO agents were spawned. Fix the taskId and retry.`,
+                display: true,
+              }, { triggerTurn: true, deliverAs: "followUp" });
               return {
                 content: [{ type: "text", text: `${taskErr} (agent: ${t.agent})` }],
                 details: mkd("single")([]),
@@ -783,8 +795,15 @@ export function registerSubagentTool(
           };
         }
         if (params.taskId == null) {
+          const errorMsg = `Missing required parameter: taskId. Every async agent MUST have a taskId.\n\nIf this agent is working on a task: pass the task ID (e.g., taskId: "5")\nIf this agent is NOT linked to any task: pass taskId: "-1"\n\nExample: subagent(agent="${params.agent}", task="...", async=true, name="${params.name}", taskId="-1")`;
+          // Force a follow-up turn so the AI MUST deal with this error
+          pi.sendMessage({
+            customType: "subagent-taskid-error",
+            content: `🚨 CRITICAL: Async subagent call for "${params.agent}" was REJECTED — missing taskId. The agent was NOT spawned. You MUST retry the subagent call with taskId. Use TaskList to find the task ID, or pass taskId: "-1" if not linked to any task. Do NOT proceed without fixing this.`,
+            display: true,
+          }, { triggerTurn: true, deliverAs: "followUp" });
           return {
-            content: [{ type: "text", text: `Missing required parameter: taskId. Every async agent MUST have a taskId.\n\nIf this agent is working on a task: pass the task ID (e.g., taskId: "5")\nIf this agent is NOT linked to any task: pass taskId: "-1"\n\nExample: subagent(agent="${params.agent}", task="...", async=true, name="${params.name}", taskId="-1")` }],
+            content: [{ type: "text", text: errorMsg }],
             details: mkd("single")([]),
             isError: true,
           };
@@ -792,6 +811,11 @@ export function registerSubagentTool(
         {
           const taskErr = validateTaskId(params.taskId, params.cwd, ctx.sessionManager?.getSessionId?.());
           if (taskErr) {
+            pi.sendMessage({
+              customType: "subagent-taskid-error",
+              content: `🚨 CRITICAL: ${taskErr} The agent was NOT spawned. Fix the taskId and retry.`,
+              display: true,
+            }, { triggerTurn: true, deliverAs: "followUp" });
             return {
               content: [{ type: "text", text: taskErr }],
               details: mkd("single")([]),

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -551,6 +551,9 @@ def run(json_path: str) -> None:
             err = validate_reply(reply, comment_path, status)
             if err:
                 lazy_errors.append(err)
+            # Ensure reply field is always populated (posting uses reply, not skip_reason)
+            elif status != "pending" and not comment.get("reply") and comment.get("skip_reason"):
+                comment["reply"] = comment["skip_reason"]
     if lazy_errors:
         eprint(f"\nError: {len(lazy_errors)} lazy/vague replies detected. Fix them before posting:\n")
         for err in lazy_errors:

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -76,6 +76,8 @@ def validate_reply(reply: str, path: str, status: str) -> str | None:
     """
     if status == "pending":
         return None
+    if not isinstance(reply, str):
+        reply = str(reply) if reply is not None else ""
     if not reply or not reply.strip():
         return f"{path}: Empty reply for status '{status}'. Every non-pending entry needs a specific reply."
 
@@ -543,7 +545,7 @@ def run(json_path: str) -> None:
     lazy_errors: list[str] = []
     for cat in categories:
         for comment in data.get(cat, []):
-            reply = comment.get("reply") or comment.get("skip_reason") or ""
+            reply = str(comment.get("reply") or comment.get("skip_reason") or "")
             status = comment.get("status", "pending")
             comment_path = comment.get("path", "unknown")
             err = validate_reply(reply, comment_path, status)

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -47,6 +47,48 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+# Lazy reply patterns that indicate the AI didn't write a real response
+_LAZY_REPLY_PATTERNS = [
+    "previously addressed",
+    "see earlier replies",
+    "see earlier",
+    "see above",
+    "see sticky",
+    "see sticky finding",
+    "already handled",
+    "already covered",
+    "same as above",
+    "refer to previous",
+    "see prior",
+    "addressed above",
+    "covered above",
+    "handled above",
+    "see previous reply",
+    "see previous comment",
+    "see consolidated",
+]
+
+
+def validate_reply(reply: str, path: str, status: str) -> str | None:
+    """Validate a reply is not lazy/vague. Returns error message or None if OK.
+
+    Pending entries are skipped (no reply expected).
+    """
+    if status == "pending":
+        return None
+    if not reply or not reply.strip():
+        return f"{path}: Empty reply for status '{status}'. Every non-pending entry needs a specific reply."
+
+    reply_lower = reply.lower().strip()
+    for pattern in _LAZY_REPLY_PATTERNS:
+        if pattern in reply_lower:
+            return (
+                f"{path}: Lazy reply detected — contains '{pattern}'. "
+                f"Write a specific reply explaining what was done or why it was skipped. "
+                f"Current reply: {reply[:100]}"
+            )
+    return None
+
 
 def eprint(*args: Any, **kwargs: Any) -> None:
     """Print to stderr."""
@@ -496,6 +538,26 @@ def run(json_path: str) -> None:
         sys.exit(0)
 
     eprint(f"Processing {total_thread_count} threads sequentially...")
+
+    # Validate replies — block lazy/vague replies before posting
+    lazy_errors: list[str] = []
+    for cat in categories:
+        for comment in data.get(cat, []):
+            reply = comment.get("reply") or comment.get("skip_reason") or ""
+            status = comment.get("status", "pending")
+            comment_path = comment.get("path", "unknown")
+            err = validate_reply(reply, comment_path, status)
+            if err:
+                lazy_errors.append(err)
+    if lazy_errors:
+        eprint(f"\nError: {len(lazy_errors)} lazy/vague replies detected. Fix them before posting:\n")
+        for err in lazy_errors:
+            eprint(f"  ✗ {err}")
+        eprint(
+            "\nEvery reply must be specific — explain what was fixed"
+            " (with commit SHA) or why it was skipped (with technical reason)."
+        )
+        sys.exit(1)
 
     # Counters for summary
     addressed_count = 0

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -180,7 +180,7 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
         "Line": 5,
         "Summary": 40,
         "Status": 15,
-        "Reply": 40,
+        "Reply": 80,
     }
 
     def pad(text: str, width: int) -> str:
@@ -270,7 +270,7 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
     rows_html = ""
     for i, c in enumerate(comments, 1):
         summary = escape(extract_summary(c["body"], 80))
-        reply = escape((c.get("reply") or c.get("skip_reason") or "")[:100])
+        reply = escape(c.get("reply") or c.get("skip_reason") or "")
         status = c.get("status") or "pending"
         is_sticky = (c.get("type") or "").startswith("qodo_")
         sticky_badge = ' <span title="Still in Qodo sticky comment">📌</span>' if is_sticky else ""

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -208,6 +208,9 @@ def format_tui_table(comments: list[dict], pr_info: dict) -> str:
     for i, c in enumerate(comments, 1):
         summary = extract_summary(c["body"], col_widths["Summary"])
         status = c.get("status") or "pending"
+        is_sticky = (c.get("type") or "").startswith("qodo_")
+        if is_sticky:
+            status = f"{status} \U0001f4cc"
         file_name = (c.get("path") or "").split("/")[-1]
         line_num = str(c.get("line") or "")
 
@@ -269,6 +272,8 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
         summary = escape(extract_summary(c["body"], 80))
         reply = escape((c.get("reply") or c.get("skip_reason") or "")[:100])
         status = c.get("status") or "pending"
+        is_sticky = (c.get("type") or "").startswith("qodo_")
+        sticky_badge = ' <span title="Still in Qodo sticky comment">📌</span>' if is_sticky else ""
         bg = status_colors.get(status, "#e2e3e5")
         path = escape(c.get("path") or "")
         rows_html += f"""
@@ -280,7 +285,7 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
             <td>{summary}</td>
             <td style="background-color: {bg}; font-weight: bold;
                 color: {status_text_colors.get(status, "#c9d1d9")};">
-                {escape(status)}</td>
+                {escape(status)}{sticky_badge}</td>
             <td>{reply}</td>
         </tr>"""
 

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -270,7 +270,11 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
     rows_html = ""
     for i, c in enumerate(comments, 1):
         summary = escape(extract_summary(c["body"], 80))
-        reply = escape(c.get("reply") or c.get("skip_reason") or "")
+        raw_reply = c.get("reply") or c.get("skip_reason") or ""
+        if len(raw_reply) > 200:
+            reply = f"<details><summary>{escape(raw_reply[:150])}...</summary>{escape(raw_reply)}</details>"
+        else:
+            reply = escape(raw_reply)
         status = c.get("status") or "pending"
         is_sticky = (c.get("type") or "").startswith("qodo_")
         sticky_badge = ' <span title="Still in Qodo sticky comment">📌</span>' if is_sticky else ""

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -1,8 +1,9 @@
-"""Review handler status — query reviews DB and display all comments for current PR.
+"""Review handler status — query reviews DB and display deduplicated findings for current PR.
 
-Outputs:
-1. TUI table to stdout
-2. HTML file saved to /tmp/pi-work/<project>/review-status-<pr>.html
+Shows the latest status per unique finding (keyed by source + path + summary).
+Duplicate entries from multiple review cycles are merged, keeping the most recent.
+
+Output: HTML report saved to /tmp/pi-work/<project>/review-status-<pr>.html
 """
 
 import json

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -143,12 +143,22 @@ def extract_summary(body: str, max_len: int = 60) -> str:
 
 
 def deduplicate_comments(comments: list[dict]) -> list[dict]:
-    """Deduplicate comments — keep latest status for same path+line+source+summary."""
+    """Deduplicate comments — keep latest status for same source+path+summary.
+
+    Line numbers are excluded from the key because they shift between commits.
+    Summary is normalized: stripped, lowercased, whitespace collapsed, first 40 chars.
+    """
     seen: dict[str, dict] = {}
     for c in comments:
-        # Normalize summary for dedup: strip HTML, lowercase, first 30 chars
-        raw = extract_summary(c["body"], 50).lower().strip()
-        key = f"{c['source']}:{c['path']}:{c['line']}:{raw[:30]}"
+        raw = extract_summary(c["body"], 60).lower().strip()
+        # Strip emoji badges, quality labels, and Qodo type markers
+        raw = re.sub(r"[\U0001f300-\U0001f9ff\u2600-\u27bf\u2700-\u27bf≡☼➹📎]", "", raw)
+        raw = re.sub(
+            r"\b(bug|rule violation|requirement gap|correctness|reliability|maintainability|performance)\b", "", raw
+        )
+        # Collapse whitespace and take first 40 chars for stable matching
+        normalized = re.sub(r"\s+", " ", raw).strip()[:40]
+        key = f"{c['source']}:{c.get('path', '')}:{normalized}"
         seen[key] = c  # Last one wins (latest cycle)
     return list(seen.values())
 

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -157,7 +157,7 @@ def deduplicate_comments(comments: list[dict]) -> list[dict]:
             r"\b(bug|rule violation|requirement gap|correctness|reliability|maintainability|performance)\b", "", raw
         )
         # Collapse whitespace and take first 40 chars for stable matching
-        normalized = re.sub(r"\s+", " ", raw).strip()[:40]
+        normalized = re.sub(r"\s+", " ", raw).strip()[:80]
         key = f"{c['source']}:{c.get('path', '')}:{normalized}"
         seen[key] = c  # Last one wins (latest cycle)
     return list(seen.values())
@@ -434,9 +434,6 @@ def run(pr_number: int | None = None) -> None:
     pr_info["owner"] = owner
     pr_info["repo"] = repo
     comments = deduplicate_comments(query_comments(db_path, pr_num))
-
-    # TUI output
-    print(format_tui_table(comments, pr_info))
 
     # HTML output
     html = generate_html(comments, pr_info)

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -418,7 +418,7 @@ def run(pr_number: int | None = None) -> None:
     owner, repo = get_pr_repo_info(db_path, pr_num)
     pr_info["owner"] = owner
     pr_info["repo"] = repo
-    comments = query_comments(db_path, pr_num)
+    comments = deduplicate_comments(query_comments(db_path, pr_num))
 
     # TUI output
     print(format_tui_table(comments, pr_info))

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -287,9 +287,9 @@ Mark Task 4 as `completed`.
 
 Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
 
-- **Task 5** — `code-reviewer-quality` — General code quality and maintainability
-- **Task 6** — `code-reviewer-guidelines` — Project guidelines and style adherence
-- **Task 7** — `code-reviewer-security` — Bugs, logic errors, and security vulnerabilities
+- **Task 5** — `code-reviewer-quality`
+- **Task 6** — `code-reviewer-guidelines`
+- **Task 7** — `code-reviewer-security`
 
 Mark Tasks 5, 6, 7 as `in_progress` when spawning the agents.
 
@@ -300,13 +300,8 @@ Provide each agent with:
 
 Each agent should analyze for security, bugs, error handling, and performance issues and return their findings as prose.
 
-Mark each reviewer task as `completed` ONLY when its findings are fully received and stored.
-
-Async agent results surface automatically in the conversation when complete.
-Each reviewer's findings are delivered as its async result text — store them
-in the conversation context. Mark the reviewer's task as `completed` only
-after reading and storing its findings.
-Wait for ALL 3 results before proceeding.
+When each reviewer finishes, its task is auto-completed (see orchestrator rules on taskId).
+Task 8 (Merge findings) auto-unblocks when all 3 reviewer tasks complete.
 
 > 🚨 **DO NOT proceed to Phase 3 until ALL THREE reviewer tasks (5, 6, 7) are `completed`.**
 > Task 8 is blocked by Tasks 4, 5, 6, and 7 — this is enforced by `addBlockedBy`.

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -194,7 +194,8 @@ If the raw arguments contain a PR number or URL:
 
 Mark Task 1 as `completed`.
 
-Tasks 2, 3, and 4 are independent — execute them in parallel.
+Tasks 2 and 3 are independent — execute them in parallel.
+Task 4 depends on Task 2 (needs the diff data) and will start after Task 2 completes.
 
 ### Phase 1a: Fetch PR Diff — Task 2
 
@@ -286,9 +287,9 @@ Mark Task 4 as `completed`.
 
 Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
 
-- **Task 5** — `superpowers:code-reviewer` — General code quality and maintainability
-- **Task 6** — `pr-review-toolkit:code-reviewer` — Project guidelines and style adherence
-- **Task 7** — `feature-dev:code-reviewer` — Bugs, logic errors, and security vulnerabilities
+- **Task 5** — `code-reviewer-quality` — General code quality and maintainability
+- **Task 6** — `code-reviewer-guidelines` — Project guidelines and style adherence
+- **Task 7** — `code-reviewer-security` — Bugs, logic errors, and security vulnerabilities
 
 Mark Tasks 5, 6, 7 as `in_progress` when spawning the agents.
 
@@ -301,8 +302,10 @@ Each agent should analyze for security, bugs, error handling, and performance is
 
 Mark each reviewer task as `completed` ONLY when its findings are fully received and stored.
 
-Async agent results surface automatically when complete — no polling needed.
-When a reviewer's result arrives, mark its task as `completed`.
+Async agent results surface automatically in the conversation when complete.
+Each reviewer's findings are delivered as its async result text — store them
+in the conversation context. Mark the reviewer's task as `completed` only
+after reading and storing its findings.
 Wait for ALL 3 results before proceeding.
 
 > 🚨 **DO NOT proceed to Phase 3 until ALL THREE reviewer tasks (5, 6, 7) are `completed`.**

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -288,11 +288,13 @@ Mark Task 4 as `completed`.
 Mark Tasks 5, 6, 7 as `in_progress`, then spawn ALL 3 review agents as async subagents
 with `taskId` linking each to its task:
 
+Use the actual task IDs returned by `TaskCreate` — do NOT hardcode IDs.
+
 ```text
 subagent(tasks=[
-  {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "5"},
-  {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "6"},
-  {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "7"},
+  {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "<actual task 5 ID>"},
+  {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "<actual task 6 ID>"},
+  {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "<actual task 7 ID>"},
 ])
 ```
 
@@ -304,7 +306,7 @@ Provide each agent with:
 Each agent should analyze for security, bugs, error handling, and performance issues
 and return their findings as prose.
 
-**After spawning, verify the response says "Async agent spawned" for all 3.**
+**After spawning, verify the response confirms all 3 agents were spawned.**
 If any spawn fails, STOP and report the error — do NOT continue waiting.
 
 **After spawning, your turn is DONE.** Do NOT poll, sleep, call TaskOutput,

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -285,26 +285,32 @@ Mark Task 4 as `completed`.
 
 ### Phase 2: Code Analysis — Tasks 5, 6, 7
 
-Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
+Mark Tasks 5, 6, 7 as `in_progress`, then spawn ALL 3 review agents as async subagents
+with `taskId` linking each to its task:
 
-- **Task 5** — `code-reviewer-quality`
-- **Task 6** — `code-reviewer-guidelines`
-- **Task 7** — `code-reviewer-security`
-
-Mark Tasks 5, 6, 7 as `in_progress` when spawning the agents.
+```text
+subagent(tasks=[
+  {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "5"},
+  {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "6"},
+  {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "7"},
+])
+```
 
 Provide each agent with:
 
 - The diff content from Phase 1a
 - The AGENTS.md content from Phase 1b (or "No AGENTS.md found" if empty)
 
-Each agent should analyze for security, bugs, error handling, and performance issues and return their findings as prose.
+Each agent should analyze for security, bugs, error handling, and performance issues
+and return their findings as prose.
 
-When each reviewer finishes, its task is auto-completed (see orchestrator rules on taskId).
+**After spawning, verify the response says "Async agent spawned" for all 3.**
+If any spawn fails, STOP and report the error — do NOT continue waiting.
+
+**After spawning, your turn is DONE.** Do NOT poll, sleep, call TaskOutput,
+or check status. Results arrive automatically as follow-up messages.
+When each reviewer finishes, its task is auto-completed via `taskId`.
 Task 8 (Merge findings) auto-unblocks when all 3 reviewer tasks complete.
-
-> 🚨 **DO NOT proceed to Phase 3 until ALL THREE reviewer tasks (5, 6, 7) are `completed`.**
-> Task 8 is blocked by Tasks 4, 5, 6, and 7 — this is enforced by `addBlockedBy`.
 
 ### Phase 3: Merge & Deduplicate Findings — Task 8
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -50,9 +50,89 @@ If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool ins
 - `/pr-review 123` - Review PR #123 in current repo
 - `/pr-review https://github.com/owner/repo/pull/123` - Review from URL
 
+## Task Plan
+
+Before starting any work, create ALL tasks upfront using `TaskCreate`, then set their dependencies
+using `TaskUpdate` with `addBlockedBy`. The task system enforces execution order — blocked tasks cannot start.
+
+### Task List
+
+| Task | Title | blockedBy |
+|------|-------|-----------|
+| 1 | PR Detection | — |
+| 2 | Fetch PR diff | 1 |
+| 3 | Fetch AGENTS.md | 1 |
+| 4 | Check past review comments | 1, 2 |
+| 5 | Review — Code Quality | 2, 3 |
+| 6 | Review — Guidelines | 2, 3 |
+| 7 | Review — Security | 2, 3 |
+| 8 | Merge & deduplicate findings | 4, 5, 6, 7 |
+| 9 | User selection | 8 |
+| 10 | Post comments | 9 |
+| 11 | Store comments | 10 |
+| 12 | Summary | 11 |
+
+### Dependency Graph
+
+```text
+Task 1 (PR Detection)
+ ├── Task 2 (Fetch diff) ─────────────┐
+ ├── Task 3 (Fetch AGENTS.md) ────────┤
+ │    Tasks 2+3 unblock:              │
+ │    ├── Task 5 (Review: Quality)    │
+ │    ├── Task 6 (Review: Guidelines) │
+ │    └── Task 7 (Review: Security)   │
+ └── Task 4 (Past comments) ──────────┤  (also needs Task 2)
+                                       ▼
+                            Task 8 (Merge findings)
+                                       │
+                            Task 9 (User selection)
+                                       │
+                            Task 10 (Post comments)
+                                       │
+                            Task 11 (Store comments)
+                                       │
+                            Task 12 (Summary)
+```
+
+Create all 12 tasks using `TaskCreate` NOW, before starting any work.
+Then IMMEDIATELY set dependencies using `TaskUpdate` with `addBlockedBy` for each task per the table above.
+
+`TaskCreate` does NOT accept `addBlockedBy` — dependencies MUST be set via `TaskUpdate` after creation.
+
+Example two-step flow:
+
+```text
+# Step 1: Create all tasks
+TaskCreate(subject="PR Detection", ...)          → Task 1
+TaskCreate(subject="Fetch PR diff", ...)          → Task 2
+TaskCreate(subject="Fetch AGENTS.md", ...)        → Task 3
+...all 12 tasks...
+
+# Step 2: Set dependencies
+TaskUpdate(taskId="2", addBlockedBy=["1"])
+TaskUpdate(taskId="3", addBlockedBy=["1"])
+TaskUpdate(taskId="4", addBlockedBy=["1", "2"])
+TaskUpdate(taskId="5", addBlockedBy=["2", "3"])
+TaskUpdate(taskId="6", addBlockedBy=["2", "3"])
+TaskUpdate(taskId="7", addBlockedBy=["2", "3"])
+TaskUpdate(taskId="8", addBlockedBy=["4", "5", "6", "7"])
+TaskUpdate(taskId="9", addBlockedBy=["8"])
+TaskUpdate(taskId="10", addBlockedBy=["9"])
+TaskUpdate(taskId="11", addBlockedBy=["10"])
+TaskUpdate(taskId="12", addBlockedBy=["11"])
+```
+
+> 🚨 **HARD RULE: NEVER start a task while its `blockedBy` tasks are incomplete.**
+> The task system enforces this via `addBlockedBy` — but even if you could bypass it, **DON'T**.
+> Posting comments from partial reviewer results is a **CRITICAL violation**.
+> ALL 3 reviewers (Tasks 5, 6, 7) MUST complete before merging findings (Task 8).
+
 ## Workflow
 
-### Phase 0: PR Detection (when no arguments provided)
+### Phase 0: PR Detection — Task 1
+
+Mark Task 1 as `in_progress`.
 
 If the raw arguments are empty:
 
@@ -110,9 +190,15 @@ If the raw arguments contain a PR number or URL:
      gh pr view {pr_number} --json headRefOid --jq '.headRefOid'
      ```
 
-1. Store `owner`, `repo`, `pr_number`, and `head_sha` — these are used by Phase 1c and Phase 4.
+1. Store `owner`, `repo`, `pr_number`, and `head_sha` — these are used by Phase 1c and Phase 5.
 
-### Phase 1a: Data Fetching
+Mark Task 1 as `completed`.
+
+Tasks 2, 3, and 4 are independent — execute them in parallel.
+
+### Phase 1a: Fetch PR Diff — Task 2
+
+Mark Task 2 as `in_progress`.
 
 Run the diff command to get PR data:
 
@@ -130,7 +216,11 @@ myk-pi-tools pr diff <raw_arguments>
 
 Store the JSON output containing metadata, diff, and files.
 
-### Phase 1b: Fetch AGENTS.md
+Mark Task 2 as `completed`.
+
+### Phase 1b: Fetch AGENTS.md — Task 3
+
+Mark Task 3 as `in_progress`.
 
 Run the claude-md command to get project rules:
 
@@ -148,7 +238,11 @@ myk-pi-tools pr claude-md <raw_arguments>
 
 Store the output as `claude_md_content`.
 
-### Phase 1c: Check Past Review Comments (MANDATORY)
+Mark Task 3 as `completed`.
+
+### Phase 1c: Check Past Review Comments — Task 4
+
+Mark Task 4 as `in_progress`.
 
 Fetch ALL human review threads (resolved + unresolved) from the PR:
 
@@ -169,7 +263,7 @@ Parse the JSON output. For the `human` list, categorize each thread:
 **Unresolved threads:**
 
 - These are still open — the PR author hasn't addressed them yet.
-- Include them in the findings presented to the user in Phase 3.
+- Include them in the findings presented to the user in Phase 4.
 - Mark as "⚠️ UNRESOLVED from previous review"
 
 **Resolved threads:**
@@ -183,16 +277,20 @@ Parse the JSON output. For the `human` list, categorize each thread:
     - Valid response (by design, wrong assumption, clarification) → mark as "✅ Resolved — response accepted"
     - Invalid/missing response → include in findings as "❌ Resolved without code change or valid response"
 
-**All past comment statuses are included in the combined findings in Phase 3 —
+**All past comment statuses are included in the combined findings in Phase 4 —
 not presented as a separate summary.**
 
-### Phase 2: Code Analysis
+Mark Task 4 as `completed`.
 
-Delegate to ALL 3 review agents IN PARALLEL (single message with 3 Task tool calls):
+### Phase 2: Code Analysis — Tasks 5, 6, 7
 
-- `superpowers:code-reviewer` - General code quality and maintainability
-- `pr-review-toolkit:code-reviewer` - Project guidelines and style adherence
-- `feature-dev:code-reviewer` - Bugs, logic errors, and security vulnerabilities
+Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
+
+- **Task 5** — `superpowers:code-reviewer` — General code quality and maintainability
+- **Task 6** — `pr-review-toolkit:code-reviewer` — Project guidelines and style adherence
+- **Task 7** — `feature-dev:code-reviewer` — Bugs, logic errors, and security vulnerabilities
+
+Mark Tasks 5, 6, 7 as `in_progress` when spawning the agents.
 
 Provide each agent with:
 
@@ -200,9 +298,27 @@ Provide each agent with:
 - The AGENTS.md content from Phase 1b (or "No AGENTS.md found" if empty)
 
 Each agent should analyze for security, bugs, error handling, and performance issues and return their findings as prose.
-Merge and deduplicate the findings from all 3 reviewers before proceeding.
 
-### Phase 3: User Selection
+Mark each reviewer task as `completed` ONLY when its findings are fully received and stored.
+
+Async agent results surface automatically when complete — no polling needed.
+When a reviewer's result arrives, mark its task as `completed`.
+Wait for ALL 3 results before proceeding.
+
+> 🚨 **DO NOT proceed to Phase 3 until ALL THREE reviewer tasks (5, 6, 7) are `completed`.**
+> Task 8 is blocked by Tasks 4, 5, 6, and 7 — this is enforced by `addBlockedBy`.
+
+### Phase 3: Merge & Deduplicate Findings — Task 8
+
+Mark Task 8 as `in_progress`.
+
+Merge and deduplicate the findings from all 3 reviewers AND the past review comment analysis from Task 4 into a single combined findings list.
+
+Mark Task 8 as `completed`.
+
+### Phase 4: User Selection — Task 9
+
+Mark Task 9 as `in_progress`.
 
 Present ALL findings to user in one combined list, grouped by severity (CRITICAL, WARNING, SUGGESTION).
 This includes:
@@ -223,7 +339,11 @@ Ask which to post:
 - 'none' = Skip posting
 - Specific numbers = Post only those
 
-### Phase 4: Post Comments
+Mark Task 9 as `completed`.
+
+### Phase 5: Post Comments — Task 10
+
+Mark Task 10 as `in_progress`.
 
 If user selected findings, create temp directory and write JSON to temp file:
 
@@ -237,7 +357,11 @@ Use the `owner`, `repo`, `pr_number`, and `head_sha` from Phase 0 or Phase 1a me
 myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} /tmp/pi-work/$(basename $PWD)/pr-review-comments.json
 ```
 
-### Phase 4b: Store Posted Comments (MANDATORY)
+Mark Task 10 as `completed`.
+
+### Phase 5b: Store Posted Comments — Task 11
+
+Mark Task 11 as `in_progress`.
 
 After posting comments, store them in the PR review database for future cycle tracking:
 
@@ -271,6 +395,12 @@ myk-pi-tools pr store-pr-review /tmp/pi-work/$(basename $PWD)/pr-review-store.js
 **This step is MANDATORY — never skip it.** The database is used by future `/pr-review`
 runs to track which comments were posted and verify they were addressed.
 
-### Phase 5: Summary
+Mark Task 11 as `completed`.
+
+### Phase 6: Summary — Task 12
+
+Mark Task 12 as `in_progress`.
 
 Display final summary with counts and links.
+
+Mark Task 12 as `completed`.

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -468,8 +468,13 @@ Check the poll RAW output (not the worker's summary — look for the exact JSON 
 
   **On exit, display the Remaining Findings Summary (MANDATORY):**
 
-  Parse the poll output for any unresolved sticky findings (findings that were skipped,
-  not addressed, or still pending). Display them in a table:
+  The `{"approved": true}` response does NOT contain finding details.
+  Instead, read the last saved reviews JSON file (`/tmp/pi-work/pr-{pr_number}-reviews.json`)
+  to get unresolved sticky findings (status = skipped, not_addressed, or pending).
+  If the JSON file was already deleted by `reviews store`, re-fetch with:
+  `myk-pi-tools reviews fetch`
+
+  Display remaining findings in a table:
 
   ```text
   🎉 {source} approved PR #{pr_number}. Auto loop complete.

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -469,10 +469,10 @@ Check the poll RAW output (not the worker's summary — look for the exact JSON 
   **On exit, display the Remaining Findings Summary (MANDATORY):**
 
   The `{"approved": true}` response does NOT contain finding details.
-  Instead, read the last saved reviews JSON file (`/tmp/pi-work/pr-{pr_number}-reviews.json`)
-  to get unresolved sticky findings (status = skipped, not_addressed, or pending).
+  Instead, read the last saved reviews JSON file — its path was in the
+  `metadata.json_path` field from the most recent `reviews fetch` or `reviews poll` output.
   If the JSON file was already deleted by `reviews store`, re-fetch with:
-  `myk-pi-tools reviews fetch`
+  `myk-pi-tools reviews fetch` (passing the same arguments used in Phase 1, if any)
 
   Display remaining findings in a table:
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -462,10 +462,31 @@ can continue working. When the result surfaces, process it:
 
 Check the poll RAW output (not the worker's summary — look for the exact JSON string):
 
-- If output contains the EXACT string `"approved": true`: **EXIT the loop**. Notify the user:
-  "🎉 All auto-approved reviewers approved this PR — no actionable comments. Auto loop complete."
+- If output contains the EXACT string `"approved": true`: **EXIT the loop**.
   **CRITICAL:** Only exit on the literal JSON `{"approved": true}` from the CLI output.
   Do NOT exit because the worker says "approved" or "0 comments" in its summary.
+
+  **On exit, display the Remaining Findings Summary (MANDATORY):**
+
+  Parse the poll output for any unresolved sticky findings (findings that were skipped,
+  not addressed, or still pending). Display them in a table:
+
+  ```text
+  🎉 {source} approved PR #{pr_number}. Auto loop complete.
+
+  ## Remaining Findings ({count})
+
+  | # | Type | File | Finding | Why remaining |
+  |---|------|------|---------|---------------|
+  | 1 | Bug | path/to/file.py:17 | Finding title | Skipped — reason from the reply |
+  ```
+
+  - Show EVERY unresolved finding — skipped, not_addressed, or stale sticky
+  - **Type** = the finding type (Bug, Requirement gap, Rule violation, etc.)
+  - **Finding** = the finding title (bold text from the body)
+  - **Why remaining** = the status + reason (from the reply field)
+  - If zero remaining findings: show `## Remaining Findings (0)` with "All findings resolved."
+  - This is the ONLY user-facing output on exit — no per-cycle summaries, no fix history
 - If **new comments found from auto-approved sources**: Run Phases 2-8 again with
   auto-approve behavior for the relevant sources.
   After completing, spawn another async worker (go to 9a+9b again).
@@ -525,5 +546,5 @@ Each cycle displays a status update so the user knows the loop is active:
 [auto] Found {N} new comments — processing...
 [auto] No new comments. Next check in 5 minutes...
 [auto] CodeRabbit rate-limited. Handling automatically via reviews poll --source coderabbit...
-[auto] 🎉 All auto-approved reviewers approved! No actionable comments. Loop complete.
+[auto] 🎉 {source} approved PR #{pr_number}. Displaying remaining findings summary.
 ```

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -19,17 +19,75 @@ $ARGUMENTS
 
 Review uncommitted changes or changes compared to a specified branch.
 
-**MANDATORY: This command MUST use 3 review agents in parallel via Task tool.**
-
 ## Usage
 
 - `/review-local` - Review uncommitted changes (staged + unstaged)
 - `/review-local main` - Review changes compared to main branch
 - `/review-local feature/branch` - Review changes compared to specified branch
 
+## Task Plan
+
+Before starting any work, create ALL tasks upfront using `TaskCreate`, then set their dependencies
+using `TaskUpdate` with `addBlockedBy`. The task system enforces execution order — blocked tasks cannot start.
+
+### Task List
+
+| Task | Title | blockedBy |
+|------|-------|-----------|
+| 1 | Get diff | — |
+| 2 | Review — Code Quality | 1 |
+| 3 | Review — Guidelines | 1 |
+| 4 | Review — Security | 1 |
+| 5 | Merge & deduplicate findings | 2, 3, 4 |
+| 6 | Present review | 5 |
+
+### Dependency Graph
+
+```text
+Task 1 (Get diff)
+ ├── Task 2 (Review: Code Quality)  ──┐
+ ├── Task 3 (Review: Guidelines)    ──┤
+ └── Task 4 (Review: Security)      ──┤
+                                       ▼
+                            Task 5 (Merge findings)
+                                       │
+                            Task 6 (Present review)
+```
+
+Create all 6 tasks using `TaskCreate` NOW, before starting any work.
+Then IMMEDIATELY set dependencies using `TaskUpdate` with `addBlockedBy` for each task per the table above.
+
+`TaskCreate` does NOT accept `addBlockedBy` — dependencies MUST be set via `TaskUpdate` after creation.
+
+Example two-step flow:
+
+```text
+# Step 1: Create all tasks
+TaskCreate(subject="Get diff", ...)                    → Task 1
+TaskCreate(subject="Review — Code Quality", ...)       → Task 2
+TaskCreate(subject="Review — Guidelines", ...)         → Task 3
+TaskCreate(subject="Review — Security", ...)           → Task 4
+TaskCreate(subject="Merge & deduplicate findings", ...)→ Task 5
+TaskCreate(subject="Present review", ...)              → Task 6
+
+# Step 2: Set dependencies
+TaskUpdate(taskId="2", addBlockedBy=["1"])
+TaskUpdate(taskId="3", addBlockedBy=["1"])
+TaskUpdate(taskId="4", addBlockedBy=["1"])
+TaskUpdate(taskId="5", addBlockedBy=["2", "3", "4"])
+TaskUpdate(taskId="6", addBlockedBy=["5"])
+```
+
+> 🚨 **HARD RULE: NEVER start a task while its `blockedBy` tasks are incomplete.**
+> The task system enforces this via `addBlockedBy` — but even if you could bypass it, **DON'T**.
+> Merging findings from partial reviewer results is a **CRITICAL violation**.
+> ALL 3 reviewers (Tasks 2, 3, 4) MUST complete before merging findings (Task 5).
+
 ## Workflow
 
-### Step 1: Get the diff
+### Phase 1: Get Diff — Task 1
+
+Mark Task 1 as `in_progress`.
 
 **If the raw arguments are not empty:**
 
@@ -47,15 +105,19 @@ Get all uncommitted changes (staged + unstaged):
 git diff HEAD
 ```
 
-### Step 2: Route to review agents (MANDATORY)
+Mark Task 1 as `completed`.
 
-**CRITICAL: You MUST use the Task tool to call ALL 3 review agents IN PARALLEL (single message):**
+### Phase 2: Code Analysis — Tasks 2, 3, 4
 
-- `superpowers:code-reviewer` - General code quality and maintainability
-- `pr-review-toolkit:code-reviewer` - Project guidelines and style adherence
-- `feature-dev:code-reviewer` - Bugs, logic errors, and security vulnerabilities
+Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
 
-Delegate to all 3 with the diff and ask them to analyze for:
+- **Task 2** — `superpowers:code-reviewer` — General code quality and maintainability
+- **Task 3** — `pr-review-toolkit:code-reviewer` — Project guidelines and style adherence
+- **Task 4** — `feature-dev:code-reviewer` — Bugs, logic errors, and security vulnerabilities
+
+Mark Tasks 2, 3, 4 as `in_progress` when spawning the agents.
+
+Provide each agent with the diff content from Phase 1 and ask them to analyze for:
 
 1. Code quality and best practices
 2. Potential bugs or logic errors
@@ -66,10 +128,31 @@ Delegate to all 3 with the diff and ask them to analyze for:
 7. Code duplication
 8. Suggestions for improvement
 
-### Step 3: Present the review
+Mark each reviewer task as `completed` ONLY when its findings are fully received and stored.
 
-Merge and deduplicate findings from all 3 reviewers. Display grouped by:
+Async agent results surface automatically when complete — no polling needed.
+When a reviewer's result arrives, mark its task as `completed`.
+Wait for ALL 3 results before proceeding.
 
-- Critical issues (must fix)
-- Warnings (should fix)
-- Suggestions (nice to have)
+> 🚨 **DO NOT proceed to Phase 3 until ALL THREE reviewer tasks (2, 3, 4) are `completed`.**
+> Task 5 is blocked by Tasks 2, 3, and 4 — this is enforced by `addBlockedBy`.
+
+### Phase 3: Merge & Deduplicate Findings — Task 5
+
+Mark Task 5 as `in_progress`.
+
+Merge and deduplicate the findings from all 3 reviewers into a single combined findings list.
+
+Mark Task 5 as `completed`.
+
+### Phase 4: Present Review — Task 6
+
+Mark Task 6 as `in_progress`.
+
+Display findings grouped by severity:
+
+- **Critical issues** (must fix)
+- **Warnings** (should fix)
+- **Suggestions** (nice to have)
+
+Mark Task 6 as `completed`.

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -110,13 +110,14 @@ Mark Task 1 as `completed`.
 ### Phase 2: Code Analysis — Tasks 2, 3, 4
 
 Mark Tasks 2, 3, 4 as `in_progress`, then spawn ALL 3 review agents as async subagents
-with `taskId` linking each to its task:
+with `taskId` linking each to its task.
+Use the actual task IDs returned by `TaskCreate` — do NOT hardcode IDs.
 
 ```text
 subagent(tasks=[
-  {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "2"},
-  {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "3"},
-  {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "4"},
+  {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "<actual task 2 ID>"},
+  {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "<actual task 3 ID>"},
+  {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "<actual task 4 ID>"},
 ])
 ```
 
@@ -131,7 +132,7 @@ Provide each agent with the diff content from Phase 1 and ask them to analyze fo
 7. Code duplication
 8. Suggestions for improvement
 
-**After spawning, verify the response says "Async agent spawned" for all 3.**
+**After spawning, verify the response confirms all 3 agents were spawned.**
 If any spawn fails, STOP and report the error — do NOT continue waiting.
 
 **After spawning, your turn is DONE.** Do NOT poll, sleep, call TaskOutput,

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -111,9 +111,9 @@ Mark Task 1 as `completed`.
 
 Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
 
-- **Task 2** — `superpowers:code-reviewer` — General code quality and maintainability
-- **Task 3** — `pr-review-toolkit:code-reviewer` — Project guidelines and style adherence
-- **Task 4** — `feature-dev:code-reviewer` — Bugs, logic errors, and security vulnerabilities
+- **Task 2** — `code-reviewer-quality` — General code quality and maintainability
+- **Task 3** — `code-reviewer-guidelines` — Project guidelines and style adherence
+- **Task 4** — `code-reviewer-security` — Bugs, logic errors, and security vulnerabilities
 
 Mark Tasks 2, 3, 4 as `in_progress` when spawning the agents.
 

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -111,9 +111,9 @@ Mark Task 1 as `completed`.
 
 Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
 
-- **Task 2** — `code-reviewer-quality` — General code quality and maintainability
-- **Task 3** — `code-reviewer-guidelines` — Project guidelines and style adherence
-- **Task 4** — `code-reviewer-security` — Bugs, logic errors, and security vulnerabilities
+- **Task 2** — `code-reviewer-quality`
+- **Task 3** — `code-reviewer-guidelines`
+- **Task 4** — `code-reviewer-security`
 
 Mark Tasks 2, 3, 4 as `in_progress` when spawning the agents.
 
@@ -128,11 +128,8 @@ Provide each agent with the diff content from Phase 1 and ask them to analyze fo
 7. Code duplication
 8. Suggestions for improvement
 
-Mark each reviewer task as `completed` ONLY when its findings are fully received and stored.
-
-Async agent results surface automatically when complete — no polling needed.
-When a reviewer's result arrives, mark its task as `completed`.
-Wait for ALL 3 results before proceeding.
+When each reviewer finishes, its task is auto-completed (see orchestrator rules on taskId).
+Task 5 (Merge findings) auto-unblocks when all 3 reviewer tasks complete.
 
 > 🚨 **DO NOT proceed to Phase 3 until ALL THREE reviewer tasks (2, 3, 4) are `completed`.**
 > Task 5 is blocked by Tasks 2, 3, and 4 — this is enforced by `addBlockedBy`.

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -109,13 +109,16 @@ Mark Task 1 as `completed`.
 
 ### Phase 2: Code Analysis — Tasks 2, 3, 4
 
-Spawn ALL 3 review agents as async subagents. Each reviewer is its own task:
+Mark Tasks 2, 3, 4 as `in_progress`, then spawn ALL 3 review agents as async subagents
+with `taskId` linking each to its task:
 
-- **Task 2** — `code-reviewer-quality`
-- **Task 3** — `code-reviewer-guidelines`
-- **Task 4** — `code-reviewer-security`
-
-Mark Tasks 2, 3, 4 as `in_progress` when spawning the agents.
+```text
+subagent(tasks=[
+  {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "2"},
+  {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "3"},
+  {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "4"},
+])
+```
 
 Provide each agent with the diff content from Phase 1 and ask them to analyze for:
 
@@ -128,11 +131,13 @@ Provide each agent with the diff content from Phase 1 and ask them to analyze fo
 7. Code duplication
 8. Suggestions for improvement
 
-When each reviewer finishes, its task is auto-completed (see orchestrator rules on taskId).
-Task 5 (Merge findings) auto-unblocks when all 3 reviewer tasks complete.
+**After spawning, verify the response says "Async agent spawned" for all 3.**
+If any spawn fails, STOP and report the error — do NOT continue waiting.
 
-> 🚨 **DO NOT proceed to Phase 3 until ALL THREE reviewer tasks (2, 3, 4) are `completed`.**
-> Task 5 is blocked by Tasks 2, 3, and 4 — this is enforced by `addBlockedBy`.
+**After spawning, your turn is DONE.** Do NOT poll, sleep, call TaskOutput,
+or check status. Results arrive automatically as follow-up messages.
+When each reviewer finishes, its task is auto-completed via `taskId`.
+Task 5 (Merge findings) auto-unblocks when all 3 reviewer tasks complete.
 
 ### Phase 3: Merge & Deduplicate Findings — Task 5
 

--- a/rules/60-task-tracking.md
+++ b/rules/60-task-tracking.md
@@ -93,3 +93,39 @@ Task tracking works alongside — not instead of — existing workflow rules:
 - **Tasks are code-enforced** — the extension injects reminders if you ignore tasks for 4+ turns
 - **Never abandon tasks** — if scope changes, use `TaskUpdate` with `status: "deleted"` to remove obsolete tasks
 - **The task list is your contract** — complete every task or explicitly remove it
+
+---
+
+## Async Agent taskId (MANDATORY — code-enforced)
+
+**Every async agent call MUST include `taskId`.** This is enforced by the subagent tool —
+calls without `taskId` are rejected.
+
+- If the agent is working on a task: pass the task ID (e.g., `taskId: "5"`)
+- If the agent is NOT linked to any task: pass `taskId: "-1"`
+
+When `taskId` is a real task ID, the task auto-completes when the agent finishes successfully.
+No manual `TaskUpdate` needed — the system handles it.
+
+```text
+# Async agent linked to task 5 — auto-completes on success
+subagent(agent="code-reviewer-quality", task="...", cwd="...", async=true, name="Review Quality", taskId="5")
+
+# Async agent NOT linked to any task
+subagent(agent="worker", task="...", cwd="...", async=true, name="Qodo Poll", taskId="-1")
+
+# Parallel async agents linked to tasks
+subagent(tasks=[
+  {agent: "code-reviewer-quality", task: "...", cwd: "...", name: "Review Quality", taskId: "5"},
+  {agent: "code-reviewer-guidelines", task: "...", cwd: "...", name: "Review Guidelines", taskId: "6"},
+  {agent: "code-reviewer-security", task: "...", cwd: "...", name: "Review Security", taskId: "7"},
+])
+```
+
+**Rules:**
+
+- ✅ **ALWAYS** pass `taskId` — the tool rejects async calls without it
+- ✅ Pass `"-1"` when the agent is not linked to any task
+- ✅ The task auto-completes on success, stays `in_progress` on failure
+- ❌ **NEVER** manually `TaskUpdate` a task to `completed` if it has an async agent — the agent handles it
+- ❌ **NEVER** omit `taskId` — the call will fail with a clear error


### PR DESCRIPTION
## Summary

Fixes the AI posting review comments before all reviewers finish, and makes reviewer agents self-sufficient in reading project guidelines.

## Changes

### Prompts (`pr-review.md`, `review-local.md`)
- Restructure to use `TaskCreate` + `TaskUpdate(addBlockedBy)` dependencies
- Each reviewer is its own task, merge task blocked by all 3
- Prevents posting comments before all reviewers finish
- Two-step create→update flow (`TaskCreate` doesn't accept `addBlockedBy`)
- Explicit task lifecycle markers (in_progress/completed) per phase
- Task dependency table and graph as visual reference

### Agents (all 3 `code-reviewer-*` agents)
- Add mandatory "Project Guidelines" section to independently read AGENTS.md/CLAUDE.md
- AGENTS.md takes precedence — only fall back to CLAUDE.md if AGENTS.md doesn't exist
- No longer depends on calling prompt to provide guidelines

Closes #486