### PR TITLE
fix(reviews): auto-skip already-replied Qodo sticky findings without pushback

### DIFF
--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1382,8 +1382,9 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         categorized = process_and_categorize(all_threads, owner, repo, pr_number=int(pr_number))
 
         # Enrich qodo findings with Qodo replies AFTER process_and_categorize sets already_replied
-        if qodo_replies:
-            _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
+        # Always call enrichment (even with empty replies) so _enrichment_checked is set
+        # on already_replied findings, enabling auto-skip for the "Qodo silent" case.
+        _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies or [])
 
         # Post-enrichment: auto-skip already-replied sticky findings where Qodo didn't push back
         auto_skip_replied_findings(categorized.get("qodo", []))

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -881,6 +881,35 @@ def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: 
                 break
 
 
+def auto_skip_replied_findings(findings: list[dict[str, Any]]) -> int:
+    """Auto-skip already-replied Qodo sticky findings where Qodo didn't push back.
+
+    Prevents re-posting duplicate consolidated comments for findings we already
+    replied to and Qodo silently accepted (no qodo_response). Runs in all modes
+    (not just autoqodo) — already-replied findings without pushback should never
+    be re-processed regardless of invocation mode.
+
+    Findings WITH qodo_response remain actionable — Qodo pushed back and needs a re-fix.
+
+    Returns the count of findings that were auto-skipped.
+    """
+    count = 0
+    for finding in findings:
+        if (
+            finding.get("already_replied")
+            and not finding.get("qodo_response")
+            and not finding.get("is_auto_skipped")
+            and finding.get("status") == "pending"
+        ):
+            finding["is_auto_skipped"] = True
+            finding["status"] = "skipped"
+            finding["skip_reason"] = "Already replied, Qodo did not push back"
+            count += 1
+    if count:
+        print_stderr(f"Auto-skipped {count} previously replied finding(s) (Qodo silent acceptance)")
+    return count
+
+
 def process_and_categorize(
     threads: list[dict[str, Any]], owner: str, repo: str, pr_number: int | None = None
 ) -> dict[str, list[dict[str, Any]]]:
@@ -995,8 +1024,9 @@ def process_and_categorize(
             enriched["reply"] = "Qodo reply — informational context, not a finding to fix"
 
         # Check for previously dismissed similar comment (only if status is pending)
-        # Qodo sticky findings are never auto-skipped — they persist intentionally
-        # until properly resolved and must always be re-evaluated.
+        # Qodo sticky findings are not auto-skipped by the dismissed-comment check below —
+        # dedup for already-replied sticky findings is handled separately by
+        # auto_skip_replied_findings() post-enrichment.
         if (
             source != "qodo"
             and (dismissed_by_path or dismissed_by_comment_id or dismissed_by_key)
@@ -1345,6 +1375,9 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         # Enrich qodo findings with Qodo replies AFTER process_and_categorize sets already_replied
         if qodo_replies:
             _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
+
+        # Post-enrichment: auto-skip already-replied sticky findings where Qodo didn't push back
+        auto_skip_replied_findings(categorized.get("qodo", []))
 
         # Build final output
         final_output = {

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -838,19 +838,19 @@ def fetch_qodo_sticky_findings(
     return results
 
 
-def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: list[dict[str, Any]]) -> int:
+def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: list[dict[str, Any]]) -> None:
     """Enrich qodo findings with qodo_response from matching reply comments.
 
     Matches replies to findings using path:line from the quoted heading
     (primary) or title comparison (fallback). Modifies findings in-place.
     Marks matched replies with _matched=True.
 
-    Returns the number of unmatched replies (replies that exist but couldn't
-    be matched to any finding).
     """
     for finding in findings:
         if not finding.get("already_replied"):
             continue
+
+        finding["_enrichment_checked"] = True
 
         finding_path = finding.get("path") or ""
         finding_line = finding.get("line")
@@ -882,15 +882,12 @@ def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: 
 
             if matched:
                 finding["qodo_response"] = reply["qodo_response"]
-                reply["_matched"] = True
                 break
 
-    # Count unmatched replies — these indicate potential missed pushback
-    unmatched = sum(1 for r in replies if not r.get("_matched"))
-    return unmatched
+    return None
 
 
-def auto_skip_replied_findings(findings: list[dict[str, Any]], unmatched_replies: int = 0) -> int:
+def auto_skip_replied_findings(findings: list[dict[str, Any]]) -> int:
     """Auto-skip already-replied Qodo sticky findings where Qodo didn't push back.
 
     Prevents re-posting duplicate consolidated comments for findings we already
@@ -898,26 +895,17 @@ def auto_skip_replied_findings(findings: list[dict[str, Any]], unmatched_replies
     (not just autoqodo) — already-replied findings without pushback should never
     be re-processed regardless of invocation mode.
 
+    Only skips findings that passed through enrichment (_enrichment_checked=True),
+    ensuring the enrichment step had a chance to set qodo_response if a reply existed.
     Findings WITH qodo_response remain actionable — Qodo pushed back and needs a re-fix.
-
-    If unmatched_replies > 0, auto-skip is disabled because unmatched Qodo replies
-    may contain pushback that failed to match to a finding. In this case, findings
-    remain actionable to prevent silently dropping pushback.
 
     Returns the count of findings that were auto-skipped.
     """
-    # If there are unmatched Qodo replies, don't auto-skip — pushback may be missed
-    if unmatched_replies > 0:
-        print_stderr(
-            f"Warning: {unmatched_replies} Qodo reply(s) couldn't be matched to findings"
-            " — skipping auto-skip to prevent missed pushback"
-        )
-        return 0
-
     count = 0
     for finding in findings:
         if (
             finding.get("already_replied")
+            and finding.get("_enrichment_checked")
             and not finding.get("qodo_response")
             and not finding.get("is_auto_skipped")
             and finding.get("status") == "pending"
@@ -1394,12 +1382,11 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         categorized = process_and_categorize(all_threads, owner, repo, pr_number=int(pr_number))
 
         # Enrich qodo findings with Qodo replies AFTER process_and_categorize sets already_replied
-        _unmatched_replies = 0
         if qodo_replies:
-            _unmatched_replies = _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
+            _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
 
         # Post-enrichment: auto-skip already-replied sticky findings where Qodo didn't push back
-        auto_skip_replied_findings(categorized.get("qodo", []), unmatched_replies=_unmatched_replies)
+        auto_skip_replied_findings(categorized.get("qodo", []))
 
         # Build final output
         final_output = {

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -838,11 +838,15 @@ def fetch_qodo_sticky_findings(
     return results
 
 
-def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: list[dict[str, Any]]) -> None:
+def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: list[dict[str, Any]]) -> int:
     """Enrich qodo findings with qodo_response from matching reply comments.
 
     Matches replies to findings using path:line from the quoted heading
     (primary) or title comparison (fallback). Modifies findings in-place.
+    Marks matched replies with _matched=True.
+
+    Returns the number of unmatched replies (replies that exist but couldn't
+    be matched to any finding).
     """
     for finding in findings:
         if not finding.get("already_replied"):
@@ -878,10 +882,15 @@ def _enrich_findings_with_qodo_replies(findings: list[dict[str, Any]], replies: 
 
             if matched:
                 finding["qodo_response"] = reply["qodo_response"]
+                reply["_matched"] = True
                 break
 
+    # Count unmatched replies — these indicate potential missed pushback
+    unmatched = sum(1 for r in replies if not r.get("_matched"))
+    return unmatched
 
-def auto_skip_replied_findings(findings: list[dict[str, Any]]) -> int:
+
+def auto_skip_replied_findings(findings: list[dict[str, Any]], unmatched_replies: int = 0) -> int:
     """Auto-skip already-replied Qodo sticky findings where Qodo didn't push back.
 
     Prevents re-posting duplicate consolidated comments for findings we already
@@ -891,8 +900,20 @@ def auto_skip_replied_findings(findings: list[dict[str, Any]]) -> int:
 
     Findings WITH qodo_response remain actionable — Qodo pushed back and needs a re-fix.
 
+    If unmatched_replies > 0, auto-skip is disabled because unmatched Qodo replies
+    may contain pushback that failed to match to a finding. In this case, findings
+    remain actionable to prevent silently dropping pushback.
+
     Returns the count of findings that were auto-skipped.
     """
+    # If there are unmatched Qodo replies, don't auto-skip — pushback may be missed
+    if unmatched_replies > 0:
+        print_stderr(
+            f"Warning: {unmatched_replies} Qodo reply(s) couldn't be matched to findings"
+            " — skipping auto-skip to prevent missed pushback"
+        )
+        return 0
+
     count = 0
     for finding in findings:
         if (
@@ -1373,11 +1394,12 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         categorized = process_and_categorize(all_threads, owner, repo, pr_number=int(pr_number))
 
         # Enrich qodo findings with Qodo replies AFTER process_and_categorize sets already_replied
+        _unmatched_replies = 0
         if qodo_replies:
-            _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
+            _unmatched_replies = _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
 
         # Post-enrichment: auto-skip already-replied sticky findings where Qodo didn't push back
-        auto_skip_replied_findings(categorized.get("qodo", []))
+        auto_skip_replied_findings(categorized.get("qodo", []), unmatched_replies=_unmatched_replies)
 
         # Build final output
         final_output = {

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1287,7 +1287,7 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         print_stderr(f"Found {len(all_threads)} {label} thread(s)")
 
         # Skip bot comment fetching when filtering by specific user
-        qodo_replies: list[dict[str, Any]] = []
+        qodo_replies: list[dict[str, Any]] | None = None
         if not user:
             # Fetch CodeRabbit body-embedded comments from review bodies
             print_stderr("Fetching CodeRabbit body-embedded comments...")
@@ -1382,9 +1382,11 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         categorized = process_and_categorize(all_threads, owner, repo, pr_number=int(pr_number))
 
         # Enrich qodo findings with Qodo replies AFTER process_and_categorize sets already_replied
-        # Always call enrichment (even with empty replies) so _enrichment_checked is set
-        # on already_replied findings, enabling auto-skip for the "Qodo silent" case.
-        _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies or [])
+        # Only run enrichment when reply fetch was actually attempted (not user-specific mode).
+        # When qodo_replies is None (fetch skipped), enrichment doesn't run and
+        # _enrichment_checked isn't set, preventing incorrect auto-skip.
+        if qodo_replies is not None:
+            _enrich_findings_with_qodo_replies(categorized.get("qodo", []), qodo_replies)
 
         # Post-enrichment: auto-skip already-replied sticky findings where Qodo didn't push back
         auto_skip_replied_findings(categorized.get("qodo", []))

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -140,10 +140,12 @@ Returns JSON with:
 >
 > If autoqodo mode is ON:
 >
-> **Qodo sticky findings are NEVER auto-skipped.** Unlike CodeRabbit, Qodo sticky
-> findings persist intentionally until resolved. Even if a finding was previously
-> addressed or dismissed, it must be re-evaluated and fixed again. The `is_auto_skipped`
-> flag does not apply to Qodo sources.
+> **Qodo sticky findings with `is_auto_skipped=true` are auto-skipped.** When a finding
+> has `already_replied=true` and Qodo did not push back (no `qodo_response`), it is
+> auto-skipped — Qodo's silence is treated as implicit acceptance. These findings are
+> presented in the table as auto-skipped but are NOT actionable.
+> Findings where Qodo DID push back (`qodo_response` exists) remain actionable and
+> MUST be re-fixed with a different approach.
 >
 > 🚨 **MANDATORY: Read the FULL Qodo sticky JSON data before acting.**
 > Qodo sticky findings contain critical fields beyond the title:
@@ -201,15 +203,15 @@ Returns JSON with:
 >    - OR the code does not match the spec — FIX THE CODE
 >    - NEVER post the same reply again. That means you haven't actually addressed it.
 >
->    🚨 **STICKY FINDINGS ARE ALWAYS ACTIONABLE — NEVER SKIP.**
->    If a finding appears in the Qodo sticky comment, it MUST be addressed with a code fix
->    or spec update. `already_replied`, `previous_reply`, and `qodo_response` are CONTEXT
->    for making a better fix — they are NOT reasons to skip.
->    When a sticky finding has `previous_reply` + `qodo_response`, the AI MUST:
->    1. Read `previous_reply` — what we said before
->    2. Read `qodo_response` — what Qodo said back
->    3. Make a DIFFERENT fix that addresses Qodo's specific concern
+>    🚨 **STICKY FINDINGS WITH `qodo_response` ARE ALWAYS ACTIONABLE.**
+>    If a sticky finding has `qodo_response` (Qodo pushed back), it MUST be re-fixed
+>    with a different approach. `previous_reply` shows what you said before, `qodo_response`
+>    shows Qodo's pushback — use both to make a BETTER fix.
 >    Repeating the same reply or approach is a HARD VIOLATION.
+>
+>    **STICKY FINDINGS WITHOUT `qodo_response` are auto-skipped by the code.**
+>    If `already_replied=true` and no `qodo_response`, the finding is `is_auto_skipped=true`.
+>    Qodo's silence = implicit acceptance. Do NOT re-process these.
 >
 >    **Qodo reply detection (consolidated comment responses):**
 >    When we post consolidated PR comments mentioning `@qodo-code-review`, Qodo may

--- a/tests/python/test_auto_skip_replied.py
+++ b/tests/python/test_auto_skip_replied.py
@@ -76,8 +76,8 @@ class TestAutoSkipRepliedFindings:
         count = auto_skip_replied_findings(findings)
         assert count == 0
 
-    def test_mixed_findings(self) -> None:
-        """Mix of already-replied (no response), already-replied (with response), and new."""
+    def test_mixed_silent_accept_is_skipped(self) -> None:
+        """In a mixed list, the silent-accept finding is auto-skipped."""
         findings: list[dict[str, Any]] = [
             {"already_replied": True, "status": "pending", "body": "Silent accept"},
             {"already_replied": True, "qodo_response": "Not fixed", "status": "pending", "body": "Pushback"},
@@ -87,8 +87,26 @@ class TestAutoSkipRepliedFindings:
         assert count == 1
         assert findings[0]["is_auto_skipped"] is True
         assert findings[0]["status"] == "skipped"
+
+    def test_mixed_pushback_remains_actionable(self) -> None:
+        """In a mixed list, the pushback finding stays pending."""
+        findings: list[dict[str, Any]] = [
+            {"already_replied": True, "status": "pending", "body": "Silent accept"},
+            {"already_replied": True, "qodo_response": "Not fixed", "status": "pending", "body": "Pushback"},
+            {"status": "pending", "body": "New finding"},
+        ]
+        auto_skip_replied_findings(findings)
         assert not findings[1].get("is_auto_skipped")
         assert findings[1]["status"] == "pending"
+
+    def test_mixed_new_finding_remains_actionable(self) -> None:
+        """In a mixed list, the new finding stays pending."""
+        findings: list[dict[str, Any]] = [
+            {"already_replied": True, "status": "pending", "body": "Silent accept"},
+            {"already_replied": True, "qodo_response": "Not fixed", "status": "pending", "body": "Pushback"},
+            {"status": "pending", "body": "New finding"},
+        ]
+        auto_skip_replied_findings(findings)
         assert not findings[2].get("is_auto_skipped")
         assert findings[2]["status"] == "pending"
 
@@ -139,3 +157,22 @@ class TestAutoSkipRepliedFindings:
         findings: list[dict[str, Any]] = []
         count = auto_skip_replied_findings(findings)
         assert count == 0
+
+    def test_unmatched_replies_disables_auto_skip(self) -> None:
+        """When unmatched replies exist, auto-skip is disabled to prevent missed pushback."""
+        findings: list[dict[str, Any]] = [
+            {"already_replied": True, "status": "pending", "body": "Would normally be skipped"},
+        ]
+        count = auto_skip_replied_findings(findings, unmatched_replies=1)
+        assert count == 0
+        assert not findings[0].get("is_auto_skipped")
+        assert findings[0]["status"] == "pending"
+
+    def test_zero_unmatched_replies_allows_auto_skip(self) -> None:
+        """When all replies matched (unmatched=0), auto-skip works normally."""
+        findings: list[dict[str, Any]] = [
+            {"already_replied": True, "status": "pending", "body": "Should be skipped"},
+        ]
+        count = auto_skip_replied_findings(findings, unmatched_replies=0)
+        assert count == 1
+        assert findings[0]["is_auto_skipped"] is True

--- a/tests/python/test_auto_skip_replied.py
+++ b/tests/python/test_auto_skip_replied.py
@@ -201,3 +201,17 @@ class TestAutoSkipRepliedFindings:
         count = auto_skip_replied_findings(findings)
         assert count == 1
         assert findings[0]["is_auto_skipped"] is True
+
+    def test_enrichment_with_empty_replies_sets_checked(self) -> None:
+        """When no Qodo replies exist, enrichment still sets _enrichment_checked."""
+        from myk_pi_tools.reviews.fetch import _enrich_findings_with_qodo_replies
+
+        findings: list[dict[str, Any]] = [
+            {"already_replied": True, "status": "pending", "body": "Silent Qodo"},
+        ]
+        _enrich_findings_with_qodo_replies(findings, [])
+        assert findings[0].get("_enrichment_checked") is True
+        # Now auto-skip should work
+        count = auto_skip_replied_findings(findings)
+        assert count == 1
+        assert findings[0]["is_auto_skipped"] is True

--- a/tests/python/test_auto_skip_replied.py
+++ b/tests/python/test_auto_skip_replied.py
@@ -1,0 +1,141 @@
+"""Tests for auto_skip_replied_findings — post-enrichment dedup for Qodo sticky findings."""
+
+from typing import Any
+
+from myk_pi_tools.reviews.fetch import auto_skip_replied_findings
+
+
+class TestAutoSkipRepliedFindings:
+    """Test the post-enrichment auto-skip pass for already-replied Qodo findings."""
+
+    def test_already_replied_no_qodo_response_is_auto_skipped(self) -> None:
+        """already_replied=True + no qodo_response → is_auto_skipped=True."""
+        findings: list[dict[str, Any]] = [
+            {
+                "already_replied": True,
+                "status": "pending",
+                "body": "Some finding",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 1
+        assert findings[0]["is_auto_skipped"] is True
+        assert findings[0]["status"] == "skipped"
+        assert findings[0]["skip_reason"] == "Already replied, Qodo did not push back"
+
+    def test_already_replied_with_qodo_response_remains_actionable(self) -> None:
+        """already_replied=True + qodo_response present → stays pending (Qodo pushed back)."""
+        findings: list[dict[str, Any]] = [
+            {
+                "already_replied": True,
+                "qodo_response": "Still present, not fixed",
+                "status": "pending",
+                "body": "Some finding",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 0
+        assert not findings[0].get("is_auto_skipped")
+        assert findings[0]["status"] == "pending"
+
+    def test_not_already_replied_remains_actionable(self) -> None:
+        """No already_replied → stays pending (new finding)."""
+        findings: list[dict[str, Any]] = [
+            {
+                "status": "pending",
+                "body": "New finding",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 0
+        assert not findings[0].get("is_auto_skipped")
+        assert findings[0]["status"] == "pending"
+
+    def test_already_auto_skipped_not_re_processed(self) -> None:
+        """Already is_auto_skipped → not re-processed."""
+        findings: list[dict[str, Any]] = [
+            {
+                "already_replied": True,
+                "is_auto_skipped": True,
+                "status": "skipped",
+                "body": "Already skipped",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 0
+
+    def test_non_pending_status_not_skipped(self) -> None:
+        """already_replied=True but status is 'addressed' → not re-processed."""
+        findings: list[dict[str, Any]] = [
+            {
+                "already_replied": True,
+                "status": "addressed",
+                "body": "Already addressed",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 0
+
+    def test_mixed_findings(self) -> None:
+        """Mix of already-replied (no response), already-replied (with response), and new."""
+        findings: list[dict[str, Any]] = [
+            {"already_replied": True, "status": "pending", "body": "Silent accept"},
+            {"already_replied": True, "qodo_response": "Not fixed", "status": "pending", "body": "Pushback"},
+            {"status": "pending", "body": "New finding"},
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 1
+        assert findings[0]["is_auto_skipped"] is True
+        assert findings[0]["status"] == "skipped"
+        assert not findings[1].get("is_auto_skipped")
+        assert findings[1]["status"] == "pending"
+        assert not findings[2].get("is_auto_skipped")
+        assert findings[2]["status"] == "pending"
+
+    def test_empty_qodo_response_treated_as_no_response(self) -> None:
+        """already_replied=True + empty qodo_response → auto-skipped (empty = no pushback)."""
+        findings: list[dict[str, Any]] = [
+            {
+                "already_replied": True,
+                "qodo_response": "",
+                "status": "pending",
+                "body": "Finding with empty response",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 1
+        assert findings[0]["is_auto_skipped"] is True
+
+    def test_already_replied_false_explicit_remains_actionable(self) -> None:
+        """already_replied=False (explicit) → stays pending (not replied)."""
+        findings: list[dict[str, Any]] = [
+            {
+                "already_replied": False,
+                "status": "pending",
+                "body": "Explicit false",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 0
+        assert not findings[0].get("is_auto_skipped")
+        assert findings[0]["status"] == "pending"
+
+    def test_qodo_response_none_treated_as_no_response(self) -> None:
+        """already_replied=True + qodo_response=None → auto-skipped (None = no pushback)."""
+        findings: list[dict[str, Any]] = [
+            {
+                "already_replied": True,
+                "qodo_response": None,
+                "status": "pending",
+                "body": "Finding with None response",
+            }
+        ]
+        count = auto_skip_replied_findings(findings)
+        assert count == 1
+        assert findings[0]["is_auto_skipped"] is True
+
+    def test_empty_findings_list(self) -> None:
+        """Empty findings list → returns 0, no errors."""
+        findings: list[dict[str, Any]] = []
+        count = auto_skip_replied_findings(findings)
+        assert count == 0

--- a/tests/python/test_auto_skip_replied.py
+++ b/tests/python/test_auto_skip_replied.py
@@ -9,10 +9,11 @@ class TestAutoSkipRepliedFindings:
     """Test the post-enrichment auto-skip pass for already-replied Qodo findings."""
 
     def test_already_replied_no_qodo_response_is_auto_skipped(self) -> None:
-        """already_replied=True + no qodo_response → is_auto_skipped=True."""
+        """already_replied=True + _enrichment_checked + no qodo_response → is_auto_skipped=True."""
         findings: list[dict[str, Any]] = [
             {
                 "already_replied": True,
+                "_enrichment_checked": True,
                 "status": "pending",
                 "body": "Some finding",
             }
@@ -28,6 +29,7 @@ class TestAutoSkipRepliedFindings:
         findings: list[dict[str, Any]] = [
             {
                 "already_replied": True,
+                "_enrichment_checked": True,
                 "qodo_response": "Still present, not fixed",
                 "status": "pending",
                 "body": "Some finding",
@@ -56,6 +58,7 @@ class TestAutoSkipRepliedFindings:
         findings: list[dict[str, Any]] = [
             {
                 "already_replied": True,
+                "_enrichment_checked": True,
                 "is_auto_skipped": True,
                 "status": "skipped",
                 "body": "Already skipped",
@@ -69,6 +72,7 @@ class TestAutoSkipRepliedFindings:
         findings: list[dict[str, Any]] = [
             {
                 "already_replied": True,
+                "_enrichment_checked": True,
                 "status": "addressed",
                 "body": "Already addressed",
             }
@@ -79,8 +83,14 @@ class TestAutoSkipRepliedFindings:
     def test_mixed_silent_accept_is_skipped(self) -> None:
         """In a mixed list, the silent-accept finding is auto-skipped."""
         findings: list[dict[str, Any]] = [
-            {"already_replied": True, "status": "pending", "body": "Silent accept"},
-            {"already_replied": True, "qodo_response": "Not fixed", "status": "pending", "body": "Pushback"},
+            {"already_replied": True, "_enrichment_checked": True, "status": "pending", "body": "Silent accept"},
+            {
+                "already_replied": True,
+                "_enrichment_checked": True,
+                "qodo_response": "Not fixed",
+                "status": "pending",
+                "body": "Pushback",
+            },
             {"status": "pending", "body": "New finding"},
         ]
         count = auto_skip_replied_findings(findings)
@@ -91,8 +101,14 @@ class TestAutoSkipRepliedFindings:
     def test_mixed_pushback_remains_actionable(self) -> None:
         """In a mixed list, the pushback finding stays pending."""
         findings: list[dict[str, Any]] = [
-            {"already_replied": True, "status": "pending", "body": "Silent accept"},
-            {"already_replied": True, "qodo_response": "Not fixed", "status": "pending", "body": "Pushback"},
+            {"already_replied": True, "_enrichment_checked": True, "status": "pending", "body": "Silent accept"},
+            {
+                "already_replied": True,
+                "_enrichment_checked": True,
+                "qodo_response": "Not fixed",
+                "status": "pending",
+                "body": "Pushback",
+            },
             {"status": "pending", "body": "New finding"},
         ]
         auto_skip_replied_findings(findings)
@@ -102,8 +118,14 @@ class TestAutoSkipRepliedFindings:
     def test_mixed_new_finding_remains_actionable(self) -> None:
         """In a mixed list, the new finding stays pending."""
         findings: list[dict[str, Any]] = [
-            {"already_replied": True, "status": "pending", "body": "Silent accept"},
-            {"already_replied": True, "qodo_response": "Not fixed", "status": "pending", "body": "Pushback"},
+            {"already_replied": True, "_enrichment_checked": True, "status": "pending", "body": "Silent accept"},
+            {
+                "already_replied": True,
+                "_enrichment_checked": True,
+                "qodo_response": "Not fixed",
+                "status": "pending",
+                "body": "Pushback",
+            },
             {"status": "pending", "body": "New finding"},
         ]
         auto_skip_replied_findings(findings)
@@ -115,6 +137,7 @@ class TestAutoSkipRepliedFindings:
         findings: list[dict[str, Any]] = [
             {
                 "already_replied": True,
+                "_enrichment_checked": True,
                 "qodo_response": "",
                 "status": "pending",
                 "body": "Finding with empty response",
@@ -129,6 +152,7 @@ class TestAutoSkipRepliedFindings:
         findings: list[dict[str, Any]] = [
             {
                 "already_replied": False,
+                "_enrichment_checked": True,
                 "status": "pending",
                 "body": "Explicit false",
             }
@@ -143,6 +167,7 @@ class TestAutoSkipRepliedFindings:
         findings: list[dict[str, Any]] = [
             {
                 "already_replied": True,
+                "_enrichment_checked": True,
                 "qodo_response": None,
                 "status": "pending",
                 "body": "Finding with None response",
@@ -158,21 +183,21 @@ class TestAutoSkipRepliedFindings:
         count = auto_skip_replied_findings(findings)
         assert count == 0
 
-    def test_unmatched_replies_disables_auto_skip(self) -> None:
-        """When unmatched replies exist, auto-skip is disabled to prevent missed pushback."""
+    def test_not_enrichment_checked_not_skipped(self) -> None:
+        """already_replied=True but no _enrichment_checked → not skipped (enrichment didn't run)."""
         findings: list[dict[str, Any]] = [
-            {"already_replied": True, "status": "pending", "body": "Would normally be skipped"},
+            {"already_replied": True, "status": "pending", "body": "Not checked"},
         ]
-        count = auto_skip_replied_findings(findings, unmatched_replies=1)
+        count = auto_skip_replied_findings(findings)
         assert count == 0
         assert not findings[0].get("is_auto_skipped")
         assert findings[0]["status"] == "pending"
 
-    def test_zero_unmatched_replies_allows_auto_skip(self) -> None:
-        """When all replies matched (unmatched=0), auto-skip works normally."""
+    def test_enrichment_checked_allows_auto_skip(self) -> None:
+        """already_replied=True + _enrichment_checked=True + no response → auto-skipped."""
         findings: list[dict[str, Any]] = [
-            {"already_replied": True, "status": "pending", "body": "Should be skipped"},
+            {"already_replied": True, "_enrichment_checked": True, "status": "pending", "body": "Checked"},
         ]
-        count = auto_skip_replied_findings(findings, unmatched_replies=0)
+        count = auto_skip_replied_findings(findings)
         assert count == 1
         assert findings[0]["is_auto_skipped"] is True


### PR DESCRIPTION
## Summary

Fixes the autoqodo polling loop posting duplicate consolidated PR comments every cycle. When a Qodo sticky finding has been replied to (`already_replied=True`) and Qodo didn't push back (no `qodo_response`), the finding is now auto-skipped instead of being re-processed.

## Root Cause

PR #470 added `already_replied` as a context signal but didn't set `is_auto_skipped`. PR #514's prompt hardening then told the LLM to "NEVER skip sticky findings" — the code signal and prompt contradicted each other, causing the LLM to re-post every cycle.

## Fix

**Post-enrichment auto-skip pass** (per @rnetser's suggestion):

1. `process_and_categorize()` runs first — sets `already_replied=True` + `previous_reply`
2. `_enrich_findings_with_qodo_replies()` runs second — adds `qodo_response` where Qodo pushed back
3. **New:** `auto_skip_replied_findings()` runs third — if `already_replied=True` AND no `qodo_response` → `is_auto_skipped=True`

Findings where Qodo DID push back (`qodo_response` exists) remain actionable.

## Changes

- `myk_pi_tools/reviews/fetch.py` — new `auto_skip_replied_findings()` function + call after enrichment
- `prompts/review-handler.md` — updated Qodo sticky rules to align with code (removed "NEVER auto-skip" contradiction)
- `tests/python/test_auto_skip_replied.py` — 10 tests covering all edge cases

## Testing

- 67 Python tests pass (including 10 new)
- 48 Node tests pass
- All tox environments green

Closes #546