### PR TITLE
feat: add global settings fallback and DCO (Signed-off-by) support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -415,8 +415,9 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 | `allow_push_to_protected_branches` | boolean | disabled | `PI_ALLOW_PUSH_TO_PROTECTED_BRANCHES` | Allow commits/pushes to protected branches |
 | `use_worktrees` | boolean | disabled | `PI_USE_WORKTREES` | Force worktree-only workflow |
 | `dream_interval_hours` | number | 3 | `PI_DREAM_INTERVAL_HOURS` | Dream frequency |
+| `dco` | boolean | disabled | `PI_DCO` | Add --signoff to all commits (DCO) |
 
-Resolution: project file → env var → default.
+Resolution: project file → global `~/.pi/pi-config-settings.json` → env var → default.
 
 Module: `extensions/orchestrator/project-settings.ts`
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Create `.pi/pi-config-settings.json` in your project to override global defaults
 }
 ```
 
-Resolution order: project file → env var → default.
+Resolution order: project file → global `~/.pi/pi-config-settings.json` → env var → default.
 
 Global env vars: `PI_COMMIT_TRAILER`, `PI_ALLOW_PUSH_TO_PROTECTED_BRANCHES`, `PI_USE_WORKTREES`, `PI_DREAM_INTERVAL_HOURS`
 

--- a/agents/git-expert.md
+++ b/agents/git-expert.md
@@ -25,6 +25,24 @@ You are a Git Expert responsible for all local git operations and version contro
 - This agent does NOT run tests. Before pushing, ask the orchestrator if tests have passed.
 - This agent does NOT fix code. If pre-commit hooks fail, report the error.
 
+## DCO (Developer Certificate of Origin)
+
+Before every commit, check if DCO is enabled:
+
+```bash
+# Check via pi-config project settings
+# If dco is true in .pi/pi-config-settings.json or ~/.pi/pi-config-settings.json,
+# or PI_DCO=true is set, add --signoff to every git commit command.
+```
+
+When DCO is enabled, add `--signoff` to all commit commands:
+
+```bash
+echo -e "Your commit title" | git commit --signoff -F -
+```
+
+The `--signoff` flag adds a `Signed-off-by: Name <email>` trailer using the committer's git identity.
+
 ## Commit Message Format
 
 ALWAYS use `-F -` to read commit message from stdin:

--- a/agents/git-expert.md
+++ b/agents/git-expert.md
@@ -30,9 +30,10 @@ You are a Git Expert responsible for all local git operations and version contro
 Before every commit, check if DCO is enabled:
 
 ```bash
-# Check via pi-config project settings
-# If dco is true in .pi/pi-config-settings.json or ~/.pi/pi-config-settings.json,
-# or PI_DCO=true is set, add --signoff to every git commit command.
+# Check if DCO is enabled (any of these means enabled):
+cat .pi/pi-config-settings.json 2>/dev/null | grep -q '"dco".*true' && DCO=true
+[ -z "$DCO" ] && cat ~/.pi/pi-config-settings.json 2>/dev/null | grep -q '"dco".*true' && DCO=true
+[ -z "$DCO" ] && [ "$PI_DCO" = "true" ] && DCO=true
 ```
 
 When DCO is enabled, add `--signoff` to all commit commands:

--- a/agents/git-expert.md
+++ b/agents/git-expert.md
@@ -33,7 +33,7 @@ Before every commit, check if DCO is enabled:
 # Check if DCO is enabled (any of these means enabled):
 cat .pi/pi-config-settings.json 2>/dev/null | grep -q '"dco".*true' && DCO=true
 [ -z "$DCO" ] && cat ~/.pi/pi-config-settings.json 2>/dev/null | grep -q '"dco".*true' && DCO=true
-[ -z "$DCO" ] && [ "$PI_DCO" = "true" ] && DCO=true
+[ -z "$DCO" ] && case "${PI_DCO,,}" in true|1|yes|on) DCO=true;; esac
 ```
 
 When DCO is enabled, add `--signoff` to all commit commands:

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -118,7 +118,7 @@ export function clearSettingsCache(): void {
 }
 
 /**
- * Get a setting value. Resolution: project file → env var → default.
+ * Get a setting value. Resolution: project file → global ~/.pi/pi-config-settings.json → env var → default.
  */
 export function getSetting(cwd: string, key: "commit_trailer"): boolean | string;
 export function getSetting(cwd: string, key: "allow_push_to_protected_branches"): boolean;

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -3,8 +3,9 @@
  *
  * Resolution order:
  * 1. Project .pi/pi-config-settings.json (wins if set)
- * 2. Global env var (PI_COMMIT_TRAILER, PI_USE_WORKTREES, PI_DREAM_INTERVAL_HOURS)
- * 3. Default (only dream_interval_hours has a default of 3)
+ * 2. Global ~/.pi/pi-config-settings.json (fallback for all projects)
+ * 3. Env var (PI_COMMIT_TRAILER, PI_USE_WORKTREES, PI_DREAM_INTERVAL_HOURS, PI_DCO)
+ * 4. Default (only dream_interval_hours has a default of 3)
  */
 
 import { existsSync, statSync, readFileSync } from "node:fs";
@@ -26,11 +27,10 @@ function getSettingsPath(cwd: string): string {
   return join(cwd, ".pi", SETTINGS_FILENAME);
 }
 
-function loadProjectSettings(cwd: string): ProjectSettings {
-  const settingsPath = getSettingsPath(cwd);
-  if (!existsSync(settingsPath)) return {};
+function parseSettingsFile(filePath: string): ProjectSettings {
+  if (!existsSync(filePath)) return {};
   try {
-    const raw = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    const raw = JSON.parse(readFileSync(filePath, "utf-8"));
     if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
     const result: ProjectSettings = {};
     if (typeof raw.commit_trailer === "boolean" || typeof raw.commit_trailer === "string") result.commit_trailer = raw.commit_trailer;
@@ -41,29 +41,18 @@ function loadProjectSettings(cwd: string): ProjectSettings {
     }
     if (typeof raw.dco === "boolean") result.dco = raw.dco;
     return result;
-  } catch {
+  } catch (e: any) {
+    console.debug(`[project-settings] failed to parse ${filePath}:`, e?.message?.slice(0, 100));
     return {};
   }
 }
 
+function loadProjectSettings(cwd: string): ProjectSettings {
+  return parseSettingsFile(getSettingsPath(cwd));
+}
+
 function loadGlobalSettings(): ProjectSettings {
-  const globalPath = join(homedir(), ".pi", SETTINGS_FILENAME);
-  if (!existsSync(globalPath)) return {};
-  try {
-    const raw = JSON.parse(readFileSync(globalPath, "utf-8"));
-    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
-    const result: ProjectSettings = {};
-    if (typeof raw.commit_trailer === "boolean" || typeof raw.commit_trailer === "string") result.commit_trailer = raw.commit_trailer;
-    if (typeof raw.allow_push_to_protected_branches === "boolean") result.allow_push_to_protected_branches = raw.allow_push_to_protected_branches;
-    if (typeof raw.use_worktrees === "boolean") result.use_worktrees = raw.use_worktrees;
-    if (typeof raw.dream_interval_hours === "number" && Number.isFinite(raw.dream_interval_hours)) {
-      result.dream_interval_hours = raw.dream_interval_hours;
-    }
-    if (typeof raw.dco === "boolean") result.dco = raw.dco;
-    return result;
-  } catch {
-    return {};
-  }
+  return parseSettingsFile(join(homedir(), ".pi", SETTINGS_FILENAME));
 }
 
 function parseBoolEnv(name: string): boolean | undefined {
@@ -108,9 +97,7 @@ function getSettings(cwd: string): ProjectSettings {
   let mtime = 0;
   try { if (existsSync(settingsPath)) mtime = statSync(settingsPath).mtimeMs; } catch {}
   if (mtime === cachedMtime) return cachedSettings;
-  const projectSettings2 = loadProjectSettings(cwd);
-  const globalSettings2 = loadGlobalSettings();
-  cachedSettings = { ...globalSettings2, ...projectSettings2 };
+  cachedSettings = { ...loadGlobalSettings(), ...loadProjectSettings(cwd) };
   cachedMtime = mtime;
   return cachedSettings;
 }

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -9,6 +9,7 @@
 
 import { existsSync, statSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { homedir } from "node:os";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
 interface ProjectSettings {
@@ -16,6 +17,7 @@ interface ProjectSettings {
   allow_push_to_protected_branches?: boolean;
   use_worktrees?: boolean;
   dream_interval_hours?: number;
+  dco?: boolean;
 }
 
 const SETTINGS_FILENAME = "pi-config-settings.json";
@@ -37,6 +39,27 @@ function loadProjectSettings(cwd: string): ProjectSettings {
     if (typeof raw.dream_interval_hours === "number" && Number.isFinite(raw.dream_interval_hours)) {
       result.dream_interval_hours = raw.dream_interval_hours;
     }
+    if (typeof raw.dco === "boolean") result.dco = raw.dco;
+    return result;
+  } catch {
+    return {};
+  }
+}
+
+function loadGlobalSettings(): ProjectSettings {
+  const globalPath = join(homedir(), ".pi", SETTINGS_FILENAME);
+  if (!existsSync(globalPath)) return {};
+  try {
+    const raw = JSON.parse(readFileSync(globalPath, "utf-8"));
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return {};
+    const result: ProjectSettings = {};
+    if (typeof raw.commit_trailer === "boolean" || typeof raw.commit_trailer === "string") result.commit_trailer = raw.commit_trailer;
+    if (typeof raw.allow_push_to_protected_branches === "boolean") result.allow_push_to_protected_branches = raw.allow_push_to_protected_branches;
+    if (typeof raw.use_worktrees === "boolean") result.use_worktrees = raw.use_worktrees;
+    if (typeof raw.dream_interval_hours === "number" && Number.isFinite(raw.dream_interval_hours)) {
+      result.dream_interval_hours = raw.dream_interval_hours;
+    }
+    if (typeof raw.dco === "boolean") result.dco = raw.dco;
     return result;
   } catch {
     return {};
@@ -67,7 +90,9 @@ function getSettings(cwd: string): ProjectSettings {
   const now = Date.now();
   // Different cwd — always reload
   if (cwd !== cachedCwd) {
-    cachedSettings = loadProjectSettings(cwd);
+    const projectSettings = loadProjectSettings(cwd);
+    const globalSettings = loadGlobalSettings();
+    cachedSettings = { ...globalSettings, ...projectSettings };
     cachedCwd = cwd;
     try {
       const settingsPath = getSettingsPath(cwd);
@@ -83,7 +108,9 @@ function getSettings(cwd: string): ProjectSettings {
   let mtime = 0;
   try { if (existsSync(settingsPath)) mtime = statSync(settingsPath).mtimeMs; } catch {}
   if (mtime === cachedMtime) return cachedSettings;
-  cachedSettings = loadProjectSettings(cwd);
+  const projectSettings2 = loadProjectSettings(cwd);
+  const globalSettings2 = loadGlobalSettings();
+  cachedSettings = { ...globalSettings2, ...projectSettings2 };
   cachedMtime = mtime;
   return cachedSettings;
 }
@@ -101,6 +128,7 @@ export function getSetting(cwd: string, key: "commit_trailer"): boolean | string
 export function getSetting(cwd: string, key: "allow_push_to_protected_branches"): boolean;
 export function getSetting(cwd: string, key: "use_worktrees"): boolean;
 export function getSetting(cwd: string, key: "dream_interval_hours"): number;
+export function getSetting(cwd: string, key: "dco"): boolean;
 export function getSetting(cwd: string, key: string): boolean | string | number {
   const settings = getSettings(cwd);
 
@@ -132,6 +160,12 @@ export function getSetting(cwd: string, key: string): boolean | string | number 
       const env = parseNumEnv("PI_DREAM_INTERVAL_HOURS");
       if (env !== undefined) return env;
       return 3; // default: 3 hours
+    }
+    case "dco": {
+      if (settings.dco !== undefined) return settings.dco;
+      const env = parseBoolEnv("PI_DCO");
+      if (env !== undefined) return env;
+      return false; // default: disabled
     }
     default:
       return false;

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -72,6 +72,7 @@ function parseNumEnv(name: string): number | undefined {
 let cachedCwd = "";
 let cachedSettings: ProjectSettings = {};
 let cachedMtime = 0;
+let cachedGlobalMtime = 0;
 let lastMtimeCheck = 0;
 const MTIME_CHECK_INTERVAL_MS = 30_000; // Check file mtime at most every 30s
 
@@ -87,6 +88,10 @@ function getSettings(cwd: string): ProjectSettings {
       const settingsPath = getSettingsPath(cwd);
       cachedMtime = existsSync(settingsPath) ? statSync(settingsPath).mtimeMs : 0;
     } catch { cachedMtime = 0; }
+    try {
+      const globalPath = join(homedir(), ".pi", SETTINGS_FILENAME);
+      cachedGlobalMtime = existsSync(globalPath) ? statSync(globalPath).mtimeMs : 0;
+    } catch { cachedGlobalMtime = 0; }
     lastMtimeCheck = now;
     return cachedSettings;
   }
@@ -94,11 +99,15 @@ function getSettings(cwd: string): ProjectSettings {
   if (now - lastMtimeCheck < MTIME_CHECK_INTERVAL_MS) return cachedSettings;
   lastMtimeCheck = now;
   const settingsPath = getSettingsPath(cwd);
+  const globalPath = join(homedir(), ".pi", SETTINGS_FILENAME);
   let mtime = 0;
+  let globalMtime = 0;
   try { if (existsSync(settingsPath)) mtime = statSync(settingsPath).mtimeMs; } catch {}
-  if (mtime === cachedMtime) return cachedSettings;
+  try { if (existsSync(globalPath)) globalMtime = statSync(globalPath).mtimeMs; } catch {}
+  if (mtime === cachedMtime && globalMtime === cachedGlobalMtime) return cachedSettings;
   cachedSettings = { ...loadGlobalSettings(), ...loadProjectSettings(cwd) };
   cachedMtime = mtime;
+  cachedGlobalMtime = globalMtime;
   return cachedSettings;
 }
 

--- a/pi-config-settings.example.json
+++ b/pi-config-settings.example.json
@@ -2,5 +2,6 @@
   "commit_trailer": "Assisted-by",
   "allow_push_to_protected_branches": false,
   "use_worktrees": false,
-  "dream_interval_hours": 3
+  "dream_interval_hours": 3,
+  "dco": false
 }


### PR DESCRIPTION
## Summary

Adds `~/.pi/pi-config-settings.json` as a global settings fallback and introduces DCO support via a `dco` boolean setting.

## Changes

- **project-settings.ts** — Added `parseSettingsFile` shared helper, global settings fallback (`~/.pi/pi-config-settings.json`), and `dco` boolean setting with `PI_DCO` env fallback. Resolution: project → global → env → default
- **git-expert.md** — Added DCO section with actionable check and `--signoff` instructions
- **pi-config-settings.example.json** — Added `dco: false`
- **AGENTS.md** — Updated settings table with `dco` row and resolution order

Closes #510
Closes #506