### PR TITLE
fix(coms): survive laptop suspend/resume without losing connections

### DIFF
--- a/extensions/coms/coms-net-server.ts
+++ b/extensions/coms/coms-net-server.ts
@@ -1338,12 +1338,13 @@ function staleScanTick(): void {
 	// Detect time jump (suspend/resume): if elapsed >> expected interval,
 	// skip this tick to let agents heartbeat back in.
 	if (elapsed > Math.max(STALE_SCAN_INTERVAL_MS * 3, 30_000)) {
+		const ts = nowIso();
 		for (const [, p] of state.projects) {
 			for (const [, entry] of p.agents) {
-				entry.last_seen_at = nowIso();
-				if (entry.status === "stale") {
-					entry.status = "online";
-				}
+				entry.last_seen_at = ts;
+				// Don't change status here — let the next heartbeat trigger the
+				// stale→online transition, which handleHeartbeat() will broadcast
+				// to SSE consumers.
 			}
 		}
 		logLine("⏸", C_YELLOW, "time-jump", `detected ${Math.round(elapsed / 1000)}s gap — resetting agent timestamps`);

--- a/extensions/coms/coms-net-server.ts
+++ b/extensions/coms/coms-net-server.ts
@@ -1328,9 +1328,27 @@ let staleScanTimer: ReturnType<typeof setInterval> | null = null;
 let ttlScanTimer: ReturnType<typeof setInterval> | null = null;
 let keepaliveTimer: ReturnType<typeof setInterval> | null = null;
 let shuttingDown = false;
+let lastStaleScanAt = Date.now();
 
 function staleScanTick(): void {
 	const now = Date.now();
+	const elapsed = now - lastStaleScanAt;
+	lastStaleScanAt = now;
+
+	// Detect time jump (suspend/resume): if elapsed >> expected interval,
+	// skip this tick to let agents heartbeat back in.
+	if (elapsed > Math.max(STALE_SCAN_INTERVAL_MS * 3, 30_000)) {
+		for (const [, p] of state.projects) {
+			for (const [, entry] of p.agents) {
+				entry.last_seen_at = nowIso();
+				if (entry.status === "stale") {
+					entry.status = "online";
+				}
+			}
+		}
+		logLine("⏸", C_YELLOW, "time-jump", `detected ${Math.round(elapsed / 1000)}s gap — resetting agent timestamps`);
+		return;
+	}
 	for (const [projectName, p] of state.projects) {
 		for (const [sid, entry] of p.agents) {
 			const last = Date.parse(entry.last_seen_at);
@@ -1429,6 +1447,7 @@ function keepaliveTick(): void {
 }
 
 function startLoops(): void {
+	lastStaleScanAt = Date.now();
 	staleScanTimer = setInterval(staleScanTick, STALE_SCAN_INTERVAL_MS);
 	ttlScanTimer = setInterval(ttlScanTick, TTL_SCAN_INTERVAL_MS);
 	keepaliveTimer = setInterval(keepaliveTick, SSE_KEEPALIVE_MS);

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -303,8 +303,6 @@ function removeRegistryEntry(project: string, sessionId: string): void {
 
 async function pruneDeadEntries(project: string): Promise<RegistryEntry[]> {
 	const entries = readAllRegistryEntries(project);
-	const now = Date.now();
-	const staleThresholdMs = KEEPALIVE_INTERVAL_MS * 2;
 	const socketsDir = path.join(COMS_DIR, "sockets");
 
 	// Phase 1: Sync pre-filter (fast — no I/O)
@@ -319,21 +317,15 @@ async function pruneDeadEntries(project: string): Promise<RegistryEntry[]> {
 			removeRegistryEntry(project, entry.session_id);
 			continue;
 		}
-		// Check heartbeat/started_at freshness
+		// Check heartbeat/started_at structural validity (malformed = remove, missing = remove)
+		// Timestamp staleness is NOT checked here — stale entries go to Phase 2 for socket probing.
+		// This prevents false pruning after laptop suspend/resume when all timestamps are stale
+		// but peers are still alive.
 		const lastSeen = entry.heartbeat_at ?? entry.started_at;
 		if (lastSeen) {
 			const lastSeenMs = new Date(lastSeen).getTime();
 			if (isNaN(lastSeenMs)) {
 				removeRegistryEntry(project, entry.session_id);
-				continue;
-			}
-			const age = now - lastSeenMs;
-			if (age > staleThresholdMs) {
-				removeRegistryEntry(project, entry.session_id);
-				if (entry.endpoint.startsWith(socketsDir + path.sep) || entry.endpoint.startsWith(socketsDir + "/")) {
-					try { fs.unlinkSync(entry.endpoint); } catch { /* best-effort */ }
-					try { fs.unlinkSync(`${entry.endpoint}.ping`); } catch { /* best-effort */ }
-				}
 				continue;
 			}
 		} else {

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -74,7 +74,7 @@ export function registerRules(
 ): void {
   const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
   let rebuildDone = false;
-  let taskFocusJustFired = false;
+
 
   // Run full rebuild on session start (once per session, not every turn)
   pi.on("session_start", async (_event, ctx) => {
@@ -280,12 +280,27 @@ export function registerRules(
     // Task-focus enforcement: if this turn had no tool calls but tasks are active,
     // the LLM likely answered a side question and forgot to resume work.
     // Inject a follow-up to force it back on track.
+    // Don't re-fire if the triggering message was the reminder itself — only
+    // re-fire after a real interaction (user input, async result, coms inbound).
     try {
       const turnToolResults = (_event as any).toolResults;
       const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
-      if (taskFocusJustFired) {
-        taskFocusJustFired = false;
-      } else if (!hadToolCalls) {
+      // Check if this turn was triggered by our own reminder — if so, skip.
+      // Walk the session branch backwards to find the most recent custom entry.
+      let triggeredByReminder = false;
+      try {
+        const branch = ctx.sessionManager.getBranch();
+        for (let i = branch.length - 1; i >= 0; i--) {
+          const entry = branch[i];
+          if (entry.type === "custom" && (entry as any).customType === "task-focus-enforcement") {
+            triggeredByReminder = true;
+            break;
+          }
+          // Stop scanning at the first user or assistant message (only check recent custom entries)
+          if (entry.type === "message") break;
+        }
+      } catch { /* best-effort */ }
+      if (!hadToolCalls && !triggeredByReminder) {
         // Check for active tasks — session-scoped task file only
         const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
         const sessionId = ctx.sessionManager?.getSessionId?.();
@@ -308,7 +323,6 @@ export function registerRules(
                 content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
                 display: true,
               }, { triggerTurn: true, deliverAs: "followUp" });
-              taskFocusJustFired = true;
               break;
             }
           } catch { continue; }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -286,39 +286,32 @@ export function registerRules(
       if (taskFocusJustFired) {
         taskFocusJustFired = false;
       } else if (!hadToolCalls) {
-        // Skip task-focus reminder when async agents are in-flight — the LLM is
-        // correctly waiting for their results to arrive as follow-up messages.
-        const asyncRunning = getAsyncJobs ? getAsyncJobs().length : 0;
-        if (asyncRunning > 0) {
-          // noop — async results will trigger the next turn
-        } else {
-          // Check for active tasks — session-scoped task file only
-          const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
-          const sessionId = ctx.sessionManager?.getSessionId?.();
-          const candidates: string[] = [];
-          if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
-          candidates.push(path.join(tasksDir, "tasks.json"));
-          for (const taskFile of candidates) {
-            try {
-              if (!fs.existsSync(taskFile)) continue;
-              const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
-              const tasks = data.tasks || [];
-              const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
-              if (activeTasks.length > 0) {
-                const summary = activeTasks
-                  .slice(0, 3)
-                  .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
-                  .join(", ");
-                pi.sendMessage({
-                  customType: "task-focus-enforcement",
-                  content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
-                  display: true,
-                }, { triggerTurn: true, deliverAs: "followUp" });
-                taskFocusJustFired = true;
-                break;
-              }
-            } catch { continue; }
-          }
+        // Check for active tasks — session-scoped task file only
+        const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
+        const sessionId = ctx.sessionManager?.getSessionId?.();
+        const candidates: string[] = [];
+        if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+        candidates.push(path.join(tasksDir, "tasks.json"));
+        for (const taskFile of candidates) {
+          try {
+            if (!fs.existsSync(taskFile)) continue;
+            const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
+            const tasks = data.tasks || [];
+            const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
+            if (activeTasks.length > 0) {
+              const summary = activeTasks
+                .slice(0, 3)
+                .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
+                .join(", ");
+              pi.sendMessage({
+                customType: "task-focus-enforcement",
+                content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
+                display: true,
+              }, { triggerTurn: true, deliverAs: "followUp" });
+              taskFocusJustFired = true;
+              break;
+            }
+          } catch { continue; }
         }
       }
     } catch (e: any) { console.debug("[rules] task-focus enforcement failed:", e?.message?.slice(0, 100)); }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -74,7 +74,7 @@ export function registerRules(
 ): void {
   const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
   let rebuildDone = false;
-  let taskFocusJustFired = false;
+  let lastTaskFocusReminderAt = 0;
 
 
   // Run full rebuild on session start (once per session, not every turn)
@@ -281,19 +281,20 @@ export function registerRules(
     // Task-focus enforcement: if this turn had no tool calls but tasks are active,
     // the LLM likely answered a side question and forgot to resume work.
     // Inject a follow-up to force it back on track.
-    // After firing, suppress until the LLM actually does work (has tool calls),
-    // preventing infinite reminder loops when the LLM responds without acting.
+    // After firing, cooldown for 2 minutes to prevent rapid re-firing.
+    // Cooldown resets immediately when the LLM does actual work (tool calls).
+    // After cooldown expires, re-fire if tasks are still active — prevents
+    // permanent suppression when the LLM ignores reminders.
     try {
       const turnToolResults = (_event as any).toolResults;
       const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
-      if (taskFocusJustFired) {
-        // Reminder was fired last turn — check if LLM acted on it
-        if (hadToolCalls) {
-          // LLM did work — reset, allow future reminders
-          taskFocusJustFired = false;
-        }
-        // Either way, don't fire again this turn
-      } else if (!hadToolCalls) {
+      // Reset cooldown when LLM does actual work
+      if (hadToolCalls) {
+        lastTaskFocusReminderAt = 0;
+      }
+      const cooldownMs = 120_000; // 2 minutes
+      const coolingDown = lastTaskFocusReminderAt > 0 && (Date.now() - lastTaskFocusReminderAt) < cooldownMs;
+      if (!hadToolCalls && !coolingDown) {
         // Check for active tasks — session-scoped task file only
         const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
         const sessionId = ctx.sessionManager?.getSessionId?.();
@@ -316,7 +317,7 @@ export function registerRules(
                 content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
                 display: true,
               }, { triggerTurn: true, deliverAs: "followUp" });
-              taskFocusJustFired = true;
+              lastTaskFocusReminderAt = Date.now();
               break;
             }
           } catch { continue; }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -74,6 +74,7 @@ export function registerRules(
 ): void {
   const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
   let rebuildDone = false;
+  let taskFocusJustFired = false;
 
 
   // Run full rebuild on session start (once per session, not every turn)
@@ -280,27 +281,19 @@ export function registerRules(
     // Task-focus enforcement: if this turn had no tool calls but tasks are active,
     // the LLM likely answered a side question and forgot to resume work.
     // Inject a follow-up to force it back on track.
-    // Don't re-fire if the triggering message was the reminder itself — only
-    // re-fire after a real interaction (user input, async result, coms inbound).
+    // After firing, suppress until the LLM actually does work (has tool calls),
+    // preventing infinite reminder loops when the LLM responds without acting.
     try {
       const turnToolResults = (_event as any).toolResults;
       const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
-      // Check if this turn was triggered by our own reminder — if so, skip.
-      // Walk the session branch backwards to find the most recent custom entry.
-      let triggeredByReminder = false;
-      try {
-        const branch = ctx.sessionManager.getBranch();
-        for (let i = branch.length - 1; i >= 0; i--) {
-          const entry = branch[i];
-          if (entry.type === "custom" && (entry as any).customType === "task-focus-enforcement") {
-            triggeredByReminder = true;
-            break;
-          }
-          // Stop scanning at the first user or assistant message (only check recent custom entries)
-          if (entry.type === "message") break;
+      if (taskFocusJustFired) {
+        // Reminder was fired last turn — check if LLM acted on it
+        if (hadToolCalls) {
+          // LLM did work — reset, allow future reminders
+          taskFocusJustFired = false;
         }
-      } catch { /* best-effort */ }
-      if (!hadToolCalls && !triggeredByReminder) {
+        // Either way, don't fire again this turn
+      } else if (!hadToolCalls) {
         // Check for active tasks — session-scoped task file only
         const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
         const sessionId = ctx.sessionManager?.getSessionId?.();
@@ -323,6 +316,7 @@ export function registerRules(
                 content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
                 display: true,
               }, { triggerTurn: true, deliverAs: "followUp" });
+              taskFocusJustFired = true;
               break;
             }
           } catch { continue; }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -292,10 +292,13 @@ export function registerRules(
         const branch = ctx.sessionManager.getBranch();
         for (let i = branch.length - 1; i >= 0; i--) {
           const entry = branch[i];
+          // Skip non-message entries (tool results, custom entries, memory injections)
+          if (entry.type !== "message") continue;
+          const role = (entry as any).message?.role;
           // Skip assistant messages (current turn's response)
-          if (entry.type === "message" && (entry as any).message?.role === "assistant") continue;
-          // Found the triggering entry
-          if (entry.type === "message" && (entry as any).message?.role === "user") {
+          if (role === "assistant") continue;
+          // Found a non-assistant message — check if it's from the user
+          if (role === "user") {
             userTriggered = true;
           }
           break;

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -80,6 +80,7 @@ export function registerRules(
   // Run full rebuild on session start (once per session, not every turn)
   pi.on("session_start", async (_event, ctx) => {
     rebuildDone = false;
+    lastTaskFocusReminderAt = 0;
     try {
       rebuildAndOrganize(ctx.cwd);
       rebuildDone = true;

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -286,32 +286,39 @@ export function registerRules(
       if (taskFocusJustFired) {
         taskFocusJustFired = false;
       } else if (!hadToolCalls) {
-        // Check for active tasks — session-scoped task file only
-        const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
-        const sessionId = ctx.sessionManager?.getSessionId?.();
-        const candidates: string[] = [];
-        if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
-        candidates.push(path.join(tasksDir, "tasks.json"));
-        for (const taskFile of candidates) {
-          try {
-            if (!fs.existsSync(taskFile)) continue;
-            const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
-            const tasks = data.tasks || [];
-            const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
-            if (activeTasks.length > 0) {
-              const summary = activeTasks
-                .slice(0, 3)
-                .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
-                .join(", ");
-              pi.sendMessage({
-                customType: "task-focus-enforcement",
-                content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
-                display: true,
-              }, { triggerTurn: true, deliverAs: "followUp" });
-              taskFocusJustFired = true;
-              break;
-            }
-          } catch { continue; }
+        // Skip task-focus reminder when async agents are in-flight — the LLM is
+        // correctly waiting for their results to arrive as follow-up messages.
+        const asyncRunning = getAsyncJobs ? getAsyncJobs().length : 0;
+        if (asyncRunning > 0) {
+          // noop — async results will trigger the next turn
+        } else {
+          // Check for active tasks — session-scoped task file only
+          const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
+          const sessionId = ctx.sessionManager?.getSessionId?.();
+          const candidates: string[] = [];
+          if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+          candidates.push(path.join(tasksDir, "tasks.json"));
+          for (const taskFile of candidates) {
+            try {
+              if (!fs.existsSync(taskFile)) continue;
+              const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
+              const tasks = data.tasks || [];
+              const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
+              if (activeTasks.length > 0) {
+                const summary = activeTasks
+                  .slice(0, 3)
+                  .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
+                  .join(", ");
+                pi.sendMessage({
+                  customType: "task-focus-enforcement",
+                  content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
+                  display: true,
+                }, { triggerTurn: true, deliverAs: "followUp" });
+                taskFocusJustFired = true;
+                break;
+              }
+            } catch { continue; }
+          }
         }
       }
     } catch (e: any) { console.debug("[rules] task-focus enforcement failed:", e?.message?.slice(0, 100)); }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -74,13 +74,11 @@ export function registerRules(
 ): void {
   const isSubagent = process.env.PI_SUBAGENT_CHILD === "1";
   let rebuildDone = false;
-  let lastTaskFocusReminderAt = 0;
 
 
   // Run full rebuild on session start (once per session, not every turn)
   pi.on("session_start", async (_event, ctx) => {
     rebuildDone = false;
-    lastTaskFocusReminderAt = 0;
     try {
       rebuildAndOrganize(ctx.cwd);
       rebuildDone = true;
@@ -282,20 +280,28 @@ export function registerRules(
     // Task-focus enforcement: if this turn had no tool calls but tasks are active,
     // the LLM likely answered a side question and forgot to resume work.
     // Inject a follow-up to force it back on track.
-    // After firing, cooldown for 2 minutes to prevent rapid re-firing.
-    // Cooldown resets immediately when the LLM does actual work (tool calls).
-    // After cooldown expires, re-fire if tasks are still active — prevents
-    // permanent suppression when the LLM ignores reminders.
+    // Only fire after user messages — not after follow-ups (reminders, async
+    // results, coms inbound). This prevents infinite reminder loops naturally:
+    // the reminder triggers a follow-up turn, which is not user-triggered.
     try {
       const turnToolResults = (_event as any).toolResults;
       const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
-      // Reset cooldown when LLM does actual work
-      if (hadToolCalls) {
-        lastTaskFocusReminderAt = 0;
-      }
-      const cooldownMs = 120_000; // 2 minutes
-      const coolingDown = lastTaskFocusReminderAt > 0 && (Date.now() - lastTaskFocusReminderAt) < cooldownMs;
-      if (!hadToolCalls && !coolingDown) {
+      // Check if this turn was triggered by a user message
+      let userTriggered = false;
+      try {
+        const branch = ctx.sessionManager.getBranch();
+        for (let i = branch.length - 1; i >= 0; i--) {
+          const entry = branch[i];
+          // Skip assistant messages (current turn's response)
+          if (entry.type === "message" && (entry as any).message?.role === "assistant") continue;
+          // Found the triggering entry
+          if (entry.type === "message" && (entry as any).message?.role === "user") {
+            userTriggered = true;
+          }
+          break;
+        }
+      } catch { /* best-effort */ }
+      if (!hadToolCalls && userTriggered) {
         // Check for active tasks — session-scoped task file only
         const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
         const sessionId = ctx.sessionManager?.getSessionId?.();
@@ -318,7 +324,6 @@ export function registerRules(
                 content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
                 display: true,
               }, { triggerTurn: true, deliverAs: "followUp" });
-              lastTaskFocusReminderAt = Date.now();
               break;
             }
           } catch { continue; }


### PR DESCRIPTION
## Summary

Fixes coms connections being permanently lost after laptop lid close/open (suspend/resume).

## Root Cause

`pruneDeadEntries()` in `coms-p2p.ts` checked timestamp staleness in Phase 1 (sync pre-filter) and pruned entries **AND deleted socket files** before Phase 2 (socket probes) could verify if peers were alive. After suspend/resume, all peers have stale timestamps → all get pruned → socket files deleted → peers permanently unreachable.

Same issue in `coms-net-server.ts` where `staleScanTick()` removed all agents after resume.

## Changes

### `extensions/coms/coms-p2p.ts`
- Removed timestamp-based pruning from Phase 1 — only prune structurally invalid entries (no endpoint, missing socket file, malformed timestamp)
- Timestamp-stale entries now flow to Phase 2 for socket probing
- If socket probe succeeds, peer is kept alive regardless of timestamp age

### `extensions/coms/coms-net-server.ts`
- Added time-jump detection to `staleScanTick()` — if gap between scans > 30s, assume suspend/resume
- On time-jump: reset all agent `last_seen_at` timestamps and restore stale agents to online
- Agents get a full grace period to heartbeat back in
- Initialize `lastStaleScanAt` in `startLoops()` to avoid false trigger on startup

### `extensions/orchestrator/rules.ts`
- Skip task-focus enforcement reminder when async agents are in-flight
- The LLM is correctly idle waiting for async results — no reminder needed

Closes #537