### PR TITLE
fix: replace tool-based commit trailer selection with ctx.ui.select()

### DIFF
--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -35,8 +35,8 @@ function normalizeForRepeatCheck(command: string): string {
 // Repeat detection file — set to project dir on first use
 let REPEAT_FILE = "";
 
-/** Cached trailer identity selection for comma-separated commit_trailer values */
-let cachedTrailerIdentity: string | null = null;
+/** Cached trailer selection for comma-separated commit_trailer values (reset on session_start) */
+let cachedTrailerSelection: string | null = null;
 
 /** Escape a string for safe inclusion in double-quoted shell strings */
 function escapeForDoubleQuote(s: string): string {
@@ -91,46 +91,8 @@ function resolveEffectiveCwd(command: string, sessionCwd: string): string {
 
 export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): void {
 
-  // Track whether select_commit_trailer tool has been registered
-  let trailerToolRegistered = false;
-
-  /** Lazily register select_commit_trailer tool on first need */
-  function ensureTrailerTool(): void {
-    if (trailerToolRegistered) return;
-    trailerToolRegistered = true;
-    pi.registerTool({
-      name: "select_commit_trailer",
-      description: "Select which commit trailer name to use for this session. " +
-        "Call this when a git commit is blocked because multiple trailer options are configured. " +
-        "Pass the trailer name WITHOUT the numeric prefix (e.g., 'Assisted-by', not '1) Assisted-by').",
-      parameters: {
-        type: "object" as const,
-        properties: {
-          identity: {
-            type: "string",
-            description: "The selected trailer name (e.g., 'Assisted-by')",
-          },
-        },
-        required: ["identity"],
-      },
-      async execute(_toolCallId: string, params: { identity: string }, _signal: unknown, _onUpdate: unknown, ctx: any) {
-        const options = getTrailerOptions(ctx.cwd);
-        if (!options) {
-          return { content: [{ type: "text", text: "No trailer options configured." }] };
-        }
-        const identity = params.identity.trim();
-        if (!options.includes(identity)) {
-          return { content: [{ type: "text", text: `Invalid identity. Must be one of: ${options.join(", ")}` }] };
-        }
-        setTrailerIdentity(identity);
-        return { content: [{ type: "text", text: `Commit trailer identity set to: ${identity}. You can now retry the git commit.` }] };
-      },
-    });
-  }
-
-  // Reset trailer identity cache on session start
   pi.on("session_start", () => {
-    cachedTrailerIdentity = null;
+    cachedTrailerSelection = null;
   });
 
   pi.on("tool_call", async (event, ctx) => {
@@ -351,27 +313,30 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             let trailerName: string;
 
             if (trailerSetting.includes(",")) {
-              // Multiple trailer name options — need user selection
-              if (!cachedTrailerIdentity) {
-                ensureTrailerTool();
-                const options = getTrailerOptions(gitCwd) ?? [];
-                const optionsList = options.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
-                return {
-                  block: true,
-                  reason: `\u26d4 Select commit trailer before committing. Options: ${optionsList}. Ask the user which trailer to use, then call select_commit_trailer with their choice.`,
-                };
+              // Multiple trailer name options — ask user directly
+              const options = trailerSetting.split(",").map(s => s.trim()).filter(Boolean);
+              if (options.length === 0) return undefined;  // malformed setting, skip trailer
+              if (options.length === 1) {
+                trailerName = options[0];
+              } else if (cachedTrailerSelection && options.includes(cachedTrailerSelection)) {
+                trailerName = cachedTrailerSelection;
+              } else if (!ctx.hasUI) {
+                // No UI available — default to first option
+                trailerName = options[0];
+              } else {
+                const selected = await ctx.ui.select(
+                  "Select commit trailer:",
+                  options,
+                );
+                if (!selected || !options.includes(selected)) {
+                  return {
+                    block: true,
+                    reason: "Commit trailer selection cancelled by user.",
+                  };
+                }
+                trailerName = selected;
+                cachedTrailerSelection = selected;
               }
-              // Validate cached selection is still in current options
-              const currentOptions = getTrailerOptions(gitCwd) ?? [];
-              if (!currentOptions.includes(cachedTrailerIdentity)) {
-                cachedTrailerIdentity = null;
-                const optionsList = currentOptions.map((o: string, i: number) => `${i + 1}) ${o}`).join(", ");
-                return {
-                  block: true,
-                  reason: `\u26d4 Cached trailer is no longer valid. Options: ${optionsList}. Ask the user which trailer to use, then call select_commit_trailer with their choice.`,
-                };
-              }
-              trailerName = cachedTrailerIdentity;
             } else {
               // Single trailer name
               trailerName = trailerSetting;
@@ -495,20 +460,6 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     return undefined;
   });
-}
-
-/** Set the cached commit trailer identity (called by select_commit_trailer tool) */
-export function setTrailerIdentity(identity: string): void {
-  cachedTrailerIdentity = identity;
-}
-
-/** Get available trailer options from setting (null if not comma-separated) */
-export function getTrailerOptions(cwd: string): string[] | null {
-  const setting = getSetting(cwd, "commit_trailer");
-  if (typeof setting === "string" && setting.includes(",")) {
-    return setting.split(",").map(s => s.trim()).filter(Boolean);
-  }
-  return null;
 }
 
 // trigger re-scan

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -318,7 +318,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
               if (options.length === 0) {
                 return {
                   block: true,
-                  reason: `⛔ Malformed commit_trailer setting: "${trailerSetting}" — no valid trailer names found. Fix the setting in .pi/pi-config-settings.json or PI_COMMIT_TRAILER env var.`,
+                  reason: `⛔ Malformed commit_trailer setting: "${trailerSetting.replace(/[\x00-\x1f\x7f-\x9f]/g, "")}" — no valid trailer names found. Fix the setting in .pi/pi-config-settings.json or PI_COMMIT_TRAILER env var.`,
                 };
               }
               if (options.length === 1) {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -315,7 +315,12 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
             if (trailerSetting.includes(",")) {
               // Multiple trailer name options — ask user directly
               const options = trailerSetting.split(",").map(s => s.trim()).filter(Boolean);
-              if (options.length === 0) return undefined;  // malformed setting, skip trailer
+              if (options.length === 0) {
+                return {
+                  block: true,
+                  reason: `⛔ Malformed commit_trailer setting: "${trailerSetting}" — no valid trailer names found. Fix the setting in .pi/pi-config-settings.json or PI_COMMIT_TRAILER env var.`,
+                };
+              }
               if (options.length === 1) {
                 trailerName = options[0];
               } else if (cachedTrailerSelection && options.includes(cachedTrailerSelection)) {


### PR DESCRIPTION
## Summary

Replaces the `select_commit_trailer` tool + caching flow with a direct `ctx.ui.select()` call in the enforcement hook.

## Problem

When `commit_trailer` is set to comma-separated values (e.g., `"Assisted-by, Co-authored-by"`), commits from subagents (git-expert) silently fail because:
- `select_commit_trailer` tool isn't in git-expert's tool list
- git-expert can't ask the user (no `ask_user` tool)
- Commit gets blocked with no way to resolve

## Fix

- Replace tool-based flow with `ctx.ui.select()` in the enforcement hook (same pattern as dangerous command confirmation)
- Remove `select_commit_trailer` tool, `ensureTrailerTool()`, `setTrailerIdentity()`, `getTrailerOptions()`
- Add session-level cache (`cachedTrailerSelection`) to avoid prompting on every commit
- Guard against empty/malformed options arrays
- Handle single-option comma-separated values without prompting
- `!ctx.hasUI` fallback defaults to first option

Closes #527