### PR TITLE
feat(coms): auto-deliver responses via followUp, remove coms_await

### DIFF
--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -7,7 +7,7 @@
  * Bun HTTP/SSE hub instead of per-agent Unix sockets / named pipes. The
  * user-facing tool surface is renamed for total separation from v1:
  *
- *   tools         coms_net_list / coms_net_send / coms_net_get / coms_net_await
+ *   tools         coms_net_list / coms_net_send / coms_net_get
  *   slash command /coms-net
  *   widget key    "coms-net-pool"   (placement: belowEditor only)
  *   audit channel "coms-net-log"
@@ -607,7 +607,7 @@ export default function (pi: ExtensionAPI) {
 					content: buildInboundContent(
 						`[inbound coms-net message from ${senderName} @ ${senderCwd}]\n` +
 						`[reply by writing a normal assistant message — your turn output is auto-returned to ${senderName}. ` +
-						`DO NOT call coms_net_send/coms_net_await/coms_net_get to reply; that creates a ping-pong loop.]`,
+						`DO NOT call coms_net_send/coms_net_get to reply; that creates a ping-pong loop.]`,
 						promptText, tasks),
 					display: true,
 					details: {
@@ -646,8 +646,32 @@ export default function (pi: ExtensionAPI) {
 		if (pending) {
 			pending.result = { response: responseVal, error: errVal };
 			try { pending.resolve(pending.result); } catch { /* ignore */ }
-			// Delete after a delay — coms_net_get poll has time to read the result
-			setTimeout(() => { pendingReplies.delete(msg_id); }, MESSAGE_TIMEOUT_MS).unref();
+
+			// Auto-deliver response as followUp so the LLM sees it without polling
+			const targetName = pending.target_name ?? "peer";
+			const responseText = errVal
+				? `[coms response from ${targetName}] Error: ${errVal}`
+				: typeof responseVal === "string"
+					? `[coms response from ${targetName}] ${responseVal}`
+					: `[coms response from ${targetName}] ${JSON.stringify(responseVal, null, 2)}`;
+			try {
+				pi.sendMessage(
+					{
+						customType: "coms-response",
+						content: responseText,
+						display: true,
+						details: {
+							msg_id,
+							target_name: targetName,
+							error: errVal,
+						},
+					},
+					{ deliverAs: "followUp", triggerTurn: true },
+				);
+			} catch { /* best-effort */ }
+
+			// Clean up after short delay — coms_net_get may still poll briefly
+			setTimeout(() => { pendingReplies.delete(msg_id); }, 60_000).unref();
 			try {
 				pi.appendEntry("coms-net-log", {
 					event: "response_in",
@@ -1122,7 +1146,7 @@ export default function (pi: ExtensionAPI) {
 		description:
 			"INITIATE a new outbound message to a peer agent on the coms-net hub. " +
 			"Returns synchronously with a msg_id once the server queues the prompt. " +
-			"Use coms_net_get (non-blocking) or coms_net_await (blocking) with that msg_id to retrieve the peer's reply.\n\n" +
+			"The response auto-delivers as a followUp message when the peer replies \u2014 no polling needed. Use coms_net_get for non-blocking status checks if needed.\n\n" +
 			"⚠️  DO NOT call this tool to REPLY to an inbound message. " +
 			"When you receive a `[from <peer>] …` follow-up, just write your answer as your normal assistant message — " +
 			"the coms-net extension automatically captures the final assistant text at the end of your turn and " +
@@ -1251,7 +1275,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Coms Net Get",
 		description:
 			"Non-blocking poll of a reply to YOUR OWN coms_net_send. Returns status pending|complete|error and (when complete) the response. " +
-			"Same caveat as coms_net_await: only use msg_ids you got back from coms_net_send, never msg_ids from an inbound `[from <peer>] …` prompt — " +
+			"Only use msg_ids you got back from coms_net_send, never msg_ids from an inbound `[from <peer>] …` prompt — " +
 			"those belong to the peer, and replying to them happens automatically via your normal assistant message at end of turn.",
 		parameters: Type.Object({
 			msg_id: Type.String({ description: "msg_id returned by coms_net_send." }),
@@ -1315,101 +1339,6 @@ export default function (pi: ExtensionAPI) {
 				: status === "pending" || status === "queued" || status === "delivered" ? "warning"
 				: "error";
 			return new Text(theme.fg(color, status), 0, 0);
-		},
-	});
-
-	pi.registerTool({
-		name: "coms_net_await",
-		label: "Coms Net Await",
-		description:
-			"Block until the reply to YOUR OWN outbound coms_net_send arrives, or the timeout fires (default 30 min). " +
-			"Only call this with a msg_id that YOU received as the return value of a coms_net_send call you just made.\n\n" +
-			"⚠️  Do NOT call this with a msg_id that came in via an inbound `[from <peer>] …` prompt — those msg_ids belong to the *peer's* outbound, not yours. " +
-			"To reply to an inbound message, do nothing special: just answer normally as your assistant message, " +
-			"and the extension will auto-submit your final text back to the caller when your turn ends.",
-		parameters: Type.Object({
-			msg_id: Type.String({ description: "msg_id returned by coms_net_send." }),
-			timeout_ms: Type.Optional(Type.Number({ description: "Override the default timeout (ms). Server cap applies." })),
-		}),
-		async execute(_callId, params) {
-			const msg_id = (params as any).msg_id as string;
-			const timeoutMs = typeof (params as any).timeout_ms === "number" && (params as any).timeout_ms > 0
-				? (params as any).timeout_ms
-				: MESSAGE_TIMEOUT_MS;
-
-			// Local SSE-resolved fast path.
-			const pending = pendingReplies.get(msg_id);
-			if (pending && pending.result) {
-				const r = pending.result;
-				if (r.error) {
-					return {
-						content: [{ type: "text" as const, text: `coms_net_await: error — ${r.error}` }],
-						details: { error: r.error },
-					};
-				}
-				const resp = r.response;
-				return {
-					content: [{ type: "text" as const, text: typeof resp === "string" ? resp : JSON.stringify(resp, null, 2) }],
-					details: { response: resp },
-				};
-			}
-
-			// Race local pending promise against server long-poll, capped at timeoutMs.
-			const localPromise: Promise<{ response?: any; error?: string | null }> = pending
-				? pending.promise
-				: new Promise(() => { /* never resolves on its own; SSE will */ });
-
-			// Server long-poll. Cap server timeout to the requested timeout (server enforces its own max too).
-			const serverTimeoutMs = Math.min(timeoutMs, MESSAGE_TIMEOUT_MS);
-			const ac = new AbortController();
-			const serverPromise = httpFetch(
-				"GET",
-				`/v1/messages/${encodeURIComponent(msg_id)}/await?timeout_ms=${serverTimeoutMs}`,
-				undefined,
-				{ timeoutMs: serverTimeoutMs + 5_000, signal: ac.signal },
-			).then((data: any) => {
-				if (data?.status === "complete") return { response: data.response, error: null };
-				if (data?.status === "error") return { response: null, error: data.error ?? "error" };
-				if (data?.status === "timeout") return { response: null, error: "timeout" };
-				return { response: data?.response, error: data?.error ?? null };
-			}).catch((err) => {
-				if (err instanceof HttpError && err.status === 404) {
-					return { response: null, error: "unknown msg_id" };
-				}
-				return { response: null, error: safeError(err) };
-			});
-
-			const timeoutPromise = new Promise<{ error: string }>((resolve) => {
-				const t = setTimeout(() => resolve({ error: "timeout" }), timeoutMs);
-				try { (t as any).unref?.(); } catch { /* ignore */ }
-			});
-
-			const winner = await Promise.race([localPromise, serverPromise, timeoutPromise]);
-			try { ac.abort(); } catch { /* ignore */ }
-
-			if ((winner as any).error) {
-				return {
-					content: [{ type: "text" as const, text: `coms_net_await: error — ${(winner as any).error}` }],
-					details: { error: (winner as any).error },
-				};
-			}
-			const resp = (winner as any).response;
-			return {
-				content: [{ type: "text" as const, text: typeof resp === "string" ? resp : JSON.stringify(resp, null, 2) }],
-				details: { response: resp },
-			};
-		},
-		renderCall(args, theme) {
-			const id = (args as any).msg_id ?? "?";
-			return new Text(
-				theme.fg("toolTitle", theme.bold("coms_net_await ")) + theme.fg("warning", id),
-				0, 0,
-			);
-		},
-		renderResult(result, _options, theme) {
-			const d = result.details as any;
-			if (d?.error) return new Text(theme.fg("error", `✗ ${d.error}`), 0, 0);
-			return new Text(theme.fg("success", "✓ response received"), 0, 0);
 		},
 	});
 
@@ -1492,7 +1421,7 @@ export default function (pi: ExtensionAPI) {
 						content: buildInboundContent(
 						`[inbound coms-net message from ${next.sender_name} @ ${next.sender_cwd}]\n` +
 						`[reply by writing a normal assistant message — your turn output is auto-returned to ${next.sender_name}. ` +
-						`DO NOT call coms_net_send/coms_net_await/coms_net_get to reply; that creates a ping-pong loop.]`,
+						`DO NOT call coms_net_send/coms_net_get to reply; that creates a ping-pong loop.]`,
 						next.prompt, next.tasks),
 						display: true,
 						details: {

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -8,7 +8,7 @@
  * ~/.pi/coms/projects/<project>/agents/<name>.json.
  *
  * Phase A (foundation): identity resolution, registry I/O, transport bind/send,
- * connection handlers. Phase B: tools (coms_list/send/get/await), agent_end
+ * connection handlers. Phase B: tools (coms_list/send/get), agent_end
  * response capture. Phase C: live pool widget, ping + keepalive cycles, /coms
  * slash command, clean shutdown lifecycle.
  *
@@ -692,8 +692,32 @@ export default function (pi: ExtensionAPI) {
 			} catch {
 				// ignore
 			}
-			// Delete after timeout window — coms_get/coms_await may still poll
-			setTimeout(() => { pendingReplies.delete(env.msg_id); }, TIMEOUT_MS).unref();
+
+			// Auto-deliver response as followUp so the LLM sees it without polling
+			const targetName = pending.target_name ?? "peer";
+			const responseText = env.error
+				? `[coms response from ${targetName}] Error: ${env.error}`
+				: typeof env.response === "string"
+					? `[coms response from ${targetName}] ${env.response}`
+					: `[coms response from ${targetName}] ${JSON.stringify(env.response, null, 2)}`;
+			try {
+				pi.sendMessage(
+					{
+						customType: "coms-response",
+						content: responseText,
+						display: true,
+						details: {
+							msg_id: env.msg_id,
+							target_name: targetName,
+							error: env.error ?? null,
+						},
+					},
+					{ deliverAs: "followUp", triggerTurn: true },
+				);
+			} catch { /* best-effort */ }
+
+			// Clean up immediately since response was delivered
+			setTimeout(() => { pendingReplies.delete(env.msg_id); }, 60_000).unref();
 		} else {
 			try {
 				pi.appendEntry("coms-log", { event: "orphan_response", msg_id: env.msg_id });
@@ -1357,7 +1381,7 @@ export default function (pi: ExtensionAPI) {
 		label: "Coms Send",
 		description:
 			"Send a prompt to a peer agent. Returns synchronously with a msg_id once the receiver acks. " +
-			"Use coms_get (non-blocking) or coms_await (blocking) with the msg_id to retrieve the response. " +
+			"The response auto-delivers as a followUp message when the peer replies — no polling needed. Use coms_get for non-blocking status checks if needed. " +
 			"Throws if the receiver is unreachable or rejects the envelope.\n\n" +
 			"When delegating multiple work items, use the `tasks` parameter to include structured task definitions. " +
 			"The peer receives them as an instruction to create tasks via TaskCreate and track progress in their task widget.",
@@ -1516,59 +1540,6 @@ export default function (pi: ExtensionAPI) {
 			const status = d?.status ?? "?";
 			const color = status === "complete" ? "success" : status === "pending" ? "warning" : "error";
 			return new Text(theme.fg(color, status), 0, 0);
-		},
-	});
-
-	pi.registerTool({
-		name: "coms_await",
-		label: "Coms Await",
-		description:
-			"Block until a pending coms_send reply lands or the timeout fires. Default timeout 30 minutes (PI_COMS_TIMEOUT_MS).",
-		parameters: Type.Object({
-			msg_id: Type.String({ description: "msg_id returned by coms_send." }),
-			timeout_ms: Type.Optional(Type.Number({ description: "Override the default timeout (ms)." })),
-		}),
-		async execute(_callId, params) {
-			const entry = pendingReplies.get(params.msg_id);
-			if (!entry) {
-				return {
-					content: [{ type: "text" as const, text: `coms_await: unknown msg_id ${params.msg_id}` }],
-					details: { error: "unknown msg_id" },
-				};
-			}
-			const timeoutMs = typeof params.timeout_ms === "number" && params.timeout_ms > 0
-				? params.timeout_ms
-				: TIMEOUT_MS;
-
-			const timed = new Promise<{ error: string }>((resolve) => {
-				const t = setTimeout(() => resolve({ error: "timeout" }), timeoutMs);
-				try { (t as any).unref?.(); } catch { /* ignore */ }
-			});
-
-			const winner = await Promise.race([entry.promise, timed]);
-			if ((winner as any).error) {
-				return {
-					content: [{ type: "text" as const, text: `coms_await: error — ${(winner as any).error}` }],
-					details: { error: (winner as any).error },
-				};
-			}
-			const resp = (winner as any).response;
-			return {
-				content: [{ type: "text" as const, text: typeof resp === "string" ? resp : JSON.stringify(resp, null, 2) }],
-				details: { response: resp },
-			};
-		},
-		renderCall(args, theme) {
-			const id = (args as any).msg_id ?? "?";
-			return new Text(
-				theme.fg("toolTitle", theme.bold("coms_await ")) + theme.fg("warning", id),
-				0, 0,
-			);
-		},
-		renderResult(result, _options, theme) {
-			const d = result.details as any;
-			if (d?.error) return new Text(theme.fg("error", `✗ ${d.error}`), 0, 0);
-			return new Text(theme.fg("success", "✓ response received"), 0, 0);
 		},
 	});
 

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -670,7 +670,9 @@ _QUOTED_HEADING_FULL_RE = re.compile(r"###\s+`([^`]+)`\s*(?:\([^)]*\))?\s*(?:—
 _CONSOLIDATED_COMMENT_MARKER = "The following review comments were reviewed"
 
 
-def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
+def fetch_qodo_reply_comments(
+    owner: str, repo: str, pr_number: str, *, comments: list[dict[str, Any]] | None = None
+) -> list[dict[str, Any]]:
     """Fetch Qodo replies to our consolidated PR comments.
 
     Scans issue comments for Qodo bot replies that quote our consolidated
@@ -683,13 +685,17 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
     ``qodo_response`` to existing findings) and as first-class threads in
     the categorized output.
 
+    Args:
+        comments: Pre-fetched issue comments. If None, fetches from API.
+
     Returns:
         List of thread-like dicts with keys: thread_id, node_id, comment_id,
         author, path, line, body, source, type, quoted_location, quoted_title,
         qodo_response.
     """
-    endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
-    comments = run_gh_api(endpoint, paginate=True)
+    if comments is None:
+        endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+        comments = run_gh_api(endpoint, paginate=True)
 
     if comments is None or not isinstance(comments, list):
         return []
@@ -773,13 +779,19 @@ def fetch_qodo_reply_comments(owner: str, repo: str, pr_number: str) -> list[dic
     return results
 
 
-def fetch_qodo_sticky_findings(owner: str, repo: str, pr_number: str) -> list[dict[str, Any]]:
+def fetch_qodo_sticky_findings(
+    owner: str, repo: str, pr_number: str, *, comments: list[dict[str, Any]] | None = None
+) -> list[dict[str, Any]]:
     """Fetch unresolved findings from Qodo's sticky summary comment.
+
+    Args:
+        comments: Pre-fetched issue comments. If None, fetches from API.
 
     Returns thread-like dicts for each unresolved finding.
     """
-    endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
-    comments = run_gh_api(endpoint, paginate=True)
+    if comments is None:
+        endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+        comments = run_gh_api(endpoint, paginate=True)
 
     if comments is None or not isinstance(comments, list):
         return []
@@ -1245,9 +1257,14 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
                 print_stderr(f"Found {len(body_comment_threads)} body-embedded comment(s)")
                 all_threads = merge_threads(all_threads, body_comment_threads)
 
+            # Fetch issue comments once for both sticky and reply parsing
+            issue_comments = run_gh_api(
+                f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100", paginate=True
+            )
+
             # Fetch Qodo sticky comment findings
             print_stderr("Fetching Qodo sticky comment findings...")
-            qodo_sticky_findings = fetch_qodo_sticky_findings(owner, repo, pr_number)
+            qodo_sticky_findings = fetch_qodo_sticky_findings(owner, repo, pr_number, comments=issue_comments)
             if qodo_sticky_findings:
                 print_stderr(f"Found {len(qodo_sticky_findings)} unresolved Qodo sticky finding(s)")
 
@@ -1255,7 +1272,7 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
 
             # Fetch Qodo replies to our consolidated comments (independent of sticky findings)
             print_stderr("Fetching Qodo reply comments...")
-            qodo_replies = fetch_qodo_reply_comments(owner, repo, pr_number)
+            qodo_replies = fetch_qodo_reply_comments(owner, repo, pr_number, comments=issue_comments)
             if qodo_replies:
                 print_stderr(f"Found {len(qodo_replies)} Qodo reply comment(s)")
                 all_threads = merge_threads(all_threads, qodo_replies)

--- a/prompts/create-coms-feature-manager.md
+++ b/prompts/create-coms-feature-manager.md
@@ -17,7 +17,7 @@ $ARGUMENTS
 > Do not silently skip steps or apply manual fixes that hide the root cause.
 
 Generates a project-specific **coms feature manager** prompt from the template.
-The coms feature manager pattern uses pi's coms system (`coms_send`/`coms_await`/`coms_list`)
+The coms feature manager pattern uses pi's coms system (`coms_send`/`coms_list` — responses auto-deliver as followUp)
 to coordinate between a manager agent (reviewer) and a coder agent (implementer).
 
 ## What This Creates

--- a/rules/55-coms-protocol.md
+++ b/rules/55-coms-protocol.md
@@ -40,7 +40,6 @@ coms_net_list      # Networked peers
 | List peers | `coms_list` | `coms_net_list` |
 | Send message | `coms_send` | `coms_net_send` |
 | Poll for response | `coms_get` | `coms_net_get` |
-| Block until response | `coms_await` | `coms_net_await` |
 
 ---
 
@@ -73,14 +72,14 @@ When you receive an inbound message, it appears as:
 
 ## Outbound Messages — How to Initiate
 
-To START a new conversation with a peer, use the send tool then await the response.
+To START a new conversation with a peer, use the send tool then **end your turn**. The response auto-delivers as a followUp message when the peer replies — no polling or blocking needed.
 
 ### Example: Outbound conversation (P2P)
 
 ```text
 1. coms_list                          # Find available peers
 2. coms_send(peer="pi-2", msg="...")  # Send the question
-3. coms_await                         # Wait for response (ESC to interrupt)
+3. (end turn)                         # Response arrives as followUp automatically
 ```
 
 ### Example: Outbound conversation (Networked)
@@ -88,8 +87,10 @@ To START a new conversation with a peer, use the send tool then await the respon
 ```text
 1. coms_net_list                          # Find available peers
 2. coms_net_send(peer="pi-2", msg="...")  # Send the question
-3. coms_net_await                         # Wait for response (ESC to interrupt)
+3. (end turn)                             # Response arrives as followUp automatically
 ```
+
+Use `coms_get` / `coms_net_get` for non-blocking status checks if needed.
 
 ---
 
@@ -122,8 +123,7 @@ The peer sees the tasks in their task widget and can track progress. Tasks are c
 
 ## Key Rules
 
-1. **`coms_await` / `coms_net_await` are interruptible** — user can press ESC to cancel.
-   Use them freely for outbound conversations.
+1. **Responses auto-deliver** — after `coms_send` / `coms_net_send`, end your turn. The peer's response arrives as a followUp message automatically.
 2. **Never call send tools to reply** to inbound messages — your assistant text is the reply
 3. **Always check peers first** — use list tools before sending to verify the peer exists
 4. **Try both systems** — when asked to interact with peers without specifying which system, try `coms_` first, then `coms_net_` if it fails (or vice versa)

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -16,7 +16,7 @@ You do NOT write code. You review, direct the coder, and verify everything works
 
 - **Sole owner** of feature quality and completeness
 - You do NOT write, edit, or commit code — manager and reviewer only
-- Communicate with coder peer via `coms_send` / `coms_await` — discover peer name via `coms_list` or `coms_net_list`
+- Communicate with coder peer via `coms_send` (responses auto-deliver as followUp) — discover peer name via `coms_list` or `coms_net_list`
 - **Use structured tasks** when delegating work — pass `tasks` parameter in `coms_send` so the coder's task widget tracks deliverables
 - Gate PR creation — coder CANNOT push/create PR without your explicit approval
 - **You NEVER merge PRs.** Only the user (human) merges. Your job ends at "ready to merge."
@@ -182,7 +182,7 @@ Your first message MUST include review/feedback AND this standing rules block (c
 
 - **Incomplete reports** → push back: "What files changed? Use the required format."
 - **Verify reports** against actual diff: `git diff --stat` / `git diff -- <files>`. Check for unreported files.
-- **After feedback** → always `coms_await`. After approval → `coms_await` again.
+- **After feedback** → end turn and wait for followUp response. After approval → wait for followUp again.
 - **Before declaring PR ready** → check: "Any pending changes I haven't reviewed?"
 - **Never assume silence = nothing happened.**
 
@@ -260,8 +260,8 @@ the e2e-tester runs verification after deploy is confirmed healthy.
 Send verification tasks via the active coms transport with structured `tasks`,
 then await the returned `msg_id` using the matching tool:
 
-- P2P: `coms_send` → `coms_await(msg_id=...)`
-- Networked: `coms_net_send` → `coms_net_await(msg_id=...)`
+- P2P: `coms_send` → response auto-delivers as followUp
+- Networked: `coms_net_send` → response auto-delivers as followUp
 
 Tasks to delegate:
 

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -16,9 +16,10 @@ You do NOT write code. You review, direct the coder, and verify everything works
 
 - **Sole owner** of feature quality and completeness
 - You do NOT write, edit, or commit code — manager and reviewer only
-- Communicate with coder peer via `coms_send` (P2P) or `coms_net_send` (networked)
-  — responses auto-deliver as followUp. Discover peers via `coms_list` (P2P) or
-  `coms_net_list` (networked). Use the same transport for discovery and sending.
+- Communicate with coder peer via `coms_send` (P2P) or `coms_net_send` (networked).
+  After sending, **end your turn** — the response auto-delivers as a followUp in a new turn.
+  Discover peers via `coms_list` (P2P) or `coms_net_list` (networked).
+  Use the same transport for discovery and sending.
 - **Use structured tasks** when delegating work — pass `tasks` parameter in `coms_send` so the coder's task widget tracks deliverables
 - Gate PR creation — coder CANNOT push/create PR without your explicit approval
 - **You NEVER merge PRs.** Only the user (human) merges. Your job ends at "ready to merge."

--- a/templates/coms-feature-manager-prompt.md
+++ b/templates/coms-feature-manager-prompt.md
@@ -16,7 +16,9 @@ You do NOT write code. You review, direct the coder, and verify everything works
 
 - **Sole owner** of feature quality and completeness
 - You do NOT write, edit, or commit code — manager and reviewer only
-- Communicate with coder peer via `coms_send` (responses auto-deliver as followUp) — discover peer name via `coms_list` or `coms_net_list`
+- Communicate with coder peer via `coms_send` (P2P) or `coms_net_send` (networked)
+  — responses auto-deliver as followUp. Discover peers via `coms_list` (P2P) or
+  `coms_net_list` (networked). Use the same transport for discovery and sending.
 - **Use structured tasks** when delegating work — pass `tasks` parameter in `coms_send` so the coder's task widget tracks deliverables
 - Gate PR creation — coder CANNOT push/create PR without your explicit approval
 - **You NEVER merge PRs.** Only the user (human) merges. Your job ends at "ready to merge."


### PR DESCRIPTION
## Summary

`coms_await` blocked the chat — the LLM's turn couldn't finish until the peer responded. Now responses auto-deliver as followUp messages, like inbound prompts already do.

## Changes

### Coms response auto-delivery
- `handleResponse()` in both `coms-p2p.ts` and `coms-net.ts` now injects peer responses as followUp messages via `pi.sendMessage({ deliverAs: "followUp", triggerTurn: true })`
- Removed `coms_await` tool from `coms-p2p.ts`
- Removed `coms_net_await` tool from `coms-net.ts`
- Updated `coms_send` / `coms_net_send` descriptions
- Updated `rules/55-coms-protocol.md` — removed await references, documented new flow

### Reviews API optimization (Ref #530)
- `fetch_qodo_sticky_findings()` and `fetch_qodo_reply_comments()` now accept optional `comments` parameter
- `run()` fetches issue comments once and passes to both, halving API calls

## New flow
```
coms_send → end turn → response auto-arrives as followUp → new turn
```

Closes #535