### PR TITLE
fix: async results dir PID collision + entrypoint simplification + task-focus enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,7 @@ All async agent temp files live under project-scoped subdirectories:
 ├── nvim-qf-<pid>-<ts>.json      # Nvim quickfix data (ephemeral)
 ├── async-cfg-<id>.json          # Async runner config (ephemeral)
 ├── subagent-<random>/           # Subagent prompt temp dir (ephemeral)
-├── async-results-pid-<pid>/     # Async agent completion results (picked up by poller)
+├── async-results-pid-<pid>-<starttime>/  # Async agent completion results (starttime prevents container PID collisions)
 └── worker-<id>/                 # Async agent working dir
     ├── status.json              # Agent state (running/complete/failed)
     ├── session.json             # Parent PID + starttime for zombie detection
@@ -365,6 +365,7 @@ Clean-room TypeScript implementation under MIT — not a code translation.
 - `before_agent_start`: injects situation report + vector-matched memories + session history
 - Social closer gate: skips search for trivial messages ("ok", "thanks", "👍")
 - `turn_end`: file-change memory reminders (vector search on modified file paths)
+- `turn_end`: task-focus enforcement — if turn had no tool calls but active tasks exist, injects follow-up to force LLM to resume work
 - Retrieval telemetry: logs injected memories to `.pi/data/memory-telemetry.jsonl`
 - Ground Truth instruction: tells LLM to trust injected context as authoritative
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,18 +11,15 @@ PI_PKG_DIR="$HOME/.pi/agent/git/github.com"
 
 if [ ! -d "$PI_PKG_DIR/myk-org/pi-config" ]; then
     pi install git:github.com/myk-org/pi-config
-else
-    pi update git:github.com/myk-org/pi-config
 fi
-
-# Update myk-pi-tools to latest from local pi-config source
-uv tool install --force myk-pi-tools --from "$PI_PKG_DIR/myk-org/pi-config" 2>/dev/null || true
 
 if [ ! -d "$PI_PKG_DIR/myk-org/pi-vertex-claude" ]; then
     pi install git:github.com/myk-org/pi-vertex-claude
-else
-    pi update git:github.com/myk-org/pi-vertex-claude
 fi
+
+# Update all installed packages + myk-pi-tools
+pi update --all
+uv tool install --force myk-pi-tools --from "$PI_PKG_DIR/myk-org/pi-config" 2>/dev/null || true
 
 # Register pi packages if not already present
 # (installed globally in Docker image, just need pi to know about them)

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -585,7 +585,7 @@ export function registerAsyncAgents(
           // Check if parent pi process is alive via /proc/PID/stat starttime
           try {
             const stat = fs.readFileSync(`/proc/${parentPid}/stat`, "utf-8");
-            const currentStartTime = stat.split(" ")[21];
+            const currentStartTime = parseProcStartTime(stat);
             if (currentStartTime === parentStartTime) continue; // alive, same process
           } catch {} // /proc not found = dead
           // Parent dead or PID reused — zombie, delete

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -586,6 +586,7 @@ export function registerAsyncAgents(
           try {
             const stat = fs.readFileSync(`/proc/${parentPid}/stat`, "utf-8");
             const currentStartTime = parseProcStartTime(stat);
+            if (!currentStartTime) continue; // parse failed — can't verify, skip conservatively
             if (currentStartTime === parentStartTime) continue; // alive, same process
           } catch {} // /proc not found = dead
           // Parent dead or PID reused — zombie, delete

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -32,7 +32,7 @@ const taskStoreReady: Promise<void> = (async () => {
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentConfig } from "./agents.js";
-import { getPiInvocation, getProjectTmpDir } from "./utils.js";
+import { getPiInvocation, getProjectTmpDir, parseProcStartTime } from "./utils.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -81,7 +81,14 @@ function readAsyncStatus(workerDir: string): any | null {
 
 /** Derive a stable directory name from a session file path. */
 function sessionResultsDirName(): string {
-  return `async-results-pid-${process.pid}`;
+  let startTime = "";
+  try {
+    const stat = fs.readFileSync(`/proc/${process.pid}/stat`, "utf-8");
+    startTime = parseProcStartTime(stat) || "";
+  } catch {}
+  return startTime
+    ? `async-results-pid-${process.pid}-${startTime}`
+    : `async-results-pid-${process.pid}`;
 }
 
 export function formatDuration(ms: number): string {
@@ -420,7 +427,7 @@ export function registerAsyncAgents(
     let parentStartTime = "";
     for (let attempt = 0; attempt < 3; attempt++) {
       try {
-        parentStartTime = fs.readFileSync(`/proc/${process.pid}/stat`, "utf-8").split(" ")[21] || "";
+        parentStartTime = parseProcStartTime(fs.readFileSync(`/proc/${process.pid}/stat`, "utf-8")) || "";
         if (parentStartTime) break;
       } catch { /* retry */ }
     }

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -17,7 +17,7 @@ import * as path from "node:path";
 import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { discoverAgents } from "./agents.js";
-import { getProjectTmpDir } from "./utils.js";
+import { getProjectTmpDir, parseProcStartTime } from "./utils.js";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -40,17 +40,6 @@ let CRON_FILE = ""; // Set on session_start to project-scoped dir
 /** Unique session suffix — prevents PID collisions across containers */
 /** Suffix must be unique across containers but stable across reloads (same process).
  *  Use process start time from /proc or process.uptime() as a stable identifier. */
-/** Parse start time (field 22) from /proc stat content — handles comm fields with spaces */
-function parseProcStartTime(statContent: string): string | null {
-  // Field 2 (comm) is wrapped in parens and may contain spaces/parens.
-  // Find the LAST ')' to reliably skip it, then split remaining fields.
-  const closeParenIdx = statContent.lastIndexOf(")");
-  if (closeParenIdx < 0) return null;
-  const fields = statContent.slice(closeParenIdx + 2).split(" ");
-  // After comm: field 3=state(idx 0), field 4=ppid(idx 1), ... field 22=starttime(idx 19)
-  return fields[19] || null;
-}
-
 const SESSION_SUFFIX = (() => {
   try {
     const stat = fs.readFileSync("/proc/self/stat", "utf-8");

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -74,6 +74,7 @@ export function registerRules(
 ): void {
   const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
   let rebuildDone = false;
+  let taskFocusJustFired = false;
 
   // Run full rebuild on session start (once per session, not every turn)
   pi.on("session_start", async (_event, ctx) => {
@@ -275,6 +276,43 @@ export function registerRules(
         lastInjectedMemories = [];
       }
     } catch (e: any) { console.debug("[rules] telemetry usage detection failed:", e?.message?.slice(0, 100)); }
+
+    // Task-focus enforcement: if this turn had no tool calls but tasks are active,
+    // the LLM likely answered a side question and forgot to resume work.
+    // Inject a follow-up to force it back on track.
+    try {
+      const turnToolResults = (_event as any).toolResults;
+      const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
+      if (taskFocusJustFired) {
+        taskFocusJustFired = false;
+      } else if (!hadToolCalls) {
+        // Check for active tasks via pi-tasks TaskStore
+        const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
+        if (fs.existsSync(tasksDir)) {
+          const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith(".json"));
+          for (const tf of taskFiles) {
+            try {
+              const data = JSON.parse(fs.readFileSync(path.join(tasksDir, tf), "utf-8"));
+              const tasks = data.tasks || [];
+              const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
+              if (activeTasks.length > 0) {
+                const summary = activeTasks
+                  .slice(0, 3)
+                  .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
+                  .join(", ");
+                pi.sendMessage({
+                  customType: "task-focus-enforcement",
+                  content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
+                  display: true,
+                }, { triggerTurn: true, deliverAs: "followUp" });
+                taskFocusJustFired = true;
+                break; // Only fire once per turn
+              }
+            } catch { continue; }
+          }
+        }
+      }
+    } catch (e: any) { console.debug("[rules] task-focus enforcement failed:", e?.message?.slice(0, 100)); }
 
     // Check what files were modified in this turn by looking at tool results
     const toolResults = (_event as any).toolResults;

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -286,30 +286,32 @@ export function registerRules(
       if (taskFocusJustFired) {
         taskFocusJustFired = false;
       } else if (!hadToolCalls) {
-        // Check for active tasks via pi-tasks TaskStore
+        // Check for active tasks — session-scoped task file only
         const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
-        if (fs.existsSync(tasksDir)) {
-          const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith(".json"));
-          for (const tf of taskFiles) {
-            try {
-              const data = JSON.parse(fs.readFileSync(path.join(tasksDir, tf), "utf-8"));
-              const tasks = data.tasks || [];
-              const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
-              if (activeTasks.length > 0) {
-                const summary = activeTasks
-                  .slice(0, 3)
-                  .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
-                  .join(", ");
-                pi.sendMessage({
-                  customType: "task-focus-enforcement",
-                  content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
-                  display: true,
-                }, { triggerTurn: true, deliverAs: "followUp" });
-                taskFocusJustFired = true;
-                break; // Only fire once per turn
-              }
-            } catch { continue; }
-          }
+        const sessionId = ctx.sessionManager?.getSessionId?.();
+        const candidates: string[] = [];
+        if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+        candidates.push(path.join(tasksDir, "tasks.json"));
+        for (const taskFile of candidates) {
+          try {
+            if (!fs.existsSync(taskFile)) continue;
+            const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
+            const tasks = data.tasks || [];
+            const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
+            if (activeTasks.length > 0) {
+              const summary = activeTasks
+                .slice(0, 3)
+                .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
+                .join(", ");
+              pi.sendMessage({
+                customType: "task-focus-enforcement",
+                content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
+                display: true,
+              }, { triggerTurn: true, deliverAs: "followUp" });
+              taskFocusJustFired = true;
+              break;
+            }
+          } catch { continue; }
         }
       }
     } catch (e: any) { console.debug("[rules] task-focus enforcement failed:", e?.message?.slice(0, 100)); }

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -91,6 +91,17 @@ export function getProjectTmpDir(cwd: string): string {
   return dir;
 }
 
+/** Parse start time (field 22) from /proc stat content — handles comm fields with spaces */
+export function parseProcStartTime(statContent: string): string | null {
+  // Field 2 (comm) is wrapped in parens and may contain spaces/parens.
+  // Find the LAST ')' to reliably skip it, then split remaining fields.
+  const closeParenIdx = statContent.lastIndexOf(")");
+  if (closeParenIdx < 0) return null;
+  const fields = statContent.slice(closeParenIdx + 2).split(" ");
+  // After comm: field 3=state(idx 0), field 4=ppid(idx 1), ... field 22=starttime(idx 19)
+  return fields[19] || null;
+}
+
 /** Safely call ctx.getSystemPromptOptions() — returns null if unavailable. */
 export function tryGetSystemPromptOptions(ctx: any): { contextFiles?: any[]; skills?: any[]; selectedTools?: any[]; promptGuidelines?: any[] } | null {
   try {


### PR DESCRIPTION
## Changes

### 1. Async results dir PID collision fix (container-only)
`sessionResultsDirName()` now includes process start time from `/proc/self/stat` alongside PID, preventing result delivery to wrong sessions when PIDs are reused in containers.

### 2. Shared `parseProcStartTime()` helper
Extracted robust `/proc/stat` parser from `cron.ts` to `utils.ts` — handles process names with spaces. Used by `async-agents.ts` (2 call sites) and `cron.ts`.

### 3. Entrypoint simplification
Replaced individual `pi update` calls with single `pi update --all`.

### 4. Task-focus enforcement
New `turn_end` hook in `rules.ts`: when a turn has no tool calls but active tasks exist, injects a `triggerTurn: true` follow-up forcing the LLM to resume work. Includes infinite-loop guard (fires once, skips next turn).

Closes #524