### PR TITLE
feat(coms): show pending inbound message count in widget top border

### DIFF
--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -963,13 +963,13 @@ export default function (pi: ExtensionAPI) {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms-net ");
 			const leftFill = theme.fg("dim", "━");
 			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
-			const pendingSuffix = pendingCount > 0 ? ` (${pendingCount} pending)` : "";
+			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 4 : 0;
 			// "┏━ coms-net ━" prefix has 13 visible cells.
 			const remaining = safeWidth - 13 - rightTagVisLen - 1; // -1 for "┓"
 			if (identity && remaining >= 1) {
-				const pendingPart = pendingCount > 0 ? theme.fg("warning", pendingSuffix) : "";
+				const pendingPart = pendingCount > 0 ? theme.fg("warning", pendingSuffix) : theme.fg("dim", pendingSuffix);
 				const rightTag =
 					theme.fg("dim", " ") +
 					hexFg(identity.color, identity.name) +

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -439,10 +439,11 @@ export default function (pi: ExtensionAPI) {
 	// ━━ Pool snapshot diff (used to gate widget renders) ━━━━━━━━━━━━━━━━━━━
 
 	function poolSnapshotKey(): string {
+		const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
 		const arr = [...peerCards.values()]
 			.map(c => `${c.session_id}|${c.name}|${c.color}|${c.model}|${c.context_used_pct}|${c.queue_depth}|${c.status}|${c.purpose}|${c.explicit ? 1 : 0}`)
 			.sort();
-		return arr.join("\n");
+		return `pending=${pendingCount}\n` + arr.join("\n");
 	}
 
 	function maybeRequestRender(): void {
@@ -573,6 +574,7 @@ export default function (pi: ExtensionAPI) {
 			fulfilled: false,
 		};
 		inboundQueue.set(msg_id, inbound);
+		maybeRequestRender();
 
 		// If already processing another inbound, just queue — agent_end will drain FIFO.
 		if (processingInbound) {
@@ -622,6 +624,7 @@ export default function (pi: ExtensionAPI) {
 			} catch { /* best-effort */ }
 		} catch (err) {
 			inboundQueue.delete(msg_id);
+			maybeRequestRender();
 			currentInbound = null;
 			processingInbound = false;
 			audit("prompt_in_failed", { msg_id, reason: safeError(err) });
@@ -965,7 +968,7 @@ export default function (pi: ExtensionAPI) {
 			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
 			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
-			const rightTagVisLen = identity ? nameLen + 4 : 0;
+			const rightTagVisLen = identity ? nameLen + 3 : 0;
 			// "┏━ coms-net ━" prefix has 13 visible cells.
 			const remaining = safeWidth - 13 - rightTagVisLen - 1; // -1 for "┓"
 			if (identity && remaining >= 1) {

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -438,8 +438,14 @@ export default function (pi: ExtensionAPI) {
 
 	// ━━ Pool snapshot diff (used to gate widget renders) ━━━━━━━━━━━━━━━━━━━
 
+	function getPendingInboundCount(): number {
+		let count = 0;
+		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== currentInbound) count++;
+		return count;
+	}
+
 	function poolSnapshotKey(): string {
-		const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled && i !== currentInbound).length;
+		const pendingCount = getPendingInboundCount();
 		const arr = [...peerCards.values()]
 			.map(c => `${c.session_id}|${c.name}|${c.color}|${c.model}|${c.context_used_pct}|${c.queue_depth}|${c.status}|${c.purpose}|${c.explicit ? 1 : 0}`)
 			.sort();
@@ -965,7 +971,7 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms-net ");
 			const leftFill = theme.fg("dim", "━");
-			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled && i !== currentInbound).length;
+			const pendingCount = getPendingInboundCount();
 			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 3 : 0;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -439,7 +439,7 @@ export default function (pi: ExtensionAPI) {
 	// ━━ Pool snapshot diff (used to gate widget renders) ━━━━━━━━━━━━━━━━━━━
 
 	function poolSnapshotKey(): string {
-		const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
+		const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled && i !== currentInbound).length;
 		const arr = [...peerCards.values()]
 			.map(c => `${c.session_id}|${c.name}|${c.color}|${c.model}|${c.context_used_pct}|${c.queue_depth}|${c.status}|${c.purpose}|${c.explicit ? 1 : 0}`)
 			.sort();
@@ -965,7 +965,7 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms-net ");
 			const leftFill = theme.fg("dim", "━");
-			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
+			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled && i !== currentInbound).length;
 			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 3 : 0;

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -962,14 +962,18 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms-net ");
 			const leftFill = theme.fg("dim", "━");
-			const nameLen = identity ? identity.name.length : 0;
+			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
+			const pendingSuffix = pendingCount > 0 ? ` (${pendingCount} pending)` : "";
+			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 4 : 0;
 			// "┏━ coms-net ━" prefix has 13 visible cells.
 			const remaining = safeWidth - 13 - rightTagVisLen - 1; // -1 for "┓"
 			if (identity && remaining >= 1) {
+				const pendingPart = pendingCount > 0 ? theme.fg("warning", pendingSuffix) : "";
 				const rightTag =
 					theme.fg("dim", " ") +
 					hexFg(identity.color, identity.name) +
+					pendingPart +
 					theme.fg("dim", " ━");
 				const middle = theme.fg("dim", "━".repeat(remaining));
 				const right = theme.fg("dim", "┓");

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -1018,13 +1018,17 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms ");
 			const leftFill = theme.fg("dim", "━");
-			const nameLen = identity ? identity.name.length : 0;
+			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
+			const pendingSuffix = pendingCount > 0 ? ` (${pendingCount} pending)` : "";
+			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 4 : 0;
 			const remaining = safeWidth - 9 /* "┏━ coms ━" */ - rightTagVisLen - 1 /* "┓" */;
 			if (identity && remaining >= 1) {
+				const pendingPart = pendingCount > 0 ? theme.fg("warning", pendingSuffix) : "";
 				const rightTag =
 					theme.fg("dim", " ") +
 					hexFg(identity.color, identity.name) +
+					pendingPart +
 					theme.fg("dim", " ━");
 				const middle = theme.fg("dim", "━".repeat(remaining));
 				const right = theme.fg("dim", "┓");

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -527,6 +527,17 @@ export default function (pi: ExtensionAPI) {
 	let currentInbound: InboundContext | null = null;
 	let processingInbound = false;
 
+	let lastPoolSnapshot = "";
+	function maybeRefreshWidget(): void {
+		if (!currentCtx?.hasUI) return;
+		let pc = 0;
+		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== currentInbound) pc++;
+		const key = `pending=${pc}|` + [...peerCards.entries()].map(([k, v]) => `${k}:${v.staleCount}`).sort().join(",");
+		if (key === lastPoolSnapshot) return;
+		lastPoolSnapshot = key;
+		try { installPoolWidget(currentCtx); } catch {}
+	}
+
 	// Phase A stub handlers — each just acks valid envelopes. Phase B replaces these.
 	function ackOk(socket: net.Socket, msg_id: string): void {
 		try {
@@ -567,7 +578,7 @@ export default function (pi: ExtensionAPI) {
 			fulfilled: false,
 		};
 		inboundQueue.set(env.msg_id, inbound);
-		if (currentCtx?.hasUI) { try { installPoolWidget(currentCtx); } catch {} }
+		maybeRefreshWidget();
 
 		// 3. If already processing another inbound, just queue — agent_end will drain FIFO.
 		if (processingInbound) {
@@ -604,7 +615,7 @@ export default function (pi: ExtensionAPI) {
 			);
 		} catch (err) {
 			inboundQueue.delete(env.msg_id);
-			if (currentCtx?.hasUI) { try { installPoolWidget(currentCtx); } catch {} }
+			maybeRefreshWidget();
 			currentInbound = null;
 			processingInbound = false;
 			nack(socket, env.msg_id, "internal error");
@@ -1577,7 +1588,7 @@ export default function (pi: ExtensionAPI) {
 
 		inbound.fulfilled = true;
 		inboundQueue.delete(inbound.msg_id);
-		if (currentCtx?.hasUI) { try { installPoolWidget(currentCtx); } catch {} }
+		maybeRefreshWidget();
 		currentInbound = null;
 
 		// FIFO drain: pick the next queued (oldest unfulfilled) inbound

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -1020,7 +1020,7 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms ");
 			const leftFill = theme.fg("dim", "━");
-			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
+			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled && i !== currentInbound).length;
 			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 3 : 0;

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -1019,12 +1019,12 @@ export default function (pi: ExtensionAPI) {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms ");
 			const leftFill = theme.fg("dim", "━");
 			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
-			const pendingSuffix = pendingCount > 0 ? ` (${pendingCount} pending)` : "";
+			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 4 : 0;
 			const remaining = safeWidth - 9 /* "┏━ coms ━" */ - rightTagVisLen - 1 /* "┓" */;
 			if (identity && remaining >= 1) {
-				const pendingPart = pendingCount > 0 ? theme.fg("warning", pendingSuffix) : "";
+				const pendingPart = pendingCount > 0 ? theme.fg("warning", pendingSuffix) : theme.fg("dim", pendingSuffix);
 				const rightTag =
 					theme.fg("dim", " ") +
 					hexFg(identity.color, identity.name) +

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -1031,7 +1031,8 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms ");
 			const leftFill = theme.fg("dim", "━");
-			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled && i !== currentInbound).length;
+			let pendingCount = 0;
+			for (const i of inboundQueue.values()) if (!i.fulfilled && i !== currentInbound) pendingCount++;
 			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 3 : 0;

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -567,6 +567,7 @@ export default function (pi: ExtensionAPI) {
 			fulfilled: false,
 		};
 		inboundQueue.set(env.msg_id, inbound);
+		if (currentCtx?.hasUI) { try { installPoolWidget(currentCtx); } catch {} }
 
 		// 3. If already processing another inbound, just queue — agent_end will drain FIFO.
 		if (processingInbound) {
@@ -603,6 +604,7 @@ export default function (pi: ExtensionAPI) {
 			);
 		} catch (err) {
 			inboundQueue.delete(env.msg_id);
+			if (currentCtx?.hasUI) { try { installPoolWidget(currentCtx); } catch {} }
 			currentInbound = null;
 			processingInbound = false;
 			nack(socket, env.msg_id, "internal error");
@@ -1021,7 +1023,7 @@ export default function (pi: ExtensionAPI) {
 			const pendingCount = [...inboundQueue.values()].filter(i => !i.fulfilled).length;
 			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
-			const rightTagVisLen = identity ? nameLen + 4 : 0;
+			const rightTagVisLen = identity ? nameLen + 3 : 0;
 			const remaining = safeWidth - 9 /* "┏━ coms ━" */ - rightTagVisLen - 1 /* "┓" */;
 			if (identity && remaining >= 1) {
 				const pendingPart = pendingCount > 0 ? theme.fg("warning", pendingSuffix) : theme.fg("dim", pendingSuffix);
@@ -1575,6 +1577,7 @@ export default function (pi: ExtensionAPI) {
 
 		inbound.fulfilled = true;
 		inboundQueue.delete(inbound.msg_id);
+		if (currentCtx?.hasUI) { try { installPoolWidget(currentCtx); } catch {} }
 		currentInbound = null;
 
 		// FIFO drain: pick the next queued (oldest unfulfilled) inbound

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -415,6 +415,14 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             }
           }
         }
+
+        // DCO enforcement — inject --signoff when dco setting is enabled
+        if (getSetting(gitCwd, "dco") && !command.includes("--signoff")) {
+          event.input.command = event.input.command.replace(
+            /\bgit\s+commit\b/,
+            "git commit --signoff",
+          );
+        }
       }
 
       // Block pushes to protected branches

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -415,14 +415,6 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             }
           }
         }
-
-        // DCO enforcement — inject --signoff when dco setting is enabled
-        if (getSetting(gitCwd, "dco") && !command.includes("--signoff")) {
-          event.input.command = event.input.command.replace(
-            /\bgit\s+commit\b/,
-            "git commit --signoff",
-          );
-        }
       }
 
       // Block pushes to protected branches


### PR DESCRIPTION
## Summary

Shows the number of pending inbound messages next to the peer's identity name in the coms widget top border.

**No pending messages:**
```
┏━ coms ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ e2e-tester ━┓
```

**With pending messages:**
```
┏━ coms ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ e2e-tester (2 pending) ━┓
```

## Changes

- **coms-p2p.ts** — Count unfulfilled `inboundQueue` entries and append `(N pending)` in warning color to the identity name in the top border
- **coms-net.ts** — Same change for networked coms widget

Closes #519