### PR TITLE
refactor: migrate temp files to /tmp/pi-data/<project>/, clone repo for PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ docker run --rm -it \
   -v "$HOME/.ssh":"$HOME/.ssh":ro \
   -v "$HOME/.config/gh":"$HOME/.config/gh":ro \
   -v /tmp/pi-work:/tmp/pi-work:rw \
+  -v /tmp/pi-data:/tmp/pi-data:rw \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest
 ```
@@ -486,6 +487,7 @@ PI_PIDIFF_ENABLE=false pi
 | `-v "$HOME/.coderabbit":"$HOME/.coderabbit":rw` | CodeRabbit CLI auth and review data |
 | `-v "$HOME/screenshots":"$HOME/screenshots"` | Share screenshots/images with the agent |
 | `-v /tmp/pi-work:/tmp/pi-work:rw` | Persistent temp files (survives container restarts) |
+| `-v /tmp/pi-data:/tmp/pi-data:rw` | Project-scoped temp files (reviews, releases, async agents) |
 | `-v /var/run/docker.sock:/var/run/docker.sock:ro` + `--group-add $(stat -c '%g' /var/run/docker.sock)` | Docker container inspection via `docker-safe` |
 | `-v /var/run/podman/podman.sock:/var/run/podman/podman.sock:ro` | Podman container inspection via `docker-safe` |
 
@@ -554,6 +556,7 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro \
   -v "$HOME/screenshots":"$HOME/screenshots":ro \
   -v /tmp/pi-work:/tmp/pi-work:rw \
+  -v /tmp/pi-data:/tmp/pi-data:rw \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --group-add $(stat -c '%g' /var/run/docker.sock) \
   -w "$PWD" \

--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@ docker run --rm -it \
   -v "$HOME/.gitignore-global":"$HOME/.gitignore-global":ro \
   -v "$HOME/.ssh":"$HOME/.ssh":ro \
   -v "$HOME/.config/gh":"$HOME/.config/gh":ro \
-  -v /tmp/pi-work:/tmp/pi-work:rw \
   -v /tmp/pi-data:/tmp/pi-data:rw \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest
@@ -486,7 +485,6 @@ PI_PIDIFF_ENABLE=false pi
 | `-v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro` | GitLab CLI config (auth tokens, host settings) |
 | `-v "$HOME/.coderabbit":"$HOME/.coderabbit":rw` | CodeRabbit CLI auth and review data |
 | `-v "$HOME/screenshots":"$HOME/screenshots"` | Share screenshots/images with the agent |
-| `-v /tmp/pi-work:/tmp/pi-work:rw` | Persistent temp files (survives container restarts) |
 | `-v /tmp/pi-data:/tmp/pi-data:rw` | Project-scoped temp files (reviews, releases, async agents) |
 | `-v /var/run/docker.sock:/var/run/docker.sock:ro` + `--group-add $(stat -c '%g' /var/run/docker.sock)` | Docker container inspection via `docker-safe` |
 | `-v /var/run/podman/podman.sock:/var/run/podman/podman.sock:ro` | Podman container inspection via `docker-safe` |
@@ -555,7 +553,6 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.config/cursor/auth.json":"$HOME/.config/cursor/auth.json":ro \
   -v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro \
   -v "$HOME/screenshots":"$HOME/screenshots":ro \
-  -v /tmp/pi-work:/tmp/pi-work:rw \
   -v /tmp/pi-data:/tmp/pi-data:rw \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --group-add $(stat -c '%g' /var/run/docker.sock) \

--- a/agents/security-auditor.md
+++ b/agents/security-auditor.md
@@ -13,7 +13,7 @@ You are NOT reviewing our own code. You are evaluating a third-party repo we are
 
 ## Audit Process
 
-1. **Clone the repo** (if not already cloned) to `/tmp/pi-work/` with `--depth 1`
+1. **Clone the repo** (if not already cloned) to `${PROJECT_TMP_DIR}/` with `--depth 1`
 2. **Run all audit categories** below systematically
 3. **Produce a structured report** with findings, severity, and a final verdict
 

--- a/extensions/image-gen/image-gen.ts
+++ b/extensions/image-gen/image-gen.ts
@@ -10,6 +10,7 @@
 import { Type } from "typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -95,7 +96,7 @@ function getExtensionForMime(mimeType: string): string {
 // Same logic as getProjectTmpDir in extensions/orchestrator/utils.ts
 function getTempDir(cwd: string): string {
     const project = cwd.replace(/^[\/\\]/, "").replace(/[\/\\]/g, "__");
-    const dir = path.join("/tmp/pi-data", project);
+    const dir = path.join(os.tmpdir(), "pi-data", project);
     fs.mkdirSync(dir, { recursive: true });
     return dir;
 }

--- a/extensions/image-gen/image-gen.ts
+++ b/extensions/image-gen/image-gen.ts
@@ -93,8 +93,8 @@ function getExtensionForMime(mimeType: string): string {
 }
 
 function getTempDir(cwd: string): string {
-    const basename = path.basename(cwd);
-    const dir = path.join("/tmp/pi-work", basename);
+    const project = cwd.replace(/^\//, "").replace(/\//g, "__");
+    const dir = path.join("/tmp/pi-data", project);
     fs.mkdirSync(dir, { recursive: true });
     return dir;
 }

--- a/extensions/image-gen/image-gen.ts
+++ b/extensions/image-gen/image-gen.ts
@@ -92,8 +92,9 @@ function getExtensionForMime(mimeType: string): string {
     return map[mimeType] ?? "png";
 }
 
+// Same logic as getProjectTmpDir in extensions/orchestrator/utils.ts
 function getTempDir(cwd: string): string {
-    const project = cwd.replace(/^\//, "").replace(/\//g, "__");
+    const project = cwd.replace(/^[\/\\]/, "").replace(/[\/\\]/g, "__");
     const dir = path.join("/tmp/pi-data", project);
     fs.mkdirSync(dir, { recursive: true });
     return dir;

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -542,6 +542,8 @@ export function registerAsyncAgents(
 
     // Set project-scoped dir first (getProjectTmpDir creates it if missing)
     PROJECT_TMP_DIR = getProjectTmpDir(ctx.cwd);
+    // Export as env var so prompts/CLI commands can reference it
+    process.env.PROJECT_TMP_DIR = PROJECT_TMP_DIR;
 
     // Set results dir — PID-scoped under project dir
     ASYNC_RESULTS_DIR = path.join(PROJECT_TMP_DIR, sessionResultsDirName());

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -59,6 +59,7 @@ export interface AsyncJob {
   groupId?: string;
   taskId?: string;
   cwd?: string;
+  projectCwd?: string;
   sessionId?: string;
 }
 
@@ -277,7 +278,7 @@ export function registerAsyncAgents(
       // Auto-complete linked task directly in the store file (no AI involvement)
       if (j.taskId && j.taskId !== "-1" && j.status === "complete" && j.cwd) {
         try {
-          const completed = await autoCompleteTask(j.taskId, j.cwd, j.sessionId);
+          const completed = await autoCompleteTask(j.taskId, j.projectCwd || j.cwd, j.sessionId);
           asyncLog(`auto-completed task #${j.taskId}: ${completed}`);
         } catch (e: any) {
           autoCompleteError = `\n\n⚠️ Failed to auto-complete task #${j.taskId}: ${e?.message}. Run TaskUpdate(taskId="${j.taskId}", status="completed") manually.`;
@@ -355,7 +356,7 @@ export function registerAsyncAgents(
         // Auto-complete linked task directly in the store file (no AI involvement)
         if (job.taskId && job.taskId !== "-1" && data.success && job.cwd) {
           try {
-            const completed = await autoCompleteTask(job.taskId, job.cwd, job.sessionId);
+            const completed = await autoCompleteTask(job.taskId, job.projectCwd || job.cwd, job.sessionId);
             asyncLog(`auto-completed task #${job.taskId}: ${completed}`);
           } catch (e: any) {
             autoCompleteError = `\n\n⚠️ Failed to auto-complete task #${job.taskId}: ${e?.message}. Run TaskUpdate(taskId="${job.taskId}", status="completed") manually.`;
@@ -433,6 +434,7 @@ export function registerAsyncAgents(
       parentStartTime,
       taskId: options?.taskId || null,
       cwd,
+      projectCwd: asyncState.lastCtx?.sessionManager?.getCwd?.() || null,
       sessionId: asyncState.lastCtx?.sessionManager?.getSessionId?.() || null,
     }), { mode: 0o600 });
 
@@ -523,6 +525,7 @@ export function registerAsyncAgents(
       groupId: options?.groupId,
       taskId: options?.taskId,
       cwd,
+      projectCwd: asyncState.lastCtx?.sessionManager?.getCwd?.(),
       sessionId: asyncState.lastCtx?.sessionManager?.getSessionId?.(),
     };
     asyncState.jobs.set(id, job);
@@ -618,6 +621,7 @@ export function registerAsyncAgents(
             fireAndForget: marker.fireAndForget || false,
             taskId: marker.taskId || undefined,
             cwd: marker.cwd || undefined,
+            projectCwd: marker.projectCwd || undefined,
             sessionId: marker.sessionId || undefined,
           };
           asyncState.jobs.set(id, job);

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -357,7 +357,6 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       return {
         block: true,
         reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (where PROJECT_TMP_DIR is from getProjectTmpDir)`,
-
       };
     }
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -353,7 +353,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     // Enforce temp files go to /tmp/pi-data/ — not bare /tmp/
     // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
-    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command)) {
+    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
       return {
         block: true,
         reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (where PROJECT_TMP_DIR is from getProjectTmpDir)`,

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -353,7 +353,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     // Enforce temp files go to /tmp/pi-data/ — not bare /tmp/
     // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
-    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
+    if (/(?:^|[;&|]\s*)mktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
       return {
         block: true,
         reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (where PROJECT_TMP_DIR is from getProjectTmpDir)`,

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -378,3 +378,5 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     return undefined;
   });
 }
+
+// trigger re-scan

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -351,12 +351,13 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       }
     }
 
-    // Enforce temp files go to /tmp/pi-work/ — not bare /tmp/
+    // Enforce temp files go to /tmp/pi-data/ or /tmp/pi-work/ — not bare /tmp/
     // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
-    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-work/.test(command)) {
+    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-(work|data)/.test(command)) {
       return {
         block: true,
-        reason: `⛔ mktemp must use /tmp/pi-work/$(basename $PWD)/ prefix. Use: mktemp /tmp/pi-work/$(basename $PWD)/XXXXXX`,
+        reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (where PROJECT_TMP_DIR is from getProjectTmpDir)`,
+
       };
     }
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -353,7 +353,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     // Enforce temp files go to /tmp/pi-data/ — not bare /tmp/
     // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
-    if (/(?:^|[;&|]\s*)mktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
+    if (/(?:^|[;&|$( \t])mktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
       return {
         block: true,
         reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (where PROJECT_TMP_DIR is from getProjectTmpDir)`,

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -351,9 +351,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       }
     }
 
-    // Enforce temp files go to /tmp/pi-data/ or /tmp/pi-work/ — not bare /tmp/
+    // Enforce temp files go to /tmp/pi-data/ — not bare /tmp/
     // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
-    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-(work|data)/.test(command)) {
+    if (/\bmktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command)) {
       return {
         block: true,
         reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (where PROJECT_TMP_DIR is from getProjectTmpDir)`,

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -580,7 +580,7 @@ export function registerSubagentTool(
       "For multi-step workflows, use chain mode with {previous} placeholder.",
       "Set async: true when you don't need the result immediately for your next step. The result will surface automatically when complete. Use sync (default) only when the next step depends on this agent's output.",
       "ALWAYS use async: true for independent tasks that can run in parallel — code reviews, opening issues, research, analysis. Only use sync when the very next step depends on this agent's output (e.g., chain where step 2 needs step 1's result).",
-      "ALWAYS pass cwd — use the project directory for current repo work, or the target path for external repos (e.g., /tmp/pi-work/...).",
+      "ALWAYS pass cwd — use the project directory for current repo work, or the target path for external repos (e.g., ${PROJECT_TMP_DIR}/...).",
       "ALWAYS provide estimatedSeconds for sync agents. If estimated time is 30 seconds or more, you MUST use async: true instead.",
     ],
     parameters: SubagentParams,
@@ -748,7 +748,7 @@ export function registerSubagentTool(
           }
           for (const t of params.tasks) {
             const tid = (t as any).taskId as string;
-            const taskErr = validateTaskId(tid, t.cwd, ctx.sessionManager?.getSessionId?.());
+            const taskErr = validateTaskId(tid, ctx.cwd, ctx.sessionManager?.getSessionId?.());
             if (taskErr) {
               pi.sendMessage({
                 customType: "subagent-taskid-error",
@@ -832,7 +832,7 @@ export function registerSubagentTool(
           };
         }
         {
-          const taskErr = validateTaskId(params.taskId, params.cwd, ctx.sessionManager?.getSessionId?.());
+          const taskErr = validateTaskId(params.taskId, ctx.cwd, ctx.sessionManager?.getSessionId?.());
           if (taskErr) {
             pi.sendMessage({
               customType: "subagent-taskid-error",

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -10,7 +10,7 @@ if [ "$(id -u)" != "0" ]; then
         exec sudo --preserve-env "$0" "$@"
     fi
     # No PI_HOST_USER and no docker socket — skip root setup, run entrypoint directly as node
-    for d in /tmp/pi-work /tmp/pi-data; do
+    for d in /tmp/pi-data; do
         if ! mkdir -p "$d" 2>/dev/null; then
             echo "WARNING: failed to create $d — temp files may fail. Fix with: sudo mkdir -p $d && sudo chown $(id -u):$(id -g) $d" >&2
         elif _probe="$d/.pi-probe-$$" && ! touch "$_probe" 2>/dev/null; then
@@ -93,7 +93,7 @@ if [ -S "$DOCKER_SOCK" ]; then
 fi
 
 # Ensure temp dirs exist and are owned by node (not root)
-for d in /tmp/pi-work /tmp/pi-data; do
+for d in /tmp/pi-data; do
     # Refuse to operate on symlinks — prevents chown escape
     if [ -L "$d" ]; then
         echo "WARNING: $d is a symlink — removing to prevent chown escape" >&2

--- a/myk_pi_tools/reviews/commands.py
+++ b/myk_pi_tools/reviews/commands.py
@@ -16,20 +16,21 @@ def reviews() -> None:
     "--include-resolved", is_flag=True, default=False, help="Include resolved threads (with is_resolved field)"
 )
 @click.option("--user", default=None, help="Filter threads by author username")
-def reviews_fetch(review_url: str, include_resolved: bool, user: str | None) -> None:
+@click.option("--output-dir", required=True, help="Directory for output JSON file")
+def reviews_fetch(review_url: str, include_resolved: bool, user: str | None, output_dir: str) -> None:
     """Fetch review threads from current PR.
 
     Fetches review threads from the current branch's PR
     and categorizes them by source (human, qodo, coderabbit).
 
-    Saves output to /tmp/pi-work/pr-<number>-reviews.json
+    Saves output to <output-dir>/pr-<number>-reviews.json
 
     REVIEW_URL: Optional specific review URL for context
     (e.g., #pullrequestreview-XXX or #discussion_rXXX)
     """
     from myk_pi_tools.reviews.fetch import run
 
-    exit_code = run(review_url, include_resolved=include_resolved, user=user)
+    exit_code = run(review_url, include_resolved=include_resolved, user=user, output_dir=output_dir)
     sys.exit(exit_code)
 
 
@@ -41,7 +42,8 @@ def reviews_fetch(review_url: str, include_resolved: bool, user: str | None) -> 
     default="coderabbit",
     help="Which reviewer to poll for (default: coderabbit)",
 )
-def reviews_poll(review_url: str, source: str) -> None:
+@click.option("--output-dir", required=True, help="Directory for output JSON file")
+def reviews_poll(review_url: str, source: str, output_dir: str) -> None:
     """Poll for reviews until new actionable comments appear.
 
     Loops internally until something actionable happens, then returns
@@ -55,7 +57,7 @@ def reviews_poll(review_url: str, source: str) -> None:
     """
     from myk_pi_tools.reviews.poll import run
 
-    exit_code = run(review_url, source=source)
+    exit_code = run(review_url, source=source, output_dir=output_dir)
     sys.exit(exit_code)
 
 
@@ -78,17 +80,18 @@ def reviews_post(json_path: str) -> None:
 
 @reviews.command("pending-fetch")
 @click.argument("pr_url")
-def reviews_pending_fetch(pr_url: str) -> None:
+@click.option("--output-dir", required=True, help="Directory for output JSON file")
+def reviews_pending_fetch(pr_url: str, output_dir: str) -> None:
     """Fetch pending review comments from a PR.
 
     Fetches the authenticated user's PENDING review and its comments
-    from a GitHub PR. Saves output to /tmp/pi-work/pr-<number>-pending-review.json
+    from a GitHub PR. Saves output to <output-dir>/pr-<number>-pending-review.json
 
     PR_URL: GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)
     """
     from myk_pi_tools.reviews.pending_fetch import run
 
-    exit_code = run(pr_url)
+    exit_code = run(pr_url, output_dir=output_dir)
     sys.exit(exit_code)
 
 
@@ -111,7 +114,8 @@ def reviews_pending_update(json_path: str, submit: bool) -> None:  # noqa: FBT00
 
 @reviews.command("status")
 @click.option("--pr", type=int, default=None, help="PR number (default: auto-detect from current branch)")
-def reviews_status(pr: int | None) -> None:
+@click.option("--output-dir", required=True, help="Directory for output HTML report")
+def reviews_status(pr: int | None, output_dir: str) -> None:
     """Show review status for current PR.
 
     Queries the reviews database and displays all comments across all
@@ -119,7 +123,7 @@ def reviews_status(pr: int | None) -> None:
     """
     from myk_pi_tools.reviews.status import run
 
-    run(pr_number=pr)
+    run(pr_number=pr, output_dir=output_dir)
 
 
 @reviews.command("store")

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -4,7 +4,7 @@ This module fetches review threads from the current branch's PR
 (supports resolved/unresolved filtering and user filtering).
 and categorizes them by source (human, qodo, coderabbit).
 
-Output: JSON with metadata and categorized comments saved to /tmp/pi-work/pr-<number>-reviews.json
+Output: JSON with metadata and categorized comments saved to <output_dir>/pr-<number>-reviews.json
 """
 
 from __future__ import annotations
@@ -1025,13 +1025,14 @@ def fetch_review_body(owner: str, repo: str, pr_number: str, review_id: str) -> 
     return result if isinstance(result, dict) else None
 
 
-def run(review_url: str = "", include_resolved: bool = False, user: str | None = None) -> int:
+def run(review_url: str = "", include_resolved: bool = False, user: str | None = None, *, output_dir: str) -> int:
     """Main entry point.
 
     Args:
         review_url: Optional specific review URL for context.
         include_resolved: If True, include resolved threads with is_resolved field.
         user: If set, only return threads where the first comment author matches.
+        output_dir: Directory for output JSON file.
 
     Returns:
         Exit code (0 for success, 1 for error).
@@ -1046,13 +1047,8 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         print_stderr(f"Repository: {owner}/{repo}, PR: {pr_number}")
 
         # Ensure output directory exists
-        tmp_base = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
-        out_dir = tmp_base / "pi-work"
+        out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-        try:
-            out_dir.chmod(0o700)
-        except OSError as e:
-            print_stderr(f"Warning: unable to set permissions on {out_dir}: {e}")
 
         json_path = out_dir / f"pr-{pr_number}-reviews.json"
 

--- a/myk_pi_tools/reviews/pending_fetch.py
+++ b/myk_pi_tools/reviews/pending_fetch.py
@@ -3,7 +3,7 @@
 This module fetches the current user's PENDING review on a PR, retrieves all
 comments within that review, and outputs them as JSON for refinement.
 
-Output: JSON with metadata and comments saved to /tmp/pi-work/pr-<number>-pending-review.json
+Output: JSON with metadata and comments saved to <output_dir>/pr-<number>-pending-review.json
 """
 
 from __future__ import annotations
@@ -176,13 +176,14 @@ def fetch_pending_review_comments(
     return comments
 
 
-def run(pr_url: str) -> int:
+def run(pr_url: str, *, output_dir: str) -> int:
     """Main entry point.
 
     Fetches the authenticated user's pending review and its comments from a PR.
 
     Args:
         pr_url: GitHub PR URL (e.g., https://github.com/owner/repo/pull/123).
+        output_dir: Directory for output JSON file.
 
     Returns:
         Exit code (0 for success, 1 for error).
@@ -250,15 +251,8 @@ def run(pr_url: str) -> int:
         diff = ""
         print_stderr("Warning: Could not fetch diff, continuing without it")
 
-    # Temp files in /tmp/pi-work/ follow the standard pattern used by all review commands.
-    # The directory has 0o700 permissions to restrict access on shared machines.
-    tmp_base = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
-    out_dir = tmp_base / "pi-work"
+    out_dir = Path(output_dir)
     out_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
-    try:
-        out_dir.chmod(0o700)
-    except OSError as e:
-        print_stderr(f"Warning: unable to set permissions on {out_dir}: {e}")
 
     safe_repo = f"{owner}-{repo}".replace("/", "-")
     json_path = out_dir / f"pr-{safe_repo}-{pr_number}-pending-review.json"

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -33,15 +33,12 @@ _RATE_LIMIT_BUFFER_SECONDS = 30
 _POLL_SLEEP_SECONDS = 300  # 5 minutes between cycles when no rate limit
 
 
-def _print_poll_summary(pr_number: str) -> None:
+def _print_poll_summary(pr_number: str, output_dir: str) -> None:
     """Print a summary line showing total/new/skipped counts after fetch."""
     import json
-    import os
-    import tempfile
     from pathlib import Path
 
-    tmp_base = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
-    json_path = tmp_base / "pi-work" / f"pr-{pr_number}-reviews.json"
+    json_path = Path(output_dir) / f"pr-{pr_number}-reviews.json"
 
     if not json_path.exists():
         return
@@ -66,19 +63,16 @@ def _print_poll_summary(pr_number: str) -> None:
     print_stderr(f"[poll] Summary: {total} total, {new} new, {skipped} auto-skipped")
 
 
-def _has_actionable_comments(pr_number: str) -> bool:
+def _has_actionable_comments(pr_number: str, output_dir: str) -> bool:
     """Check if the fetched reviews JSON has any actionable (non-auto-skipped) comments.
 
     Reads the JSON file written by fetch_run and checks if any comments
     have status 'pending' and are NOT auto-skipped.
     """
     import json
-    import os
-    import tempfile
     from pathlib import Path
 
-    tmp_base = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
-    json_path = tmp_base / "pi-work" / f"pr-{pr_number}-reviews.json"
+    json_path = Path(output_dir) / f"pr-{pr_number}-reviews.json"
 
     if not json_path.exists():
         # Can't determine — assume actionable to be safe
@@ -98,15 +92,12 @@ def _has_actionable_comments(pr_number: str) -> bool:
     return False
 
 
-def _has_actionable_qodo_comments(pr_number: str) -> bool:
+def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
     """Check if fetched reviews have actionable Qodo comments (not auto-skipped)."""
     import json
-    import os
-    import tempfile
     from pathlib import Path
 
-    tmp_base = Path(os.environ.get("TMPDIR") or tempfile.gettempdir())
-    json_path = tmp_base / "pi-work" / f"pr-{pr_number}-reviews.json"
+    json_path = Path(output_dir) / f"pr-{pr_number}-reviews.json"
 
     if not json_path.exists():
         return True
@@ -357,7 +348,7 @@ def _print_approval_summary(approval: dict) -> None:
     print_stderr("")
 
 
-def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> int:
+def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, output_dir: str) -> int:
     """Poll for Qodo reviews in a loop until approved or new comments.
 
     Flow per cycle:
@@ -374,11 +365,11 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
 
         # Step 1: Fetch reviews first
         print_stderr("[poll] Fetching reviews...")
-        fetch_result = fetch_run(review_url)
+        fetch_result = fetch_run(review_url, output_dir=output_dir)
 
         if fetch_result == 0:
-            _print_poll_summary(pr_number)
-            has_actionable = _has_actionable_qodo_comments(pr_number)
+            _print_poll_summary(pr_number, output_dir)
+            has_actionable = _has_actionable_qodo_comments(pr_number, output_dir)
             if has_actionable:
                 # Before returning, check if Qodo is mid-review — if so, wait for it to finish
                 _comments_endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
@@ -428,7 +419,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str) -> in
         time.sleep(_POLL_SLEEP_SECONDS)
 
 
-def run(review_url: str = "", source: str = "coderabbit") -> int:
+def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) -> int:
     """Poll for reviews in a loop until approval or new comments.
 
     Steps (repeated in a loop):
@@ -444,7 +435,7 @@ def run(review_url: str = "", source: str = "coderabbit") -> int:
     owner, repo, pr_number = get_pr_info(review_url)
 
     if source == "qodo":
-        return _run_qodo_poll(review_url, owner, repo, pr_number)
+        return _run_qodo_poll(review_url, owner, repo, pr_number, output_dir)
 
     # CodeRabbit poll (source == "coderabbit" or "all")
     owner_repo = f"{owner}/{repo}"
@@ -464,13 +455,13 @@ def run(review_url: str = "", source: str = "coderabbit") -> int:
 
         # Step 3: Fetch reviews — get actionable comments before waiting on rate limit
         print_stderr("[poll] Fetching reviews...")
-        fetch_result = fetch_run(review_url)
+        fetch_result = fetch_run(review_url, output_dir=output_dir)
 
         if fetch_result == 0:
-            _print_poll_summary(pr_number)
+            _print_poll_summary(pr_number, output_dir)
             # Check if there are actionable (non-auto-skipped) comments
             # fetch_run saves JSON to a predictable path
-            has_actionable = _has_actionable_comments(pr_number)
+            has_actionable = _has_actionable_comments(pr_number, output_dir)
             if has_actionable:
                 return 0
             print_stderr("[poll] All fetched comments are auto-skipped (previously addressed). No new comments.")

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -351,7 +351,10 @@ def save_html(html: str, output_dir: str, pr_number: int) -> Path:
     tmp_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     html_path = tmp_dir / f"review-status-{pr_number}.html"
     html_path.write_text(html, encoding="utf-8")
-    html_path.chmod(0o600)
+    try:
+        html_path.chmod(0o600)
+    except OSError:
+        pass
     return html_path
 
 

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -348,9 +348,10 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
 def save_html(html: str, output_dir: str, pr_number: int) -> Path:
     """Save HTML to output directory and return path."""
     tmp_dir = Path(output_dir)
-    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     html_path = tmp_dir / f"review-status-{pr_number}.html"
     html_path.write_text(html, encoding="utf-8")
+    html_path.chmod(0o600)
     return html_path
 
 

--- a/myk_pi_tools/reviews/status.py
+++ b/myk_pi_tools/reviews/status.py
@@ -3,7 +3,7 @@
 Shows the latest status per unique finding (keyed by source + path + summary).
 Duplicate entries from multiple review cycles are merged, keeping the most recent.
 
-Output: HTML report saved to /tmp/pi-work/<project>/review-status-<pr>.html
+Output: HTML report saved to <output_dir>/review-status-<pr>.html
 """
 
 import json
@@ -345,9 +345,9 @@ def generate_html(comments: list[dict], pr_info: dict) -> str:
 </html>"""
 
 
-def save_html(html: str, project_name: str, pr_number: int) -> Path:
-    """Save HTML to temp directory and return path."""
-    tmp_dir = Path("/tmp/pi-work") / project_name
+def save_html(html: str, output_dir: str, pr_number: int) -> Path:
+    """Save HTML to output directory and return path."""
+    tmp_dir = Path(output_dir)
     tmp_dir.mkdir(parents=True, exist_ok=True)
     html_path = tmp_dir / f"review-status-{pr_number}.html"
     html_path.write_text(html, encoding="utf-8")
@@ -399,10 +399,9 @@ def list_prs_from_db(db_path: Path) -> None:
     print("\nUse: myk-pi-tools reviews status --pr <number>")
 
 
-def run(pr_number: int | None = None) -> None:
+def run(pr_number: int | None = None, *, output_dir: str) -> None:
     """Main entry point for reviews status command."""
     project_root = get_project_root()
-    project_name = project_root.name
     db_path = project_root / ".pi" / "data" / "reviews.db"
 
     if not db_path.exists():
@@ -442,7 +441,7 @@ def run(pr_number: int | None = None) -> None:
 
     # HTML output
     html = generate_html(comments, pr_info)
-    html_path = save_html(html, project_name, pr_num)
+    html_path = save_html(html, output_dir, pr_num)
 
     # Check if in container
     in_container = os.path.exists("/.dockerenv") or os.path.exists("/run/.containerenv")
@@ -482,4 +481,9 @@ def run(pr_number: int | None = None) -> None:
 
 
 if __name__ == "__main__":
-    run()
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Usage: status.py <output-dir>", file=sys.stderr)
+        sys.exit(1)
+    run(output_dir=sys.argv[1])

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -131,7 +131,7 @@ TaskUpdate(taskId="12", addBlockedBy=["11"])
 ## Workflow
 
 **PROJECT_TMP_DIR** is the project-scoped temp directory from `getProjectTmpDir(cwd)`.
-All temp files for this workflow go there — never use `/tmp/pi-work/` directly.
+All temp files for this workflow go there —
 
 ### Phase 0: PR Detection — Task 1
 
@@ -207,19 +207,13 @@ Mark Task 2 as `in_progress`.
 Clone the target repo and checkout the PR branch. This gives reviewers full repo access
 instead of passing a truncated diff in the prompt.
 
-```bash
-# Shallow clone to temp dir (timestamp suffix avoids collisions)
-REVIEW_DIR="/tmp/pi-work/pr-review-${owner}-${repo}-${pr_number}-$(date +%s)"
-git clone --depth 50 "https://github.com/${owner}/${repo}.git" "$REVIEW_DIR"
-cd "$REVIEW_DIR"
+**Delegate to `git-expert`** with this task:
 
-# Checkout the PR (handles both forked and non-forked PRs)
-gh pr checkout ${pr_number}
-
-# Get the base branch for diff comparison
-BASE_BRANCH=$(gh pr view ${pr_number} --json baseRefName --jq '.baseRefName')
-git fetch origin "$BASE_BRANCH" --depth 50
-```
+> Clone `https://github.com/{owner}/{repo}.git` (depth 50) to `{PROJECT_TMP_DIR}/pr-review-{owner}-{repo}-{pr_number}`.
+> Then run: gh pr checkout {pr_number}
+> Then get the base branch: gh pr view {pr_number} --json baseRefName --jq '.baseRefName'
+> Then fetch the base: git fetch origin {base_branch} --depth 50
+> Report REVIEW_DIR and BASE_BRANCH.
 
 Store:
 
@@ -409,8 +403,4 @@ Mark Task 12 as `completed`.
 After the review is complete (all phases done):
 
 1. Delete all tasks: `TaskUpdate(taskId="N", status="deleted")` for every task created in this workflow
-2. Clean up the clone:
-
-```bash
-rm -rf "$REVIEW_DIR"
-```
+2. Delegate to `git-expert`: remove the clone directory `REVIEW_DIR`

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -60,12 +60,12 @@ using `TaskUpdate` with `addBlockedBy`. The task system enforces execution order
 | Task | Title | blockedBy |
 |------|-------|-----------|
 | 1 | PR Detection | — |
-| 2 | Fetch PR diff | 1 |
-| 3 | Fetch AGENTS.md | 1 |
+| 2 | Clone & checkout PR | 1 |
+| 3 | (auto-complete — reviewers read from clone) | 1 |
 | 4 | Check past review comments | 1, 2 |
-| 5 | Review — Code Quality | 2, 3 |
-| 6 | Review — Guidelines | 2, 3 |
-| 7 | Review — Security | 2, 3 |
+| 5 | Review — Code Quality | 2 |
+| 6 | Review — Guidelines | 2 |
+| 7 | Review — Security | 2 |
 | 8 | Merge & deduplicate findings | 4, 5, 6, 7 |
 | 9 | User selection | 8 |
 | 10 | Post comments | 9 |
@@ -76,9 +76,9 @@ using `TaskUpdate` with `addBlockedBy`. The task system enforces execution order
 
 ```text
 Task 1 (PR Detection)
- ├── Task 2 (Fetch diff) ─────────────┐
- ├── Task 3 (Fetch AGENTS.md) ────────┤
- │    Tasks 2+3 unblock:              │
+ ├── Task 2 (Clone & checkout PR) ────┐
+ │    Task 3 auto-completes instantly  │
+ │    Task 2 unblocks:                │
  │    ├── Task 5 (Review: Quality)    │
  │    ├── Task 6 (Review: Guidelines) │
  │    └── Task 7 (Review: Security)   │
@@ -113,9 +113,9 @@ TaskCreate(subject="Fetch AGENTS.md", ...)        → Task 3
 TaskUpdate(taskId="2", addBlockedBy=["1"])
 TaskUpdate(taskId="3", addBlockedBy=["1"])
 TaskUpdate(taskId="4", addBlockedBy=["1", "2"])
-TaskUpdate(taskId="5", addBlockedBy=["2", "3"])
-TaskUpdate(taskId="6", addBlockedBy=["2", "3"])
-TaskUpdate(taskId="7", addBlockedBy=["2", "3"])
+TaskUpdate(taskId="5", addBlockedBy=["2"])
+TaskUpdate(taskId="6", addBlockedBy=["2"])
+TaskUpdate(taskId="7", addBlockedBy=["2"])
 TaskUpdate(taskId="8", addBlockedBy=["4", "5", "6", "7"])
 TaskUpdate(taskId="9", addBlockedBy=["8"])
 TaskUpdate(taskId="10", addBlockedBy=["9"])
@@ -197,49 +197,42 @@ Mark Task 1 as `completed`.
 Tasks 2 and 3 are independent — execute them in parallel.
 Task 4 depends on Task 2 (needs the diff data) and will start after Task 2 completes.
 
-### Phase 1a: Fetch PR Diff — Task 2
+### Phase 1a: Clone & Checkout PR — Task 2
 
 Mark Task 2 as `in_progress`.
 
-Run the diff command to get PR data:
-
-If PR was auto-detected (no arguments):
-
-```bash
-myk-pi-tools pr diff {pr_number}
-```
-
-Otherwise:
+Clone the target repo and checkout the PR branch. This gives reviewers full repo access
+instead of passing a truncated diff in the prompt.
 
 ```bash
-myk-pi-tools pr diff <raw_arguments>
+# Shallow clone to temp dir
+REVIEW_DIR="/tmp/pi-work/pr-review-${owner}-${repo}-${pr_number}"
+rm -rf "$REVIEW_DIR"
+git clone --depth 50 "https://github.com/${owner}/${repo}.git" "$REVIEW_DIR"
+cd "$REVIEW_DIR"
+
+# Checkout the PR (handles both forked and non-forked PRs)
+gh pr checkout ${pr_number}
+
+# Get the base branch for diff comparison
+BASE_BRANCH=$(gh pr view ${pr_number} --json baseRefName --jq '.baseRefName')
+git fetch origin "$BASE_BRANCH" --depth 50
 ```
 
-Store the JSON output containing metadata, diff, and files.
+Store:
+
+- `REVIEW_DIR` — the clone path (used as `cwd` for reviewers)
+- `BASE_BRANCH` — the PR's target branch (used for `git diff`)
+
+If cloning or checkout fails, fall back to `myk-pi-tools pr diff` (original behavior).
 
 Mark Task 2 as `completed`.
 
-### Phase 1b: Fetch AGENTS.md — Task 3
+### Phase 1b: (Removed — reviewers read AGENTS.md from clone)
 
-Mark Task 3 as `in_progress`.
-
-Run the claude-md command to get project rules:
-
-If PR was auto-detected (no arguments):
-
-```bash
-myk-pi-tools pr claude-md {pr_number}
-```
-
-Otherwise:
-
-```bash
-myk-pi-tools pr claude-md <raw_arguments>
-```
-
-Store the output as `claude_md_content`.
-
-Mark Task 3 as `completed`.
+Task 3 is no longer needed — reviewers have full repo access via the clone
+and read AGENTS.md independently per their agent instructions.
+Mark Task 3 as `completed` immediately.
 
 ### Phase 1c: Check Past Review Comments — Task 4
 
@@ -292,16 +285,18 @@ Use the actual task IDs returned by `TaskCreate` — do NOT hardcode IDs.
 
 ```text
 subagent(tasks=[
-  {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "<actual task 5 ID>"},
-  {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "<actual task 6 ID>"},
-  {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "<actual task 7 ID>"},
+  {agent: "code-reviewer-quality", task: "Review this PR for code quality. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read any files needed for context.", cwd: "<REVIEW_DIR>", name: "Review Quality", taskId: "<task 5 ID>"},
+  {agent: "code-reviewer-guidelines", task: "Review this PR for guideline adherence. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read AGENTS.md and check compliance.", cwd: "<REVIEW_DIR>", name: "Review Guidelines", taskId: "<task 6 ID>"},
+  {agent: "code-reviewer-security", task: "Review this PR for bugs and security. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Trace data flow through changed code.", cwd: "<REVIEW_DIR>", name: "Review Security", taskId: "<task 7 ID>"},
 ])
 ```
 
-Provide each agent with:
+Each reviewer runs in the cloned repo directory (`REVIEW_DIR`) and has full access to:
 
-- The diff content from Phase 1a
-- The AGENTS.md content from Phase 1b (or "No AGENTS.md found" if empty)
+- All source files via `read` tool
+- The PR diff via `git diff origin/<BASE_BRANCH>...HEAD`
+- Project guidelines (AGENTS.md/CLAUDE.md) — read independently per agent instructions
+- File history, imports, tests — anything in the repo
 
 Each agent should analyze for security, bugs, error handling, and performance issues
 and return their findings as prose.
@@ -410,3 +405,14 @@ Mark Task 12 as `in_progress`.
 Display final summary with counts and links.
 
 Mark Task 12 as `completed`.
+
+### Cleanup
+
+After the review is complete (all phases done):
+
+1. Delete all tasks: `TaskUpdate(taskId="N", status="deleted")` for every task created in this workflow
+2. Clean up the clone:
+
+```bash
+rm -rf "$REVIEW_DIR"
+```

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -209,7 +209,7 @@ instead of passing a truncated diff in the prompt.
 
 ```bash
 # Shallow clone to temp dir (timestamp suffix avoids collisions)
-REVIEW_DIR="${PROJECT_TMP_DIR}/pr-review-${owner}-${repo}-${pr_number}-$(date +%s)"
+REVIEW_DIR="/tmp/pi-work/pr-review-${owner}-${repo}-${pr_number}-$(date +%s)"
 git clone --depth 50 "https://github.com/${owner}/${repo}.git" "$REVIEW_DIR"
 cd "$REVIEW_DIR"
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -130,6 +130,9 @@ TaskUpdate(taskId="12", addBlockedBy=["11"])
 
 ## Workflow
 
+**PROJECT_TMP_DIR** is the project-scoped temp directory from `getProjectTmpDir(cwd)`.
+All temp files for this workflow go there — never use `/tmp/pi-work/` directly.
+
 ### Phase 0: PR Detection — Task 1
 
 Mark Task 1 as `in_progress`.
@@ -205,9 +208,8 @@ Clone the target repo and checkout the PR branch. This gives reviewers full repo
 instead of passing a truncated diff in the prompt.
 
 ```bash
-# Shallow clone to temp dir
-REVIEW_DIR="/tmp/pi-work/pr-review-${owner}-${repo}-${pr_number}"
-rm -rf "$REVIEW_DIR"
+# Shallow clone to temp dir (timestamp suffix avoids collisions)
+REVIEW_DIR="${PROJECT_TMP_DIR}/pr-review-${owner}-${repo}-${pr_number}-$(date +%s)"
 git clone --depth 50 "https://github.com/${owner}/${repo}.git" "$REVIEW_DIR"
 cd "$REVIEW_DIR"
 
@@ -243,7 +245,7 @@ Fetch ALL human review threads (resolved + unresolved) from the PR:
 Use the `owner`, `repo`, and `pr_number` from Phase 0 to construct the PR URL:
 
 ```bash
-myk-pi-tools reviews fetch --user {current_github_user} --include-resolved https://github.com/{owner}/{repo}/pull/{pr_number}
+myk-pi-tools reviews fetch --output-dir ${PROJECT_TMP_DIR} --user {current_github_user} --include-resolved https://github.com/{owner}/{repo}/pull/{pr_number}
 ```
 
 Where `{current_github_user}` is obtained from:
@@ -346,16 +348,12 @@ Mark Task 9 as `completed`.
 
 Mark Task 10 as `in_progress`.
 
-If user selected findings, create temp directory and write JSON to temp file:
-
-```bash
-mkdir -p /tmp/pi-work/$(basename $PWD)
-```
+If user selected findings, write JSON to temp file:
 
 Use the `owner`, `repo`, `pr_number`, and `head_sha` from Phase 0 or Phase 1a metadata:
 
 ```bash
-myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} /tmp/pi-work/$(basename $PWD)/pr-review-comments.json
+myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} ${PROJECT_TMP_DIR}/pr-review-comments.json
 ```
 
 Mark Task 10 as `completed`.
@@ -369,7 +367,7 @@ After posting comments, store them in the PR review database for future cycle tr
 1. Write a JSON file with the posted comments:
 
 ```bash
-cat > /tmp/pi-work/$(basename $PWD)/pr-review-store.json << 'EOF'
+cat > ${PROJECT_TMP_DIR}/pr-review-store.json << 'EOF'
 {
   "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}"},
   "comments": [
@@ -390,7 +388,7 @@ EOF
 1. Store to database:
 
 ```bash
-myk-pi-tools pr store-pr-review /tmp/pi-work/$(basename $PWD)/pr-review-store.json
+myk-pi-tools pr store-pr-review ${PROJECT_TMP_DIR}/pr-review-store.json
 ```
 
 **This step is MANDATORY — never skip it.** The database is used by future `/pr-review`

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -43,12 +43,14 @@ If not found, prompt user: "myk-pi-tools is required. Install with: `uv tool ins
 
 ## Workflow
 
+**`PROJECT_TMP_DIR`** is the project-scoped temp directory from `getProjectTmpDir(cwd)` — all temp files go here.
+
 ### Phase 1: Fetch Pending Review
 
 Parse the raw arguments above as the PR URL. If empty, abort with: "PR URL required. Usage: `/refine-review https://github.com/owner/repo/pull/123`"
 
 ```bash
-myk-pi-tools reviews pending-fetch "<PR_URL>"
+myk-pi-tools reviews pending-fetch --output-dir ${PROJECT_TMP_DIR} "<PR_URL>"
 ```
 
 The command saves the review data to a JSON file and outputs the file path to stdout.

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -161,7 +161,7 @@ for future `/pr-review` cycle tracking:
 1. Write a JSON file with the submitted comments:
 
 ```bash
-cat > /tmp/pi-work/$(basename $PWD)/pr-review-store.json << 'EOF'
+cat > ${PROJECT_TMP_DIR}/pr-review-store.json << 'EOF'
 {
   "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}"},
   "comments": [
@@ -182,7 +182,7 @@ EOF
 1. Store to database:
 
 ```bash
-myk-pi-tools pr store-pr-review /tmp/pi-work/$(basename $PWD)/pr-review-store.json
+myk-pi-tools pr store-pr-review ${PROJECT_TMP_DIR}/pr-review-store.json
 ```
 
 **This step is MANDATORY — never skip it.** Only store if the review was actually

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -40,6 +40,8 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 ## Workflow
 
+**`PROJECT_TMP_DIR`** is the project-scoped temp directory from `getProjectTmpDir(cwd)` — all temp files go here.
+
 ### Phase 1: Validation
 
 If `--target <branch>` was passed to the release command:

--- a/prompts/release.md
+++ b/prompts/release.md
@@ -217,7 +217,7 @@ skipped and why before proceeding.
 Create a temp file with cleanup, write changelog to it, and create release:
 
 ```bash
-CHANGELOG_FILE=$(mktemp /tmp/pi-work/$(basename $PWD)/release-XXXXXX.md)
+CHANGELOG_FILE=$(mktemp ${PROJECT_TMP_DIR}/release-XXXXXX.md)
 trap "rm -f $CHANGELOG_FILE" EXIT
 
 cat > "$CHANGELOG_FILE" << 'EOF'

--- a/prompts/review-handler-status.md
+++ b/prompts/review-handler-status.md
@@ -21,7 +21,7 @@ Show the live state of running autoqodo/autorabbit review-handler agents.
    If none found → "No review handler agents running — nothing to show."
 
 2. For each running review agent, extract the PR number from the agent's task or worktree cwd.
-   Run `myk-pi-tools reviews status --pr <number>` to generate the HTML report.
+   Run `myk-pi-tools reviews status --output-dir ${PROJECT_TMP_DIR} --pr <number>` to generate the HTML report.
    Extract the path from `HTML report saved: <path>` in the output.
    - **Container** (`/.dockerenv` or `/run/.containerenv` exists): serve via file preview rule (`rules/45-file-preview.md`)
    - **Native**: show `file://<path>`

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -112,13 +112,13 @@ The `reviews fetch` command auto-detects the PR from the current branch.
 If a specific review URL is in the cleaned arguments:
 
 ```bash
-myk-pi-tools reviews fetch <cleaned_arguments>
+myk-pi-tools reviews fetch --output-dir ${PROJECT_TMP_DIR} <cleaned_arguments>
 ```
 
 Otherwise (auto-detect from current branch):
 
 ```bash
-myk-pi-tools reviews fetch
+myk-pi-tools reviews fetch --output-dir ${PROJECT_TMP_DIR}
 ```
 
 Returns JSON with:
@@ -434,7 +434,7 @@ Qodo if autoqodo, both if both flags active).
 **If autorabbit is ON (only):** Spawn ONE async worker:
 
 - Agent: `worker`
-- Task: `Run: myk-pi-tools reviews poll --source coderabbit [same arguments as Phase 1].`
+- Task: `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source coderabbit [same arguments as Phase 1].`
   `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
 - async: true
 - **No timeout** — the poll can take 30+ minutes (rate limit waits). NEVER set a timeout.
@@ -442,16 +442,16 @@ Qodo if autoqodo, both if both flags active).
 **If autoqodo is ON (only):** Spawn ONE async worker:
 
 - Agent: `worker`
-- Task: `Run: myk-pi-tools reviews poll --source qodo [same arguments as Phase 1].`
+- Task: `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source qodo [same arguments as Phase 1].`
   `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
 - async: true
 - **No timeout** — the poll loops internally until new Qodo comments appear. NEVER set a timeout.
 
 **If BOTH are ON:** Spawn TWO async workers in parallel:
 
-1. `Run: myk-pi-tools reviews poll --source coderabbit [same arguments as Phase 1].`
+1. `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source coderabbit [same arguments as Phase 1].`
    `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
-1. `Run: myk-pi-tools reviews poll --source qodo [same arguments as Phase 1].`
+1. `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source qodo [same arguments as Phase 1].`
    `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
 
 When EITHER returns with new comments, process them (Phases 2-8). Then re-spawn that agent.
@@ -472,7 +472,7 @@ Check the poll RAW output (not the worker's summary — look for the exact JSON 
   Instead, read the last saved reviews JSON file — its path was in the
   `metadata.json_path` field from the most recent `reviews fetch` or `reviews poll` output.
   If the JSON file was already deleted by `reviews store`, re-fetch with:
-  `myk-pi-tools reviews fetch` (passing the same arguments used in Phase 1, if any)
+  `myk-pi-tools reviews fetch --output-dir ${PROJECT_TMP_DIR}` (passing the same arguments used in Phase 1, if any)
 
   Display remaining findings in a table:
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -69,6 +69,8 @@ If not found, prompt to install: `uv tool install myk-pi-tools`
 
 ## Workflow
 
+**`PROJECT_TMP_DIR`** is the project-scoped temp directory from `getProjectTmpDir(cwd)` — all temp files go here.
+
 > **CRITICAL — BEFORE ANY CLI COMMAND:**
 > `--autorabbit` and `--autoqodo` are **command-level flags**, NOT CLI arguments.
 > **NEVER** pass `--autorabbit` or `--autoqodo` to `myk-pi-tools`. The CLI will reject it.

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -75,7 +75,7 @@ The process is iterative:
 Before declaring test failures as blockers, compare against the baseline:
 
 ```bash
-BASELINE_DIR="/tmp/pi-work/$(basename "$PWD")"
+BASELINE_DIR="${PROJECT_TMP_DIR}"
 mkdir -p "$BASELINE_DIR"
 
 # 1. Save ALL changes (staged + unstaged + untracked)

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -81,7 +81,7 @@ The tool enforces this — calls without `estimatedSeconds` or ≥ 30s are rejec
 **ALWAYS pass `cwd`** when delegating to subagents — in ALL modes (single, parallel, chain, async).
 
 - Use the project directory when working in the current repo
-- Use the target repo path when working in external repos (e.g., `/tmp/pi-work/...`)
+- Use the target repo path when working in external repos (e.g., `${PROJECT_TMP_DIR}/...`)
 
 ❌ **WRONG:** Omit cwd (subagent inherits session cwd, enforcement checks wrong repo)
 ✅ **RIGHT:** Always pass explicit cwd
@@ -164,8 +164,8 @@ After presenting your analysis, respect the user's decision.
 
 | Source | Trigger | Audit approach |
 |--------|---------|----------------|
-| **Git repos** | Adopting external repo/tool/library | Clone to `/tmp/pi-work/`, run `security-auditor` |
-| **Pi skills** | `pi skill install`, adding skill files | Clone/download source to `/tmp/pi-work/`, run `security-auditor` |
+| **Git repos** | Adopting external repo/tool/library | Clone to `${PROJECT_TMP_DIR}/`, run `security-auditor` |
+| **Pi skills** | `pi skill install`, adding skill files | Clone/download source to `${PROJECT_TMP_DIR}/`, run `security-auditor` |
 | **PyPI packages** | `uv add <unknown-pkg>`, `uv run --with <unknown-pkg>` | Clone source repo from PyPI metadata, check install hooks, scan code |
 | **npm packages** | `npm install <unknown-pkg>` | Download source, check `postinstall` scripts, scan code |
 | **MCP servers** | Adding new server to `mcp.json` | Audit the server source code before adding config |
@@ -183,7 +183,6 @@ After presenting your analysis, respect the user's decision.
 ## Temp Files
 
 **ALL temp files MUST go to the project temp dir** (`getProjectTmpDir(cwd)` → `/tmp/pi-data/<project>/`).
-External repo clones go to `/tmp/pi-work/` (shared across projects).
 
 - `<project>` is the cwd path with `/` replaced by `__` (e.g., `/home/user/git/my-repo` → `home__user__git__my-repo`)
 - This path persists across container restarts when `/tmp/pi-data` is mounted from the host
@@ -222,7 +221,7 @@ The `--with` syntax ensures dependencies are managed per-execution without modif
 
 **When exploring external Git repositories, clone locally first.**
 
-Clone to `/tmp/pi-work/` and explore using read/bash (find, rg, grep) - NOT via web fetching.
+Clone to `${PROJECT_TMP_DIR}/` and explore using read/bash (find, rg, grep) - NOT via web fetching.
 
 ### Clone the Bare Minimum
 
@@ -236,21 +235,21 @@ Clone to `/tmp/pi-work/` and explore using read/bash (find, rg, grep) - NOT via 
 
 ```bash
 # Shallow clone to temp directory
-git clone --depth 1 https://github.com/org/repo.git /tmp/pi-work/repo
+git clone --depth 1 https://github.com/org/repo.git ${PROJECT_TMP_DIR}/repo
 
 # Sparse checkout for specific directory only
-git clone --depth 1 --filter=blob:none --sparse https://github.com/org/repo.git /tmp/pi-work/repo
-cd /tmp/pi-work/repo && git sparse-checkout set src/utils
+git clone --depth 1 --filter=blob:none --sparse https://github.com/org/repo.git ${PROJECT_TMP_DIR}/repo
+cd ${PROJECT_TMP_DIR}/repo && git sparse-checkout set src/utils
 
 # Clean up when done
-rm -rf /tmp/pi-work/repo
+rm -rf ${PROJECT_TMP_DIR}/repo
 ```
 
 ❌ **Wrong:**
 
 ```bash
 # Full clone with history
-git clone https://github.com/org/repo.git /tmp/pi-work/repo
+git clone https://github.com/org/repo.git ${PROJECT_TMP_DIR}/repo
 
 # Using web fetch to browse repository files
 fetch_content(https://github.com/org/repo/blob/main/src/file.py)
@@ -260,7 +259,7 @@ fetch_content(https://github.com/org/repo/blob/main/src/file.py)
 
 For private repositories, ensure authentication is configured:
 
-- **SSH**: `git clone --depth 1 git@github.com:org/private-repo.git /tmp/pi-work/repo`
+- **SSH**: `git clone --depth 1 git@github.com:org/private-repo.git ${PROJECT_TMP_DIR}/repo`
 - **Credential helper**: Ensure `git config --global credential.helper` is set
 
 Local exploration is faster, more reliable, and provides full file access without web scraping limitations.

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -182,10 +182,11 @@ After presenting your analysis, respect the user's decision.
 
 ## Temp Files
 
-**ALL temp files MUST go to `/tmp/pi-work/<cwd-basename>/`** (e.g., `/tmp/pi-work/pi-config/`).
+**ALL temp files MUST go to the project temp dir** (`getProjectTmpDir(cwd)` → `/tmp/pi-data/<project>/`).
+External repo clones go to `/tmp/pi-work/` (shared across projects).
 
-- `<cwd-basename>` is the last segment of the current working directory (not repo name — not all dirs are repos)
-- This path persists across container restarts when `/tmp/pi-work` is mounted from the host
+- `<project>` is the cwd path with `/` replaced by `__` (e.g., `/home/user/git/my-repo` → `home__user__git__my-repo`)
+- This path persists across container restarts when `/tmp/pi-data` is mounted from the host
 
 NEVER create temp files in the project directory.
 

--- a/rules/45-file-preview.md
+++ b/rules/45-file-preview.md
@@ -2,16 +2,16 @@
 
 When generating or modifying HTML, frontend, or any browser-viewable files:
 
-1. Save the file under the project directory (`$PWD`) or `/tmp/pi-work/`
+1. Save the file under the project directory (`$PWD`) or `${PROJECT_TMP_DIR}`
 2. Find a free port and launch the server:
 
    ```bash
    HTTPD=~/.pi/agent/git/github.com/myk-org/pi-config/scripts/httpd.py
    PORT=$(uv run python3 $HTTPD --find-port)
-   nohup uv run python3 $HTTPD --port $PORT --dir /path/to/serve > /tmp/pi-work/$(basename $PWD)/httpd-$PORT.log 2>&1 &
+   nohup uv run python3 $HTTPD --port $PORT --dir /path/to/serve > ${PROJECT_TMP_DIR}/httpd-$PORT.log 2>&1 &
    disown
    sleep 0.5
-   if ! kill -0 $! 2>/dev/null; then echo "Server failed to start:"; cat /tmp/pi-work/$(basename $PWD)/httpd-$PORT.log; fi
+   if ! kill -0 $! 2>/dev/null; then echo "Server failed to start:"; cat ${PROJECT_TMP_DIR}/httpd-$PORT.log; fi
    ```
 
    Replace `/path/to/serve` with the directory containing the files.


### PR DESCRIPTION
## Summary

Two major changes:

### 1. Migrate all temp files from `/tmp/pi-work/` to `/tmp/pi-data/<project>/`

All project-scoped temp files now go to `/tmp/pi-data/<project>/` where `<project>` is the cwd with `/` replaced by `__` (same convention as `getProjectTmpDir(cwd)` used by async agents).

**Python CLI:**
- `--output-dir` is now **required** for `reviews fetch`, `poll`, `pending-fetch`, `status`
- No defaults — caller must pass the project temp dir
- Zero references to `/tmp/pi-work/` in Python CLI code

**Prompts/Rules:**
- All file paths use `${PROJECT_TMP_DIR}`
- `PROJECT_TMP_DIR` defined in each prompt that uses it
- `mktemp` enforcement updated to check for `/tmp/pi-data`

**Extensions:**
- `enforcement.ts` — mktemp regex updated
- `image-gen.ts` — project-scoped output path
- `async-agents.ts` — `projectCwd` stored on jobs for correct task store resolution
- `subagent-tool.ts` — `validateTaskId` uses `ctx.cwd` (project root) not subagent cwd

### 2. PR review clones repo for reviewers

`/pr-review` now clones the target repo and checks out the PR branch instead of passing a truncated diff in the prompt. Reviewers get full repo access — they can read any file, run `git diff`, check imports, tests, etc.

- Clone delegated to `git-expert` (no dangerous command approval prompts)
- `gh pr checkout` handles forked PRs automatically
- Reviewers run in clone cwd with `read` and `bash` tools
- Cleanup removes clone directory after review

### 3. Task auto-complete improvements

- `projectCwd` added to `AsyncJob` — stored from session's `getCwd()` at spawn time
- `autoCompleteTask` uses `projectCwd` (not subagent cwd) to find `.pi/tasks/`
- Fixes auto-complete when reviewers run in clone directory

Closes #490