### PR TITLE
fix: detect near-duplicate memories via vector similarity before adding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,6 +366,7 @@ Clean-room TypeScript implementation under MIT — not a code translation.
 - Model: `Xenova/bge-small-en-v1.5` (384 dims, runs locally via @huggingface/transformers ONNX)
 - Storage: `.pi/memory/embeddings.json`
 - Embed on write: `memory_add` embeds each entry immediately
+- Dedup on write: `memory_add` checks vector similarity (≥0.85) before inserting — reinforces existing entry if near-duplicate found in same category
 - Semantic search: `memory_search` embeds query, cosine similarity against stored vectors
 - Hybrid results: union of vector + keyword matches, deduplicated
 - Fallback: keyword-only search when @huggingface/transformers is unavailable
@@ -376,7 +377,7 @@ Clean-room TypeScript implementation under MIT — not a code translation.
 
 - `memory_search`: hybrid keyword + vector search across all topic entries
 - `memory_reinforce`: bump evidence count to prevent decay
-- `memory_add`: LLM-initiated memory writes (pinned or learned)
+- `memory_add`: LLM-initiated memory writes (pinned or learned); near-duplicate detection via vector similarity (≥0.85) auto-reinforces instead of adding
 - `memory_remove`: LLM-initiated entry removal
 - `memory_edit`: update content in-place or invalidate/supersede entries
 - `memory_reflect`: synthesize a coherent answer from recalled memories

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -281,7 +281,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
 
       // Check for near-duplicates via vector similarity (catches same lesson with different wording)
       try {
-        const vectorMatches = await vectorSearch(cwd, text, topicEntries, 5);
+        const vectorMatches = await vectorSearch(cwd, text, topicEntries, 20);
         for (const vm of vectorMatches) {
           if (vm.category === category && vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {
             const existingLine = `- [${vm.category}] ${vm.text}`;
@@ -293,8 +293,8 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
                 }],
               };
             }
-            // reinforce() failed (score entry missing) — fall through to add normally
-            break;
+            // reinforce() failed (score entry missing) — try next candidate
+            continue;
           }
         }
       } catch (err) {

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -281,6 +281,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
 
       // Check for near-duplicates via vector similarity (catches same lesson with different wording)
       try {
+        await embedMissing(cwd, topicEntries);
         const vectorMatches = await vectorSearch(cwd, text, topicEntries, 20);
         for (const vm of vectorMatches) {
           if (vm.category === category && vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -28,6 +28,8 @@ import {
 import { listTopics, readAllTopicEntries, CATEGORY_TO_TOPIC, MAX_TOPIC_CHARS, type TopicInfo } from "./memory-tree.js";
 import { embedEntry, removeEmbedding, vectorSearch, embedMissing } from "./memory-embeddings.js";
 
+const NEAR_DUPLICATE_THRESHOLD = 0.85;
+
 export function registerMemoryTools(pi: ExtensionAPI): void {
   // Only register in the orchestrator, not subagents
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
@@ -267,7 +269,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         ? `- [${category}] ${text} *(pinned)*`
         : canonicalLine;
 
-      // Check for duplicates
+      // Check for duplicates — exact match first, then vector similarity
       const topicEntries = readAllTopicEntries(cwd);
       for (const te of topicEntries) {
         if (te.text === text && te.category === category) {
@@ -275,6 +277,28 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
           reinforce(cwd, canonicalLine);
           return { content: [{ type: "text", text: `Already exists — reinforced instead: [${category}] ${text}` }] };
         }
+      }
+
+      // Check for near-duplicates via vector similarity (catches same lesson with different wording)
+      try {
+        const vectorMatches = await vectorSearch(cwd, text, topicEntries, 5);
+        for (const vm of vectorMatches) {
+          if (vm.category === category && vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {
+            const existingLine = `- [${vm.category}] ${vm.text}`;
+            if (reinforce(cwd, existingLine)) {
+              return {
+                content: [{
+                  type: "text",
+                  text: `Near-duplicate found (similarity: ${vm.similarity.toFixed(3)}) — reinforced instead: [${vm.category}] ${vm.text}`,
+                }],
+              };
+            }
+            // reinforce() failed (score entry missing) — fall through to add normally
+            break;
+          }
+        }
+      } catch (err) {
+        console.debug(`[memory] memory_add: vector dedup skipped: ${err}`);
       }
 
       const topicName = CATEGORY_TO_TOPIC[category as keyof typeof CATEGORY_TO_TOPIC];

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -281,7 +281,8 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
 
       // Check for near-duplicates via vector similarity (catches same lesson with different wording)
       try {
-        const sameCategoryEntries = topicEntries.filter(te => te.category === category);
+        const sameCategoryEntries = topicEntries.filter(te => te.category === category)
+          .filter((te, i, arr) => arr.findIndex(e => e.text === te.text) === i);
         await embedMissing(cwd, sameCategoryEntries);
         const vectorMatches = await vectorSearch(cwd, text, sameCategoryEntries, 20);
         for (const vm of vectorMatches) {

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -311,7 +311,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         if (te.text === text && te.category === category) {
           // Reinforce instead of duplicating — always use canonical line (no pinned marker)
           reinforce(cwd, canonicalLine);
-          await removeEmbedding(cwd, text, category);
+          // No removeEmbedding here — same text/category key as existing entry, embedding is still valid
           return { content: [{ type: "text", text: `Already exists — reinforced instead: [${category}] ${text}` }] };
         }
       }
@@ -364,7 +364,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       } as ScoredEntry;
       saveScores(cwd, scores);
 
-      // embedEntry already called during dedup check — this is a no-op (already in store)
+      // Embed the new entry (no-op if already embedded during dedup check above)
       await embedEntry(cwd, text, category);
 
       const pin = isPinned ? " (pinned)" : "";

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -281,10 +281,11 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
 
       // Check for near-duplicates via vector similarity (catches same lesson with different wording)
       try {
-        await embedMissing(cwd, topicEntries);
-        const vectorMatches = await vectorSearch(cwd, text, topicEntries, 20);
+        const sameCategoryEntries = topicEntries.filter(te => te.category === category);
+        await embedMissing(cwd, sameCategoryEntries);
+        const vectorMatches = await vectorSearch(cwd, text, sameCategoryEntries, 20);
         for (const vm of vectorMatches) {
-          if (vm.category === category && vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {
+          if (vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {
             const existingLine = `- [${vm.category}] ${vm.text}`;
             if (reinforce(cwd, existingLine)) {
               return {

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -269,15 +269,8 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         ? `- [${category}] ${text} *(pinned)*`
         : canonicalLine;
 
-      // Check for duplicates — exact match first, then vector similarity
+      // Check for duplicates — vector similarity first, then exact match
       const topicEntries = readAllTopicEntries(cwd);
-      for (const te of topicEntries) {
-        if (te.text === text && te.category === category) {
-          // Reinforce instead of duplicating — always use canonical line (no pinned marker)
-          reinforce(cwd, canonicalLine);
-          return { content: [{ type: "text", text: `Already exists — reinforced instead: [${category}] ${text}` }] };
-        }
-      }
 
       // Check for near-duplicates via vector similarity (catches same lesson with different wording)
       try {
@@ -288,11 +281,16 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
           return true;
         });
         await embedMissing(cwd, sameCategoryEntries);
+        // Embed the new entry now so vectorSearch can use the cached embedding
+        // and embedEntry() later is a no-op (already in store)
+        await embedEntry(cwd, text, category);
         const vectorMatches = await vectorSearch(cwd, text, sameCategoryEntries, 20);
         for (const vm of vectorMatches) {
           if (vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {
             const existingLine = `- [${vm.category}] ${vm.text}`;
             if (reinforce(cwd, existingLine)) {
+              // Remove the just-embedded entry since we're reinforcing instead of adding
+              await removeEmbedding(cwd, text, category);
               return {
                 content: [{
                   type: "text",
@@ -306,6 +304,16 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         }
       } catch (err) {
         console.debug(`[memory] memory_add: vector dedup skipped: ${err}`);
+      }
+
+      // Exact match check (fast O(n) string comparison after expensive vector check)
+      for (const te of topicEntries) {
+        if (te.text === text && te.category === category) {
+          // Reinforce instead of duplicating — always use canonical line (no pinned marker)
+          reinforce(cwd, canonicalLine);
+          await removeEmbedding(cwd, text, category);
+          return { content: [{ type: "text", text: `Already exists — reinforced instead: [${category}] ${text}` }] };
+        }
       }
 
       const topicName = CATEGORY_TO_TOPIC[category as keyof typeof CATEGORY_TO_TOPIC];
@@ -356,7 +364,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       } as ScoredEntry;
       saveScores(cwd, scores);
 
-      // Embed the new entry for vector search
+      // embedEntry already called during dedup check — this is a no-op (already in store)
       await embedEntry(cwd, text, category);
 
       const pin = isPinned ? " (pinned)" : "";

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -281,8 +281,12 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
 
       // Check for near-duplicates via vector similarity (catches same lesson with different wording)
       try {
-        const sameCategoryEntries = topicEntries.filter(te => te.category === category)
-          .filter((te, i, arr) => arr.findIndex(e => e.text === te.text) === i);
+        const seen = new Set<string>();
+        const sameCategoryEntries = topicEntries.filter(te => {
+          if (te.category !== category || seen.has(te.text)) return false;
+          seen.add(te.text);
+          return true;
+        });
         await embedMissing(cwd, sameCategoryEntries);
         const vectorMatches = await vectorSearch(cwd, text, sameCategoryEntries, 20);
         for (const vm of vectorMatches) {


### PR DESCRIPTION
## Summary

`memory_add` now checks vector similarity (≥0.85) against existing entries in the same category before creating a new entry. If a near-duplicate is found, the existing entry is reinforced instead of creating a duplicate with evidence=1.

## Problem

Same lesson added with slightly different wording across sessions (e.g., "deploy after push" vs "always deploy locally after commit+push") created separate entries each with evidence=1. Dreaming cleaned up older ones, so evidence never accumulated and the memory never reached the situation report threshold.

## Changes

- **`memory-tools.ts`** — added vector similarity near-duplicate check after exact-match dedup:
  - Named constant `NEAR_DUPLICATE_THRESHOLD = 0.85`
  - Checks `reinforce()` return value — falls through to add normally if scores are stale
  - Debug log on vector search failure
  - Clean type usage (no unnecessary `?? 0` or `!`)
- **`AGENTS.md`** — documented dedup-on-write behavior in Layer 4 and Memory Tools sections

Closes #495