### PR TITLE
refactor: migrate temp files from /tmp/pi-data/ to .pi/tmp/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,7 @@ waiting for long-running agents.
 All async agent temp files live under project-scoped subdirectories:
 
 ```text
-/tmp/pi-data/<project>/
+.pi/tmp/
 ├── debug.log                    # Async debug log
 ├── cron-<pid>.json              # Cron task state
 ├── .repeat-<pid>.json           # Repeat command detection
@@ -225,13 +225,11 @@ All async agent temp files live under project-scoped subdirectories:
     └── system-prompt.md         # Agent system prompt
 ```
 
-**Project name format:** cwd with `/` replaced by `__` (e.g., `home__myakove__git__pi-config`).
-
 **Zombie cleanup:** On `session_start`, scans project dir for dead agents.
 Checks each agent's `parentPid` + `parentStartTime` against `/proc/PID/stat` field 22.
 Dead parent = zombie = delete.
 
-**Shared helper:** `getProjectTmpDir(cwd)` in `utils.ts` — creates dir if missing, returns path.
+**Shared helper:** `getProjectTmpDir(cwd)` in `utils.ts` — returns `<cwd>/.pi/tmp/`, creates dir if missing.
 
 ### Mode-Aware Guards (`ctx.mode`)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,7 +44,7 @@ Useful debug commands inside the container:
 ```bash
 ps aux | grep pi              # Find stuck pi/subagent processes
 pkill -f 'pi.*--mode.*json'   # Kill stuck subagent processes
-cat /tmp/pi-async-agents/*/status.json  # Check async agent status
+cat .pi/tmp/worker-*/status.json  # Check async agent status
 ```
 
 ## Python Dependencies

--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@ docker run --rm -it \
   -v "$HOME/.gitignore-global":"$HOME/.gitignore-global":ro \
   -v "$HOME/.ssh":"$HOME/.ssh":ro \
   -v "$HOME/.config/gh":"$HOME/.config/gh":ro \
-  -v /tmp/pi-data:/tmp/pi-data:rw \
   -w "$PWD" \
   ghcr.io/myk-org/pi-config:latest
 ```
@@ -485,7 +484,6 @@ PI_PIDIFF_ENABLE=false pi
 | `-v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro` | GitLab CLI config (auth tokens, host settings) |
 | `-v "$HOME/.coderabbit":"$HOME/.coderabbit":rw` | CodeRabbit CLI auth and review data |
 | `-v "$HOME/screenshots":"$HOME/screenshots"` | Share screenshots/images with the agent |
-| `-v /tmp/pi-data:/tmp/pi-data:rw` | Project-scoped temp files (reviews, releases, async agents) |
 | `-v /var/run/docker.sock:/var/run/docker.sock:ro` + `--group-add $(stat -c '%g' /var/run/docker.sock)` | Docker container inspection via `docker-safe` |
 | `-v /var/run/podman/podman.sock:/var/run/podman/podman.sock:ro` | Podman container inspection via `docker-safe` |
 
@@ -553,7 +551,6 @@ alias pi-docker='docker pull ghcr.io/myk-org/pi-config:latest && \
   -v "$HOME/.config/cursor/auth.json":"$HOME/.config/cursor/auth.json":ro \
   -v "$HOME/.config/glab-cli":"$HOME/.config/glab-cli":ro \
   -v "$HOME/screenshots":"$HOME/screenshots":ro \
-  -v /tmp/pi-data:/tmp/pi-data:rw \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
   --group-add $(stat -c '%g' /var/run/docker.sock) \
   -w "$PWD" \

--- a/extensions/image-gen/image-gen.ts
+++ b/extensions/image-gen/image-gen.ts
@@ -10,7 +10,6 @@
 import { Type } from "typebox";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 import { execFileSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -95,8 +94,7 @@ function getExtensionForMime(mimeType: string): string {
 
 // Same logic as getProjectTmpDir in extensions/orchestrator/utils.ts
 function getTempDir(cwd: string): string {
-    const project = cwd.replace(/^[\/\\]/, "").replace(/[\/\\]/g, "__");
-    const dir = path.join(os.tmpdir(), "pi-data", project);
+    const dir = path.join(cwd, ".pi", "tmp");
     fs.mkdirSync(dir, { recursive: true });
     return dir;
 }

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -32,7 +32,7 @@ const taskStoreReady: Promise<void> = (async () => {
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentConfig } from "./agents.js";
-import { getPiInvocation, getProjectTmpDir, PI_TMP_BASE_DIR } from "./utils.js";
+import { getPiInvocation, getProjectTmpDir } from "./utils.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -125,11 +125,11 @@ export function registerAsyncAgents(
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
   getAsyncJobs: () => Array<{ id: string; agent: string; name?: string; task: string; status: string; startedAt: number }>;
 } {
-  let PROJECT_TMP_DIR = PI_TMP_BASE_DIR; // Updated to project-scoped dir on session_start
+  let PROJECT_TMP_DIR = getProjectTmpDir(process.cwd()); // Updated to project-scoped dir on session_start
   let ASYNC_RESULTS_DIR = ""; // Set on session_start to project-scoped dir
 
   const ASYNC_DEBUG = !!process.env.PI_ASYNC_DEBUG;
-  const EARLY_LOG_PATH = ASYNC_DEBUG ? path.join(PI_TMP_BASE_DIR, `early-debug-${process.pid}.log`) : "";
+  const EARLY_LOG_PATH = ASYNC_DEBUG ? path.join(PROJECT_TMP_DIR, `early-debug-${process.pid}.log`) : "";
   let DEBUG_LOG_PATH = EARLY_LOG_PATH; // Starts with early log, moved to project dir on session_start
   function asyncLog(msg: string) {
     if (!ASYNC_DEBUG || !DEBUG_LOG_PATH) return;

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -125,7 +125,7 @@ export function registerAsyncAgents(
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
   getAsyncJobs: () => Array<{ id: string; agent: string; name?: string; task: string; status: string; startedAt: number }>;
 } {
-  let PROJECT_TMP_DIR = getProjectTmpDir(process.cwd()); // Updated to project-scoped dir on session_start
+  let PROJECT_TMP_DIR = path.join(process.cwd(), ".pi", "tmp"); // Computed only; created on session_start
   let ASYNC_RESULTS_DIR = ""; // Set on session_start to project-scoped dir
 
   const ASYNC_DEBUG = !!process.env.PI_ASYNC_DEBUG;

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -351,12 +351,12 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       }
     }
 
-    // Enforce temp files go to /tmp/pi-data/ — not bare /tmp/
+    // Enforce temp files go to .pi/tmp/ — not bare /tmp/
     // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
-    if (/(?:^|[;&|$( \t])mktemp\b/.test(command) && !/\/tmp\/pi-data/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
+    if (/(?:^|[;&|$( \t])mktemp\b/.test(command) && !/\.pi\/tmp/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
       return {
         block: true,
-        reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (where PROJECT_TMP_DIR is from getProjectTmpDir)`,
+        reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (resolves to .pi/tmp/)`,
       };
     }
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -6,6 +6,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import * as path from "node:path";
 import { join } from "node:path";
 import { getSetting } from "./project-settings.js";
 import { getProjectTmpDir } from "./utils.js";
@@ -353,11 +354,16 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     // Enforce temp files go to .pi/tmp/ — not bare /tmp/
     // Catches: mktemp /tmp/foo, > /tmp/foo, tee /tmp/foo, cat > /tmp/foo
-    if (/(?:^|[;&|$( \t])mktemp\b/.test(command) && !/\.pi\/tmp/.test(command) && !/PROJECT_TMP_DIR/.test(command)) {
-      return {
-        block: true,
-        reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (resolves to .pi/tmp/)`,
-      };
+    if (/(?:^|[;&|$( \t])mktemp\b/.test(command)) {
+      const expectedTmpDir = path.join(ctx.cwd, ".pi", "tmp");
+      const usesEnvVar = /\$\{?PROJECT_TMP_DIR\}?/.test(command);
+      const usesExpectedPath = command.includes(expectedTmpDir);
+      if (!usesEnvVar && !usesExpectedPath) {
+        return {
+          block: true,
+          reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (resolves to ${expectedTmpDir}/)`,
+        };
+      }
     }
 
     // Dangerous command confirmation

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -358,7 +358,8 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       const expectedTmpDir = path.join(ctx.cwd, ".pi", "tmp");
       const usesEnvVar = /\$\{?PROJECT_TMP_DIR\}?/.test(command);
       const usesExpectedPath = command.includes(expectedTmpDir);
-      if (!usesEnvVar && !usesExpectedPath) {
+      const usesRelativePath = /\.pi\/tmp\//.test(command);
+      if (!usesEnvVar && !usesExpectedPath && !usesRelativePath) {
         return {
           block: true,
           reason: `⛔ mktemp must use project temp dir. Use: mktemp \${PROJECT_TMP_DIR}/XXXXXX (resolves to ${expectedTmpDir}/)`,

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -358,7 +358,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       const expectedTmpDir = path.join(ctx.cwd, ".pi", "tmp");
       const usesEnvVar = /\$\{?PROJECT_TMP_DIR\}?/.test(command);
       const usesExpectedPath = command.includes(expectedTmpDir);
-      const usesRelativePath = /\.pi\/tmp\//.test(command);
+      const usesRelativePath = /\.pi\/tmp(?:\/|[\s"']|$)/.test(command);
       if (!usesEnvVar && !usesExpectedPath && !usesRelativePath) {
         return {
           block: true,

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -4,7 +4,6 @@
 
 import { execFile } from "node:child_process";
 import * as fs from "node:fs";
-import * as os from "node:os";
 import * as path from "node:path";
 
 /** Whether notify-send is available (false = ENOENT, never retry) */
@@ -66,14 +65,10 @@ export function getPiInvocation(args: string[]): { command: string; args: string
   return { command: "pi", args };
 }
 
-/** Base temp dir for all pi data */
-export const PI_TMP_BASE_DIR = path.join(os.tmpdir(), "pi-data");
-
-/** Get project-scoped temp dir under /tmp/pi-data/<project>/ */
+/** Get project-scoped temp dir under <cwd>/.pi/tmp/ */
 export function getProjectTmpDir(cwd: string): string {
-  const projectName = cwd.replace(/^[\\/]/, "").replace(/[\\/]/g, "__");
-  const dir = path.join(PI_TMP_BASE_DIR, projectName);
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const dir = path.join(cwd, ".pi", "tmp");
+  fs.mkdirSync(dir, { recursive: true });
   return dir;
 }
 

--- a/init-entrypoint.sh
+++ b/init-entrypoint.sh
@@ -10,15 +10,6 @@ if [ "$(id -u)" != "0" ]; then
         exec sudo --preserve-env "$0" "$@"
     fi
     # No PI_HOST_USER and no docker socket — skip root setup, run entrypoint directly as node
-    for d in /tmp/pi-data; do
-        if ! mkdir -p "$d" 2>/dev/null; then
-            echo "WARNING: failed to create $d — temp files may fail. Fix with: sudo mkdir -p $d && sudo chown $(id -u):$(id -g) $d" >&2
-        elif _probe="$d/.pi-probe-$$" && ! touch "$_probe" 2>/dev/null; then
-            echo "WARNING: $d is not writable by $(whoami) — temp files may fail. Fix with: sudo chown $(id -u):$(id -g) $d" >&2
-        else
-            rm -f "$_probe" 2>/dev/null
-        fi
-    done
     exec entrypoint.sh "$@"
 fi
 
@@ -91,22 +82,6 @@ if [ -S "$DOCKER_SOCK" ]; then
         usermod -aG "$SOCK_GROUP" node
     fi
 fi
-
-# Ensure temp dirs exist and are owned by node (not root)
-for d in /tmp/pi-data; do
-    # Refuse to operate on symlinks — prevents chown escape
-    if [ -L "$d" ]; then
-        echo "WARNING: $d is a symlink — removing to prevent chown escape" >&2
-        rm -f "$d" || true
-    fi
-    if ! mkdir -p "$d" 2>/dev/null; then
-        echo "WARNING: failed to create $d — temp files may fail" >&2
-        continue
-    fi
-    if ! chown node:node "$d" 2>/dev/null; then
-        echo "WARNING: could not chown $d — temp file writes may fail on mounted volumes" >&2
-    fi
-done
 
 # Drop to node permanently — runuser replaces the process
 exec runuser -m -u node -- entrypoint.sh "$@"

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -182,12 +182,11 @@ After presenting your analysis, respect the user's decision.
 
 ## Temp Files
 
-**ALL temp files MUST go to the project temp dir** (`getProjectTmpDir(cwd)` → `/tmp/pi-data/<project>/`).
+**ALL temp files MUST go to the project temp dir** (`getProjectTmpDir(cwd)` → `<cwd>/.pi/tmp/`).
 
-- `<project>` is the cwd path with `/` replaced by `__` (e.g., `/home/user/git/my-repo` → `home__user__git__my-repo`)
-- This path persists across container restarts when `/tmp/pi-data` is mounted from the host
+- The `.pi/` directory is already gitignored — no risk of committing temp files
 
-NEVER create temp files in the project directory.
+NEVER create temp files directly in the project tree — always use `.pi/tmp/` via `getProjectTmpDir()`.
 
 ---
 


### PR DESCRIPTION
## Summary

Migrate all temp file storage from `/tmp/pi-data/<project>/` (global, path-encoded) to `<cwd>/.pi/tmp/` (project-local, already gitignored).

## Motivation

- Eliminates Docker mount `-v /tmp/pi-data:/tmp/pi-data:rw`
- No more path encoding with `__` (e.g., `home__myakove__git__pi-config`)
- No more container chown dance in `init-entrypoint.sh`
- Data collocated with project — `.pi/tmp/` lives next to `.pi/memory/`, `.pi/data/`

## Changes

### Core (`-38 lines`)
- **`utils.ts`** — `getProjectTmpDir(cwd)` returns `<cwd>/.pi/tmp/`, removed `PI_TMP_BASE_DIR`, fixed TOCTOU race
- **`async-agents.ts`** — removed `PI_TMP_BASE_DIR` import, use `process.cwd()` directly
- **`enforcement.ts`** — mktemp guard regex updated for `.pi/tmp` pattern
- **`image-gen.ts`** — `getTempDir()` uses `.pi/tmp/` pattern, removed `os` import

### Container (`-25 lines`)
- **`init-entrypoint.sh`** — removed both `/tmp/pi-data` creation/chown blocks

### Documentation
- **`README.md`** — removed Docker mount from examples and mount table (3 locations)
- **`AGENTS.md`** — updated temp directory section, removed path encoding docs
- **`DEVELOPMENT.md`** — updated stale async agent status path
- **`rules/40-critical-rules.md`** — updated temp files rule

Closes #493