### PR TITLE
fix(coms): session_id-keyed registry + socket-based liveness for container support

### DIFF
--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -318,7 +318,13 @@ function pruneDeadEntries(project: string): RegistryEntry[] {
 		// Fall back to started_at if heartbeat_at is missing (agent hasn't completed first keepalive cycle)
 		const lastSeen = entry.heartbeat_at ?? entry.started_at;
 		if (lastSeen) {
-			const age = now - new Date(lastSeen).getTime();
+			const lastSeenMs = new Date(lastSeen).getTime();
+			if (isNaN(lastSeenMs)) {
+				// Invalid timestamp — treat as stale, remove entry
+				removeRegistryEntry(project, entry.session_id);
+				continue;
+			}
+			const age = now - lastSeenMs;
 			if (age > staleThresholdMs) {
 				// Heartbeat/start too old — agent likely crashed without cleanup
 				removeRegistryEntry(project, entry.session_id);

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -231,6 +231,10 @@ function projectAgentsDir(project: string): string {
 }
 
 function registryFilePath(project: string, sessionId: string): string {
+	// Guard against path traversal from malformed session_id
+	if (sessionId.includes("/") || sessionId.includes("\\") || sessionId.includes("..")) {
+		throw new Error(`Invalid session_id: ${sessionId}`);
+	}
 	return path.join(projectAgentsDir(project), `${sessionId}.json`);
 }
 
@@ -299,37 +303,33 @@ function removeRegistryEntry(project: string, sessionId: string): void {
 
 async function pruneDeadEntries(project: string): Promise<RegistryEntry[]> {
 	const entries = readAllRegistryEntries(project);
-	const live: RegistryEntry[] = [];
 	const now = Date.now();
 	const staleThresholdMs = KEEPALIVE_INTERVAL_MS * 2;
+	const socketsDir = path.join(COMS_DIR, "sockets");
+
+	// Phase 1: Sync pre-filter (fast — no I/O)
+	const candidates: RegistryEntry[] = [];
 	for (const entry of entries) {
-		if (!entry.endpoint) {
+		if (!entry.endpoint || typeof entry.endpoint !== "string") {
 			removeRegistryEntry(project, entry.session_id);
 			continue;
 		}
 		// On Windows, endpoints are named pipes — fs.existsSync doesn't apply
 		if (process.platform !== "win32" && !fs.existsSync(entry.endpoint)) {
-			// Socket gone — agent is dead
 			removeRegistryEntry(project, entry.session_id);
 			continue;
 		}
-		// Socket exists — check heartbeat freshness to detect crashed agents
-		// whose socket files were left behind (SIGKILL, OOM, etc.)
-		// Fall back to started_at if heartbeat_at is missing (agent hasn't completed first keepalive cycle)
+		// Check heartbeat/started_at freshness
 		const lastSeen = entry.heartbeat_at ?? entry.started_at;
 		if (lastSeen) {
 			const lastSeenMs = new Date(lastSeen).getTime();
 			if (isNaN(lastSeenMs)) {
-				// Invalid timestamp — treat as stale, remove entry
 				removeRegistryEntry(project, entry.session_id);
 				continue;
 			}
 			const age = now - lastSeenMs;
 			if (age > staleThresholdMs) {
-				// Heartbeat/start too old — agent likely crashed without cleanup
 				removeRegistryEntry(project, entry.session_id);
-				// Only unlink sockets under the expected coms sockets directory
-				const socketsDir = path.join(COMS_DIR, "sockets");
 				if (entry.endpoint.startsWith(socketsDir + path.sep) || entry.endpoint.startsWith(socketsDir + "/")) {
 					try { fs.unlinkSync(entry.endpoint); } catch { /* best-effort */ }
 					try { fs.unlinkSync(`${entry.endpoint}.ping`); } catch { /* best-effort */ }
@@ -337,23 +337,27 @@ async function pruneDeadEntries(project: string): Promise<RegistryEntry[]> {
 				continue;
 			}
 		} else {
-			// No timestamp at all — malformed entry, remove it
 			removeRegistryEntry(project, entry.session_id);
 			continue;
 		}
-		// Socket file exists and heartbeat is fresh — verify socket is actually reachable
-		const verdict = await probeStaleSocket(entry.endpoint);
-		if (verdict === "stale") {
-			// Socket exists but nobody is listening — crashed without cleanup
+		candidates.push(entry);
+	}
+
+	// Phase 2: Parallel socket probes (all candidates at once)
+	if (candidates.length === 0) return [];
+	const results = await Promise.all(candidates.map(entry => probeStaleSocket(entry.endpoint)));
+	const live: RegistryEntry[] = [];
+	for (let i = 0; i < candidates.length; i++) {
+		if (results[i] === "stale") {
+			const entry = candidates[i];
 			removeRegistryEntry(project, entry.session_id);
-			const socketsDir = path.join(COMS_DIR, "sockets");
 			if (entry.endpoint.startsWith(socketsDir + path.sep) || entry.endpoint.startsWith(socketsDir + "/")) {
 				try { fs.unlinkSync(entry.endpoint); } catch { /* best-effort */ }
 				try { fs.unlinkSync(`${entry.endpoint}.ping`); } catch { /* best-effort */ }
 			}
-			continue;
+		} else {
+			live.push(candidates[i]);
 		}
-		live.push(entry);
 	}
 	return live;
 }
@@ -397,11 +401,11 @@ function probeStaleSocket(endpoint: string): Promise<"in_use" | "stale"> {
 		});
 		sock.once("error", (err: any) => {
 			clearTimeout(timer);
-			if (err && err.code === "ECONNREFUSED") {
+			if (err && (err.code === "ECONNREFUSED" || err.code === "ENOENT")) {
 				finish("stale");
 			} else {
-				// ENOENT or other — treat as stale (file may be gone or unusable)
-				finish("stale");
+				// Transient errors (EMFILE, EACCES, etc.) — treat as live to avoid false pruning
+				finish("in_use");
 			}
 		});
 	});

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -315,10 +315,12 @@ function pruneDeadEntries(project: string): RegistryEntry[] {
 		}
 		// Socket exists — check heartbeat freshness to detect crashed agents
 		// whose socket files were left behind (SIGKILL, OOM, etc.)
-		if (entry.heartbeat_at) {
-			const heartbeatAge = now - new Date(entry.heartbeat_at).getTime();
-			if (heartbeatAge > staleThresholdMs) {
-				// Heartbeat too old — agent likely crashed without cleanup
+		// Fall back to started_at if heartbeat_at is missing (agent hasn't completed first keepalive cycle)
+		const lastSeen = entry.heartbeat_at ?? entry.started_at;
+		if (lastSeen) {
+			const age = now - new Date(lastSeen).getTime();
+			if (age > staleThresholdMs) {
+				// Heartbeat/start too old — agent likely crashed without cleanup
 				removeRegistryEntry(project, entry.session_id);
 				// Only unlink sockets under the expected coms sockets directory
 				const socketsDir = path.join(COMS_DIR, "sockets");
@@ -328,6 +330,10 @@ function pruneDeadEntries(project: string): RegistryEntry[] {
 				}
 				continue;
 			}
+		} else {
+			// No timestamp at all — malformed entry, remove it
+			removeRegistryEntry(project, entry.session_id);
+			continue;
 		}
 		live.push(entry);
 	}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -1208,8 +1208,10 @@ export default function (pi: ExtensionAPI) {
 			if (byName.length > 1) {
 				// Ambiguous — sort deterministically: freshest heartbeat first, session_id tiebreaker
 				byName.sort((a, b) => {
-					const ha = a.heartbeat_at ? new Date(a.heartbeat_at).getTime() : 0;
-					const hb = b.heartbeat_at ? new Date(b.heartbeat_at).getTime() : 0;
+					const haRaw = a.heartbeat_at ? new Date(a.heartbeat_at).getTime() : 0;
+					const hbRaw = b.heartbeat_at ? new Date(b.heartbeat_at).getTime() : 0;
+					const ha = isNaN(haRaw) ? 0 : haRaw;
+					const hb = isNaN(hbRaw) ? 0 : hbRaw;
 					if (hb !== ha) return hb - ha; // freshest first
 					return a.session_id.localeCompare(b.session_id); // stable tiebreak
 				});

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -343,9 +343,15 @@ async function pruneDeadEntries(project: string): Promise<RegistryEntry[]> {
 		candidates.push(entry);
 	}
 
-	// Phase 2: Parallel socket probes (all candidates at once)
+	// Phase 2: Parallel socket probes (capped at 10 concurrent to avoid EMFILE)
 	if (candidates.length === 0) return [];
-	const results = await Promise.all(candidates.map(entry => probeStaleSocket(entry.endpoint)));
+	const PROBE_CONCURRENCY = 10;
+	const results: ("in_use" | "stale")[] = [];
+	for (let start = 0; start < candidates.length; start += PROBE_CONCURRENCY) {
+		const batch = candidates.slice(start, start + PROBE_CONCURRENCY);
+		const batchResults = await Promise.all(batch.map(entry => probeStaleSocket(entry.endpoint)));
+		results.push(...batchResults);
+	}
 	const live: RegistryEntry[] = [];
 	for (let i = 0; i < candidates.length; i++) {
 		if (results[i] === "stale") {

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -303,7 +303,12 @@ function pruneDeadEntries(project: string): RegistryEntry[] {
 	const now = Date.now();
 	const staleThresholdMs = KEEPALIVE_INTERVAL_MS * 2;
 	for (const entry of entries) {
-		if (!entry.endpoint || !fs.existsSync(entry.endpoint)) {
+		if (!entry.endpoint) {
+			removeRegistryEntry(project, entry.session_id);
+			continue;
+		}
+		// On Windows, endpoints are named pipes — fs.existsSync doesn't apply
+		if (process.platform !== "win32" && !fs.existsSync(entry.endpoint)) {
 			// Socket gone — agent is dead
 			removeRegistryEntry(project, entry.session_id);
 			continue;
@@ -315,8 +320,12 @@ function pruneDeadEntries(project: string): RegistryEntry[] {
 			if (heartbeatAge > staleThresholdMs) {
 				// Heartbeat too old — agent likely crashed without cleanup
 				removeRegistryEntry(project, entry.session_id);
-				try { fs.unlinkSync(entry.endpoint); } catch { /* best-effort */ }
-				try { fs.unlinkSync(`${entry.endpoint}.ping`); } catch { /* best-effort */ }
+				// Only unlink sockets under the expected coms sockets directory
+				const socketsDir = path.join(COMS_DIR, "sockets");
+				if (entry.endpoint.startsWith(socketsDir + path.sep) || entry.endpoint.startsWith(socketsDir + "/")) {
+					try { fs.unlinkSync(entry.endpoint); } catch { /* best-effort */ }
+					try { fs.unlinkSync(`${entry.endpoint}.ping`); } catch { /* best-effort */ }
+				}
 				continue;
 			}
 		}
@@ -1191,13 +1200,20 @@ export default function (pi: ExtensionAPI) {
 			const byName = localEntries.filter((e) => e.name === target);
 			if (byName.length === 1) return byName[0];
 			if (byName.length > 1) {
-				// Ambiguous — log and return first match
+				// Ambiguous — sort deterministically: freshest heartbeat first, session_id tiebreaker
+				byName.sort((a, b) => {
+					const ha = a.heartbeat_at ? new Date(a.heartbeat_at).getTime() : 0;
+					const hb = b.heartbeat_at ? new Date(b.heartbeat_at).getTime() : 0;
+					if (hb !== ha) return hb - ha; // freshest first
+					return a.session_id.localeCompare(b.session_id); // stable tiebreak
+				});
 				try {
 					pi.appendEntry("coms-log", {
 						event: "ambiguous_target",
 						target,
 						matches: byName.length,
 						selected_session: byName[0].session_id,
+						selected_heartbeat: byName[0].heartbeat_at ?? null,
 					});
 				} catch { /* best-effort */ }
 				return byName[0];

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -297,7 +297,7 @@ function removeRegistryEntry(project: string, sessionId: string): void {
 	}
 }
 
-function pruneDeadEntries(project: string): RegistryEntry[] {
+async function pruneDeadEntries(project: string): Promise<RegistryEntry[]> {
 	const entries = readAllRegistryEntries(project);
 	const live: RegistryEntry[] = [];
 	const now = Date.now();
@@ -341,12 +341,24 @@ function pruneDeadEntries(project: string): RegistryEntry[] {
 			removeRegistryEntry(project, entry.session_id);
 			continue;
 		}
+		// Socket file exists and heartbeat is fresh — verify socket is actually reachable
+		const verdict = await probeStaleSocket(entry.endpoint);
+		if (verdict === "stale") {
+			// Socket exists but nobody is listening — crashed without cleanup
+			removeRegistryEntry(project, entry.session_id);
+			const socketsDir = path.join(COMS_DIR, "sockets");
+			if (entry.endpoint.startsWith(socketsDir + path.sep) || entry.endpoint.startsWith(socketsDir + "/")) {
+				try { fs.unlinkSync(entry.endpoint); } catch { /* best-effort */ }
+				try { fs.unlinkSync(`${entry.endpoint}.ping`); } catch { /* best-effort */ }
+			}
+			continue;
+		}
 		live.push(entry);
 	}
 	return live;
 }
 
-function pruneDeadEntriesAllProjects(): RegistryEntry[] {
+async function pruneDeadEntriesAllProjects(): Promise<RegistryEntry[]> {
 	const root = path.join(COMS_DIR, "projects");
 	let projects: string[];
 	try {
@@ -361,7 +373,7 @@ function pruneDeadEntriesAllProjects(): RegistryEntry[] {
 		} catch {
 			continue;
 		}
-		out.push(...pruneDeadEntries(p));
+		out.push(...await pruneDeadEntries(p));
 	}
 	return out;
 }
@@ -1131,8 +1143,8 @@ export default function (pi: ExtensionAPI) {
 		if (!identity) return;
 		const projectFilter = displayProject ?? identity.project;
 		const live = projectFilter === "*"
-			? pruneDeadEntriesAllProjects()
-			: pruneDeadEntries(projectFilter);
+			? await pruneDeadEntriesAllProjects()
+			: await pruneDeadEntries(projectFilter);
 
 		const peers = live.filter((e) =>
 			e.session_id !== identity!.session_id && (includeExplicit || !e.explicit),
@@ -1201,10 +1213,10 @@ export default function (pi: ExtensionAPI) {
 		}
 	}
 
-	function resolveTarget(target: string): RegistryEntry | null {
+	async function resolveTarget(target: string): Promise<RegistryEntry | null> {
 		// Prefer exact session_id match first (unambiguous).
 		if (identity) {
-			const localEntries = pruneDeadEntries(identity.project);
+			const localEntries = await pruneDeadEntries(identity.project);
 			// Try session_id match first (always unambiguous)
 			const bySession = localEntries.find((e) => e.session_id === target);
 			if (bySession) return bySession;
@@ -1235,13 +1247,13 @@ export default function (pi: ExtensionAPI) {
 		}
 		// Fall back to scanning all projects by session_id.
 		for (const proj of listProjects()) {
-			const entries = pruneDeadEntries(proj);
+			const entries = await pruneDeadEntries(proj);
 			const bySession = entries.find((e) => e.session_id === target);
 			if (bySession) return bySession;
 		}
 		// Fall back to name match across projects.
 		for (const proj of listProjects()) {
-			const entries = pruneDeadEntries(proj);
+			const entries = await pruneDeadEntries(proj);
 			const byName = entries.find((e) => e.name === target);
 			if (byName) return byName;
 		}
@@ -1267,7 +1279,7 @@ export default function (pi: ExtensionAPI) {
 
 			const collected: { entry: RegistryEntry; project: string }[] = [];
 			for (const proj of projects) {
-				for (const entry of pruneDeadEntries(proj)) {
+				for (const entry of await pruneDeadEntries(proj)) {
 					if (entry.explicit && !includeExp) continue;
 					if (identity && entry.session_id === identity.session_id) continue;
 					collected.push({ entry, project: proj });
@@ -1353,7 +1365,7 @@ export default function (pi: ExtensionAPI) {
 			if (!identity) {
 				throw new Error("coms not initialised");
 			}
-			const target = resolveTarget(params.target);
+			const target = await resolveTarget(params.target);
 			if (!target) {
 				throw new Error(`coms: no live agent matching "${params.target}"`);
 			}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -92,6 +92,7 @@ interface RegistryEntry {
 	purpose: string;
 	model: string;
 	color: string;
+	/** Informational only — not used for liveness checks (socket existence + heartbeat used instead). */
 	pid: number;
 	endpoint: string;
 	cwd: string;
@@ -229,14 +230,14 @@ function projectAgentsDir(project: string): string {
 	return path.join(COMS_DIR, "projects", project, "agents");
 }
 
-function registryFilePath(project: string, name: string): string {
-	return path.join(projectAgentsDir(project), `${name}.json`);
+function registryFilePath(project: string, sessionId: string): string {
+	return path.join(projectAgentsDir(project), `${sessionId}.json`);
 }
 
 function writeRegistryAtomic(entry: RegistryEntry, project: string): string {
 	const dir = projectAgentsDir(project);
 	fs.mkdirSync(dir, { recursive: true });
-	const final = registryFilePath(project, entry.name);
+	const final = registryFilePath(project, entry.session_id);
 	const tmp = `${final}.tmp`;
 	fs.writeFileSync(tmp, JSON.stringify(entry, null, 2));
 	fs.renameSync(tmp, final);
@@ -288,9 +289,9 @@ function readAllRegistryEntriesAcrossProjects(): RegistryEntry[] {
 	return out;
 }
 
-function removeRegistryEntry(project: string, name: string): void {
+function removeRegistryEntry(project: string, sessionId: string): void {
 	try {
-		fs.unlinkSync(registryFilePath(project, name));
+		fs.unlinkSync(registryFilePath(project, sessionId));
 	} catch {
 		// best-effort
 	}
@@ -299,31 +300,29 @@ function removeRegistryEntry(project: string, name: string): void {
 function pruneDeadEntries(project: string): RegistryEntry[] {
 	const entries = readAllRegistryEntries(project);
 	const live: RegistryEntry[] = [];
+	const now = Date.now();
+	const staleThresholdMs = KEEPALIVE_INTERVAL_MS * 2;
 	for (const entry of entries) {
-		try {
-			process.kill(entry.pid, 0);
-			live.push(entry);
-		} catch (e: any) {
-			if (e && e.code === "ESRCH") {
-				removeRegistryEntry(project, entry.name);
-			} else {
-				// EPERM means the process exists but we can't signal it — treat as live.
-				live.push(entry);
+		if (!entry.endpoint || !fs.existsSync(entry.endpoint)) {
+			// Socket gone — agent is dead
+			removeRegistryEntry(project, entry.session_id);
+			continue;
+		}
+		// Socket exists — check heartbeat freshness to detect crashed agents
+		// whose socket files were left behind (SIGKILL, OOM, etc.)
+		if (entry.heartbeat_at) {
+			const heartbeatAge = now - new Date(entry.heartbeat_at).getTime();
+			if (heartbeatAge > staleThresholdMs) {
+				// Heartbeat too old — agent likely crashed without cleanup
+				removeRegistryEntry(project, entry.session_id);
+				try { fs.unlinkSync(entry.endpoint); } catch { /* best-effort */ }
+				try { fs.unlinkSync(`${entry.endpoint}.ping`); } catch { /* best-effort */ }
+				continue;
 			}
 		}
+		live.push(entry);
 	}
 	return live;
-}
-
-function resolveUniqueName(project: string, desiredName: string): string {
-	// Returns a name that doesn't collide with any LIVE registered agent.
-	// pruneDeadEntries auto-removes ESRCH entries; we only care about live ones.
-	const liveEntries = pruneDeadEntries(project);
-	const liveNames = new Set(liveEntries.map(e => e.name));
-	if (!liveNames.has(desiredName)) return desiredName;
-	let n = 2;
-	while (liveNames.has(`${desiredName}${n}`)) n++;
-	return `${desiredName}${n}`;
 }
 
 function pruneDeadEntriesAllProjects(): RegistryEntry[] {
@@ -774,15 +773,7 @@ export default function (pi: ExtensionAPI) {
 		const session_id = ulid();
 
 		const defaultName = `agent-${session_id.slice(-6)}`;
-		const desiredName = flags.name || fm.name || defaultName;
-		const name = resolveUniqueName(project, desiredName);
-		if (name !== desiredName) {
-			try {
-				pi.appendEntry("coms-log", { event: "name_collision", desired: desiredName, assigned: name, project });
-			} catch {
-				// best-effort
-			}
-		}
+		const name = flags.name || fm.name || defaultName;
 		const purpose = flags.purpose || fm.description || "";
 
 		// Color: validate at every level; fall through invalid hex to next.
@@ -986,7 +977,7 @@ export default function (pi: ExtensionAPI) {
 		const seenSessions = new Set<string>();
 
 		for (const [sid, card] of peerCards.entries()) {
-			if (identity && (sid === identity.session_id || card.name === identity.name)) continue;
+			if (identity && sid === identity.session_id) continue;
 			seenSessions.add(sid);
 			rows.push({
 				name: card.name,
@@ -1003,7 +994,7 @@ export default function (pi: ExtensionAPI) {
 		// Registry-only entries that aren't yet in peerCards → pending
 		const seenNames = new Set(rows.map((r) => r.name));
 		for (const entry of registryEntries) {
-			if (identity && (entry.session_id === identity.session_id || entry.name === identity.name)) continue;
+			if (identity && entry.session_id === identity.session_id) continue;
 			if (!includeExplicit && entry.explicit) continue;
 			if (seenSessions.has(entry.session_id)) continue;
 			if (seenNames.has(entry.name)) continue;
@@ -1163,7 +1154,7 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		for (const [sid, card] of peerCards.entries()) {
-			if (identity && (sid === identity.session_id || card.name === identity.name)) continue;
+			if (identity && sid === identity.session_id) continue;
 			if (!seenSessions.has(sid)) {
 				card.staleCount = (card.staleCount ?? 0) + 1;
 				if (card.staleCount > 6) {
@@ -1190,18 +1181,35 @@ export default function (pi: ExtensionAPI) {
 	}
 
 	function resolveTarget(target: string): RegistryEntry | null {
-		// Prefer name match within current project.
+		// Prefer exact session_id match first (unambiguous).
 		if (identity) {
 			const localEntries = pruneDeadEntries(identity.project);
-			const byName = localEntries.find((e) => e.name === target);
-			if (byName) return byName;
+			// Try session_id match first (always unambiguous)
+			const bySession = localEntries.find((e) => e.session_id === target);
+			if (bySession) return bySession;
+			// Name match — warn if ambiguous
+			const byName = localEntries.filter((e) => e.name === target);
+			if (byName.length === 1) return byName[0];
+			if (byName.length > 1) {
+				// Ambiguous — log and return first match
+				try {
+					pi.appendEntry("coms-log", {
+						event: "ambiguous_target",
+						target,
+						matches: byName.length,
+						selected_session: byName[0].session_id,
+					});
+				} catch { /* best-effort */ }
+				return byName[0];
+			}
 		}
-		// Fall back to scanning all projects by session_id (or name as last resort).
+		// Fall back to scanning all projects by session_id.
 		for (const proj of listProjects()) {
 			const entries = pruneDeadEntries(proj);
 			const bySession = entries.find((e) => e.session_id === target);
 			if (bySession) return bySession;
 		}
+		// Fall back to name match across projects.
 		for (const proj of listProjects()) {
 			const entries = pruneDeadEntries(proj);
 			const byName = entries.find((e) => e.name === target);
@@ -1231,7 +1239,7 @@ export default function (pi: ExtensionAPI) {
 			for (const proj of projects) {
 				for (const entry of pruneDeadEntries(proj)) {
 					if (entry.explicit && !includeExp) continue;
-					if (identity && (entry.session_id === identity.session_id || entry.name === identity.name)) continue;
+					if (identity && entry.session_id === identity.session_id) continue;
 					collected.push({ entry, project: proj });
 				}
 			}
@@ -1680,7 +1688,7 @@ export default function (pi: ExtensionAPI) {
 			if (process.platform !== "win32") {
 				try { fs.unlinkSync(identity.endpoint); } catch { /* ignore */ }
 			}
-			try { removeRegistryEntry(identity.project, identity.name); } catch { /* ignore */ }
+			try { removeRegistryEntry(identity.project, identity.session_id); } catch { /* ignore */ }
 			try {
 				pi.appendEntry("coms-log", { event: "shutdown", session_id: identity.session_id });
 			} catch { /* best-effort */ }

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -349,8 +349,8 @@ async function pruneDeadEntries(project: string): Promise<RegistryEntry[]> {
 	const results: ("in_use" | "stale")[] = [];
 	for (let start = 0; start < candidates.length; start += PROBE_CONCURRENCY) {
 		const batch = candidates.slice(start, start + PROBE_CONCURRENCY);
-		const batchResults = await Promise.all(batch.map(entry => probeStaleSocket(entry.endpoint)));
-		results.push(...batchResults);
+		const batchResults = await Promise.allSettled(batch.map(entry => probeStaleSocket(entry.endpoint)));
+		results.push(...batchResults.map(r => r.status === "fulfilled" ? r.value : "in_use" as const));
 	}
 	const live: RegistryEntry[] = [];
 	for (let i = 0; i < candidates.length; i++) {


### PR DESCRIPTION
## Summary

Fixes P2P coms being completely non-functional when multiple pi containers share the same `~/.pi` directory (e.g., rootcoz multi-container setup with 5 containers).

## Root Cause

Two interacting bugs:

1. **Registry files keyed by `name`** — when two containers register with the same `--cname`, they overwrite each other's registry file (`{name}.json`), making one unreachable.

2. **`pruneDeadEntries()` uses `process.kill(pid, 0)`** — broken across container PID namespaces. All containers store `pid: 81` (their internal pi PID). When container A checks container B's entry, it checks PID 81 in its own namespace — which is alive (container A's own pi process). So the check always passes for the wrong process, and dead entries are never pruned.

Combined effect: registry directory constantly flips between different agent sets, all peers show ✗ (failed), sockets work fine but discovery is broken.

## Changes

- **Registry files keyed by `session_id`** instead of `name` — `{session_id}.json` is guaranteed unique per agent, eliminates file collisions
- **Socket existence + heartbeat staleness** replaces PID-based liveness — checks `fs.existsSync(endpoint)` plus heartbeat age (>2× keepalive interval = dead). Works across PID namespaces
- **Removed `resolveUniqueName()`** — no longer needed since files are session_id-keyed; multiple agents can share the same display name
- **Ambiguous target detection** in `resolveTarget()` — logs warning when multiple agents share a name, returns first match
- **Self-skip filtering** simplified to session_id-only checks (removed redundant name comparisons)

## Testing

- Pre-commit: 20/20 checks passed
- Pytest: 57/57 tests passed

Closes #528