### PR TITLE
fix: harden dangerous command enforcement with bypass patterns and anti-circumvention messaging

### DIFF
--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -467,8 +467,10 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     }
 
     // Dangerous command confirmation
+    // Collapse bash line continuations (backslash-newline) before splitting
+    const normalized = command.replace(/\\\r?\n/g, " ");
     // Split on statement separators to avoid matching across unrelated statements
-    const statements = command.split(/\n|;|&&|\|\|/).map(s => s.trim()).filter(Boolean);
+    const statements = normalized.split(/\n|;|&&|\|\|/).map(s => s.trim()).filter(Boolean);
     if (statements.some((stmt) => DANGEROUS.some((p) => p.test(stmt)))) {
       if (!ctx.hasUI)
         return {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -467,7 +467,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     }
 
     // Dangerous command confirmation
-    if (DANGEROUS.some((p) => p.test(command))) {
+    // Split on statement separators to avoid matching across unrelated statements
+    const statements = command.split(/\n|;|&&|\|\|/).map(s => s.trim()).filter(Boolean);
+    if (statements.some((stmt) => DANGEROUS.some((p) => p.test(stmt)))) {
       if (!ctx.hasUI)
         return {
           block: true,

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -471,14 +471,14 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       if (!ctx.hasUI)
         return {
           block: true,
-          reason: "Dangerous command blocked (no UI for confirmation)",
+          reason: "Dangerous command blocked (no UI for confirmation). Do NOT retry with an equivalent command — report this block to the user.",
         };
 
       const ok = await ctx.ui.select(
         `⚠️ Dangerous command:\n\n  ${command}\n\nAllow?`,
         ["Yes", "No"],
       );
-      if (ok !== "Yes") return { block: true, reason: "Blocked by user" };
+      if (ok !== "Yes") return { block: true, reason: "Blocked by user. Do NOT retry with an equivalent command — stop and report." };
     }
 
     return undefined;

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -471,14 +471,14 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       if (!ctx.hasUI)
         return {
           block: true,
-          reason: "Dangerous command blocked (no UI for confirmation). Do NOT retry with an equivalent command — stop and report this block.",
+          reason: "Dangerous command blocked (no UI for confirmation). Do NOT retry with an equivalent command (e.g., find -delete, perl, python os.remove). Stop and report this block to the user.",
         };
 
       const ok = await ctx.ui.select(
         `⚠️ Dangerous command:\n\n  ${command}\n\nAllow?`,
         ["Yes", "No"],
       );
-      if (ok !== "Yes") return { block: true, reason: "Blocked by user. Do NOT retry with an equivalent command — stop and report." };
+      if (ok !== "Yes") return { block: true, reason: "Blocked by user. Do NOT retry with an equivalent command (e.g., find -delete, perl, python os.remove). Stop and report this block to the user." };
     }
 
     return undefined;

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -471,7 +471,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       if (!ctx.hasUI)
         return {
           block: true,
-          reason: "Dangerous command blocked (no UI for confirmation). Do NOT retry with an equivalent command — report this block to the user.",
+          reason: "Dangerous command blocked (no UI for confirmation). Do NOT retry with an equivalent command — stop and report this block.",
         };
 
       const ok = await ctx.ui.select(

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -154,9 +154,9 @@ export const DANGEROUS = [
   /\b(chmod|chown)\b.*777/i,
   /\bmkfs\b/i,
   /\bdd\b.*\bof=\/dev\//i,
-  /\bgit\s+reset\s+--hard\b/i,
-  /\bgit\s+clean\s+(?:-[a-z]*f|--force)/i,
-  /\bfind\b.*\s-delete\b/i,
-  /\bfind\b.*-exec(?:dir)?\s+(?:\/\S+\/)?rm\b/i,
+  /\bgit\b[\s\S]*\breset\b[\s\S]*--hard\b/i,
+  /\bgit\b[\s\S]*\bclean\b[\s\S]*(?:--force|-\S*f)/i,
+  /\bfind\b[\s\S]*\s-delete\b/i,
+  /\bfind\b[\s\S]*-exec(?:dir)?\s+(?:\/\S+\/)?rm\b/i,
   /\bxargs\s+(?:-\S+\s+)*(?:\/\S+\/)?rm\b/i,
 ];

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -154,4 +154,9 @@ export const DANGEROUS = [
   /\b(chmod|chown)\b.*777/i,
   /\bmkfs\b/i,
   /\bdd\b.*\bof=\/dev\//i,
+  /\bgit\s+reset\s+--hard\b/i,
+  /\bgit\s+clean\s+-[a-z]*f/i,
+  /\bfind\b.*\s-delete\b/i,
+  /\bfind\b.*-exec\s+rm\b/i,
+  /\bxargs\s+rm\b/i,
 ];

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -155,8 +155,8 @@ export const DANGEROUS = [
   /\bmkfs\b/i,
   /\bdd\b.*\bof=\/dev\//i,
   /\bgit\s+reset\s+--hard\b/i,
-  /\bgit\s+clean\s+-[a-z]*f/i,
+  /\bgit\s+clean\s+(?:-[a-z]*f|--force)/i,
   /\bfind\b.*\s-delete\b/i,
-  /\bfind\b.*-exec\s+rm\b/i,
-  /\bxargs\s+rm\b/i,
+  /\bfind\b.*-exec(?:dir)?\s+(?:\/\S+\/)?rm\b/i,
+  /\bxargs\s+(?:-\S+\s+)*(?:\/\S+\/)?rm\b/i,
 ];


### PR DESCRIPTION
## Summary

Expands the dangerous command enforcement to catch bypass variants and prevents LLM agents from retrying with equivalent unguarded commands.

## Changes

- **git-helpers.ts** — Added 5 new patterns to DANGEROUS array: `git reset --hard`, `git clean -f/--force`, `find -delete`, `find -exec(dir) rm`, `xargs rm` (with flags/absolute path handling)
- **enforcement.ts** — Updated block reason messages with anti-circumvention wording: "Do NOT retry with an equivalent command — stop and report this block"

Closes #503
Closes #504
