### PR TITLE
feat(templates): add dedicated e2e-tester peer role to coms feature manager

### DIFF
--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -582,6 +582,7 @@ export function registerSubagentTool(
       "ALWAYS use async: true for independent tasks that can run in parallel — code reviews, opening issues, research, analysis. Only use sync when the very next step depends on this agent's output (e.g., chain where step 2 needs step 1's result).",
       "ALWAYS pass cwd — use the project directory for current repo work, or the target path for external repos (e.g., ${PROJECT_TMP_DIR}/...).",
       "ALWAYS provide estimatedSeconds for sync agents. If estimated time is 30 seconds or more, you MUST use async: true instead.",
+      "After spawning async agents, END YOUR TURN. Do NOT write bash loops, sleep commands, or poll for results — the system delivers results automatically as a follow-up message. Spawn the agent and stop.",
     ],
     parameters: SubagentParams,
 

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -53,10 +53,10 @@ waiting for builds/CI, and any task where you don't need the result immediately.
 Only use sync (default) when the **very next step** depends on this agent's output.
 
 ❌ **WRONG:** Spawn 3 sync reviewers → wait for all → respond
-✅ **RIGHT:** Spawn 3 async reviewers → continue → results surface when complete
+✅ **RIGHT:** Spawn 3 async reviewers → end turn → results arrive as follow-up
 
 ❌ **WRONG:** `sleep 60 && check status` — blocks the session
-✅ **RIGHT:** Spawn async agent to poll and notify when done
+✅ **RIGHT:** Spawn async agent → end turn → system delivers result automatically
 
 **After spawning async agents, END YOUR TURN.** Do NOT write bash loops, sleep commands,
 or poll for results. The system delivers async results automatically as a follow-up message

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -58,6 +58,15 @@ Only use sync (default) when the **very next step** depends on this agent's outp
 ❌ **WRONG:** `sleep 60 && check status` — blocks the session
 ✅ **RIGHT:** Spawn async agent to poll and notify when done
 
+**After spawning async agents, END YOUR TURN.** Do NOT write bash loops, sleep commands,
+or poll for results. The system delivers async results automatically as a follow-up message
+that starts a new LLM turn. Your only job is to spawn the agent and stop.
+
+❌ **WRONG:** Spawn async agent → `while true; do sleep 30; check status; done`
+❌ **WRONG:** Spawn async agent → `bash("sleep 60 && cat result.json")`
+❌ **WRONG:** Spawn async agent → keep talking / checking / waiting in the same turn
+✅ **RIGHT:** Spawn async agent → end turn → result arrives as follow-up → process it then
+
 **Kill async agents when their result is no longer needed.**
 Don't let them run to completion wasting resources. Use `asyncKill` immediately.
 

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -61,6 +61,7 @@ Only use sync (default) when the **very next step** depends on this agent's outp
 **After spawning async agents, END YOUR TURN.** Do NOT write bash loops, sleep commands,
 or poll for results. The system delivers async results automatically as a follow-up message
 that starts a new LLM turn. Your only job is to spawn the agent and stop.
+(`fireAndForget: true` agents are silent — no follow-up message is delivered.)
 
 ❌ **WRONG:** Spawn async agent → `while true; do sleep 30; check status; done`
 ❌ **WRONG:** Spawn async agent → `bash("sleep 60 && cat result.json")`

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -253,9 +253,12 @@ subagent(agent="worker", task="{{DEPLOY_TASK}}", cwd="{{PROJECT_DIR}}", async=tr
 
 ### Delegation
 
-E2E verification is owned by the dedicated **e2e-tester** peer. Send verification tasks via `coms_send` with structured `tasks`:
+E2E verification is owned by the dedicated **e2e-tester** peer.
+The manager handles deployment (see Dev Server Operations above);
+the e2e-tester runs verification after deploy is confirmed healthy.
 
-- Deploy/start the dev environment
+Send verification tasks via `coms_send` with structured `tasks`:
+
 - Run through all E2E scenarios (happy + unhappy paths)
 - Report results back with the verification report format below
 

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -257,12 +257,18 @@ E2E verification is owned by the dedicated **e2e-tester** peer.
 The manager handles deployment (see Dev Server Operations above);
 the e2e-tester runs verification after deploy is confirmed healthy.
 
-Send verification tasks via the active coms transport (`coms_send` or `coms_net_send`) with structured `tasks`:
+Send verification tasks via the active coms transport with structured `tasks`,
+then await using the matching tool:
+
+- P2P: `coms_send` → `coms_await`
+- Networked: `coms_net_send` → `coms_net_await`
+
+Tasks to delegate:
 
 - Run through all E2E scenarios (happy + unhappy paths)
 - Report results back with the verification report format below
 
-Do NOT run E2E verification yourself — delegate entirely to the e2e-tester peer and `coms_await` the results.
+Do NOT run E2E verification yourself — delegate entirely to the e2e-tester peer and await the results.
 
 ### Unhappy Paths (MANDATORY)
 

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -258,10 +258,10 @@ The manager handles deployment (see Dev Server Operations above);
 the e2e-tester runs verification after deploy is confirmed healthy.
 
 Send verification tasks via the active coms transport with structured `tasks`,
-then await using the matching tool:
+then await the returned `msg_id` using the matching tool:
 
-- P2P: `coms_send` → `coms_await`
-- Networked: `coms_net_send` → `coms_net_await`
+- P2P: `coms_send` → `coms_await(msg_id=...)`
+- Networked: `coms_net_send` → `coms_net_await(msg_id=...)`
 
 Tasks to delegate:
 

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -257,7 +257,7 @@ E2E verification is owned by the dedicated **e2e-tester** peer.
 The manager handles deployment (see Dev Server Operations above);
 the e2e-tester runs verification after deploy is confirmed healthy.
 
-Send verification tasks via `coms_send` with structured `tasks`:
+Send verification tasks via the active coms transport (`coms_send` or `coms_net_send`) with structured `tasks`:
 
 - Run through all E2E scenarios (happy + unhappy paths)
 - Report results back with the verification report format below

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -49,6 +49,7 @@ Read the issue(s) or task the user wants to work on. Analyze:
   - Multiple **coders** for independent issues/features
   - A **planner** + **coder** for complex architecture work
   - A **coder** + **test-writer** for test-heavy features
+  - An **e2e-tester** when the project requires live/E2E verification (dedicated peer runs and verifies E2E scenarios)
   - A single **coder** for simple tasks
 - **Name each peer** with a meaningful name reflecting its role (e.g., `coder-api`, `coder-frontend`, `planner`, `test-writer`)
 
@@ -249,6 +250,16 @@ subagent(agent="worker", task="{{DEPLOY_TASK}}", cwd="{{PROJECT_DIR}}", async=tr
      Include the appropriate verification approach for your project.
 
 ## E2E Verification
+
+### Delegation
+
+E2E verification is owned by the dedicated **e2e-tester** peer. Send verification tasks via `coms_send` with structured `tasks`:
+
+- Deploy/start the dev environment
+- Run through all E2E scenarios (happy + unhappy paths)
+- Report results back with the verification report format below
+
+Do NOT run E2E verification yourself — delegate entirely to the e2e-tester peer and `coms_await` the results.
 
 ### Unhappy Paths (MANDATORY)
 


### PR DESCRIPTION
## Summary

Adds a dedicated **e2e-tester** peer role to the coms feature manager template. When a project requires live/E2E verification, the manager now assigns a dedicated peer to run and verify E2E scenarios instead of doing it itself.

## Changes

- **Work Evaluation roles** — added `e2e-tester` as a peer role option the manager considers during setup
- **E2E Verification section** — added `### Delegation` subsection instructing the manager to delegate all E2E work to the `e2e-tester` peer via `coms_send` with structured tasks