### PR TITLE
fix: prevent worker agent from setting bash timeout on poll commands

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -20,3 +20,11 @@ You are a general-purpose development agent. Handle any task that doesn't have a
 - General code writing and refactoring
 - File system operations
 - Research and analysis
+
+## Long-Running Commands
+
+When running commands that poll, sleep, or wait (e.g., `reviews poll`, `watch`, monitoring loops):
+
+- **Do NOT set a bash timeout** unless the task explicitly specifies one
+- These commands can run for 30+ minutes — a short timeout kills them mid-sleep
+- If the task says "do NOT set a timeout", omit the timeout parameter entirely

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -516,6 +516,7 @@ Qodo if autoqodo, both if both flags active).
 - Agent: `worker`
 - Task: `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source coderabbit [same arguments as Phase 1].`
   `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
+  `IMPORTANT: Do NOT set a timeout on the bash call — this command sleeps 300s between cycles and can run for 30+ minutes.`
 - async: true
 - **No timeout** — the poll can take 30+ minutes (rate limit waits). NEVER set a timeout.
 
@@ -524,6 +525,7 @@ Qodo if autoqodo, both if both flags active).
 - Agent: `worker`
 - Task: `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source qodo [same arguments as Phase 1].`
   `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
+  `IMPORTANT: Do NOT set a timeout on the bash call — this command sleeps 300s between cycles and can run for 30+ minutes.`
 - async: true
 - **No timeout** — the poll loops internally until new Qodo comments appear. NEVER set a timeout.
 
@@ -531,8 +533,10 @@ Qodo if autoqodo, both if both flags active).
 
 1. `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source coderabbit [same arguments as Phase 1].`
    `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
+   `IMPORTANT: Do NOT set a timeout on the bash call — this command sleeps 300s between cycles and can run for 30+ minutes.`
 1. `Run: myk-pi-tools reviews poll --output-dir ${PROJECT_TMP_DIR} --source qodo [same arguments as Phase 1].`
    `Return the EXACT raw stdout output — do NOT summarize, interpret, or rephrase it.`
+   `IMPORTANT: Do NOT set a timeout on the bash call — this command sleeps 300s between cycles and can run for 30+ minutes.`
 
 When EITHER returns with new comments, process them (Phases 2-8). Then re-spawn that agent.
 The other agent keeps running independently.


### PR DESCRIPTION
## Summary

Fixes worker agents killing long-running `reviews poll` commands by setting `timeout: 120` on bash calls. The poll sleeps 300s between cycles — the 120s timeout kills it mid-sleep.

## Root Cause

Two bugs found:
1. **Worker agent timeout** — worker sets `timeout: 120` on bash, but poll sleeps 300s
2. **`_is_qodo_reviewing()` false positive** — `"review agent"` marker matched PR summary text containing "review agents" (fixed in PR #550)

## Fix

Two-layer defense:
1. **`agents/worker.md`** — new "Long-Running Commands" section: do NOT set bash timeout on polling/watching commands
2. **`prompts/review-handler.md`** — explicit `IMPORTANT: Do NOT set a timeout` inside all 4 poll worker task strings

The existing `**No timeout**` comments were orchestrator-facing. The new instructions go inside the task string where the worker actually sees them.

Closes #551