### PR TITLE
feat: commit trailer with custom identities + allow_push_to_protected_branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,7 +411,8 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 
 | Setting | Type | Default | Env var | Description |
 |---|---|---|---|---|
-| `co_author` | boolean | disabled | `PI_CO_AUTHOR` | Co-author trailer in commits |
+| `commit_trailer` | boolean \| string | disabled | `PI_COMMIT_TRAILER` | Commit trailer: `true` = PI only, `"Name <email>"` = custom + PI, `"A, B"` = ask user + PI |
+| `allow_push_to_protected_branches` | boolean | disabled | `PI_ALLOW_PUSH_TO_PROTECTED_BRANCHES` | Allow commits/pushes to protected branches |
 | `use_worktrees` | boolean | disabled | `PI_USE_WORKTREES` | Force worktree-only workflow |
 | `dream_interval_hours` | number | 3 | `PI_DREAM_INTERVAL_HOURS` | Dream frequency |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,7 +411,7 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 
 | Setting | Type | Default | Env var | Description |
 |---|---|---|---|---|
-| `commit_trailer` | boolean \| string | disabled | `PI_COMMIT_TRAILER` | Commit trailer: `true` = PI only, `"Name <email>"` = custom + PI, `"A, B"` = ask user + PI |
+| `commit_trailer` | string | disabled | `PI_COMMIT_TRAILER` | Commit trailer name: `"Assisted-by"` = adds `Assisted-by: PI (<model>)`, `"A, B"` = ask user which trailer |
 | `allow_push_to_protected_branches` | boolean | disabled | `PI_ALLOW_PUSH_TO_PROTECTED_BRANCHES` | Allow commits/pushes to protected branches |
 | `use_worktrees` | boolean | disabled | `PI_USE_WORKTREES` | Force worktree-only workflow |
 | `dream_interval_hours` | number | 3 | `PI_DREAM_INTERVAL_HOURS` | Dream frequency |

--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ Create `.pi/pi-config-settings.json` in your project to override global defaults
 
 ```json
 {
-  "co_author": true,
+  "commit_trailer": true,
+  "allow_push_to_protected_branches": false,
   "use_worktrees": true,
   "dream_interval_hours": 6
 }
@@ -229,7 +230,7 @@ Create `.pi/pi-config-settings.json` in your project to override global defaults
 
 Resolution order: project file → env var → default.
 
-Global env vars: `PI_CO_AUTHOR`, `PI_USE_WORKTREES`, `PI_DREAM_INTERVAL_HOURS`
+Global env vars: `PI_COMMIT_TRAILER`, `PI_ALLOW_PUSH_TO_PROTECTED_BRANCHES`, `PI_USE_WORKTREES`, `PI_DREAM_INTERVAL_HOURS`
 
 ### Override agents
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Create `.pi/pi-config-settings.json` in your project to override global defaults
 
 ```json
 {
-  "commit_trailer": true,
+  "commit_trailer": "Assisted-by",
   "allow_push_to_protected_branches": false,
   "use_worktrees": true,
   "dream_interval_hours": 6

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -89,41 +89,43 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
   // Track whether select_commit_trailer tool has been registered
   let trailerToolRegistered = false;
 
-  // Reset trailer identity cache on session start + conditionally register tool
-  pi.on("session_start", (_event, ctx) => {
-    cachedTrailerIdentity = null;
-    // Only register the tool when commit_trailer has multiple options
-    if (!trailerToolRegistered && getTrailerOptions(ctx.cwd)) {
-      trailerToolRegistered = true;
-      pi.registerTool({
-        name: "select_commit_trailer",
-        description: "Select which commit trailer identity to use for this session. " +
-          "Call this when a git commit is blocked because multiple trailer identities are configured. " +
-          "Pass the user's chosen identity string exactly as shown in the block reason.",
-        parameters: {
-          type: "object" as const,
-          properties: {
-            identity: {
-              type: "string",
-              description: "The selected trailer identity string (e.g., 'Jane Doe <jane@example.com>')",
-            },
+  /** Lazily register select_commit_trailer tool on first need */
+  function ensureTrailerTool(): void {
+    if (trailerToolRegistered) return;
+    trailerToolRegistered = true;
+    pi.registerTool({
+      name: "select_commit_trailer",
+      description: "Select which commit trailer identity to use for this session. " +
+        "Call this when a git commit is blocked because multiple trailer identities are configured. " +
+        "Pass the user's chosen identity string exactly as shown in the block reason.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          identity: {
+            type: "string",
+            description: "The selected trailer identity string (e.g., 'Jane Doe <jane@example.com>')",
           },
-          required: ["identity"],
         },
-        execute: async (params: { identity: string }, ctx: any) => {
-          const options = getTrailerOptions(ctx.cwd);
-          if (!options) {
-            return { content: [{ type: "text", text: "No trailer options configured." }] };
-          }
-          const identity = params.identity.trim();
-          if (!options.includes(identity)) {
-            return { content: [{ type: "text", text: `Invalid identity. Must be one of: ${options.join(", ")}` }] };
-          }
-          setTrailerIdentity(identity);
-          return { content: [{ type: "text", text: `Commit trailer identity set to: ${identity}. You can now retry the git commit.` }] };
-        },
-      });
-    }
+        required: ["identity"],
+      },
+      async execute(_toolCallId: string, params: { identity: string }, _signal: unknown, _onUpdate: unknown, ctx: any) {
+        const options = getTrailerOptions(ctx.cwd);
+        if (!options) {
+          return { content: [{ type: "text", text: "No trailer options configured." }] };
+        }
+        const identity = params.identity.trim();
+        if (!options.includes(identity)) {
+          return { content: [{ type: "text", text: `Invalid identity. Must be one of: ${options.join(", ")}` }] };
+        }
+        setTrailerIdentity(identity);
+        return { content: [{ type: "text", text: `Commit trailer identity set to: ${identity}. You can now retry the git commit.` }] };
+      },
+    });
+  }
+
+  // Reset trailer identity cache on session start
+  pi.on("session_start", () => {
+    cachedTrailerIdentity = null;
   });
 
   pi.on("tool_call", async (event, ctx) => {
@@ -346,6 +348,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             if (typeof trailerSetting === "string" && trailerSetting.includes(",")) {
               // Multiple options — need user selection
               if (!cachedTrailerIdentity) {
+                ensureTrailerTool();
                 const options = getTrailerOptions(ctx.cwd) ?? [];
                 const optionsList = options.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
                 return {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -35,6 +35,9 @@ function normalizeForRepeatCheck(command: string): string {
 // Repeat detection file — set to project dir on first use
 let REPEAT_FILE = "";
 
+/** Cached trailer identity selection for comma-separated commit_trailer values */
+let cachedTrailerIdentity: string | null = null;
+
 function ensureRepeatFile(cwd: string): void {
   if (!REPEAT_FILE) {
     REPEAT_FILE = join(getProjectTmpDir(cwd), `.repeat-${process.pid}.json`);
@@ -78,6 +81,40 @@ function resolveEffectiveCwd(command: string, sessionCwd: string): string {
 
 export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): void {
 
+  // Register select_commit_trailer tool for choosing trailer identity
+  pi.registerTool({
+    name: "select_commit_trailer",
+    description: "Select which commit trailer identity to use for this session. " +
+      "Call this when a git commit is blocked because multiple trailer identities are configured. " +
+      "Pass the user's chosen identity string exactly as shown in the block reason.",
+    parameters: {
+      type: "object" as const,
+      properties: {
+        identity: {
+          type: "string",
+          description: "The selected trailer identity string (e.g., 'Jane Doe <jane@example.com>')",
+        },
+      },
+      required: ["identity"],
+    },
+    execute: async (params: { identity: string }, ctx: any) => {
+      const options = getTrailerOptions(ctx.cwd);
+      if (!options) {
+        return { content: [{ type: "text", text: "No trailer options configured — commit_trailer setting is not comma-separated." }] };
+      }
+      const identity = params.identity.trim();
+      if (!options.includes(identity)) {
+        return { content: [{ type: "text", text: `Invalid identity. Must be one of: ${options.join(", ")}` }] };
+      }
+      setTrailerIdentity(identity);
+      return { content: [{ type: "text", text: `Commit trailer identity set to: ${identity}. You can now retry the git commit.` }] };
+    },
+  });
+
+  // Reset trailer identity cache on session start
+  pi.on("session_start", () => {
+    cachedTrailerIdentity = null;
+  });
 
   pi.on("tool_call", async (event, ctx) => {
     if (!isToolCallEventType("bash", event)) return undefined;
@@ -258,7 +295,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       const mainBranch = getMainBranch(gitCwd);
       const protectedBranches = getProtectedBranches(gitCwd);
 
-      // Block commits to protected branches
+      // Block commits to protected branches (unless allow_push_to_protected is set)
       if (hasGitSub(command, "commit")) {
         if (!branch)
           return {
@@ -266,7 +303,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             reason:
               "⛔ Detached HEAD. Create a branch first: git checkout -b my-branch",
           };
-        if (protectedBranches.has(branch))
+        if (protectedBranches.has(branch) && !getSetting(ctx.cwd, "allow_push_to_protected_branches"))
           return {
             block: true,
             reason: `⛔ Cannot commit to '${branch}' (protected). Create a feature branch.\nHint: If you're combining git checkout + git commit in one bash call, split them into SEPARATE bash calls. Branch is checked before execution.`,
@@ -288,32 +325,56 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             reason: `⛔ Branch '${branch}' already merged into '${mainBranch}'. Create a new branch.`,
           };
 
-        // Co-author trailer injection
-        if (getSetting(ctx.cwd, "co_author")) {
+        // Commit trailer injection (Assisted-by)
+        const trailerSetting = getSetting(ctx.cwd, "commit_trailer");
+        if (trailerSetting) {
           const model = (ctx as any).model;
-          if (model?.id && !command.includes("Co-authored-by:")) {
-            // Pattern A: echo "..." | git commit -F -
-            const pipeIdx = command.lastIndexOf("|");
-            if (pipeIdx !== -1 && /git\s+commit\s+.*-F\s*-/.test(command.slice(pipeIdx))) {
-              const echoPart = command.slice(0, pipeIdx);
-              const gitPart = command.slice(pipeIdx);
-              // Find the closing quote of the echo
-              const lastDoubleQuote = echoPart.lastIndexOf('"');
-              const lastSingleQuote = echoPart.lastIndexOf("'");
-              const lastQuoteIdx = Math.max(lastDoubleQuote, lastSingleQuote);
-              if (lastQuoteIdx > 0) {
-                event.input.command =
-                  echoPart.slice(0, lastQuoteIdx) + `\\n\\nCo-authored-by: PI (${model.id}) <noreply@pi.dev>` + echoPart.slice(lastQuoteIdx) + gitPart;
+          if (model?.id && !command.includes("Assisted-by:")) {
+            // Determine trailer lines
+            let trailerLines: string | null = null;
+
+            if (typeof trailerSetting === "string" && trailerSetting.includes(",")) {
+              // Multiple options — need user selection
+              if (!cachedTrailerIdentity) {
+                const options = getTrailerOptions(ctx.cwd) ?? [];
+                const optionsList = options.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
+                return {
+                  block: true,
+                  reason: `\u26d4 Select commit trailer identity before committing. Options: ${optionsList}. Ask the user which identity to use, then call select_commit_trailer with their choice.`,
+                };
               }
+              trailerLines = `Assisted-by: ${cachedTrailerIdentity}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
+            } else if (typeof trailerSetting === "string") {
+              // Single custom identity
+              trailerLines = `Assisted-by: ${trailerSetting}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
+            } else {
+              // true — PI only
+              trailerLines = `Assisted-by: PI (${model.id}) <noreply@pi.dev>`;
             }
-            // Pattern B: git commit -m "..."
-            else {
-              const mFlagMatch = command.match(/git\s+commit\s+.*-m\s+(["'])([\s\S]*?)\1/);
-              if (mFlagMatch) {
-                const fullMatch = mFlagMatch[0];
-                const insertPos = command.indexOf(fullMatch) + fullMatch.length - 1; // before closing quote
-                event.input.command =
-                  command.slice(0, insertPos) + `\n\nCo-authored-by: PI (${model.id}) <noreply@pi.dev>` + command.slice(insertPos);
+
+            if (trailerLines) {
+              // Pattern A: echo "..." | git commit -F -
+              const pipeIdx = command.lastIndexOf("|");
+              if (pipeIdx !== -1 && /git\s+commit\s+.*-F\s*-/.test(command.slice(pipeIdx))) {
+                const echoPart = command.slice(0, pipeIdx);
+                const gitPart = command.slice(pipeIdx);
+                const lastDoubleQuote = echoPart.lastIndexOf('"');
+                const lastSingleQuote = echoPart.lastIndexOf("'");
+                const lastQuoteIdx = Math.max(lastDoubleQuote, lastSingleQuote);
+                if (lastQuoteIdx > 0) {
+                  event.input.command =
+                    echoPart.slice(0, lastQuoteIdx) + `\\n\\n${trailerLines.replace(/\n/g, "\\n")}` + echoPart.slice(lastQuoteIdx) + gitPart;
+                }
+              }
+              // Pattern B: git commit -m "..."
+              else {
+                const mFlagMatch = command.match(/git\s+commit\s+.*-m\s+(["'])([\s\S]*?)\1/);
+                if (mFlagMatch) {
+                  const fullMatch = mFlagMatch[0];
+                  const insertPos = command.indexOf(fullMatch) + fullMatch.length - 1;
+                  event.input.command =
+                    command.slice(0, insertPos) + `\n\n${trailerLines}` + command.slice(insertPos);
+                }
               }
             }
           }
@@ -323,18 +384,20 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       // Block pushes to protected branches
       if (hasGitSub(command, "push")) {
         // Block if currently on a protected branch
-        if (branch && protectedBranches.has(branch))
-          return {
-            block: true,
-            reason: `⛔ Cannot push to '${branch}' (protected). Create a feature branch.\nHint: If you're combining git checkout + git push in one bash call, split them into SEPARATE bash calls. Branch is checked before execution.`,
-          };
-        // Block explicit push to any protected branch (e.g., git push origin v2.10)
-        for (const pb of protectedBranches) {
-          if (new RegExp(`\\bgit\\b.*\\bpush\\b.*\\b${pb.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(command))
+        if (!getSetting(ctx.cwd, "allow_push_to_protected_branches")) {
+          if (branch && protectedBranches.has(branch))
             return {
               block: true,
-              reason: `⛔ Cannot push to '${pb}' (protected). Create a feature branch.`,
+              reason: `⛔ Cannot push to '${branch}' (protected). Create a feature branch.\nHint: If you're combining git checkout + git push in one bash call, split them into SEPARATE bash calls. Branch is checked before execution.`,
             };
+          // Block explicit push to any protected branch (e.g., git push origin v2.10)
+          for (const pb of protectedBranches) {
+            if (new RegExp(`\\bgit\\b.*\\bpush\\b.*\\b${pb.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(command))
+              return {
+                block: true,
+                reason: `⛔ Cannot push to '${pb}' (protected). Create a feature branch.`,
+              };
+          }
         }
         if (branch) {
           const pr = getPrMergeStatus(branch, gitCwd);
@@ -384,6 +447,20 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     return undefined;
   });
+}
+
+/** Set the cached commit trailer identity (called by select_commit_trailer tool) */
+export function setTrailerIdentity(identity: string): void {
+  cachedTrailerIdentity = identity;
+}
+
+/** Get available trailer options from setting (null if not comma-separated) */
+export function getTrailerOptions(cwd: string): string[] | null {
+  const setting = getSetting(cwd, "commit_trailer");
+  if (typeof setting === "string" && setting.includes(",")) {
+    return setting.split(",").map(s => s.trim()).filter(Boolean);
+  }
+  return null;
 }
 
 // trigger re-scan

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -341,7 +341,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         const trailerSetting = getSetting(ctx.cwd, "commit_trailer");
         if (typeof trailerSetting === "string") {
           const model = (ctx as any).model;
-          const piIdentity = `PI (${model?.id || "unknown"}) <noreply@pi.dev>`;
+          const piIdentity = `PI (${model.id}) <noreply@pi.dev>`;
           if (model?.id && !command.includes(`: ${piIdentity}`)) {
             let trailerName: string;
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -38,9 +38,14 @@ let REPEAT_FILE = "";
 /** Cached trailer identity selection for comma-separated commit_trailer values */
 let cachedTrailerIdentity: string | null = null;
 
-/** Escape a string for safe inclusion in shell single/double-quoted strings */
-function shellEscapeTrailer(s: string): string {
-  return s.replace(/[\\'"`$!]/g, "\\$&");
+/** Escape a string for safe inclusion in double-quoted shell strings */
+function escapeForDoubleQuote(s: string): string {
+  return s.replace(/[\\"`$!]/g, "\\$&");
+}
+
+/** Escape a string for safe inclusion in single-quoted shell strings */
+function escapeForSingleQuote(s: string): string {
+  return s.replace(/'/g, "'\\''");
 }
 
 function ensureRepeatFile(cwd: string): void {
@@ -315,7 +320,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             reason:
               "⛔ Detached HEAD. Create a branch first: git checkout -b my-branch",
           };
-        if (protectedBranches.has(branch) && !getSetting(ctx.cwd, "allow_push_to_protected_branches"))
+        if (protectedBranches.has(branch) && !getSetting(gitCwd, "allow_push_to_protected_branches"))
           return {
             block: true,
             reason: `⛔ Cannot commit to '${branch}' (protected). Create a feature branch.\nHint: If you're combining git checkout + git commit in one bash call, split them into SEPARATE bash calls. Branch is checked before execution.`,
@@ -338,7 +343,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
           };
 
         // Commit trailer injection — setting value is the trailer name (e.g., "Assisted-by")
-        const trailerSetting = getSetting(ctx.cwd, "commit_trailer");
+        const trailerSetting = getSetting(gitCwd, "commit_trailer");
         if (typeof trailerSetting === "string") {
           const modelId = (ctx as any).model?.id;
           if (modelId) {
@@ -349,7 +354,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
               // Multiple trailer name options — need user selection
               if (!cachedTrailerIdentity) {
                 ensureTrailerTool();
-                const options = getTrailerOptions(ctx.cwd) ?? [];
+                const options = getTrailerOptions(gitCwd) ?? [];
                 const optionsList = options.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
                 return {
                   block: true,
@@ -357,7 +362,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
                 };
               }
               // Validate cached selection is still in current options
-              const currentOptions = getTrailerOptions(ctx.cwd) ?? [];
+              const currentOptions = getTrailerOptions(gitCwd) ?? [];
               if (!currentOptions.includes(cachedTrailerIdentity)) {
                 cachedTrailerIdentity = null;
                 const optionsList = currentOptions.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
@@ -372,33 +377,40 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
               trailerName = trailerSetting;
             }
 
-            // Skip if this specific trailer already exists in the command (check both raw and escaped forms)
-            const trailerLines = `${shellEscapeTrailer(trailerName)}: ${piIdentity}`;
-            if (command.includes(trailerLines) || command.includes(`${trailerName}: ${piIdentity}`)) return undefined;
+            // Raw trailer line for duplicate detection (what the commit message should contain)
+            const rawTrailerLine = `${trailerName}: ${piIdentity}`;
+            if (command.includes(rawTrailerLine)) return undefined;
 
-            if (trailerLines) {
-              // Pattern A: echo "..." | git commit -F -
-              const pipeIdx = command.lastIndexOf("|");
-              if (pipeIdx !== -1 && /git\s+commit\s+.*-F\s*-/.test(command.slice(pipeIdx))) {
-                const echoPart = command.slice(0, pipeIdx);
-                const gitPart = command.slice(pipeIdx);
-                const lastDoubleQuote = echoPart.lastIndexOf('"');
-                const lastSingleQuote = echoPart.lastIndexOf("'");
-                const lastQuoteIdx = Math.max(lastDoubleQuote, lastSingleQuote);
-                if (lastQuoteIdx > 0) {
-                  event.input.command =
-                    echoPart.slice(0, lastQuoteIdx) + `\\n\\n${trailerLines.replace(/\n/g, "\\n")}` + echoPart.slice(lastQuoteIdx) + gitPart;
-                }
+            // Pattern A: echo "..." | git commit -F -
+            const pipeIdx = command.lastIndexOf("|");
+            if (pipeIdx !== -1 && /git\s+commit\s+.*-F\s*-/.test(command.slice(pipeIdx))) {
+              const echoPart = command.slice(0, pipeIdx);
+              const gitPart = command.slice(pipeIdx);
+              const lastDoubleQuote = echoPart.lastIndexOf('"');
+              const lastSingleQuote = echoPart.lastIndexOf("'");
+              const lastQuoteIdx = Math.max(lastDoubleQuote, lastSingleQuote);
+              if (lastQuoteIdx > 0) {
+                // Determine quote context for correct escaping
+                const quoteChar = echoPart[lastQuoteIdx];
+                const escaped = quoteChar === "'"
+                  ? `${escapeForSingleQuote(trailerName)}: ${piIdentity}`
+                  : `${escapeForDoubleQuote(trailerName)}: ${piIdentity}`;
+                event.input.command =
+                  echoPart.slice(0, lastQuoteIdx) + `\\n\\n${escaped.replace(/\n/g, "\\n")}` + echoPart.slice(lastQuoteIdx) + gitPart;
               }
-              // Pattern B: git commit -m "..."
-              else {
-                const mFlagMatch = command.match(/git\s+commit\s+.*-m\s+(["'])([\s\S]*?)\1/);
-                if (mFlagMatch) {
-                  const fullMatch = mFlagMatch[0];
-                  const insertPos = command.indexOf(fullMatch) + fullMatch.length - 1;
-                  event.input.command =
-                    command.slice(0, insertPos) + `\n\n${trailerLines}` + command.slice(insertPos);
-                }
+            }
+            // Pattern B: git commit -m "..." or git commit -m '...'
+            else {
+              const mFlagMatch = command.match(/git\s+commit\s+.*-m\s+(["'])([\s\S]*?)\1/);
+              if (mFlagMatch) {
+                const quoteChar = mFlagMatch[1];
+                const escaped = quoteChar === "'"
+                  ? `${escapeForSingleQuote(trailerName)}: ${piIdentity}`
+                  : `${escapeForDoubleQuote(trailerName)}: ${piIdentity}`;
+                const fullMatch = mFlagMatch[0];
+                const insertPos = command.indexOf(fullMatch) + fullMatch.length - 1;
+                event.input.command =
+                  command.slice(0, insertPos) + `\n\n${escaped}` + command.slice(insertPos);
               }
             }
           }
@@ -408,7 +420,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       // Block pushes to protected branches
       if (hasGitSub(command, "push")) {
         // Block if currently on a protected branch
-        if (!getSetting(ctx.cwd, "allow_push_to_protected_branches")) {
+        if (!getSetting(gitCwd, "allow_push_to_protected_branches")) {
           if (branch && protectedBranches.has(branch))
             return {
               block: true,

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -95,15 +95,15 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     trailerToolRegistered = true;
     pi.registerTool({
       name: "select_commit_trailer",
-      description: "Select which commit trailer identity to use for this session. " +
-        "Call this when a git commit is blocked because multiple trailer identities are configured. " +
-        "Pass the identity string WITHOUT the numeric prefix (e.g., 'Jane Doe <jane@example.com>', not '1) Jane Doe <jane@example.com>').",
+      description: "Select which commit trailer name to use for this session. " +
+        "Call this when a git commit is blocked because multiple trailer options are configured. " +
+        "Pass the trailer name WITHOUT the numeric prefix (e.g., 'Assisted-by', not '1) Assisted-by').",
       parameters: {
         type: "object" as const,
         properties: {
           identity: {
             type: "string",
-            description: "The selected trailer identity string (e.g., 'Jane Doe <jane@example.com>')",
+            description: "The selected trailer name (e.g., 'Assisted-by')",
           },
         },
         required: ["identity"],
@@ -337,43 +337,42 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             reason: `⛔ Branch '${branch}' already merged into '${mainBranch}'. Create a new branch.`,
           };
 
-        // Commit trailer injection (Assisted-by)
+        // Commit trailer injection — setting value is the trailer name (e.g., "Assisted-by")
         const trailerSetting = getSetting(ctx.cwd, "commit_trailer");
-        if (trailerSetting) {
+        if (typeof trailerSetting === "string") {
           const model = (ctx as any).model;
-          if (model?.id && !command.includes("Assisted-by:")) {
-            // Determine trailer lines
-            let trailerLines: string | null = null;
+          const piIdentity = `PI (${model?.id || "unknown"}) <noreply@pi.dev>`;
+          if (model?.id && !command.includes(`: ${piIdentity}`)) {
+            let trailerName: string;
 
-            if (typeof trailerSetting === "string" && trailerSetting.includes(",")) {
-              // Multiple options — need user selection
+            if (trailerSetting.includes(",")) {
+              // Multiple trailer name options — need user selection
               if (!cachedTrailerIdentity) {
                 ensureTrailerTool();
                 const options = getTrailerOptions(ctx.cwd) ?? [];
                 const optionsList = options.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
                 return {
                   block: true,
-                  reason: `\u26d4 Select commit trailer identity before committing. Options: ${optionsList}. Ask the user which identity to use, then call select_commit_trailer with their choice.`,
+                  reason: `\u26d4 Select commit trailer before committing. Options: ${optionsList}. Ask the user which trailer to use, then call select_commit_trailer with their choice.`,
                 };
               }
-              // Validate cached identity is still in current options
+              // Validate cached selection is still in current options
               const currentOptions = getTrailerOptions(ctx.cwd) ?? [];
               if (!currentOptions.includes(cachedTrailerIdentity)) {
                 cachedTrailerIdentity = null;
                 const optionsList = currentOptions.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
                 return {
                   block: true,
-                  reason: `\u26d4 Cached trailer identity is no longer valid. Options: ${optionsList}. Ask the user which identity to use, then call select_commit_trailer with their choice.`,
+                  reason: `\u26d4 Cached trailer is no longer valid. Options: ${optionsList}. Ask the user which trailer to use, then call select_commit_trailer with their choice.`,
                 };
               }
-              trailerLines = `Assisted-by: ${shellEscapeTrailer(cachedTrailerIdentity)}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
-            } else if (typeof trailerSetting === "string") {
-              // Single custom identity
-              trailerLines = `Assisted-by: ${shellEscapeTrailer(trailerSetting)}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
+              trailerName = cachedTrailerIdentity;
             } else {
-              // true — PI only
-              trailerLines = `Assisted-by: PI (${model.id}) <noreply@pi.dev>`;
+              // Single trailer name
+              trailerName = trailerSetting;
             }
+
+            const trailerLines = `${shellEscapeTrailer(trailerName)}: ${piIdentity}`;
 
             if (trailerLines) {
               // Pattern A: echo "..." | git commit -F -

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -97,7 +97,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       name: "select_commit_trailer",
       description: "Select which commit trailer identity to use for this session. " +
         "Call this when a git commit is blocked because multiple trailer identities are configured. " +
-        "Pass the user's chosen identity string exactly as shown in the block reason.",
+        "Pass the identity string WITHOUT the numeric prefix (e.g., 'Jane Doe <jane@example.com>', not '1) Jane Doe <jane@example.com>').",
       parameters: {
         type: "object" as const,
         properties: {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -340,9 +340,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         // Commit trailer injection — setting value is the trailer name (e.g., "Assisted-by")
         const trailerSetting = getSetting(ctx.cwd, "commit_trailer");
         if (typeof trailerSetting === "string") {
-          const model = (ctx as any).model;
-          const piIdentity = `PI (${model.id}) <noreply@pi.dev>`;
-          if (model?.id && !command.includes(`: ${piIdentity}`)) {
+          const modelId = (ctx as any).model?.id;
+          if (modelId && !command.includes(`: PI (${modelId}) <noreply@pi.dev>`)) {
+            const piIdentity = `PI (${modelId}) <noreply@pi.dev>`;
             let trailerName: string;
 
             if (trailerSetting.includes(",")) {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -372,9 +372,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
               trailerName = trailerSetting;
             }
 
-            // Skip if this specific trailer already exists in the command
-            if (command.includes(`${trailerName}: ${piIdentity}`)) return undefined;
+            // Skip if this specific trailer already exists in the command (check both raw and escaped forms)
             const trailerLines = `${shellEscapeTrailer(trailerName)}: ${piIdentity}`;
+            if (command.includes(trailerLines) || command.includes(`${trailerName}: ${piIdentity}`)) return undefined;
 
             if (trailerLines) {
               // Pattern A: echo "..." | git commit -F -

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -38,6 +38,11 @@ let REPEAT_FILE = "";
 /** Cached trailer identity selection for comma-separated commit_trailer values */
 let cachedTrailerIdentity: string | null = null;
 
+/** Escape a string for safe inclusion in shell single/double-quoted strings */
+function shellEscapeTrailer(s: string): string {
+  return s.replace(/[\\'"`$!]/g, "\\$&");
+}
+
 function ensureRepeatFile(cwd: string): void {
   if (!REPEAT_FILE) {
     REPEAT_FILE = join(getProjectTmpDir(cwd), `.repeat-${process.pid}.json`);
@@ -81,39 +86,44 @@ function resolveEffectiveCwd(command: string, sessionCwd: string): string {
 
 export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): void {
 
-  // Register select_commit_trailer tool for choosing trailer identity
-  pi.registerTool({
-    name: "select_commit_trailer",
-    description: "Select which commit trailer identity to use for this session. " +
-      "Call this when a git commit is blocked because multiple trailer identities are configured. " +
-      "Pass the user's chosen identity string exactly as shown in the block reason.",
-    parameters: {
-      type: "object" as const,
-      properties: {
-        identity: {
-          type: "string",
-          description: "The selected trailer identity string (e.g., 'Jane Doe <jane@example.com>')",
-        },
-      },
-      required: ["identity"],
-    },
-    execute: async (params: { identity: string }, ctx: any) => {
-      const options = getTrailerOptions(ctx.cwd);
-      if (!options) {
-        return { content: [{ type: "text", text: "No trailer options configured — commit_trailer setting is not comma-separated." }] };
-      }
-      const identity = params.identity.trim();
-      if (!options.includes(identity)) {
-        return { content: [{ type: "text", text: `Invalid identity. Must be one of: ${options.join(", ")}` }] };
-      }
-      setTrailerIdentity(identity);
-      return { content: [{ type: "text", text: `Commit trailer identity set to: ${identity}. You can now retry the git commit.` }] };
-    },
-  });
+  // Track whether select_commit_trailer tool has been registered
+  let trailerToolRegistered = false;
 
-  // Reset trailer identity cache on session start
-  pi.on("session_start", () => {
+  // Reset trailer identity cache on session start + conditionally register tool
+  pi.on("session_start", (_event, ctx) => {
     cachedTrailerIdentity = null;
+    // Only register the tool when commit_trailer has multiple options
+    if (!trailerToolRegistered && getTrailerOptions(ctx.cwd)) {
+      trailerToolRegistered = true;
+      pi.registerTool({
+        name: "select_commit_trailer",
+        description: "Select which commit trailer identity to use for this session. " +
+          "Call this when a git commit is blocked because multiple trailer identities are configured. " +
+          "Pass the user's chosen identity string exactly as shown in the block reason.",
+        parameters: {
+          type: "object" as const,
+          properties: {
+            identity: {
+              type: "string",
+              description: "The selected trailer identity string (e.g., 'Jane Doe <jane@example.com>')",
+            },
+          },
+          required: ["identity"],
+        },
+        execute: async (params: { identity: string }, ctx: any) => {
+          const options = getTrailerOptions(ctx.cwd);
+          if (!options) {
+            return { content: [{ type: "text", text: "No trailer options configured." }] };
+          }
+          const identity = params.identity.trim();
+          if (!options.includes(identity)) {
+            return { content: [{ type: "text", text: `Invalid identity. Must be one of: ${options.join(", ")}` }] };
+          }
+          setTrailerIdentity(identity);
+          return { content: [{ type: "text", text: `Commit trailer identity set to: ${identity}. You can now retry the git commit.` }] };
+        },
+      });
+    }
   });
 
   pi.on("tool_call", async (event, ctx) => {
@@ -343,10 +353,20 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
                   reason: `\u26d4 Select commit trailer identity before committing. Options: ${optionsList}. Ask the user which identity to use, then call select_commit_trailer with their choice.`,
                 };
               }
-              trailerLines = `Assisted-by: ${cachedTrailerIdentity}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
+              // Validate cached identity is still in current options
+              const currentOptions = getTrailerOptions(ctx.cwd) ?? [];
+              if (!currentOptions.includes(cachedTrailerIdentity)) {
+                cachedTrailerIdentity = null;
+                const optionsList = currentOptions.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
+                return {
+                  block: true,
+                  reason: `\u26d4 Cached trailer identity is no longer valid. Options: ${optionsList}. Ask the user which identity to use, then call select_commit_trailer with their choice.`,
+                };
+              }
+              trailerLines = `Assisted-by: ${shellEscapeTrailer(cachedTrailerIdentity)}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
             } else if (typeof trailerSetting === "string") {
               // Single custom identity
-              trailerLines = `Assisted-by: ${trailerSetting}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
+              trailerLines = `Assisted-by: ${shellEscapeTrailer(trailerSetting)}\nAssisted-by: PI (${model.id}) <noreply@pi.dev>`;
             } else {
               // true — PI only
               trailerLines = `Assisted-by: PI (${model.id}) <noreply@pi.dev>`;

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -341,7 +341,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         const trailerSetting = getSetting(ctx.cwd, "commit_trailer");
         if (typeof trailerSetting === "string") {
           const modelId = (ctx as any).model?.id;
-          if (modelId && !command.includes(`: PI (${modelId}) <noreply@pi.dev>`)) {
+          if (modelId) {
             const piIdentity = `PI (${modelId}) <noreply@pi.dev>`;
             let trailerName: string;
 
@@ -372,6 +372,8 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
               trailerName = trailerSetting;
             }
 
+            // Skip if this specific trailer already exists in the command
+            if (command.includes(`${trailerName}: ${piIdentity}`)) return undefined;
             const trailerLines = `${shellEscapeTrailer(trailerName)}: ${piIdentity}`;
 
             if (trailerLines) {

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -3,16 +3,17 @@
  *
  * Resolution order:
  * 1. Project .pi/pi-config-settings.json (wins if set)
- * 2. Global env var (PI_CO_AUTHOR, PI_USE_WORKTREES, PI_DREAM_INTERVAL_HOURS)
+ * 2. Global env var (PI_COMMIT_TRAILER, PI_USE_WORKTREES, PI_DREAM_INTERVAL_HOURS)
  * 3. Default (only dream_interval_hours has a default of 3)
  */
 
-import { existsSync, lstatSync, statSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { existsSync, statSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 interface ProjectSettings {
-  co_author?: boolean;
+  commit_trailer?: boolean | string;
+  allow_push_to_protected_branches?: boolean;
   use_worktrees?: boolean;
   dream_interval_hours?: number;
 }
@@ -30,7 +31,8 @@ function loadProjectSettings(cwd: string): ProjectSettings {
     const raw = JSON.parse(readFileSync(settingsPath, "utf-8"));
     if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
     const result: ProjectSettings = {};
-    if (typeof raw.co_author === "boolean") result.co_author = raw.co_author;
+    if (typeof raw.commit_trailer === "boolean" || typeof raw.commit_trailer === "string") result.commit_trailer = raw.commit_trailer;
+    if (typeof raw.allow_push_to_protected_branches === "boolean") result.allow_push_to_protected_branches = raw.allow_push_to_protected_branches;
     if (typeof raw.use_worktrees === "boolean") result.use_worktrees = raw.use_worktrees;
     if (typeof raw.dream_interval_hours === "number" && Number.isFinite(raw.dream_interval_hours)) {
       result.dream_interval_hours = raw.dream_interval_hours;
@@ -39,13 +41,6 @@ function loadProjectSettings(cwd: string): ProjectSettings {
   } catch {
     return {};
   }
-}
-
-function saveProjectSettings(cwd: string, settings: ProjectSettings): void {
-  const settingsPath = getSettingsPath(cwd);
-  const dir = dirname(settingsPath);
-  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + "\n", "utf-8");
 }
 
 function parseBoolEnv(name: string): boolean | undefined {
@@ -94,7 +89,7 @@ function getSettings(cwd: string): ProjectSettings {
 }
 
 /** Clear cache — call after migration or manual edits */
-function clearSettingsCache(): void {
+export function clearSettingsCache(): void {
   cachedCwd = "";
   cachedSettings = {};
 }
@@ -102,18 +97,29 @@ function clearSettingsCache(): void {
 /**
  * Get a setting value. Resolution: project file → env var → default.
  */
-export function getSetting(cwd: string, key: "co_author"): boolean;
+export function getSetting(cwd: string, key: "commit_trailer"): boolean | string;
+export function getSetting(cwd: string, key: "allow_push_to_protected_branches"): boolean;
 export function getSetting(cwd: string, key: "use_worktrees"): boolean;
 export function getSetting(cwd: string, key: "dream_interval_hours"): number;
-export function getSetting(cwd: string, key: string): boolean | number {
+export function getSetting(cwd: string, key: string): boolean | string | number {
   const settings = getSettings(cwd);
 
   switch (key) {
-    case "co_author": {
-      if (settings.co_author !== undefined) return settings.co_author;
-      const env = parseBoolEnv("PI_CO_AUTHOR");
-      if (env !== undefined) return env;
+    case "commit_trailer": {
+      if (settings.commit_trailer !== undefined) return settings.commit_trailer;
+      const envStr = process.env.PI_COMMIT_TRAILER;
+      if (envStr !== undefined && envStr !== "") {
+        if (["true", "1", "yes", "on"].includes(envStr.toLowerCase())) return true;
+        if (["false", "0", "no", "off"].includes(envStr.toLowerCase())) return false;
+        return envStr; // treat as custom trailer string
+      }
       return false; // default: disabled
+    }
+    case "allow_push_to_protected_branches": {
+      if (settings.allow_push_to_protected_branches !== undefined) return settings.allow_push_to_protected_branches;
+      const env = parseBoolEnv("PI_ALLOW_PUSH_TO_PROTECTED_BRANCHES");
+      if (env !== undefined) return env;
+      return false; // default: block pushes to protected branches
     }
     case "use_worktrees": {
       if (settings.use_worktrees !== undefined) return settings.use_worktrees;
@@ -133,54 +139,12 @@ export function getSetting(cwd: string, key: string): boolean | number {
 }
 
 /**
- * One-time migration: .pi-co-author file → pi-config-settings.json
- * Call on session_start. If .pi-co-author exists, migrate and delete it.
- */
-function migrateCoAuthorFile(cwd: string): void {
-  const legacyPath = join(cwd, ".pi-co-author");
-  if (!existsSync(legacyPath)) return;
-
-  try {
-    const settingsPath = getSettingsPath(cwd);
-    const dir = dirname(settingsPath);
-    // Guard against symlink attacks — skip migration if .pi or settings file is a symlink
-    if (existsSync(dir) && lstatSync(dir).isSymbolicLink()) {
-      console.debug("[project-settings] .pi dir is a symlink — skipping write, deleting legacy file");
-      try { unlinkSync(legacyPath); } catch {}
-      return;
-    }
-    if (existsSync(settingsPath) && lstatSync(settingsPath).isSymbolicLink()) {
-      console.debug("[project-settings] settings file is a symlink — skipping write, deleting legacy file");
-      try { unlinkSync(legacyPath); } catch {}
-      return;
-    }
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    // Read raw JSON to preserve unknown keys
-    let raw: Record<string, unknown> = {};
-    if (existsSync(settingsPath)) {
-      try { raw = JSON.parse(readFileSync(settingsPath, "utf-8")); } catch {}
-      if (typeof raw !== "object" || raw === null || Array.isArray(raw)) raw = {};
-    }
-    if (raw.co_author === undefined) {
-      raw.co_author = true;
-    }
-    writeFileSync(settingsPath, JSON.stringify(raw, null, 2) + "\n", "utf-8");
-    unlinkSync(legacyPath);
-    console.debug("[project-settings] Migrated .pi-co-author → pi-config-settings.json");
-    clearSettingsCache();
-  } catch (e: any) {
-    console.debug("[project-settings] migration failed:", e?.message?.slice(0, 100));
-  }
-}
-
-/**
  * Register project settings — runs migration on session_start.
  */
 export function registerProjectSettings(pi: ExtensionAPI): void {
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
 
   pi.on("session_start", (_event, ctx) => {
-    migrateCoAuthorFile(ctx.cwd);
     clearSettingsCache();
   });
 }

--- a/pi-config-settings.example.json
+++ b/pi-config-settings.example.json
@@ -1,5 +1,5 @@
 {
-  "commit_trailer": true,
+  "commit_trailer": "Assisted-by",
   "allow_push_to_protected_branches": false,
   "use_worktrees": false,
   "dream_interval_hours": 3

--- a/pi-config-settings.example.json
+++ b/pi-config-settings.example.json
@@ -1,5 +1,6 @@
 {
-  "co_author": true,
+  "commit_trailer": true,
+  "allow_push_to_protected_branches": false,
   "use_worktrees": false,
   "dream_interval_hours": 3
 }


### PR DESCRIPTION
## Summary

Two new project settings:

### `commit_trailer` (replaces `co_author`)

Setting value is the **trailer name** (git trailer key). Code fills in `PI (<model>) <noreply@pi.dev>` automatically.

| Value | Behavior |
|-------|----------|
| missing / `false` / `true` | No trailers (default) |
| `"Assisted-by"` | Appends `Assisted-by: PI (<model>) <noreply@pi.dev>` |
| `"Assisted-by, Co-authored-by"` | Block commit, ask user which trailer name, cache for session |

### `allow_push_to_protected_branches`

| Value | Behavior |
|-------|----------|
| missing / `false` | Block commits/pushes to protected branches (default) |
| `true` | Allow commits/pushes to protected branches |

## Changes

- **`project-settings.ts`** — rename `co_author` → `commit_trailer` (boolean | string), add `allow_push_to_protected_branches`, remove dead code/unused imports
- **`enforcement.ts`** — trailer injection uses setting value as trailer name, lazy `select_commit_trailer` tool registration, shell-escape trailers, cache validation, null model guard, protected branch bypass
- **`README.md`** — updated settings example and env var list
- **`AGENTS.md`** — updated settings table
- **`pi-config-settings.example.json`** — updated example

Closes #500