### PR TITLE
feat: support user and project custom rules directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,8 +183,17 @@ pi-config/
 
 ### Modifying Orchestrator Rules
 
-- Edit files in the `rules/` directory.
+Rules are loaded from three directories (later layers override same-filename entries):
+
+| Layer | Path | Scope | Number range |
+|-------|------|-------|--------------|
+| Package | `<pi-config>/rules/` | All users, all projects | `00-69` |
+| User | `~/.pi/agent/rules/` | All projects for this user | `70-89` |
+| Project | `<project>/.pi/rules/` | Current project only | `90-99` |
+
 - Rules auto-load in **alphabetical order** (hence the numeric prefixes).
+- Same-filename override: project > user > package.
+- Missing directories are silently skipped.
 - Changes take effect on the **next pi session** — no restart of running sessions.
 
 ### Async-Only Agents

--- a/README.md
+++ b/README.md
@@ -253,11 +253,19 @@ To add a custom rule, create a `.md` file in the appropriate directory:
 ```bash
 # User-level rule (applies to all projects)
 mkdir -p ~/.pi/agent/rules
-echo '# My Rule\n\nYour orchestrator instructions here.' > ~/.pi/agent/rules/75-my-rule.md
+cat > ~/.pi/agent/rules/75-my-rule.md << 'EOF'
+# My Rule
+
+Your orchestrator instructions here.
+EOF
 
 # Project-level rule (applies to current project only)
 mkdir -p .pi/rules
-echo '# Project Rule\n\nProject-specific instructions.' > .pi/rules/90-project-rule.md
+cat > .pi/rules/90-project-rule.md << 'EOF'
+# Project Rule
+
+Project-specific instructions.
+EOF
 ```
 
 Rules auto-load alphabetically. Same-filename entries are overridden (project > user > package). Missing directories are silently skipped.

--- a/README.md
+++ b/README.md
@@ -238,6 +238,30 @@ Place a `.md` file with the same `name` frontmatter in `~/.pi/agent/agents/` (us
 
 Priority: project > user > package (bundled).
 
+### Custom Rules
+
+The orchestrator loads rules from three directories (later layers override same-filename entries):
+
+| Layer | Path | Scope | Number range |
+|-------|------|-------|--------------|
+| Package | `<pi-config>/rules/` | All users, all projects | `00-69` |
+| User | `~/.pi/agent/rules/` | All projects for this user | `70-89` |
+| Project | `<project>/.pi/rules/` | Current project only | `90-99` |
+
+To add a custom rule, create a `.md` file in the appropriate directory:
+
+```bash
+# User-level rule (applies to all projects)
+mkdir -p ~/.pi/agent/rules
+echo '# My Rule\n\nYour orchestrator instructions here.' > ~/.pi/agent/rules/75-my-rule.md
+
+# Project-level rule (applies to current project only)
+mkdir -p .pi/rules
+echo '# Project Rule\n\nProject-specific instructions.' > .pi/rules/90-project-rule.md
+```
+
+Rules auto-load alphabetically. Same-filename entries are overridden (project > user > package). Missing directories are silently skipped.
+
 ### Add project agents
 
 Create `.pi/agents/my-agent.md` in your project with frontmatter:

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -121,7 +121,7 @@ export function registerRules(
       for (const dir of [packageRulesDir, userRulesDir, projectRulesDir]) {
         try {
           for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-            if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+            if ((!entry.isFile() && !entry.isSymbolicLink()) || !entry.name.endsWith(".md")) continue;
             const f = entry.name;
             const existing = ruleCandidates.get(f) || [];
             existing.push(path.join(dir, f));
@@ -143,7 +143,8 @@ export function registerRules(
               const stat = fs.statSync(candidates[i]);
               if (stat.size > 128 * 1024) {
                 console.debug(`[rules] ${fileName} skipped (${Math.round(stat.size / 1024)}KB > 128KB limit)`);
-                continue;
+                loaded = true; // Mark as loaded to prevent lower-precedence fallback
+                break;
               }
               ruleContents.push(fs.readFileSync(candidates[i], "utf-8"));
               loaded = true;

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -120,21 +120,27 @@ export function registerRules(
       const ruleFiles = new Map<string, string>(); // filename → full path
       for (const dir of [packageRulesDir, userRulesDir, projectRulesDir]) {
         try {
-          for (const f of fs.readdirSync(dir).filter((f) => f.endsWith(".md")).sort()) {
+          for (const f of fs.readdirSync(dir).filter((f) => f.endsWith(".md"))) {
             ruleFiles.set(f, path.join(dir, f));
           }
-        } catch {
-          // Directory missing — silently skip
+        } catch (e: any) {
+          if (e?.code !== "ENOENT") console.debug("[rules] failed to read", dir, e?.message?.slice(0, 100));
         }
       }
 
       if (ruleFiles.size > 0) {
         const sorted = [...ruleFiles.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-        extra +=
-          "\n\n" +
-          sorted
-            .map(([, filePath]) => fs.readFileSync(filePath, "utf-8"))
-            .join("\n\n");
+        try {
+          extra +=
+            "\n\n" +
+            sorted
+              .map(([, filePath]) => fs.readFileSync(filePath, "utf-8"))
+              .join("\n\n");
+        } catch (e: any) {
+          console.debug("[rules] failed to read rule file:", e?.message?.slice(0, 100));
+          extra +=
+            "\n\n[ORCHESTRATOR RULES] You are a MANAGER. Delegate work to subagents.\n";
+        }
       } else {
         extra +=
           "\n\n[ORCHESTRATOR RULES] You are a MANAGER. Delegate work to subagents.\n";

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -120,7 +120,9 @@ export function registerRules(
       const ruleCandidates = new Map<string, string[]>(); // filename → paths in precedence order
       for (const dir of [packageRulesDir, userRulesDir, projectRulesDir]) {
         try {
-          for (const f of fs.readdirSync(dir).filter((f) => f.endsWith(".md"))) {
+          for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+            if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+            const f = entry.name;
             const existing = ruleCandidates.get(f) || [];
             existing.push(path.join(dir, f));
             ruleCandidates.set(f, existing);
@@ -138,6 +140,11 @@ export function registerRules(
           let loaded = false;
           for (let i = candidates.length - 1; i >= 0; i--) {
             try {
+              const stat = fs.statSync(candidates[i]);
+              if (stat.size > 128 * 1024) {
+                console.debug(`[rules] ${fileName} skipped (${Math.round(stat.size / 1024)}KB > 128KB limit)`);
+                continue;
+              }
               ruleContents.push(fs.readFileSync(candidates[i], "utf-8"));
               loaded = true;
               break;

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -117,25 +117,36 @@ export function registerRules(
       const projectRulesDir = path.join(ctx.cwd, ".pi", "rules");
 
       // Collect rules from all layers — later layers override same-filename entries
-      const ruleFiles = new Map<string, string>(); // filename → full path
+      const ruleCandidates = new Map<string, string[]>(); // filename → paths in precedence order
       for (const dir of [packageRulesDir, userRulesDir, projectRulesDir]) {
         try {
           for (const f of fs.readdirSync(dir).filter((f) => f.endsWith(".md"))) {
-            ruleFiles.set(f, path.join(dir, f));
+            const existing = ruleCandidates.get(f) || [];
+            existing.push(path.join(dir, f));
+            ruleCandidates.set(f, existing);
           }
         } catch (e: any) {
           if (e?.code !== "ENOENT") console.debug("[rules] failed to read", dir, e?.message?.slice(0, 100));
         }
       }
 
-      if (ruleFiles.size > 0) {
-        const sorted = [...ruleFiles.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+      if (ruleCandidates.size > 0) {
+        const sorted = [...ruleCandidates.entries()].sort((a, b) => a[0].localeCompare(b[0]));
         const ruleContents: string[] = [];
-        for (const [fileName, filePath] of sorted) {
-          try {
-            ruleContents.push(fs.readFileSync(filePath, "utf-8"));
-          } catch (e: any) {
-            console.debug(`[rules] skipping ${fileName}:`, e?.message?.slice(0, 100));
+        for (const [fileName, candidates] of sorted) {
+          // Try from highest precedence (last) to lowest (first)
+          let loaded = false;
+          for (let i = candidates.length - 1; i >= 0; i--) {
+            try {
+              ruleContents.push(fs.readFileSync(candidates[i], "utf-8"));
+              loaded = true;
+              break;
+            } catch (e: any) {
+              console.debug(`[rules] ${fileName} failed from ${candidates[i]}:`, e?.message?.slice(0, 100));
+            }
+          }
+          if (!loaded) {
+            console.debug(`[rules] ${fileName}: all candidates failed, skipping`);
           }
         }
         if (ruleContents.length > 0) {

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -7,6 +7,7 @@
  */
 
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { formatDuration } from "./async-agents.js";
@@ -108,19 +109,33 @@ export function registerRules(
     let extra = "";
 
     // Orchestrator rules — skip for specialist agents
+    // Load from: package rules/ → user ~/.pi/agent/rules/ → project .pi/rules/
+    // Same-filename override: project > user > package
     if (!isSubagent) {
-      const rulesDir = path.resolve(__dirname, "..", "..", "rules");
-      try {
-        const files = fs
-          .readdirSync(rulesDir)
-          .filter((f) => f.endsWith(".md"))
-          .sort();
+      const packageRulesDir = path.resolve(__dirname, "..", "..", "rules");
+      const userRulesDir = path.join(os.homedir(), ".pi", "agent", "rules");
+      const projectRulesDir = path.join(ctx.cwd, ".pi", "rules");
+
+      // Collect rules from all layers — later layers override same-filename entries
+      const ruleFiles = new Map<string, string>(); // filename → full path
+      for (const dir of [packageRulesDir, userRulesDir, projectRulesDir]) {
+        try {
+          for (const f of fs.readdirSync(dir).filter((f) => f.endsWith(".md")).sort()) {
+            ruleFiles.set(f, path.join(dir, f));
+          }
+        } catch {
+          // Directory missing — silently skip
+        }
+      }
+
+      if (ruleFiles.size > 0) {
+        const sorted = [...ruleFiles.entries()].sort((a, b) => a[0].localeCompare(b[0]));
         extra +=
           "\n\n" +
-          files
-            .map((f) => fs.readFileSync(path.join(rulesDir, f), "utf-8"))
+          sorted
+            .map(([, filePath]) => fs.readFileSync(filePath, "utf-8"))
             .join("\n\n");
-      } catch {
+      } else {
         extra +=
           "\n\n[ORCHESTRATOR RULES] You are a MANAGER. Delegate work to subagents.\n";
       }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -130,14 +130,17 @@ export function registerRules(
 
       if (ruleFiles.size > 0) {
         const sorted = [...ruleFiles.entries()].sort((a, b) => a[0].localeCompare(b[0]));
-        try {
-          extra +=
-            "\n\n" +
-            sorted
-              .map(([, filePath]) => fs.readFileSync(filePath, "utf-8"))
-              .join("\n\n");
-        } catch (e: any) {
-          console.debug("[rules] failed to read rule file:", e?.message?.slice(0, 100));
+        const ruleContents: string[] = [];
+        for (const [fileName, filePath] of sorted) {
+          try {
+            ruleContents.push(fs.readFileSync(filePath, "utf-8"));
+          } catch (e: any) {
+            console.debug(`[rules] skipping ${fileName}:`, e?.message?.slice(0, 100));
+          }
+        }
+        if (ruleContents.length > 0) {
+          extra += "\n\n" + ruleContents.join("\n\n");
+        } else {
           extra +=
             "\n\n[ORCHESTRATOR RULES] You are a MANAGER. Delegate work to subagents.\n";
         }


### PR DESCRIPTION
## Summary

Extends rule loading to scan three directories with same-filename override semantics.

## Changes

- **rules.ts** — Extended rule loading to scan package (`rules/`), user (`~/.pi/agent/rules/`), and project (`<project>/.pi/rules/`) directories. Later layers override same-filename entries. Includes error handling for file reads and non-ENOENT directory errors.
- **AGENTS.md** — Documented three-layer rule loading with number range convention (00-69 package, 70-89 user, 90-99 project)

Closes #502