### PR TITLE
fix: silence notify-send D-Bus errors in SSH sessions

### DIFF
--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -20,7 +20,7 @@ export function terminalNotify(title: string, body: string): void {
     timeout: 2000,
   }, (err) => {
     if (err) {
-      if ((err as any).code === "ENOENT") {
+      if ((err as any).code === "ENOENT" || /DBus\.Error|not activatable|No session bus/.test(err.message)) {
         notifyAvailable = false;
       } else {
         console.debug("[utils] notify-send failed:", err.message);


### PR DESCRIPTION
## Summary

Disable `notify-send` permanently for the session when D-Bus is unavailable (SSH environments). Previously only disabled on `ENOENT` (binary not found), but SSH sessions have the binary without D-Bus, causing repeated error logs.

## Changes

- **`utils.ts`** — extend error check to match `DBus.Error`, `not activatable`, `No session bus` patterns alongside existing `ENOENT` check

Trivial fix — no issue needed.