### PR TITLE
feat(reviews): integrate Qodo replies to consolidated PR comments

### DIFF
--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -813,7 +813,12 @@ def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: 
 
         finding_path = finding.get("path") or ""
         finding_line = finding.get("line")
-        finding_loc = f"{finding_path}:{finding_line}" if finding_path and finding_line else ""
+        if finding_path and finding_line:
+            finding_loc = f"{finding_path}:{finding_line}"
+        elif finding_path:
+            finding_loc = finding_path
+        else:
+            finding_loc = ""
 
         for reply in replies:
             matched = False

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -663,8 +663,9 @@ fetch_coderabbit_outside_diff_comments = fetch_coderabbit_body_comments
 # Pattern: Qodo replies to our consolidated comments by quoting them in a blockquote
 _QODO_REPLY_QUOTE_RE = re.compile(r"^>\s*(.+)$", re.MULTILINE)
 _QODO_MENTION_RE = re.compile(r"@qodo-code-review")
-# Match finding title in quoted text: > **Finding Title**
+# Match finding title in quoted text: > **Finding Title** or > ### `path:line` (type) — Title
 _QUOTED_FINDING_TITLE_RE = re.compile(r"\*\*([^*]+)\*\*")
+_QUOTED_HEADING_TITLE_RE = re.compile(r"###\s+`[^`]+`\s*(?:\([^)]*\))?\s*(?:—|-)\s*(.+)")
 
 
 def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
@@ -672,6 +673,11 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
 
     Scans issue comments for Qodo bot replies that quote our @qodo-code-review
     consolidated posts. Extracts the quoted finding title and Qodo's response.
+
+    Note: These replies are used for enrichment only — they are matched back to
+    sticky findings via ``_enrich_findings_with_qodo_replies`` and do not produce
+    independent ``qodo_reply`` thread types. This is by design: Qodo replies
+    add context to existing findings rather than standing as separate threads.
 
     Returns:
         List of dicts with keys: quoted_title, qodo_response, comment_id.
@@ -705,8 +711,10 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
         # Reconstruct quoted text to extract the finding title
         quoted_text = "\n".join(quoted_lines)
 
-        # Extract finding title from quoted text
-        title_match = _QUOTED_FINDING_TITLE_RE.search(quoted_text)
+        # Extract finding title from quoted text (try heading format first, then bold)
+        title_match = _QUOTED_HEADING_TITLE_RE.search(quoted_text)
+        if not title_match:
+            title_match = _QUOTED_FINDING_TITLE_RE.search(quoted_text)
         quoted_title = title_match.group(1).strip() if title_match else ""
 
         # Extract Qodo's response: non-quoted lines (strip leading/trailing blank lines)
@@ -792,12 +800,12 @@ def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: 
             continue
 
         for reply in replies:
-            quoted_title = reply.get("quoted_title", "").strip().lower()
-            if not quoted_title:
+            # Match by exact normalized title comparison
+            normalized_quoted = _extract_sticky_title(f"**{reply.get('quoted_title', '')}**")
+            if not normalized_quoted:
                 continue
 
-            # Match by normalized title comparison
-            if quoted_title == finding_title or quoted_title in finding_title or finding_title in quoted_title:
+            if normalized_quoted == finding_title:
                 finding["qodo_response"] = reply["qodo_response"]
                 break
 

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -700,7 +700,7 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
         if is_qodo_sticky_comment(body):
             continue
 
-        # Must contain a blockquote that references @qodo-code-review (our consolidated comment)
+        # Must contain a blockquote that references our consolidated comment
         if not _QODO_MENTION_RE.search(body):
             continue
 
@@ -710,6 +710,10 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
 
         # Reconstruct quoted text to extract the finding title
         quoted_text = "\n".join(quoted_lines)
+
+        # Must quote our consolidated comment marker (not just any blockquote)
+        if "The following review comments were reviewed" not in quoted_text:
+            continue
 
         # Extract finding title from quoted text (try heading format first, then bold)
         title_match = _QUOTED_HEADING_TITLE_RE.search(quoted_text)
@@ -809,9 +813,16 @@ def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: 
                 continue
 
             # Use prefix matching to handle truncated titles from consolidated comments
-            shorter = min(normalized_quoted, finding_title, key=len)
-            longer = max(normalized_quoted, finding_title, key=len)
-            if longer.startswith(shorter) and len(shorter) > 10:
+            # Use prefix matching to handle truncated titles from consolidated comments
+            # When equal length, use exact equality (startswith is trivially true)
+            if len(normalized_quoted) == len(finding_title):
+                if normalized_quoted != finding_title:
+                    continue
+            else:
+                shorter = min(normalized_quoted, finding_title, key=len)
+                longer = max(normalized_quoted, finding_title, key=len)
+                if not (longer.startswith(shorter) and len(shorter) > 10):
+                    continue
                 finding["qodo_response"] = reply["qodo_response"]
                 break
 
@@ -1162,6 +1173,7 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         print_stderr(f"Found {len(all_threads)} {label} thread(s)")
 
         # Skip bot comment fetching when filtering by specific user
+        qodo_replies: list[dict[str, Any]] = []
         if not user:
             # Fetch CodeRabbit body-embedded comments from review bodies
             print_stderr("Fetching CodeRabbit body-embedded comments...")
@@ -1176,12 +1188,11 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
             if qodo_sticky_findings:
                 print_stderr(f"Found {len(qodo_sticky_findings)} unresolved Qodo sticky finding(s)")
 
-                # Fetch Qodo replies to our consolidated comments and enrich findings
+                # Fetch Qodo replies (enrichment happens after process_and_categorize sets already_replied)
                 print_stderr("Fetching Qodo reply comments...")
                 qodo_replies = fetch_qodo_reply_comments(owner, repo, pr_number)
                 if qodo_replies:
                     print_stderr(f"Found {len(qodo_replies)} Qodo reply comment(s)")
-                    _enrich_findings_with_qodo_replies(qodo_sticky_findings, qodo_replies)
 
                 all_threads = merge_threads(all_threads, qodo_sticky_findings)
 
@@ -1249,6 +1260,10 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         # Process and categorize threads
         print_stderr("Categorizing threads by source...")
         categorized = process_and_categorize(all_threads, owner, repo, pr_number=int(pr_number))
+
+        # Enrich qodo findings with Qodo replies AFTER process_and_categorize sets already_replied
+        if qodo_replies:
+            _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
 
         # Build final output
         final_output = {

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -975,6 +975,13 @@ def process_and_categorize(
                     db_record = replied_sticky[sticky_key]
                     enriched["previous_reply"] = db_record.get("reply") or ""
 
+        # qodo_reply items are Qodo's responses to our consolidated comments.
+        # They're informational context, not findings to fix — auto-skip them.
+        if source == "qodo" and enriched.get("type") == "qodo_reply":
+            enriched["is_auto_skipped"] = True
+            enriched["status"] = "skipped"
+            enriched["reply"] = "Qodo reply — informational context, not a finding to fix"
+
         # Check for previously dismissed similar comment (only if status is pending)
         # Qodo sticky findings are never auto-skipped — they persist intentionally
         # until properly resolved and must always be re-evaluated.

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -662,7 +662,7 @@ fetch_coderabbit_outside_diff_comments = fetch_coderabbit_body_comments
 
 # Pattern: Qodo replies to our consolidated comments by quoting them in a blockquote
 _QODO_REPLY_QUOTE_RE = re.compile(r"^>\s*(.+)$", re.MULTILINE)
-_QODO_MENTION_RE = re.compile(r"@qodo-code-review")
+_QODO_MENTION_RE = re.compile(r"@?qodo-code-review|code-review\[bot\]")
 # Match finding title in quoted text: > **Finding Title** or > ### `path:line` (type) — Title
 _QUOTED_FINDING_TITLE_RE = re.compile(r"\*\*([^*]+)\*\*")
 _QUOTED_HEADING_TITLE_RE = re.compile(r"###\s+`[^`]+`\s*(?:\([^)]*\))?\s*(?:—|-)\s*(.+)")

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -662,26 +662,31 @@ fetch_coderabbit_outside_diff_comments = fetch_coderabbit_body_comments
 
 # Pattern: Qodo replies to our consolidated comments by quoting them in a blockquote
 _QODO_REPLY_QUOTE_RE = re.compile(r"^>\s*(.+)$", re.MULTILINE)
-_QODO_MENTION_RE = re.compile(r"@?qodo-code-review|code-review\[bot\]")
 # Match finding title in quoted text: > **Finding Title** or > ### `path:line` (type) — Title
 _QUOTED_FINDING_TITLE_RE = re.compile(r"\*\*([^*]+)\*\*")
 # Captures: group(1)=path:line, group(2)=title
 _QUOTED_HEADING_FULL_RE = re.compile(r"###\s+`([^`]+)`\s*(?:\([^)]*\))?\s*(?:—|-)\s*(.+)")
+# Marker that identifies our consolidated PR comments (posted by review-handler)
+_CONSOLIDATED_COMMENT_MARKER = "The following review comments were reviewed"
 
 
 def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
     """Fetch Qodo replies to our consolidated PR comments.
 
-    Scans issue comments for Qodo bot replies that quote our @qodo-code-review
-    consolidated posts. Extracts the quoted finding title and Qodo's response.
+    Scans issue comments for Qodo bot replies that quote our consolidated
+    review posts. Identifies replies by the presence of the consolidated comment
+    marker ("The following review comments were reviewed") in the quoted text.
 
-    Note: These replies are used for enrichment only — they are matched back to
-    sticky findings via ``_enrich_findings_with_qodo_replies`` and do not produce
-    independent ``qodo_reply`` thread types. This is by design: Qodo replies
-    add context to existing findings rather than standing as separate threads.
+    Each reply is returned as a thread-like dict with type ``qodo_reply`` and
+    linkage to the original finding via ``quoted_location`` (path:line) and
+    ``quoted_title``. These are used both for enrichment (attaching
+    ``qodo_response`` to existing findings) and as first-class threads in
+    the categorized output.
 
     Returns:
-        List of dicts with keys: quoted_title, qodo_response, comment_id.
+        List of thread-like dicts with keys: thread_id, node_id, comment_id,
+        author, path, line, body, source, type, quoted_location, quoted_title,
+        qodo_response.
     """
     endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
     comments = run_gh_api(endpoint, paginate=True)
@@ -701,10 +706,6 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
         if is_qodo_sticky_comment(body):
             continue
 
-        # Must contain a blockquote that references our consolidated comment
-        if not _QODO_MENTION_RE.search(body):
-            continue
-
         quoted_lines = _QODO_REPLY_QUOTE_RE.findall(body)
         if not quoted_lines:
             continue
@@ -712,8 +713,9 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
         # Reconstruct quoted text to extract the finding title
         quoted_text = "\n".join(quoted_lines)
 
-        # Must quote our consolidated comment marker (not just any blockquote)
-        if "The following review comments were reviewed" not in quoted_text:
+        # Must quote our consolidated comment marker — this is the definitive
+        # identifier, not the bot mention (GitHub strips @ from quoted mentions)
+        if _CONSOLIDATED_COMMENT_MARKER not in quoted_text:
             continue
 
         # Extract path:line and title from quoted heading
@@ -738,11 +740,34 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
         qodo_response = "\n".join(response_lines).strip()
 
         if qodo_response:
+            # Parse path and line from quoted_location (e.g., "fetch.py:803")
+            reply_path = ""
+            reply_line = None
+            if quoted_location:
+                parts = quoted_location.rsplit(":", 1)
+                reply_path = parts[0]
+                if len(parts) == 2:
+                    try:
+                        reply_line = int(parts[1])
+                    except (ValueError, TypeError):
+                        pass
+
             results.append({
+                "thread_id": None,
+                "node_id": None,
+                "comment_id": comment.get("id"),
+                "author": author,
+                "path": reply_path,
+                "line": reply_line,
+                "body": qodo_response,
+                "source": "qodo",
+                "type": "qodo_reply",
+                "priority": "LOW",
+                "reply": None,
+                "status": "pending",
                 "quoted_location": quoted_location,
                 "quoted_title": quoted_title,
                 "qodo_response": qodo_response,
-                "comment_id": comment.get("id"),
             })
 
     return results
@@ -1219,13 +1244,14 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
             if qodo_sticky_findings:
                 print_stderr(f"Found {len(qodo_sticky_findings)} unresolved Qodo sticky finding(s)")
 
-                # Fetch Qodo replies (enrichment happens after process_and_categorize sets already_replied)
-                print_stderr("Fetching Qodo reply comments...")
-                qodo_replies = fetch_qodo_reply_comments(owner, repo, pr_number)
-                if qodo_replies:
-                    print_stderr(f"Found {len(qodo_replies)} Qodo reply comment(s)")
-
                 all_threads = merge_threads(all_threads, qodo_sticky_findings)
+
+            # Fetch Qodo replies to our consolidated comments (independent of sticky findings)
+            print_stderr("Fetching Qodo reply comments...")
+            qodo_replies = fetch_qodo_reply_comments(owner, repo, pr_number)
+            if qodo_replies:
+                print_stderr(f"Found {len(qodo_replies)} Qodo reply comment(s)")
+                all_threads = merge_threads(all_threads, qodo_replies)
 
         # If review URL provided, also fetch specific thread(s)
         specific_threads: list[dict[str, Any]] = []

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -660,6 +660,73 @@ def fetch_coderabbit_body_comments(owner: str, repo: str, pr_number: str) -> lis
 fetch_coderabbit_outside_diff_comments = fetch_coderabbit_body_comments
 
 
+# Pattern: Qodo replies to our consolidated comments by quoting them in a blockquote
+_QODO_REPLY_QUOTE_RE = re.compile(r"^>\s*(.+)$", re.MULTILINE)
+_QODO_MENTION_RE = re.compile(r"@qodo-code-review")
+# Match finding title in quoted text: > **Finding Title**
+_QUOTED_FINDING_TITLE_RE = re.compile(r"\*\*([^*]+)\*\*")
+
+
+def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
+    """Fetch Qodo replies to our consolidated PR comments.
+
+    Scans issue comments for Qodo bot replies that quote our @qodo-code-review
+    consolidated posts. Extracts the quoted finding title and Qodo's response.
+
+    Returns:
+        List of dicts with keys: quoted_title, qodo_response, comment_id.
+    """
+    endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+    comments = run_gh_api(endpoint, paginate=True)
+
+    if comments is None or not isinstance(comments, list):
+        return []
+
+    results: list[dict[str, Any]] = []
+
+    for comment in comments:
+        author = comment.get("user", {}).get("login") if comment.get("user") else None
+        if author not in ("qodo-code-review[bot]", "qodo-code-review"):
+            continue
+
+        body = comment.get("body", "")
+        # Skip sticky comments — we only want reply comments
+        if is_qodo_sticky_comment(body):
+            continue
+
+        # Must contain a blockquote that references @qodo-code-review (our consolidated comment)
+        if not _QODO_MENTION_RE.search(body):
+            continue
+
+        quoted_lines = _QODO_REPLY_QUOTE_RE.findall(body)
+        if not quoted_lines:
+            continue
+
+        # Reconstruct quoted text to extract the finding title
+        quoted_text = "\n".join(quoted_lines)
+
+        # Extract finding title from quoted text
+        title_match = _QUOTED_FINDING_TITLE_RE.search(quoted_text)
+        quoted_title = title_match.group(1).strip() if title_match else ""
+
+        # Extract Qodo's response: non-quoted lines (strip leading/trailing blank lines)
+        response_lines = []
+        for line in body.split("\n"):
+            stripped = line.strip()
+            if not stripped.startswith(">"):
+                response_lines.append(line)
+        qodo_response = "\n".join(response_lines).strip()
+
+        if qodo_response:
+            results.append({
+                "quoted_title": quoted_title,
+                "qodo_response": qodo_response,
+                "comment_id": comment.get("id"),
+            })
+
+    return results
+
+
 def fetch_qodo_sticky_findings(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
     """Fetch unresolved findings from Qodo's sticky summary comment.
 
@@ -711,6 +778,28 @@ def fetch_qodo_sticky_findings(owner: str, repo: str, pr_number: str) -> list[di
             results.append(thread_data)
 
     return results
+
+
+def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: list[dict[str, Any]]) -> None:
+    """Enrich sticky findings with qodo_response from matching reply comments.
+
+    Matches replies to findings by comparing the quoted title in the reply
+    to the extracted title from the finding body. Modifies findings in-place.
+    """
+    for finding in findings:
+        finding_title = _extract_sticky_title(finding.get("body", ""))
+        if not finding_title:
+            continue
+
+        for reply in replies:
+            quoted_title = reply.get("quoted_title", "").strip().lower()
+            if not quoted_title:
+                continue
+
+            # Match by normalized title comparison
+            if quoted_title == finding_title or quoted_title in finding_title or finding_title in quoted_title:
+                finding["qodo_response"] = reply["qodo_response"]
+                break
 
 
 def process_and_categorize(
@@ -1072,6 +1161,14 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
             qodo_sticky_findings = fetch_qodo_sticky_findings(owner, repo, pr_number)
             if qodo_sticky_findings:
                 print_stderr(f"Found {len(qodo_sticky_findings)} unresolved Qodo sticky finding(s)")
+
+                # Fetch Qodo replies to our consolidated comments and enrich findings
+                print_stderr("Fetching Qodo reply comments...")
+                qodo_replies = fetch_qodo_reply_comments(owner, repo, pr_number)
+                if qodo_replies:
+                    print_stderr(f"Found {len(qodo_replies)} Qodo reply comment(s)")
+                    _enrich_findings_with_qodo_replies(qodo_sticky_findings, qodo_replies)
+
                 all_threads = merge_threads(all_threads, qodo_sticky_findings)
 
         # If review URL provided, also fetch specific thread(s)

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -799,13 +799,19 @@ def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: 
         if not finding_title:
             continue
 
+        if not finding.get("already_replied"):
+            continue
+
         for reply in replies:
-            # Match by exact normalized title comparison
+            # Match by normalized title prefix comparison (titles may be truncated to 100 chars)
             normalized_quoted = _extract_sticky_title(f"**{reply.get('quoted_title', '')}**")
             if not normalized_quoted:
                 continue
 
-            if normalized_quoted == finding_title:
+            # Use prefix matching to handle truncated titles from consolidated comments
+            shorter = min(normalized_quoted, finding_title, key=len)
+            longer = max(normalized_quoted, finding_title, key=len)
+            if longer.startswith(shorter) and len(shorter) > 10:
                 finding["qodo_response"] = reply["qodo_response"]
                 break
 

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -665,7 +665,8 @@ _QODO_REPLY_QUOTE_RE = re.compile(r"^>\s*(.+)$", re.MULTILINE)
 _QODO_MENTION_RE = re.compile(r"@?qodo-code-review|code-review\[bot\]")
 # Match finding title in quoted text: > **Finding Title** or > ### `path:line` (type) — Title
 _QUOTED_FINDING_TITLE_RE = re.compile(r"\*\*([^*]+)\*\*")
-_QUOTED_HEADING_TITLE_RE = re.compile(r"###\s+`[^`]+`\s*(?:\([^)]*\))?\s*(?:—|-)\s*(.+)")
+# Captures: group(1)=path:line, group(2)=title
+_QUOTED_HEADING_FULL_RE = re.compile(r"###\s+`([^`]+)`\s*(?:\([^)]*\))?\s*(?:—|-)\s*(.+)")
 
 
 def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
@@ -715,11 +716,18 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
         if "The following review comments were reviewed" not in quoted_text:
             continue
 
-        # Extract finding title from quoted text (try heading format first, then bold)
-        title_match = _QUOTED_HEADING_TITLE_RE.search(quoted_text)
-        if not title_match:
+        # Extract path:line and title from quoted heading
+        # Heading format: ### `path:line` (type) — title
+        heading_match = _QUOTED_HEADING_FULL_RE.search(quoted_text)
+        quoted_location = ""
+        quoted_title = ""
+        if heading_match:
+            quoted_location = heading_match.group(1).strip()  # e.g. "fetch.py:803"
+            quoted_title = heading_match.group(2).strip()
+        else:
+            # Fallback: try bold title
             title_match = _QUOTED_FINDING_TITLE_RE.search(quoted_text)
-        quoted_title = title_match.group(1).strip() if title_match else ""
+            quoted_title = title_match.group(1).strip() if title_match else ""
 
         # Extract Qodo's response: non-quoted lines (strip leading/trailing blank lines)
         response_lines = []
@@ -731,6 +739,7 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
 
         if qodo_response:
             results.append({
+                "quoted_location": quoted_location,
                 "quoted_title": quoted_title,
                 "qodo_response": qodo_response,
                 "comment_id": comment.get("id"),
@@ -793,36 +802,39 @@ def fetch_qodo_sticky_findings(owner: str, repo: str, pr_number: str) -> list[di
 
 
 def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: list[dict[str, Any]]) -> None:
-    """Enrich sticky findings with qodo_response from matching reply comments.
+    """Enrich qodo findings with qodo_response from matching reply comments.
 
-    Matches replies to findings by comparing the quoted title in the reply
-    to the extracted title from the finding body. Modifies findings in-place.
+    Matches replies to findings using path:line from the quoted heading
+    (primary) or title comparison (fallback). Modifies findings in-place.
     """
     for finding in findings:
-        finding_title = _extract_sticky_title(finding.get("body", ""))
-        if not finding_title:
-            continue
-
         if not finding.get("already_replied"):
             continue
 
-        for reply in replies:
-            # Match by normalized title prefix comparison (titles may be truncated to 100 chars)
-            normalized_quoted = _extract_sticky_title(f"**{reply.get('quoted_title', '')}**")
-            if not normalized_quoted:
-                continue
+        finding_path = finding.get("path") or ""
+        finding_line = finding.get("line")
+        finding_loc = f"{finding_path}:{finding_line}" if finding_path and finding_line else ""
 
-            # Use prefix matching to handle truncated titles from consolidated comments
-            # Use prefix matching to handle truncated titles from consolidated comments
-            # When equal length, use exact equality (startswith is trivially true)
-            if len(normalized_quoted) == len(finding_title):
-                if normalized_quoted != finding_title:
-                    continue
-            else:
-                shorter = min(normalized_quoted, finding_title, key=len)
-                longer = max(normalized_quoted, finding_title, key=len)
-                if not (longer.startswith(shorter) and len(shorter) > 10):
-                    continue
+        for reply in replies:
+            matched = False
+            reply_loc = reply.get("quoted_location") or ""
+
+            # Primary: match by path:line from the quoted heading
+            if reply_loc and finding_loc and reply_loc == finding_loc:
+                matched = True
+            elif not matched and reply.get("quoted_title"):
+                # Fallback: title prefix match (titles may be truncated to 100 chars)
+                finding_title = _extract_sticky_title(finding.get("body", ""))
+                quoted_title = reply.get("quoted_title", "").strip().lower()
+                if finding_title and quoted_title and len(quoted_title) > 10:
+                    if len(quoted_title) == len(finding_title):
+                        matched = quoted_title == finding_title
+                    else:
+                        shorter = min(quoted_title, finding_title, key=len)
+                        longer = max(quoted_title, finding_title, key=len)
+                        matched = longer.startswith(shorter)
+
+            if matched:
                 finding["qodo_response"] = reply["qodo_response"]
                 break
 
@@ -877,7 +889,8 @@ def process_and_categorize(
             dismissed_by_key = {}
 
     # Preload already-replied Qodo sticky findings for dedup (exact match only)
-    replied_sticky: set[tuple[int, str, str]] = set()
+    # Maps (comment_id, body, code_diff) -> DB record (includes reply text)
+    replied_sticky: dict[tuple[int, str, str], dict[str, Any]] = {}
     if db and pr_number:
         try:
             for c in db.get_replied_sticky_findings(owner, repo, pr_number):
@@ -885,7 +898,16 @@ def process_and_categorize(
                 body = c.get("body") or ""
                 code_diff = c.get("code_diff") or ""
                 if cid is not None:
-                    replied_sticky.add((int(cid), body, code_diff))
+                    rs_key = (int(cid), body, code_diff)
+                    existing = replied_sticky.get(rs_key)
+                    if existing is None:
+                        replied_sticky[rs_key] = c
+                    else:
+                        # Prefer records with meaningful replies
+                        existing_reply = existing.get("reply") or ""
+                        new_reply = c.get("reply") or ""
+                        if "Already replied" in existing_reply and "Already replied" not in new_reply and new_reply:
+                            replied_sticky[rs_key] = c
         except Exception as e:
             print_stderr(f"Warning: Failed to preload replied sticky findings: {e}")
 
@@ -916,8 +938,12 @@ def process_and_categorize(
             cid = thread.get("comment_id")
             thread_body = thread.get("body") or ""
             thread_code_diff = thread.get("code_diff") or ""
-            if cid is not None and (int(cid), thread_body, thread_code_diff) in replied_sticky:
-                enriched["already_replied"] = True
+            if cid is not None:
+                sticky_key = (int(cid), thread_body, thread_code_diff)
+                if sticky_key in replied_sticky:
+                    enriched["already_replied"] = True
+                    db_record = replied_sticky[sticky_key]
+                    enriched["previous_reply"] = db_record.get("reply") or ""
 
         # Check for previously dismissed similar comment (only if status is pending)
         # Qodo sticky findings are never auto-skipped — they persist intentionally

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -11,6 +11,7 @@ on "no new comments" -- sleeps and retries.
 from __future__ import annotations
 
 import contextlib
+import re
 import sys
 import time
 from datetime import UTC, datetime
@@ -31,6 +32,18 @@ from myk_pi_tools.reviews.fetch import run as fetch_run
 
 _RATE_LIMIT_BUFFER_SECONDS = 30
 _POLL_SLEEP_SECONDS = 300  # 5 minutes between cycles when no rate limit
+
+# Pushback indicators in Qodo responses — Qodo disagrees with our fix/decision
+_PUSHBACK_KEYWORDS = re.compile(
+    r"(\bstill (?:present|exists?|unresolved|open|not (?:fixed|addressed|resolved))\b"
+    r"|\bnot (?:fully |completely )?(?:addressed|resolved|fixed)\b"
+    r"|\bdisagree\b|\bincorrect\b|\bwrong\b|\bissue (?:remains|persists)\b"
+    r"|\bdoes not (?:address|fix|resolve)\b"
+    r"|\bshould still\b"
+    r"|\brecommend (?:re-?evaluating|revisiting)\b"
+    r"|\bre-?open\b)",
+    re.IGNORECASE,
+)
 
 
 def _print_poll_summary(pr_number: str, output_dir: str) -> None:

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -106,7 +106,17 @@ def _has_actionable_comments(pr_number: str, output_dir: str) -> bool:
 
 
 def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
-    """Check if fetched reviews have actionable Qodo comments (not auto-skipped)."""
+    """Check if fetched reviews have actionable Qodo comments.
+
+    A comment is actionable if:
+    - Not auto-skipped AND not already replied (new finding), OR
+    - Not auto-skipped AND already replied AND qodo_response contains
+      pushback keywords (Qodo disagrees with our previous fix)
+
+    Already-replied findings WITHOUT pushback are not actionable in the poll
+    — they're waiting for Qodo to re-review after our push. The review handler
+    still processes them as mandatory when they appear in the sticky.
+    """
     import json
     from pathlib import Path
 
@@ -122,7 +132,16 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
         return True
 
     for comment in data.get("qodo", []):
-        if not comment.get("is_auto_skipped"):
+        if comment.get("is_auto_skipped"):
+            continue
+
+        # New finding — not yet replied to
+        if not comment.get("already_replied"):
+            return True
+
+        # Already replied — only actionable if Qodo pushed back
+        qodo_response = comment.get("qodo_response", "")
+        if qodo_response and _PUSHBACK_KEYWORDS.search(qodo_response):
             return True
 
     return False

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -109,7 +109,8 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
     """Check if fetched reviews have actionable Qodo comments.
 
     Sticky findings are ALWAYS actionable — already_replied is context only.
-    Only is_auto_skipped items (qodo_reply threads, dismissed comments) are skipped.
+    Only is_auto_skipped items are skipped (qodo_reply threads).
+    Note: dismissal-based auto-skip does not apply to qodo sources.
     """
     import json
     from pathlib import Path

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -11,6 +11,7 @@ on "no new comments" -- sleeps and retries.
 from __future__ import annotations
 
 import contextlib
+import re
 import sys
 import time
 from datetime import UTC, datetime
@@ -92,8 +93,31 @@ def _has_actionable_comments(pr_number: str, output_dir: str) -> bool:
     return False
 
 
+# Pushback indicators in Qodo responses — Qodo disagrees with our fix/decision
+_PUSHBACK_KEYWORDS = re.compile(
+    r"(still (?:present|exists?|unresolved|open|not (?:fixed|addressed|resolved))"
+    r"|not (?:fully |completely )?(?:addressed|resolved|fixed)"
+    r"|disagree|incorrect|wrong|issue (?:remains|persists)"
+    r"|does not (?:address|fix|resolve)"
+    r"|should (?:still|be)"
+    r"|recommend (?:re-?evaluating|revisiting)"
+    r"|re-?open)",
+    re.IGNORECASE,
+)
+
+
+def _is_qodo_pushback(qodo_response: str) -> bool:
+    """Detect if a Qodo response indicates pushback (disagreement with our fix)."""
+    return bool(_PUSHBACK_KEYWORDS.search(qodo_response))
+
+
 def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
-    """Check if fetched reviews have actionable Qodo comments (not auto-skipped)."""
+    """Check if fetched reviews have actionable Qodo comments.
+
+    A comment is actionable if:
+    - Not auto-skipped AND not already replied, OR
+    - Already replied but Qodo pushed back (qodo_response indicates disagreement)
+    """
     import json
     from pathlib import Path
 
@@ -109,7 +133,16 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
         return True
 
     for comment in data.get("qodo", []):
-        if not comment.get("is_auto_skipped") and not comment.get("already_replied"):
+        if comment.get("is_auto_skipped"):
+            continue
+
+        # Not yet replied — actionable
+        if not comment.get("already_replied"):
+            return True
+
+        # Already replied but Qodo pushed back — treat as actionable
+        qodo_response = comment.get("qodo_response", "")
+        if qodo_response and _is_qodo_pushback(qodo_response):
             return True
 
     return False

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -95,13 +95,13 @@ def _has_actionable_comments(pr_number: str, output_dir: str) -> bool:
 
 # Pushback indicators in Qodo responses — Qodo disagrees with our fix/decision
 _PUSHBACK_KEYWORDS = re.compile(
-    r"(still (?:present|exists?|unresolved|open|not (?:fixed|addressed|resolved))"
-    r"|not (?:fully |completely )?(?:addressed|resolved|fixed)"
-    r"|disagree|incorrect|wrong|issue (?:remains|persists)"
-    r"|does not (?:address|fix|resolve)"
-    r"|should (?:still|be)"
-    r"|recommend (?:re-?evaluating|revisiting)"
-    r"|re-?open)",
+    r"(\bstill (?:present|exists?|unresolved|open|not (?:fixed|addressed|resolved))\b"
+    r"|\bnot (?:fully |completely )?(?:addressed|resolved|fixed)\b"
+    r"|\bdisagree\b|\bincorrect\b|\bwrong\b|\bissue (?:remains|persists)\b"
+    r"|\bdoes not (?:address|fix|resolve)\b"
+    r"|\bshould still\b"
+    r"|\brecommend (?:re-?evaluating|revisiting)\b"
+    r"|\bre-?open\b)",
     re.IGNORECASE,
 )
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -108,14 +108,8 @@ def _has_actionable_comments(pr_number: str, output_dir: str) -> bool:
 def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
     """Check if fetched reviews have actionable Qodo comments.
 
-    A comment is actionable if:
-    - Not auto-skipped AND not already replied (new finding), OR
-    - Not auto-skipped AND already replied AND qodo_response contains
-      pushback keywords (Qodo disagrees with our previous fix)
-
-    Already-replied findings WITHOUT pushback are not actionable in the poll
-    — they're waiting for Qodo to re-review after our push. The review handler
-    still processes them as mandatory when they appear in the sticky.
+    Sticky findings are ALWAYS actionable — already_replied is context only.
+    Only is_auto_skipped items (qodo_reply threads, dismissed comments) are skipped.
     """
     import json
     from pathlib import Path
@@ -132,16 +126,7 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
         return True
 
     for comment in data.get("qodo", []):
-        if comment.get("is_auto_skipped"):
-            continue
-
-        # New finding — not yet replied to
-        if not comment.get("already_replied"):
-            return True
-
-        # Already replied — only actionable if Qodo pushed back
-        qodo_response = comment.get("qodo_response", "")
-        if qodo_response and _PUSHBACK_KEYWORDS.search(qodo_response):
+        if not comment.get("is_auto_skipped"):
             return True
 
     return False

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -11,7 +11,6 @@ on "no new comments" -- sleeps and retries.
 from __future__ import annotations
 
 import contextlib
-import re
 import sys
 import time
 from datetime import UTC, datetime
@@ -93,31 +92,8 @@ def _has_actionable_comments(pr_number: str, output_dir: str) -> bool:
     return False
 
 
-# Pushback indicators in Qodo responses — Qodo disagrees with our fix/decision
-_PUSHBACK_KEYWORDS = re.compile(
-    r"(\bstill (?:present|exists?|unresolved|open|not (?:fixed|addressed|resolved))\b"
-    r"|\bnot (?:fully |completely )?(?:addressed|resolved|fixed)\b"
-    r"|\bdisagree\b|\bincorrect\b|\bwrong\b|\bissue (?:remains|persists)\b"
-    r"|\bdoes not (?:address|fix|resolve)\b"
-    r"|\bshould still\b"
-    r"|\brecommend (?:re-?evaluating|revisiting)\b"
-    r"|\bre-?open\b)",
-    re.IGNORECASE,
-)
-
-
-def _is_qodo_pushback(qodo_response: str) -> bool:
-    """Detect if a Qodo response indicates pushback (disagreement with our fix)."""
-    return bool(_PUSHBACK_KEYWORDS.search(qodo_response))
-
-
 def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
-    """Check if fetched reviews have actionable Qodo comments.
-
-    A comment is actionable if:
-    - Not auto-skipped AND not already replied, OR
-    - Already replied but Qodo pushed back (qodo_response indicates disagreement)
-    """
+    """Check if fetched reviews have actionable Qodo comments (not auto-skipped)."""
     import json
     from pathlib import Path
 
@@ -133,16 +109,7 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
         return True
 
     for comment in data.get("qodo", []):
-        if comment.get("is_auto_skipped"):
-            continue
-
-        # Not yet replied — actionable
-        if not comment.get("already_replied"):
-            return True
-
-        # Already replied but Qodo pushed back — treat as actionable
-        qodo_response = comment.get("qodo_response", "")
-        if qodo_response and _is_qodo_pushback(qodo_response):
+        if not comment.get("is_auto_skipped"):
             return True
 
     return False

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -622,6 +622,7 @@ def run(json_path: str) -> None:
                 "qodo_finding",
                 "qodo_ux_issue",
                 "qodo_cross_repo",
+                "qodo_reply",
             ):
                 if status == "pending":
                     pending_count += 1
@@ -795,6 +796,7 @@ def run(json_path: str) -> None:
                 "qodo_finding",
                 "qodo_ux_issue",
                 "qodo_cross_repo",
+                "qodo_reply",
             ):
                 qodo_sticky_count += 1
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -148,10 +148,20 @@ Returns JSON with:
 > 🚨 **MANDATORY: Read the FULL Qodo sticky JSON data before acting.**
 > Qodo sticky findings contain critical fields beyond the title:
 >
-> - `code_diff` — the exact code the finding references (THIS is what you must fix)
-> - `evidence` — Qodo's explanation of why this is a problem
-> - `evidence_refs` — links to the specific file/line ranges involved
-> - `agent_prompt` — Qodo's suggested fix approach
+> 🚨 **ALL fields below are MANDATORY — read EVERY field before acting on a finding.**
+> Skipping any field is a violation. Each field provides critical context.
+>
+> - `code_diff` — the exact code the finding references. THIS is what you must fix.
+> - `evidence` — Qodo's explanation of why this is a problem. Read to understand the root cause.
+> - `evidence_refs` — links to the specific file/line ranges involved. Check EVERY entry.
+> - `agent_prompt` — Qodo's suggested fix approach. Follow it unless you have a better solution.
+> - `qodo_response` — Qodo's reply to our previous fix. **Read this FIRST when present.**
+>   Tells you whether Qodo accepted the fix or pushed back.
+>   **If Qodo pushed back, your previous fix was insufficient — make a DIFFERENT fix.**
+>   Do NOT repeat the same reply or approach.
+> - `previous_reply` — What we previously replied to this finding. Shows the full conversation:
+>   we said `previous_reply` → Qodo responded `qodo_response`. Use both to understand context
+>   and avoid repeating the same fix that Qodo already rejected.
 >
 > **NEVER match findings by title alone.** Two findings with the same title
 > (e.g., "Deploy ownership conflict") can reference completely different code.
@@ -201,6 +211,14 @@ Returns JSON with:
 >    - This means the autoqodo polling loop will re-surface findings where Qodo disagrees
 >      with our fix, requiring re-evaluation and a new code fix or spec update
 >    - Pushback keywords: "still present", "not fixed", "disagree", "issue remains", etc.
+>
+>    🚨 **When processing a finding with `qodo_response`:**
+>    1. Read `qodo_response` FIRST — understand what Qodo said about your previous fix
+>    2. If Qodo accepted ("looks good", "addressed", "thanks") — the finding may still
+>       be unresolved in the sticky (Qodo doesn't always auto-resolve). Reply referencing
+>       the acceptance.
+>    3. If Qodo pushed back — your previous fix was wrong or incomplete. Make a NEW,
+>       DIFFERENT fix that addresses Qodo's specific concern. Do NOT repeat the same approach.
 >
 > Combined behavior:
 >
@@ -287,8 +305,12 @@ all replies, every code suggestion/diff, and all referenced locations. Do NOT su
 
 **When fixing review comments (MANDATORY):**
 
-- **For Qodo sticky findings:** Before fixing or deciding a finding is "already addressed",
-  read the `code_diff`, `evidence`, `evidence_refs`, and `agent_prompt` fields from the JSON.
+- **For Qodo findings:** Before fixing or deciding a finding is "already addressed",
+  read the `code_diff`, `evidence`, `evidence_refs`, `agent_prompt`, `qodo_response`, and
+  `previous_reply` fields from the JSON.
+  🚨 **If `qodo_response` exists, read it FIRST** — it contains Qodo's feedback on your previous fix.
+  If Qodo pushed back, your previous approach failed — make a DIFFERENT fix.
+  `previous_reply` shows what you said before so you don't repeat it.
   These fields — not the title — define what the finding is about. Never dismiss by title alone.
   If `code_diff` is empty, use `evidence_refs` (check **every** entry, not just the first),
   `path`/`line`/`end_line` (if present — these can be empty/null), and the finding body to locate the code.

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -201,13 +201,24 @@ Returns JSON with:
 >    - OR the code does not match the spec — FIX THE CODE
 >    - NEVER post the same reply again. That means you haven't actually addressed it.
 >
+>    🚨 **STICKY FINDINGS ARE ALWAYS ACTIONABLE — NEVER SKIP.**
+>    If a finding appears in the Qodo sticky comment, it MUST be addressed with a code fix
+>    or spec update. `already_replied`, `previous_reply`, and `qodo_response` are CONTEXT
+>    for making a better fix — they are NOT reasons to skip.
+>    When a sticky finding has `previous_reply` + `qodo_response`, the AI MUST:
+>    1. Read `previous_reply` — what we said before
+>    2. Read `qodo_response` — what Qodo said back
+>    3. Make a DIFFERENT fix that addresses Qodo's specific concern
+>    Repeating the same reply or approach is a HARD VIOLATION.
+>
 >    **Qodo reply detection (consolidated comment responses):**
 >    When we post consolidated PR comments mentioning `@qodo-code-review`, Qodo may
 >    reply in a new issue comment quoting our response. These replies are now detected
 >    automatically:
 >    - Sticky findings are enriched with a `qodo_response` field containing Qodo's reply text
 >    - If Qodo's reply indicates **pushback** (e.g., "still present", "not addressed",
->      "disagree"), the finding is treated as **actionable** even if `already_replied=True`
+>      "disagree"), the finding is treated as **actionable** — `already_replied` is NOT
+>      a reason to skip. The finding MUST be re-fixed.
 >    - This means the autoqodo polling loop will re-surface findings where Qodo disagrees
 >      with our fix, requiring re-evaluation and a new code fix or spec update
 >    - Pushback keywords: "still present", "not fixed", "disagree", "issue remains", etc.
@@ -483,6 +494,14 @@ AUTOMATIC. If something is stuck, stale, or unclear — keep polling
 silently. Do NOT invent questions like "PRs are stuck, what do you
 want to do?" or "Should I keep polling?" or any variation. The loop
 runs silently until an exit condition is met. Period.**
+
+> **Exception: `qodo_requirement_gap` spec changes require user approval.**
+> When a `qodo_requirement_gap` finding needs an issue spec update (not a code fix),
+> the AI MUST ask the user before changing the spec. This is the ONLY exception to
+> the 'no user interaction in Phase 9' rule.
+>
+> - Code fix for a requirement gap → do it automatically, no user interaction needed
+> - Issue spec update for a requirement gap → ask user first via ask_user
 
 After the review flow completes (Phases 1-8), enter a polling loop
 to watch for new comments from auto-approved sources (CodeRabbit if autorabbit,

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -191,6 +191,17 @@ Returns JSON with:
 >    - OR the code does not match the spec — FIX THE CODE
 >    - NEVER post the same reply again. That means you haven't actually addressed it.
 >
+>    **Qodo reply detection (consolidated comment responses):**
+>    When we post consolidated PR comments mentioning `@qodo-code-review`, Qodo may
+>    reply in a new issue comment quoting our response. These replies are now detected
+>    automatically:
+>    - Sticky findings are enriched with a `qodo_response` field containing Qodo's reply text
+>    - If Qodo's reply indicates **pushback** (e.g., "still present", "not addressed",
+>      "disagree"), the finding is treated as **actionable** even if `already_replied=True`
+>    - This means the autoqodo polling loop will re-surface findings where Qodo disagrees
+>      with our fix, requiring re-evaluation and a new code fix or spec update
+>    - Pushback keywords: "still present", "not fixed", "disagree", "issue remains", etc.
+>
 > Combined behavior:
 >
 > 1. **Human comments** → ALWAYS follow the normal decision flow (never auto-approved).


### PR DESCRIPTION
## Summary

Detect Qodo's replies to our consolidated PR comments and enrich sticky findings with the response.

## Changes

- `myk_pi_tools/reviews/fetch.py` — added `fetch_qodo_reply_comments()` to scan for Qodo replies to our `@qodo-code-review` consolidated posts, and `_enrich_findings_with_qodo_replies()` to attach `qodo_response` field to matching sticky findings
- `myk_pi_tools/reviews/poll.py` — `_has_actionable_qodo_comments()` now detects Qodo pushback ("still present", "not addressed", etc.) and treats those findings as actionable
- `prompts/review-handler.md` — documented Qodo reply detection behavior in autoqodo section

## Testing

- pytest: 57/57 passed
- pre-commit: all passed

Ref #530