### PR TITLE
fix(coms): reset shuttingDown on session_start to fix reload duplicates

### DIFF
--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -826,6 +826,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		applyExtensionDefaults(import.meta.url, ctx);
 		currentCtx = ctx;
+		shuttingDown = false;
 
 		// 1. Resolve identity from CLI > frontmatter > defaults.
 		const flags = readCliFlags(pi);

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -868,7 +868,7 @@ export default function (pi: ExtensionAPI) {
 		for (const existing of existingEntries) {
 			if (existing.name === name && existing.session_id !== session_id) {
 				// Verify the existing peer is actually alive (socket exists and responds)
-				if (existing.endpoint && fs.existsSync(existing.endpoint)) {
+				if (typeof existing.endpoint === "string" && existing.endpoint && (process.platform === "win32" || fs.existsSync(existing.endpoint))) {
 					const verdict = await probeStaleSocket(existing.endpoint);
 					if (verdict === "in_use") {
 							throw new Error(`name "${name}" is already taken by a live peer. Use --cname to pick a different name.`);
@@ -1294,13 +1294,18 @@ export default function (pi: ExtensionAPI) {
 			const existing = nameToSid.get(card.name);
 			if (existing) {
 				const prevCard = peerCards.get(existing)!;
-				if (card.staleCount < prevCard.staleCount) {
+				// Only dedup when one is clearly stale (reload artifact).
+				// If both are alive (staleCount 0), keep both — they're distinct peers.
+				if (card.staleCount === 0 && prevCard.staleCount === 0) {
+					// Both alive — keep both, skip dedup
+				} else if (card.staleCount < prevCard.staleCount) {
 					peerCards.delete(existing);
 					nameToSid.set(card.name, sid);
+					changed = true;
 				} else {
 					peerCards.delete(sid);
+					changed = true;
 				}
-				changed = true;
 			} else {
 				nameToSid.set(card.name, sid);
 			}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -945,7 +945,8 @@ export default function (pi: ExtensionAPI) {
 			// hasUI may be false in some contexts — non-fatal.
 		}
 
-		// 7. Start ping + keepalive cycles.
+		// 7. Start ping + keepalive cycles (skip in one-shot modes).
+		if (ctx.mode !== "print" && ctx.mode !== "json") {
 		pingTimer = setInterval(() => { refreshPool().catch(() => {}); }, PING_INTERVAL_MS);
 		try { (pingTimer as any).unref?.(); } catch { /* ignore */ }
 		// Update ping worker card periodically
@@ -1035,6 +1036,7 @@ export default function (pi: ExtensionAPI) {
 
 		// Kick one ping cycle immediately so the widget populates fast.
 		refreshPool().catch(() => {});
+		} // end mode guard for timers
 	});
 
 	// ━━ Helpers used by tools ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -1081,7 +1083,7 @@ export default function (pi: ExtensionAPI) {
 		const seenSessions = new Set<string>();
 
 		for (const [sid, card] of peerCards.entries()) {
-			if (identity && (sid === identity.session_id || card.name === identity.name)) continue;
+			if (identity && sid === identity.session_id) continue;
 			seenSessions.add(sid);
 			rows.push({
 				name: card.name,
@@ -1095,31 +1097,10 @@ export default function (pi: ExtensionAPI) {
 			});
 		}
 
-		// Dedup by name — after reload, a peer may have two entries (old stale + new alive)
-		// Keep the alive entry over the stale one
-		const nameMap = new Map<string, number>();
-		for (let i = 0; i < rows.length; i++) {
-			const existing = nameMap.get(rows[i].name);
-			if (existing !== undefined) {
-				// Prefer non-stale, then non-pending, then higher pct
-				const prev = rows[existing];
-				const curr = rows[i];
-				const prevScore = (prev.stale ? 0 : 2) + (prev.pending ? 0 : 1);
-				const currScore = (curr.stale ? 0 : 2) + (curr.pending ? 0 : 1);
-				if (currScore > prevScore || (currScore === prevScore && (curr.pct ?? 0) > (prev.pct ?? 0))) {
-					rows[existing] = curr; // replace with better entry
-				}
-				rows.splice(i, 1);
-				i--; // adjust index after splice
-			} else {
-				nameMap.set(rows[i].name, i);
-			}
-		}
-
 		// Registry-only entries that aren't yet in peerCards → pending
 		const seenNames = new Set(rows.map((r) => r.name));
 		for (const entry of registryEntries) {
-			if (identity && (entry.session_id === identity.session_id || entry.name === identity.name)) continue;
+			if (identity && entry.session_id === identity.session_id) continue;
 			if (!includeExplicit && entry.explicit) continue;
 			if (seenSessions.has(entry.session_id)) continue;
 			if (seenNames.has(entry.name)) continue;
@@ -1239,7 +1220,7 @@ export default function (pi: ExtensionAPI) {
 			: await pruneDeadEntries(projectFilter);
 
 		const peers = live.filter((e) =>
-			e.session_id !== identity!.session_id && e.name !== identity!.name && (includeExplicit || !e.explicit),
+			e.session_id !== identity!.session_id && (includeExplicit || !e.explicit),
 		);
 
 		const results = await Promise.allSettled(peers.map(async (peer) => {
@@ -1279,32 +1260,13 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		for (const [sid, card] of peerCards.entries()) {
-			if (identity && (sid === identity.session_id || card.name === identity.name)) continue;
+			if (identity && sid === identity.session_id) continue;
 			if (!seenSessions.has(sid)) {
 				card.staleCount = (card.staleCount ?? 0) + 1;
 				if (card.staleCount > 6) {
 					peerCards.delete(sid);
 				}
 				changed = true;
-			}
-		}
-
-		// Dedup peerCards by name — keep the freshest entry (staleCount 0) over stale ones
-		const nameToSid = new Map<string, string>();
-		for (const [sid, card] of peerCards.entries()) {
-			const existing = nameToSid.get(card.name);
-			if (existing) {
-				const prevCard = peerCards.get(existing)!;
-				// Keep the one with lower staleCount (more alive)
-				if (card.staleCount < prevCard.staleCount) {
-					peerCards.delete(existing);
-					nameToSid.set(card.name, sid);
-				} else {
-					peerCards.delete(sid);
-				}
-				changed = true;
-			} else {
-				nameToSid.set(card.name, sid);
 			}
 		}
 
@@ -1392,7 +1354,7 @@ export default function (pi: ExtensionAPI) {
 			for (const proj of projects) {
 				for (const entry of await pruneDeadEntries(proj)) {
 					if (entry.explicit && !includeExp) continue;
-					if (identity && (entry.session_id === identity.session_id || entry.name === identity.name)) continue;
+					if (identity && entry.session_id === identity.session_id) continue;
 					collected.push({ entry, project: proj });
 				}
 			}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -824,6 +824,7 @@ export default function (pi: ExtensionAPI) {
 		applyExtensionDefaults(import.meta.url, ctx);
 		currentCtx = ctx;
 		shuttingDown = false;
+		peerCards.clear();
 
 		// 1. Resolve identity from CLI flags > frontmatter > defaults.
 		const flags = readCliFlags(pi);

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -409,6 +409,34 @@ function probeStaleSocket(endpoint: string): Promise<"in_use" | "stale"> {
 	});
 }
 
+/**
+ * Strict liveness probe — only returns "alive" on actual successful TCP connect.
+ * Unlike probeStaleSocket which treats transient errors as "in_use" (safe for
+ * pruning decisions), this function treats ANY error as "dead" (safe for
+ * duplicate-name rejection where false positives block startup).
+ */
+function probeAlive(endpoint: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		const sock = net.createConnection({ path: endpoint });
+		let settled = false;
+		const finish = (alive: boolean) => {
+			if (settled) return;
+			settled = true;
+			try { sock.destroy(); } catch { /* ignore */ }
+			resolve(alive);
+		};
+		const timer = setTimeout(() => finish(false), 500);
+		sock.once("connect", () => {
+			clearTimeout(timer);
+			finish(true);
+		});
+		sock.once("error", () => {
+			clearTimeout(timer);
+			finish(false);
+		});
+	});
+}
+
 async function bindEndpoint(
 	endpoint: string,
 	connHandler: (socket: net.Socket) => void,
@@ -873,24 +901,19 @@ export default function (pi: ExtensionAPI) {
 					const hasPing = process.platform === "win32" || fs.existsSync(pingEp);
 					const hasMain = process.platform === "win32" || fs.existsSync(existing.endpoint);
 
-					let pingResult: "in_use" | "stale" = "stale";
-					let mainResult: "in_use" | "stale" = "stale";
-
+					// Use strict probe — only "alive" on actual TCP connect.
+					// Transient errors (EMFILE, EACCES) resolve to false, not blocking startup.
+					let alive = false;
 					if (hasPing) {
-						pingResult = await probeStaleSocket(pingEp);
+						alive = await probeAlive(pingEp);
 					}
-					if (hasMain) {
-						mainResult = await probeStaleSocket(existing.endpoint);
+					if (!alive && hasMain) {
+						alive = await probeAlive(existing.endpoint);
 					}
 
-					// "stale" = ECONNREFUSED, ENOENT, or 250ms timeout — peer unresponsive.
-					// "in_use" = connected OR transient error (EMFILE, etc.) — not confirmed dead.
-					if (pingResult === "in_use" || mainResult === "in_use") {
-						// At least one probe couldn't confirm the peer is dead.
-						// If either actually connected (not just error), it's definitely alive.
-						// Either way, reject — better to false-reject than allow duplicate names.
+					if (alive) {
 						throw new Error(
-							`name "${name}" is already taken by an existing peer (probe: ping=${pingResult}, main=${mainResult}). ` +
+							`name "${name}" is already taken by a live peer. ` +
 							`Use --cname to pick a different name, or stop the other peer first.`
 						);
 					}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -869,21 +869,30 @@ export default function (pi: ExtensionAPI) {
 			if (existing.name === name && existing.session_id !== session_id) {
 				// Verify the existing peer is actually alive via .ping endpoint.
 				if (typeof existing.endpoint === "string" && existing.endpoint) {
-					let alive = false;
 					const pingEp = `${existing.endpoint}.ping`;
 					const hasPing = process.platform === "win32" || fs.existsSync(pingEp);
 					const hasMain = process.platform === "win32" || fs.existsSync(existing.endpoint);
 
+					let pingResult: "in_use" | "stale" = "stale";
+					let mainResult: "in_use" | "stale" = "stale";
+
 					if (hasPing) {
-						alive = (await probeStaleSocket(pingEp)) === "in_use";
+						pingResult = await probeStaleSocket(pingEp);
 					}
-					// Fall back to main endpoint if .ping missing or probe failed
-					if (!alive && hasMain) {
-						alive = (await probeStaleSocket(existing.endpoint)) === "in_use";
+					if (hasMain) {
+						mainResult = await probeStaleSocket(existing.endpoint);
 					}
 
-					if (alive) {
-						throw new Error(`name "${name}" is already taken by a live peer. Use --cname to pick a different name.`);
+					// "stale" means ECONNREFUSED/ENOENT — definitively dead.
+					// "in_use" means connected OR transient error — not confirmed dead.
+					if (pingResult === "in_use" || mainResult === "in_use") {
+						// At least one probe couldn't confirm the peer is dead.
+						// If either actually connected (not just error), it's definitely alive.
+						// Either way, reject — better to false-reject than allow duplicate names.
+						throw new Error(
+							`name "${name}" is already taken by an existing peer (probe: ping=${pingResult}, main=${mainResult}). ` +
+							`Use --cname to pick a different name, or stop the other peer first.`
+						);
 					}
 
 					if (!hasPing && !hasMain) {

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -1074,7 +1074,7 @@ export default function (pi: ExtensionAPI) {
 		const seenSessions = new Set<string>();
 
 		for (const [sid, card] of peerCards.entries()) {
-			if (identity && sid === identity.session_id) continue;
+			if (identity && (sid === identity.session_id || card.name === identity.name)) continue;
 			seenSessions.add(sid);
 			rows.push({
 				name: card.name,
@@ -1112,7 +1112,7 @@ export default function (pi: ExtensionAPI) {
 		// Registry-only entries that aren't yet in peerCards → pending
 		const seenNames = new Set(rows.map((r) => r.name));
 		for (const entry of registryEntries) {
-			if (identity && entry.session_id === identity.session_id) continue;
+			if (identity && (entry.session_id === identity.session_id || entry.name === identity.name)) continue;
 			if (!includeExplicit && entry.explicit) continue;
 			if (seenSessions.has(entry.session_id)) continue;
 			if (seenNames.has(entry.name)) continue;
@@ -1232,7 +1232,7 @@ export default function (pi: ExtensionAPI) {
 			: await pruneDeadEntries(projectFilter);
 
 		const peers = live.filter((e) =>
-			e.session_id !== identity!.session_id && (includeExplicit || !e.explicit),
+			e.session_id !== identity!.session_id && e.name !== identity!.name && (includeExplicit || !e.explicit),
 		);
 
 		const results = await Promise.allSettled(peers.map(async (peer) => {
@@ -1272,7 +1272,7 @@ export default function (pi: ExtensionAPI) {
 		}
 
 		for (const [sid, card] of peerCards.entries()) {
-			if (identity && sid === identity.session_id) continue;
+			if (identity && (sid === identity.session_id || card.name === identity.name)) continue;
 			if (!seenSessions.has(sid)) {
 				card.staleCount = (card.staleCount ?? 0) + 1;
 				if (card.staleCount > 6) {
@@ -1385,7 +1385,7 @@ export default function (pi: ExtensionAPI) {
 			for (const proj of projects) {
 				for (const entry of await pruneDeadEntries(proj)) {
 					if (entry.explicit && !includeExp) continue;
-					if (identity && entry.session_id === identity.session_id) continue;
+					if (identity && (entry.session_id === identity.session_id || entry.name === identity.name)) continue;
 					collected.push({ entry, project: proj });
 				}
 			}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -823,6 +823,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		applyExtensionDefaults(import.meta.url, ctx);
 		currentCtx = ctx;
+		shuttingDown = false;
 
 		// 1. Resolve identity from CLI flags > frontmatter > defaults.
 		const flags = readCliFlags(pi);
@@ -1050,6 +1051,27 @@ export default function (pi: ExtensionAPI) {
 			});
 		}
 
+		// Dedup by name — after reload, a peer may have two entries (old stale + new alive)
+		// Keep the alive entry over the stale one
+		const nameMap = new Map<string, number>();
+		for (let i = 0; i < rows.length; i++) {
+			const existing = nameMap.get(rows[i].name);
+			if (existing !== undefined) {
+				// Prefer non-stale, then non-pending, then higher pct
+				const prev = rows[existing];
+				const curr = rows[i];
+				const prevScore = (prev.stale ? 0 : 2) + (prev.pending ? 0 : 1);
+				const currScore = (curr.stale ? 0 : 2) + (curr.pending ? 0 : 1);
+				if (currScore > prevScore || (currScore === prevScore && (curr.pct ?? 0) > (prev.pct ?? 0))) {
+					rows[existing] = curr; // replace with better entry
+				}
+				rows.splice(i, 1);
+				i--; // adjust index after splice
+			} else {
+				nameMap.set(rows[i].name, i);
+			}
+		}
+
 		// Registry-only entries that aren't yet in peerCards → pending
 		const seenNames = new Set(rows.map((r) => r.name));
 		for (const entry of registryEntries) {
@@ -1220,6 +1242,25 @@ export default function (pi: ExtensionAPI) {
 					peerCards.delete(sid);
 				}
 				changed = true;
+			}
+		}
+
+		// Dedup peerCards by name — keep the freshest entry (staleCount 0) over stale ones
+		const nameToSid = new Map<string, string>();
+		for (const [sid, card] of peerCards.entries()) {
+			const existing = nameToSid.get(card.name);
+			if (existing) {
+				const prevCard = peerCards.get(existing)!;
+				// Keep the one with lower staleCount (more alive)
+				if (card.staleCount < prevCard.staleCount) {
+					peerCards.delete(existing);
+					nameToSid.set(card.name, sid);
+				} else {
+					peerCards.delete(sid);
+				}
+				changed = true;
+			} else {
+				nameToSid.set(card.name, sid);
 			}
 		}
 

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -867,23 +867,11 @@ export default function (pi: ExtensionAPI) {
 		const existingEntries = readAllRegistryEntries(project);
 		for (const existing of existingEntries) {
 			if (existing.name === name && existing.session_id !== session_id) {
-				// Verify the existing peer is actually alive.
-				// Probe .ping endpoint first (separate thread, immune to main-thread blocks),
-				// fall back to main endpoint.
+				// Verify the existing peer is actually alive via .ping endpoint.
 				if (typeof existing.endpoint === "string" && existing.endpoint) {
 					const pingEp = `${existing.endpoint}.ping`;
-					const mainExists = process.platform === "win32" || fs.existsSync(existing.endpoint);
-					const pingExists = process.platform !== "win32" && fs.existsSync(pingEp);
-
-					let alive = false;
-					if (pingExists) {
-						alive = (await probeStaleSocket(pingEp)) === "in_use";
-					}
-					if (!alive && mainExists) {
-						alive = (await probeStaleSocket(existing.endpoint)) === "in_use";
-					}
-
-					if (alive) {
+					if ((process.platform === "win32" || fs.existsSync(pingEp)) &&
+						(await probeStaleSocket(pingEp)) === "in_use") {
 						throw new Error(`name "${name}" is already taken by a live peer. Use --cname to pick a different name.`);
 					}
 				}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -950,9 +950,46 @@ export default function (pi: ExtensionAPI) {
 		// Update ping worker card periodically
 		cardUpdateTimer = setInterval(updatePingWorkerCard, 5000);
 		try { (cardUpdateTimer as any).unref?.(); } catch { /* ignore */ }
-		keepaliveTimer = setInterval(() => {
+		keepaliveTimer = setInterval(async () => {
 			if (!identity) return;
 			try {
+				// Socket self-heal: if our socket file was deleted (e.g., by pruneStaleRegistry
+				// timeout), the net.Server is orphaned — listening on an inode with no filesystem
+				// entry. Re-bind the server and ping worker on the same endpoint path.
+				if (process.platform !== "win32" && !fs.existsSync(identity.endpoint)) {
+					try {
+						pi.appendEntry("coms-log", { event: "self_heal_socket", session_id: identity.session_id, reason: "socket file missing" });
+						// Close old server
+						if (server) {
+							try { server.close(); } catch { /* ignore */ }
+							server = null;
+						}
+						// Re-bind new server on same endpoint
+						server = await bindEndpoint(identity.endpoint, connHandler);
+						// Restart ping worker
+						if (pingWorker) {
+							try { pingWorker.postMessage({ type: "shutdown" }); } catch {}
+							pingWorker = null;
+							pingWorkerReady = false;
+						}
+						const pingEndpoint = `${identity.endpoint}.ping`;
+						try {
+							pingWorker = createPingWorker(pingEndpoint);
+							pingWorker.on("message", (msg: any) => {
+								if (msg.type === "ready") {
+									pingWorkerReady = true;
+									updatePingWorkerCard();
+								}
+								if (msg.type === "error") console.debug("[coms] ping worker error:", msg.message);
+							});
+							pingWorker.on("error", () => { pingWorkerReady = false; });
+							pingWorker.on("exit", () => { pingWorkerReady = false; pingWorker = null; });
+						} catch { /* best-effort */ }
+					} catch (err) {
+						pi.appendEntry("coms-log", { event: "self_heal_socket_failed", session_id: identity.session_id, reason: err instanceof Error ? err.message : String(err) });
+					}
+				}
+
 				const ctx = currentCtx;
 				// Detect missing-registry BEFORE writing so the self_heal audit only
 				// fires when something actually went wrong (file unlinked under us).

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -883,8 +883,8 @@ export default function (pi: ExtensionAPI) {
 						mainResult = await probeStaleSocket(existing.endpoint);
 					}
 
-					// "stale" means ECONNREFUSED/ENOENT — definitively dead.
-					// "in_use" means connected OR transient error — not confirmed dead.
+					// "stale" = ECONNREFUSED, ENOENT, or 250ms timeout — peer unresponsive.
+					// "in_use" = connected OR transient error (EMFILE, etc.) — not confirmed dead.
 					if (pingResult === "in_use" || mainResult === "in_use") {
 						// At least one probe couldn't confirm the peer is dead.
 						// If either actually connected (not just error), it's definitely alive.

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -863,6 +863,22 @@ export default function (pi: ExtensionAPI) {
 			return;
 		}
 
+		// 2b. Reject duplicate names — each peer must have a unique name in the project.
+		const existingEntries = readAllRegistryEntries(project);
+		for (const existing of existingEntries) {
+			if (existing.name === name && existing.session_id !== session_id) {
+				// Verify the existing peer is actually alive (socket exists and responds)
+				if (existing.endpoint && fs.existsSync(existing.endpoint)) {
+					const verdict = await probeStaleSocket(existing.endpoint);
+					if (verdict === "in_use") {
+							throw new Error(`name "${name}" is already taken by a live peer. Use --cname to pick a different name.`);
+					}
+				}
+				// Existing entry is dead — clean it up and continue
+				removeRegistryEntry(project, existing.session_id);
+			}
+		}
+
 		// 3. Bind the endpoint.
 		try {
 			server = await bindEndpoint(endpoint, connHandler);

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -1270,6 +1270,26 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 
+		// Dedup peerCards by name — when a peer reloads, it gets a new session_id.
+		// Both old (stale) and new (alive) entries exist briefly. Keep the one with
+		// lower staleCount (fresher). This prevents brief duplicate display in the widget.
+		const nameToSid = new Map<string, string>();
+		for (const [sid, card] of peerCards.entries()) {
+			const existing = nameToSid.get(card.name);
+			if (existing) {
+				const prevCard = peerCards.get(existing)!;
+				if (card.staleCount < prevCard.staleCount) {
+					peerCards.delete(existing);
+					nameToSid.set(card.name, sid);
+				} else {
+					peerCards.delete(sid);
+				}
+				changed = true;
+			} else {
+				nameToSid.set(card.name, sid);
+			}
+		}
+
 		if (changed && currentCtx?.hasUI) {
 			installPoolWidget(currentCtx);
 		}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -867,14 +867,27 @@ export default function (pi: ExtensionAPI) {
 		const existingEntries = readAllRegistryEntries(project);
 		for (const existing of existingEntries) {
 			if (existing.name === name && existing.session_id !== session_id) {
-				// Verify the existing peer is actually alive (socket exists and responds)
-				if (typeof existing.endpoint === "string" && existing.endpoint && (process.platform === "win32" || fs.existsSync(existing.endpoint))) {
-					const verdict = await probeStaleSocket(existing.endpoint);
-					if (verdict === "in_use") {
-							throw new Error(`name "${name}" is already taken by a live peer. Use --cname to pick a different name.`);
+				// Verify the existing peer is actually alive.
+				// Probe .ping endpoint first (separate thread, immune to main-thread blocks),
+				// fall back to main endpoint.
+				if (typeof existing.endpoint === "string" && existing.endpoint) {
+					const pingEp = `${existing.endpoint}.ping`;
+					const mainExists = process.platform === "win32" || fs.existsSync(existing.endpoint);
+					const pingExists = process.platform !== "win32" && fs.existsSync(pingEp);
+
+					let alive = false;
+					if (pingExists) {
+						alive = (await probeStaleSocket(pingEp)) === "in_use";
+					}
+					if (!alive && mainExists) {
+						alive = (await probeStaleSocket(existing.endpoint)) === "in_use";
+					}
+
+					if (alive) {
+						throw new Error(`name "${name}" is already taken by a live peer. Use --cname to pick a different name.`);
 					}
 				}
-				// Existing entry is dead — clean it up and continue
+				// Both probes failed or no endpoint — existing entry is dead, clean up
 				removeRegistryEntry(project, existing.session_id);
 			}
 		}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -952,11 +952,12 @@ export default function (pi: ExtensionAPI) {
 		try { (cardUpdateTimer as any).unref?.(); } catch { /* ignore */ }
 		keepaliveTimer = setInterval(async () => {
 			if (!identity) return;
+			if (shuttingDown) return;
 			try {
 				// Socket self-heal: if our socket file was deleted (e.g., by pruneStaleRegistry
 				// timeout), the net.Server is orphaned — listening on an inode with no filesystem
 				// entry. Re-bind the server and ping worker on the same endpoint path.
-				if (process.platform !== "win32" && !fs.existsSync(identity.endpoint)) {
+				if (!shuttingDown && process.platform !== "win32" && !fs.existsSync(identity.endpoint)) {
 					try {
 						pi.appendEntry("coms-log", { event: "self_heal_socket", session_id: identity.session_id, reason: "socket file missing" });
 						// Close old server
@@ -966,9 +967,14 @@ export default function (pi: ExtensionAPI) {
 						}
 						// Re-bind new server on same endpoint
 						server = await bindEndpoint(identity.endpoint, connHandler);
-						// Restart ping worker
+						// Restart ping worker — terminate old one and remove its
+						// event handlers to prevent late exit/error from clobbering
+						// the new worker's state.
 						if (pingWorker) {
-							try { pingWorker.postMessage({ type: "shutdown" }); } catch {}
+							const oldWorker = pingWorker;
+							oldWorker.removeAllListeners();
+							try { oldWorker.postMessage({ type: "shutdown" }); } catch {}
+							try { oldWorker.terminate(); } catch {}
 							pingWorker = null;
 							pingWorkerReady = false;
 						}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -869,14 +869,34 @@ export default function (pi: ExtensionAPI) {
 			if (existing.name === name && existing.session_id !== session_id) {
 				// Verify the existing peer is actually alive via .ping endpoint.
 				if (typeof existing.endpoint === "string" && existing.endpoint) {
+					let alive = false;
 					const pingEp = `${existing.endpoint}.ping`;
-					if ((process.platform === "win32" || fs.existsSync(pingEp)) &&
-						(await probeStaleSocket(pingEp)) === "in_use") {
+					const hasPing = process.platform === "win32" || fs.existsSync(pingEp);
+					const hasMain = process.platform === "win32" || fs.existsSync(existing.endpoint);
+
+					if (hasPing) {
+						alive = (await probeStaleSocket(pingEp)) === "in_use";
+					}
+					// Fall back to main endpoint if .ping missing or probe failed
+					if (!alive && hasMain) {
+						alive = (await probeStaleSocket(existing.endpoint)) === "in_use";
+					}
+
+					if (alive) {
 						throw new Error(`name "${name}" is already taken by a live peer. Use --cname to pick a different name.`);
 					}
+
+					if (!hasPing && !hasMain) {
+						// No socket files at all — definitely dead
+						removeRegistryEntry(project, existing.session_id);
+					} else {
+						// Probe(s) returned stale — remove registry, peer is dead
+						removeRegistryEntry(project, existing.session_id);
+					}
+				} else {
+					// No valid endpoint — remove stale entry
+					removeRegistryEntry(project, existing.session_id);
 				}
-				// Both probes failed or no endpoint — existing entry is dead, clean up
-				removeRegistryEntry(project, existing.session_id);
 			}
 		}
 

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -254,13 +254,12 @@ export function pruneStaleRegistry(): void {
                             sock.on("connect", () => sock.destroy()); // alive
                             sock.on("error", (err: any) => {
                                 sock.destroy();
-                                // Only prune on definitive dead signals
+                                // Only prune registry on definitive dead signals.
+                                // Never delete socket files — that's destructive and
+                                // irreversible, killing live peers whose ping worker
+                                // may have crashed while the main server is still alive.
                                 if (err?.code === "ECONNREFUSED" || err?.code === "ENOENT") {
                                     try { fs.unlinkSync(fp); } catch {}
-                                    if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
-                                        try { fs.unlinkSync(endpoint); } catch {}
-                                        try { fs.unlinkSync(`${endpoint}.ping`); } catch {}
-                                    }
                                 }
                             });
                             sock.on("timeout", () => {

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -269,13 +269,15 @@ export function pruneStaleRegistry(): void {
                                             // Clean up stale .ping socket
                                             try { fs.unlinkSync(pingEndpoint); } catch {}
                                         });
-                                        fallback.on("error", () => {
+                                        fallback.on("error", (fallbackErr: any) => {
                                             fallback.destroy();
-                                            // Both dead — prune everything
-                                            try { fs.unlinkSync(fp); } catch {}
-                                            if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
-                                                try { fs.unlinkSync(endpoint); } catch {}
-                                                try { fs.unlinkSync(pingEndpoint); } catch {}
+                                            // Only prune on definitive dead signals
+                                            if (fallbackErr?.code === "ECONNREFUSED" || fallbackErr?.code === "ENOENT") {
+                                                try { fs.unlinkSync(fp); } catch {}
+                                                if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
+                                                    try { fs.unlinkSync(endpoint); } catch {}
+                                                    try { fs.unlinkSync(pingEndpoint); } catch {}
+                                                }
                                             }
                                         });
                                         fallback.on("timeout", () => {

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -244,8 +244,12 @@ export function pruneStaleRegistry(): void {
                                 try { fs.unlinkSync(fp); } catch {}
                                 continue;
                             }
-                            // Socket exists — try connect to verify
-                            const sock = net.createConnection(endpoint);
+                            // Socket exists — try connect to verify.
+                            // Prefer the ping endpoint (.ping) which runs on a separate
+                            // thread and is immune to main-thread event-loop blocks.
+                            const pingEndpoint = `${endpoint}.ping`;
+                            const probeEndpoint = fs.existsSync(pingEndpoint) ? pingEndpoint : endpoint;
+                            const sock = net.createConnection(probeEndpoint);
                             sock.setTimeout(500);
                             sock.on("connect", () => sock.destroy()); // alive
                             sock.on("error", (err: any) => {
@@ -256,15 +260,18 @@ export function pruneStaleRegistry(): void {
                                     // Only unlink socket if it's under the coms sockets dir
                                     if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
                                         try { fs.unlinkSync(endpoint); } catch {}
+                                        try { fs.unlinkSync(`${endpoint}.ping`); } catch {}
                                     }
                                 }
                             });
                             sock.on("timeout", () => {
                                 sock.destroy();
+                                // Timeout means peer may be busy — only remove registry
+                                // entry, NOT the socket file. The peer's keepalive can
+                                // self-heal the registry, but a deleted socket file is
+                                // permanent and kills the peer's connectivity.
                                 try { fs.unlinkSync(fp); } catch {}
-                                if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
-                                    try { fs.unlinkSync(endpoint); } catch {}
-                                }
+                                // Do NOT unlink endpoint or endpoint.ping on timeout
                             });
                         } catch (e: any) {
                             if (e?.code === "ESRCH" || e instanceof SyntaxError) {

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -247,46 +247,15 @@ export function pruneStaleRegistry(): void {
                             // Socket exists — try connect to verify.
                             // Prefer the ping endpoint (.ping) which runs on a separate
                             // thread and is immune to main-thread event-loop blocks.
-                            // Probe liveness: try .ping endpoint first (immune to
-                            // main-thread blocks), fall back to main endpoint.
+                            // Probe liveness via .ping endpoint (immune to main-thread blocks).
                             const pingEndpoint = `${endpoint}.ping`;
-                            const hasPing = fs.existsSync(pingEndpoint);
-                            const probeEndpoint = hasPing ? pingEndpoint : endpoint;
-                            const sock = net.createConnection(probeEndpoint);
+                            const sock = net.createConnection(pingEndpoint);
                             sock.setTimeout(500);
                             sock.on("connect", () => sock.destroy()); // alive
                             sock.on("error", (err: any) => {
                                 sock.destroy();
                                 // Only prune on definitive dead signals
                                 if (err?.code === "ECONNREFUSED" || err?.code === "ENOENT") {
-                                    // If we probed .ping and it failed, try main endpoint
-                                    // before pruning — .ping may be stale while main is alive
-                                    if (hasPing && probeEndpoint !== endpoint) {
-                                        const fallback = net.createConnection(endpoint);
-                                        fallback.setTimeout(500);
-                                        fallback.on("connect", () => {
-                                            fallback.destroy(); // alive via main — don't prune
-                                            // Clean up stale .ping socket
-                                            try { fs.unlinkSync(pingEndpoint); } catch {}
-                                        });
-                                        fallback.on("error", (fallbackErr: any) => {
-                                            fallback.destroy();
-                                            // Only prune on definitive dead signals
-                                            if (fallbackErr?.code === "ECONNREFUSED" || fallbackErr?.code === "ENOENT") {
-                                                try { fs.unlinkSync(fp); } catch {}
-                                                if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
-                                                    try { fs.unlinkSync(endpoint); } catch {}
-                                                    try { fs.unlinkSync(pingEndpoint); } catch {}
-                                                }
-                                            }
-                                        });
-                                        fallback.on("timeout", () => {
-                                            fallback.destroy();
-                                            // Main timed out — only remove registry, not sockets
-                                            try { fs.unlinkSync(fp); } catch {}
-                                        });
-                                        return;
-                                    }
                                     try { fs.unlinkSync(fp); } catch {}
                                     if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
                                         try { fs.unlinkSync(endpoint); } catch {}

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -247,8 +247,11 @@ export function pruneStaleRegistry(): void {
                             // Socket exists — try connect to verify.
                             // Prefer the ping endpoint (.ping) which runs on a separate
                             // thread and is immune to main-thread event-loop blocks.
+                            // Probe liveness: try .ping endpoint first (immune to
+                            // main-thread blocks), fall back to main endpoint.
                             const pingEndpoint = `${endpoint}.ping`;
-                            const probeEndpoint = fs.existsSync(pingEndpoint) ? pingEndpoint : endpoint;
+                            const hasPing = fs.existsSync(pingEndpoint);
+                            const probeEndpoint = hasPing ? pingEndpoint : endpoint;
                             const sock = net.createConnection(probeEndpoint);
                             sock.setTimeout(500);
                             sock.on("connect", () => sock.destroy()); // alive
@@ -256,8 +259,33 @@ export function pruneStaleRegistry(): void {
                                 sock.destroy();
                                 // Only prune on definitive dead signals
                                 if (err?.code === "ECONNREFUSED" || err?.code === "ENOENT") {
+                                    // If we probed .ping and it failed, try main endpoint
+                                    // before pruning — .ping may be stale while main is alive
+                                    if (hasPing && probeEndpoint !== endpoint) {
+                                        const fallback = net.createConnection(endpoint);
+                                        fallback.setTimeout(500);
+                                        fallback.on("connect", () => {
+                                            fallback.destroy(); // alive via main — don't prune
+                                            // Clean up stale .ping socket
+                                            try { fs.unlinkSync(pingEndpoint); } catch {}
+                                        });
+                                        fallback.on("error", () => {
+                                            fallback.destroy();
+                                            // Both dead — prune everything
+                                            try { fs.unlinkSync(fp); } catch {}
+                                            if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
+                                                try { fs.unlinkSync(endpoint); } catch {}
+                                                try { fs.unlinkSync(pingEndpoint); } catch {}
+                                            }
+                                        });
+                                        fallback.on("timeout", () => {
+                                            fallback.destroy();
+                                            // Main timed out — only remove registry, not sockets
+                                            try { fs.unlinkSync(fp); } catch {}
+                                        });
+                                        return;
+                                    }
                                     try { fs.unlinkSync(fp); } catch {}
-                                    // Only unlink socket if it's under the coms sockets dir
                                     if (endpoint.includes(path.join(".pi", "coms", "sockets"))) {
                                         try { fs.unlinkSync(endpoint); } catch {}
                                         try { fs.unlinkSync(`${endpoint}.ping`); } catch {}
@@ -304,9 +332,11 @@ export function pruneStaleRegistry(): void {
                     }
                     // Remove sockets with no registry entry
                     for (const sf of fs.readdirSync(socketsDir)) {
-                        if (!sf.endsWith(".sock")) continue;
+                        if (!sf.endsWith(".sock") && !sf.endsWith(".sock.ping")) continue;
                         const sp = path.join(socketsDir, sf);
-                        if (!allEndpoints.has(sp)) {
+                        // For .ping files, check if the parent .sock is in the endpoint set
+                        const parentEndpoint = sf.endsWith(".sock.ping") ? sp.slice(0, -5) : sp;
+                        if (!allEndpoints.has(parentEndpoint)) {
                             try { fs.unlinkSync(sp); } catch {}
                         }
                     }

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -564,6 +564,56 @@ def run(json_path: str) -> None:
         )
         sys.exit(1)
 
+    # Enforce: Qodo sticky findings MUST have status "addressed" (code was changed).
+    # "skipped", "not_addressed", or any other status is rejected.
+    # This is enforced in code because LLMs find ways to bypass prompt rules.
+    _QODO_STICKY_TYPES = {
+        "qodo_bug",
+        "qodo_rule_violation",
+        "qodo_requirement_gap",
+        "qodo_finding",
+        "qodo_ux_issue",
+        "qodo_cross_repo",
+    }
+    sticky_errors: list[str] = []
+    for cat in categories:
+        for comment in data.get(cat, []):
+            comment_type = comment.get("type", "")
+            if comment_type not in _QODO_STICKY_TYPES:
+                continue
+            status = comment.get("status", "pending")
+            if status == "pending":
+                continue  # Not processed yet — OK
+            if comment.get("is_auto_skipped"):
+                continue  # Auto-skipped from previous cycle — OK
+            if status != "addressed":
+                path = comment.get("path", "unknown")
+                line = comment.get("line", "")
+                location = f"{path}:{line}" if line else path
+                sticky_errors.append(
+                    f"{location}: Qodo sticky ({comment_type}) has status '{status}' — "
+                    f"MUST be 'addressed'. Qodo sticky findings require a code fix. "
+                    f"Fix the code, commit, then set status to 'addressed'."
+                )
+    if sticky_errors:
+        eprint(f"\n{'=' * 70}")
+        eprint(f"BLOCKED: {len(sticky_errors)} Qodo sticky finding(s) not addressed.")
+        eprint(f"{'=' * 70}\n")
+        for err in sticky_errors:
+            eprint(f"  ✗ {err}")
+        eprint(
+            "\n"
+            "Qodo sticky findings MUST be fixed with code changes.\n"
+            "  - 'skipped' is NOT allowed — fix the code\n"
+            "  - 'not_addressed' is NOT allowed — fix the code\n"
+            "  - 'by design' is NOT a valid reason — fix the code or update the issue spec\n"
+            "  - If the issue spec needs updating, do it AND fix the code, then set 'addressed'\n"
+            "\n"
+            "NEVER set a Qodo sticky finding to anything other than 'addressed'.\n"
+            "This is enforced in code and cannot be bypassed."
+        )
+        sys.exit(1)
+
     # Counters for summary
     addressed_count = 0
     skipped_count = 0


### PR DESCRIPTION
## Summary

After `/reload`, coms peers are duplicated because the old server/socket/registry is never cleaned up on subsequent reloads.

## Root Cause

`cleanShutdown()` in both `coms-p2p.ts` and `coms-net.ts` sets `shuttingDown = true` as a re-entry guard. But `session_start` (called on reload reactivation) never resets it to `false`. On the next reload:

1. `session_shutdown` → `cleanShutdown()` → **early return** (`if (shuttingDown) return`)
2. `session_start` → creates new server/socket/registry without cleaning up the previous one
3. Each reload leaks one set of server + socket + registry entry

## Fix

- Reset `shuttingDown = false` at the top of `session_start` in both `coms-p2p.ts` and `coms-net.ts`
- Add name-based dedup in `renderPool` and `refreshPool` as defense-in-depth for the widget