### PR TITLE
fix(deps): override undici >=6.27.0 to fix npm audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ws": "^8.0.0"
   },
   "overrides": {
-    "undici": ">=6.27.0"
+    "undici": ">=6.27.0 <9.0.0"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "discord.js": "^14.0.0",
     "ws": "^8.0.0"
   },
+  "overrides": {
+    "undici": ">=6.27.0"
+  },
   "pi": {
     "extensions": [
       "./extensions"


### PR DESCRIPTION
## Summary

discord.js 14.26.4 pins `undici@6.24.1` which has 4 known vulnerabilities (3 moderate, 1 high):

- GHSA-p88m-4jfj-68fv — HTTP header injection via Set-Cookie percent-decoding
- GHSA-vxpw-j846-p89q — WebSocket client DoS via fragment count bypass
- GHSA-35p6-xmwp-9g52 — HTTP response queue poisoning via keep-alive socket reuse
- GHSA-g8m3-5g58-fq7m — Set-Cookie SameSite attribute downgrade

## Fix

Add npm `overrides` in package.json to force `undici >= 6.27.0` across all transitive dependencies. Resolves to undici 8.5.0, 0 vulnerabilities.

```json
"overrides": {
  "undici": ">=6.27.0"
}
```