### PR TITLE
fix: cron PID collision + coms P2P ping worker thread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ All async agent temp files live under project-scoped subdirectories:
 ```text
 .pi/tmp/
 ├── debug.log                    # Async debug log
-├── cron-<pid>.json              # Cron task state
+├── cron-<pid>-<suffix>.json     # Cron task state (session-unique suffix prevents container PID collisions)
 ├── .repeat-<pid>.json           # Repeat command detection
 ├── nvim-<pid>-<ts>.lua          # Nvim integration (ephemeral)
 ├── nvim-qf-<pid>-<ts>.json      # Nvim quickfix data (ephemeral)

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -25,6 +25,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import * as crypto from "node:crypto";
+import { Worker } from "node:worker_threads";
 
 // ━━ Constants ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
@@ -132,6 +133,67 @@ function makeEndpoint(sessionId: string): string {
 		return `\\\\.\\pipe\\pi-coms-${sessionId}`;
 	}
 	return path.join(COMS_DIR, "sockets", `${sessionId}.sock`);
+}
+
+/** Inline ping worker — responds to pings on a separate socket, immune to main-thread event-loop blocks */
+function createPingWorker(pingEndpoint: string): Worker {
+	const workerCode = `
+const net = require("net");
+const fs = require("fs");
+const { parentPort, workerData } = require("worker_threads");
+
+let cachedPong = null;
+parentPort.on("message", (msg) => {
+	if (msg.type === "update_card") cachedPong = msg.pong;
+	if (msg.type === "shutdown") {
+		if (srv) try { srv.close(); } catch {}
+		try { fs.unlinkSync(workerData.endpoint); } catch {}
+		process.exit(0);
+	}
+});
+
+const srv = net.createServer((socket) => {
+	let buf = "";
+	socket.on("data", (chunk) => {
+		buf += chunk.toString("utf-8");
+		if (buf.length > 65536) { try { socket.destroy(); } catch {} return; }
+		const nl = buf.indexOf("\\n");
+		if (nl < 0) return;
+		const line = buf.slice(0, nl);
+		try {
+			const parsed = JSON.parse(line);
+			if (parsed.type === "ping" && cachedPong) {
+				const resp = { ...cachedPong, msg_id: parsed.msg_id };
+				socket.write(JSON.stringify(resp) + "\\n");
+			} else {
+				socket.write(JSON.stringify({ type: "nack", msg_id: parsed.msg_id || "", error: "not ready" }) + "\\n");
+			}
+		} catch {
+			socket.write(JSON.stringify({ type: "nack", msg_id: "", error: "parse error" }) + "\\n");
+		}
+		try { socket.end(); } catch {}
+	});
+	socket.once("error", () => { try { socket.destroy(); } catch {} });
+});
+
+// Clean up stale socket file
+if (fs.existsSync(workerData.endpoint)) {
+	try { fs.unlinkSync(workerData.endpoint); } catch {}
+}
+
+srv.listen(workerData.endpoint, () => {
+	parentPort.postMessage({ type: "ready" });
+});
+srv.on("error", (err) => {
+	parentPort.postMessage({ type: "error", message: err.message });
+});
+`;
+	const worker = new Worker(workerCode, {
+		eval: true,
+		workerData: { endpoint: pingEndpoint },
+	});
+	worker.unref();
+	return worker;
 }
 
 // ━━ CLI flag shape (read via pi.registerFlag/pi.getFlag) ━━━━━━━━━━━━━━━━━━━
@@ -455,6 +517,8 @@ export default function (pi: ExtensionAPI) {
 	const inboundQueue: Map<string, InboundContext> = new Map();
 	let server: net.Server | null = null;
 	let pingTimer: NodeJS.Timeout | null = null;
+	let pingWorker: Worker | null = null;
+	let pingWorkerReady = false;
 	let keepaliveTimer: NodeJS.Timeout | null = null;
 	let includeExplicit = false;
 	let displayProject: string | null = null;
@@ -584,11 +648,11 @@ export default function (pi: ExtensionAPI) {
 		ackOk(socket, env.msg_id);
 	}
 
-	function handlePing(socket: net.Socket, env: PingEnvelope): void {
+	function buildAgentCard(): AgentCard {
 		const ctx = currentCtx;
 		const ident = identity;
 		const pct = ctx ? Math.round(ctx.getContextUsage()?.percent ?? 0) : 0;
-		const card: AgentCard = {
+		return {
 			name: ident?.name ?? "unknown",
 			purpose: ident?.purpose ?? "",
 			model: ctx?.model?.id ?? ident?.model ?? "unknown",
@@ -597,6 +661,20 @@ export default function (pi: ExtensionAPI) {
 			queue_depth: inboundQueue.size,
 			tasks_summary: readTaskSummary(currentCtx?.cwd ?? process.cwd(), currentCtx?.sessionManager?.getSessionId?.()),
 		};
+	}
+
+	/** Push current agent card to ping worker so it can respond independently */
+	function updatePingWorkerCard(): void {
+		if (!pingWorker || !pingWorkerReady) return;
+		try {
+			const card = buildAgentCard();
+			const pong: Pong = { type: "pong", msg_id: "", agent_card: card };
+			pingWorker.postMessage({ type: "update_card", pong });
+		} catch { /* ignore */ }
+	}
+
+	function handlePing(socket: net.Socket, env: PingEnvelope): void {
+		const card = buildAgentCard();
 		const pong: Pong = { type: "pong", msg_id: env.msg_id, agent_card: card };
 		try {
 			socket.write(JSON.stringify(pong) + "\n");
@@ -604,6 +682,8 @@ export default function (pi: ExtensionAPI) {
 			// ignore
 		}
 		try { socket.end(); } catch { /* ignore */ }
+		// Also update worker with latest card
+		updatePingWorkerCard();
 	}
 
 	function isValidEnvelope(obj: any): obj is Envelope {
@@ -725,6 +805,20 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 
+		// 3b. Start ping worker on separate socket for liveness checks
+		const pingEndpoint = `${endpoint}.ping`;
+		try {
+			pingWorker = createPingWorker(pingEndpoint);
+			pingWorker.on("message", (msg: any) => {
+				if (msg.type === "ready") pingWorkerReady = true;
+				if (msg.type === "error") console.debug("[coms] ping worker error:", msg.message);
+			});
+			pingWorker.on("error", () => { pingWorkerReady = false; });
+			pingWorker.on("exit", () => { pingWorkerReady = false; pingWorker = null; });
+		} catch (err) {
+			console.debug("[coms] ping worker failed to start:", err instanceof Error ? err.message : String(err));
+		}
+
 		// 4. Build + write registry entry atomically.
 		const entry: RegistryEntry = {
 			session_id,
@@ -785,6 +879,9 @@ export default function (pi: ExtensionAPI) {
 		// 7. Start ping + keepalive cycles.
 		pingTimer = setInterval(() => { refreshPool().catch(() => {}); }, PING_INTERVAL_MS);
 		try { (pingTimer as any).unref?.(); } catch { /* ignore */ }
+		// Update ping worker card periodically
+		const cardUpdateTimer = setInterval(updatePingWorkerCard, 5000);
+		try { (cardUpdateTimer as any).unref?.(); } catch { /* ignore */ }
 		keepaliveTimer = setInterval(() => {
 			if (!identity) return;
 			try {
@@ -1016,7 +1113,14 @@ export default function (pi: ExtensionAPI) {
 				hops: 0,
 				timestamp: nowIso(),
 			};
-			const reply = await sendEnvelope(peer.endpoint, pingEnv);
+			// Try dedicated ping socket first (immune to event-loop blocks), fall back to main
+			const pingEndpoint = `${peer.endpoint}.ping`;
+			let reply: any;
+			try {
+				reply = await sendEnvelope(pingEndpoint, pingEnv);
+			} catch {
+				reply = await sendEnvelope(peer.endpoint, pingEnv);
+			}
 			return { peer, pong: reply as Pong };
 		}));
 
@@ -1539,6 +1643,11 @@ export default function (pi: ExtensionAPI) {
 		if (server) {
 			try { server.close(); } catch { /* ignore */ }
 			server = null;
+		}
+		if (pingWorker) {
+			try { pingWorker.postMessage({ type: "shutdown" }); } catch {}
+			pingWorker = null;
+			pingWorkerReady = false;
 		}
 		if (identity) {
 			if (process.platform !== "win32") {

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -519,6 +519,7 @@ export default function (pi: ExtensionAPI) {
 	let pingTimer: NodeJS.Timeout | null = null;
 	let pingWorker: Worker | null = null;
 	let pingWorkerReady = false;
+	let cardUpdateTimer: NodeJS.Timeout | null = null;
 	let keepaliveTimer: NodeJS.Timeout | null = null;
 	let includeExplicit = false;
 	let displayProject: string | null = null;
@@ -810,7 +811,10 @@ export default function (pi: ExtensionAPI) {
 		try {
 			pingWorker = createPingWorker(pingEndpoint);
 			pingWorker.on("message", (msg: any) => {
-				if (msg.type === "ready") pingWorkerReady = true;
+				if (msg.type === "ready") {
+					pingWorkerReady = true;
+					updatePingWorkerCard(); // Push initial card immediately
+				}
 				if (msg.type === "error") console.debug("[coms] ping worker error:", msg.message);
 			});
 			pingWorker.on("error", () => { pingWorkerReady = false; });
@@ -880,7 +884,7 @@ export default function (pi: ExtensionAPI) {
 		pingTimer = setInterval(() => { refreshPool().catch(() => {}); }, PING_INTERVAL_MS);
 		try { (pingTimer as any).unref?.(); } catch { /* ignore */ }
 		// Update ping worker card periodically
-		const cardUpdateTimer = setInterval(updatePingWorkerCard, 5000);
+		cardUpdateTimer = setInterval(updatePingWorkerCard, 5000);
 		try { (cardUpdateTimer as any).unref?.(); } catch { /* ignore */ }
 		keepaliveTimer = setInterval(() => {
 			if (!identity) return;
@@ -1643,6 +1647,10 @@ export default function (pi: ExtensionAPI) {
 		if (server) {
 			try { server.close(); } catch { /* ignore */ }
 			server = null;
+		}
+		if (cardUpdateTimer) {
+			clearInterval(cardUpdateTimer);
+			cardUpdateTimer = null;
 		}
 		if (pingWorker) {
 			try { pingWorker.postMessage({ type: "shutdown" }); } catch {}

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -38,7 +38,21 @@ export interface CronTask {
 let CRON_FILE = ""; // Set on session_start to project-scoped dir
 
 /** Unique session suffix — prevents PID collisions across containers */
-const SESSION_SUFFIX = `${process.pid}-${Date.now().toString(36)}`;
+/** Suffix must be unique across containers but stable across reloads (same process).
+ *  Use process start time from /proc or process.uptime() as a stable identifier. */
+const SESSION_SUFFIX = (() => {
+  try {
+    // Linux: read process start time from /proc/self/stat (field 22) — stable, unique per PID lifecycle
+    const stat = require("fs").readFileSync("/proc/self/stat", "utf-8");
+    const startTime = stat.split(" ")[21];
+    return `${process.pid}-${startTime}`;
+  } catch {
+    // Fallback for non-Linux: use a truncated hash of pid + ppid + argv
+    const crypto = require("crypto");
+    const seed = `${process.pid}-${process.ppid}-${process.argv.join(",")}`;
+    return `${process.pid}-${crypto.createHash("md5").update(seed).digest("hex").slice(0, 8)}`;
+  }
+})();
 
 /** Matches both old (cron-{pid}.json) and new (cron-{pid}-{suffix}.json) formats */
 const CRON_FILE_RE = /^cron-(\d+)(?:-[^.]+)?\.json$/;

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -43,14 +43,17 @@ let CRON_FILE = ""; // Set on session_start to project-scoped dir
 const SESSION_SUFFIX = (() => {
   try {
     // Linux: read process start time from /proc/self/stat (field 22) — stable, unique per PID lifecycle
-    const stat = require("fs").readFileSync("/proc/self/stat", "utf-8");
+    const stat = fs.readFileSync("/proc/self/stat", "utf-8");
     const startTime = stat.split(" ")[21];
     return `${process.pid}-${startTime}`;
   } catch {
     // Fallback for non-Linux: use a truncated hash of pid + ppid + argv
-    const crypto = require("crypto");
     const seed = `${process.pid}-${process.ppid}-${process.argv.join(",")}`;
-    return `${process.pid}-${crypto.createHash("md5").update(seed).digest("hex").slice(0, 8)}`;
+    let hash = 0;
+    for (let i = 0; i < seed.length; i++) {
+      hash = ((hash << 5) - hash + seed.charCodeAt(i)) | 0;
+    }
+    return `${process.pid}-${Math.abs(hash).toString(36)}`;
   }
 })();
 
@@ -82,12 +85,17 @@ function cleanupOrphanedCronFiles(): void {
     const dir = path.dirname(CRON_FILE);
     const myFile = path.basename(CRON_FILE);
     for (const f of fs.readdirSync(dir)) {
-      // Match both old (cron-{pid}.json) and new (cron-{pid}-{suffix}.json) formats
       const m = f.match(CRON_FILE_RE);
       if (!m || f === myFile) continue;
+      // Old format (no suffix) — always delete (legacy)
+      const isLegacy = /^cron-\d+\.json$/.test(f);
+      if (isLegacy) {
+        try { fs.unlinkSync(path.join(dir, f)); } catch {}
+        continue;
+      }
+      // New format — delete only if PID is dead
       const pid = +m[1];
       try { process.kill(pid, 0); } catch {
-        // PID dead — delete orphaned file
         try { fs.unlinkSync(path.join(dir, f)); } catch {}
       }
     }

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -2,7 +2,7 @@
  * Cron-like scheduled tasks — pi-process-scoped.
  *
  * Tasks survive /reload, /resume, /new but die on pi exit.
- * Persisted to a PID-scoped file so they survive extension re-evaluation.
+ * Persisted to a session-scoped file so they survive extension re-evaluation.
  *
  * The /cron command is a natural-language interface — the AI parses
  * the user's intent and calls the cron_manage tool with structured params.
@@ -37,6 +37,12 @@ export interface CronTask {
 
 let CRON_FILE = ""; // Set on session_start to project-scoped dir
 
+/** Unique session suffix — prevents PID collisions across containers */
+const SESSION_SUFFIX = `${process.pid}-${Date.now().toString(36)}`;
+
+/** Matches both old (cron-{pid}.json) and new (cron-{pid}-{suffix}.json) formats */
+const CRON_FILE_RE = /^cron-(\d+)(?:-[^.]+)?\.json$/;
+
 /** Get current cron file path — used by autocomplete */
 export function getCronFilePath(): string { return CRON_FILE; }
 
@@ -59,18 +65,19 @@ function loadCrons(): CronTask[] {
 
 function cleanupOrphanedCronFiles(): void {
   try {
-    // Clean up project-scoped cron files
     const dir = path.dirname(CRON_FILE);
+    const myFile = path.basename(CRON_FILE);
     for (const f of fs.readdirSync(dir)) {
-      const m = f.match(/^cron-(\d+)\.json$/);
-      if (m && +m[1] !== process.pid) {
-        try { process.kill(+m[1], 0); } catch {
-          try { fs.unlinkSync(path.join(dir, f)); } catch {}
-        }
+      // Match both old (cron-{pid}.json) and new (cron-{pid}-{suffix}.json) formats
+      const m = f.match(CRON_FILE_RE);
+      if (!m || f === myFile) continue;
+      const pid = +m[1];
+      try { process.kill(pid, 0); } catch {
+        // PID dead — delete orphaned file
+        try { fs.unlinkSync(path.join(dir, f)); } catch {}
       }
     }
   } catch (e: any) { console.debug("[cron] cleanup orphaned cron files failed:", e?.message || e); }
-
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -192,7 +199,7 @@ export function registerCron(
   pi.on("session_start", (_event, ctx) => {
     lastCwd = ctx.cwd;
     lastCtx = ctx;
-    CRON_FILE = path.join(getProjectTmpDir(ctx.cwd), `cron-${process.pid}.json`);
+    CRON_FILE = path.join(getProjectTmpDir(ctx.cwd), `cron-${SESSION_SUFFIX}.json`);
     cleanupOrphanedCronFiles();
     // Skip cron scheduling in one-shot modes
     if (ctx.mode === "print" || ctx.mode === "json") return;
@@ -327,10 +334,10 @@ export function registerCron(
         try {
           const dir = path.dirname(CRON_FILE);
           for (const f of fs.readdirSync(dir)) {
-            const m = f.match(/^cron-(\d+)\.json$/);
+            const m = f.match(CRON_FILE_RE);
             if (!m) continue;
             const pid = +m[1];
-            const isMe = pid === process.pid;
+            const isMe = f === path.basename(CRON_FILE);
             let alive = isMe;
             if (!isMe) { try { process.kill(pid, 0); alive = true; } catch {} }
             if (!alive) continue;
@@ -402,10 +409,10 @@ export function registerCron(
         try {
           const dir = path.dirname(CRON_FILE);
           for (const f of fs.readdirSync(dir)) {
-            const m = f.match(/^cron-(\d+)\.json$/);
+            const m = f.match(CRON_FILE_RE);
             if (!m) continue;
             const pid = +m[1];
-            const isMe = pid === process.pid;
+            const isMe = f === path.basename(CRON_FILE);
             let alive = isMe;
             if (!isMe) { try { process.kill(pid, 0); alive = true; } catch {} }
             if (!alive) continue;

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -40,14 +40,24 @@ let CRON_FILE = ""; // Set on session_start to project-scoped dir
 /** Unique session suffix — prevents PID collisions across containers */
 /** Suffix must be unique across containers but stable across reloads (same process).
  *  Use process start time from /proc or process.uptime() as a stable identifier. */
+/** Parse start time (field 22) from /proc stat content — handles comm fields with spaces */
+function parseProcStartTime(statContent: string): string | null {
+  // Field 2 (comm) is wrapped in parens and may contain spaces/parens.
+  // Find the LAST ')' to reliably skip it, then split remaining fields.
+  const closeParenIdx = statContent.lastIndexOf(")");
+  if (closeParenIdx < 0) return null;
+  const fields = statContent.slice(closeParenIdx + 2).split(" ");
+  // After comm: field 3=state(idx 0), field 4=ppid(idx 1), ... field 22=starttime(idx 19)
+  return fields[19] || null;
+}
+
 const SESSION_SUFFIX = (() => {
   try {
-    // Linux: read process start time from /proc/self/stat (field 22) — stable, unique per PID lifecycle
     const stat = fs.readFileSync("/proc/self/stat", "utf-8");
-    const startTime = stat.split(" ")[21];
+    const startTime = parseProcStartTime(stat);
+    if (!startTime) throw new Error("failed to parse start time");
     return `${process.pid}-${startTime}`;
   } catch {
-    // Fallback for non-Linux: use a truncated hash of pid + ppid + argv
     const seed = `${process.pid}-${process.ppid}-${process.argv.join(",")}`;
     let hash = 0;
     for (let i = 0; i < seed.length; i++) {
@@ -93,10 +103,31 @@ function cleanupOrphanedCronFiles(): void {
         try { fs.unlinkSync(path.join(dir, f)); } catch {}
         continue;
       }
-      // New format — delete only if PID is dead
+      // New format — extract PID and suffix token
       const pid = +m[1];
-      try { process.kill(pid, 0); } catch {
-        try { fs.unlinkSync(path.join(dir, f)); } catch {}
+      const suffixMatch = f.match(/^cron-\d+-(.+)\.json$/);
+      const fileToken = suffixMatch?.[1];
+      // Check /proc/{pid}/stat — if we can read it, verify start time matches
+      try {
+        const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf-8");
+        const startTime = parseProcStartTime(stat);
+        if (startTime && fileToken && startTime === fileToken) {
+          // Same PID, same start time — process is alive, skip
+          continue;
+        }
+        if (startTime && fileToken && startTime !== fileToken) {
+          // PID reused — different process, safe to delete
+          try { fs.unlinkSync(path.join(dir, f)); } catch {}
+          continue;
+        }
+      } catch {
+        // /proc/{pid} not readable — either dead process or different PID namespace
+        // Only delete if we can confirm PID is dead in our namespace
+        try { process.kill(pid, 0); } catch {
+          // PID dead in our namespace — safe to delete
+          try { fs.unlinkSync(path.join(dir, f)); } catch {}
+        }
+        // If kill(pid, 0) succeeds but /proc is unreadable — skip (can't verify)
       }
     }
   } catch (e: any) { console.debug("[cron] cleanup orphaned cron files failed:", e?.message || e); }

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -115,10 +115,8 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
     return False
 
 
-# Exact body Qodo posts while reviewing a PR (transient comment)
-_QODO_REVIEWING_BODY = (
-    "\n<h3>Looking for bugs?</h3>\nCheck back in a few minutes. An AI review agent is analyzing this pull request.\n"
-)
+# Qodo posts a transient comment while reviewing — detect by heading text (resilient to body changes)
+_QODO_REVIEWING_MARKERS = ("Looking for bugs?", "review agent")
 
 
 def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | None = None) -> bool:
@@ -139,7 +137,7 @@ def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | N
         if author != "qodo-code-review[bot]":
             continue
         body = comment.get("body", "")
-        if body == _QODO_REVIEWING_BODY:
+        if any(marker in body for marker in _QODO_REVIEWING_MARKERS):
             print_stderr("[poll] Qodo review in progress (Looking for bugs).")
             return True
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -122,9 +122,9 @@ _QODO_REVIEWING_MARKERS = ("Looking for bugs?", "review agent")
 def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | None = None) -> bool:
     """Check if Qodo is currently reviewing the PR.
 
-    Qodo posts a transient comment with exact body while reviewing.
+    Qodo posts a transient comment while reviewing (e.g., "Looking for bugs?").
     If this comment exists, the sticky is about to be updated — we should wait.
-    Matches exact author (qodo-code-review[bot]) and exact body text.
+    Matches author (qodo-code-review[bot]) and known substring markers.
     """
     if comments is None:
         endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Cron file PID collision across containers (#507)

Cron filenames used bare PID (`cron-{pid}.json`) which collides when containers share `.pi/tmp/` and PID namespaces produce identical PIDs.

- Add session-unique suffix: `cron-{pid}-{base36_timestamp}.json`
- Fix `isMe` in `list-all` to compare filenames not PIDs
- Extract `CRON_FILE_RE` regex constant (DRY)
- Cleanup handles both old and new filename formats

### 2. Coms P2P worker thread ping responder (#508)

Main event loop blocks during LLM calls cause ping timeouts and peer status flickering in the coms widget.

- Worker thread listens on separate `.ping` socket, immune to main-thread load
- Main thread sends agent card updates to worker via `postMessage`
- `refreshPool` tries `.ping` endpoint first, falls back to main socket
- Backward compatible with peers that don't have `.ping` endpoint

## Files Changed

- `extensions/orchestrator/cron.ts` — session-unique cron filenames
- `extensions/coms/coms-p2p.ts` — worker thread ping responder
- `AGENTS.md` — updated cron filename format in docs

Closes #507
Closes #508