### PR TITLE
fix: pushback detection, pr info, rm /tmp, dreaming onComplete, comment signature, stuck re-trigger, single JSON output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,6 +436,7 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 | `use_worktrees` | boolean | disabled | `PI_USE_WORKTREES` | Force worktree-only workflow |
 | `dream_interval_hours` | number | 3 | `PI_DREAM_INTERVAL_HOURS` | Dream frequency |
 | `dco` | boolean | disabled | `PI_DCO` | Add --signoff to all commits (DCO) |
+| `comment_signature` | boolean | disabled | `PI_COMMENT_SIGNATURE` | Append AI signature to all PR comments |
 
 Resolution: project file → global `~/.pi/pi-config-settings.json` → env var → default.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ pi-config/
 │   │   ├── index.ts                 # Main entry — imports and wires all modules
 │   │   ├── agents.ts                # Agent discovery
 │   │   ├── ask-user.ts              # ask_user tool
-│   │   ├── async-agents.ts          # Async background agent infrastructure (fireAndForget, group-aware delivery)
+│   │   ├── async-agents.ts          # Async background agent infrastructure (fireAndForget, group-aware delivery, onComplete callbacks)
 │   │   ├── async-runner.ts          # Standalone async runner (spawned detached)
 │   │   ├── btw.ts                   # /btw command
 │   │   ├── cron.ts                   # /cron scheduled tasks (interval/time-based)
@@ -246,7 +246,7 @@ Dead parent = zombie = delete.
 
 **Shared helper:** `getProjectTmpDir(cwd)` in `utils.ts` — returns `<cwd>/.pi/tmp/`, creates dir if missing.
 
-**Enforcement:** Recursive removal (`rm -rf`) targeting paths within `.pi/tmp/` is silently allowed without dangerous-command confirmation.
+**Enforcement:** Recursive removal (`rm -rf`) targeting paths within `.pi/tmp/` or `/tmp/<something>` (but not bare `/tmp`) is silently allowed without dangerous-command confirmation.
 Paths are resolved via `realpathSync()` to prevent symlink traversal.
 Read-only commands (`grep`, `cat`, etc.) containing dangerous patterns in their arguments are also excluded from confirmation prompts.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -436,7 +436,7 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 | `use_worktrees` | boolean | disabled | `PI_USE_WORKTREES` | Force worktree-only workflow |
 | `dream_interval_hours` | number | 3 | `PI_DREAM_INTERVAL_HOURS` | Dream frequency |
 | `dco` | boolean | disabled | `PI_DCO` | Add --signoff to all commits (DCO) |
-| `comment_signature` | boolean | disabled | `PI_COMMENT_SIGNATURE` | Append AI signature to all PR comments |
+| `comment_signature` | boolean | disabled | — | Append AI signature to all PR comments |
 
 Resolution: project file → global `~/.pi/pi-config-settings.json` → env var → default.
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -56,6 +56,7 @@ export interface AsyncJob {
   durationMs?: number;
   delivered?: boolean;
   fireAndForget?: boolean;
+  onComplete?: () => void;
   groupId?: string;
   taskId?: string;
   cwd?: string;
@@ -128,7 +129,7 @@ export function registerAsyncAgents(
   pi: ExtensionAPI,
   terminalNotify: (title: string, body: string) => void,
 ): {
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string; taskId?: string }) => { id: string; error?: string; model?: string };
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: AgentConfig[], options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string; taskId?: string; onComplete?: () => void }) => { id: string; error?: string; model?: string };
   killAsyncAgent: (target: string) => { killed: string[]; errors: string[] };
   getAsyncJobs: () => Array<{ id: string; agent: string; name?: string; task: string; status: string; startedAt: number }>;
 } {
@@ -266,7 +267,12 @@ export function registerAsyncAgents(
 
     // Skip delivery if ALL jobs in group are fire-and-forget
     if (groupJobs.every(j => j.fireAndForget)) {
-      for (const j of groupJobs) j.delivered = true;
+      for (const j of groupJobs) {
+        if (j.onComplete) {
+          try { j.onComplete(); } catch (e: any) { asyncLog(`onComplete callback failed for ${j.id}: ${e?.message}`); }
+        }
+        j.delivered = true;
+      }
       // Clean up result files for fire-and-forget groups
       for (const j of groupJobs) {
         const rp = path.join(ASYNC_RESULTS_DIR, `${j.id}.json`);
@@ -379,6 +385,10 @@ export function registerAsyncAgents(
         }, { triggerTurn: true, deliverAs: "followUp" });
       }
 
+      // Invoke onComplete callback if registered (e.g., dreaming → rebuildAndOrganize)
+      if (job.onComplete) {
+        try { job.onComplete(); } catch (e: any) { asyncLog(`onComplete callback failed for ${job.id}: ${e?.message}`); }
+      }
       job.delivered = true;
       // Result file already deleted above (non-grouped path)
       updateAsyncWidget();
@@ -411,7 +421,7 @@ export function registerAsyncAgents(
     task: string,
     cwd: string,
     agents: AgentConfig[],
-    options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string; taskId?: string },
+    options?: { fireAndForget?: boolean; name?: string; parentModelId?: string; parentProvider?: string; groupId?: string; taskId?: string; onComplete?: () => void },
   ): { id: string; error?: string; model?: string } {
     const agent = agents.find(a => a.name === agentName);
     if (!agent) return { id: "", error: `Unknown agent: "${agentName}"` };
@@ -529,6 +539,7 @@ export function registerAsyncAgents(
       startedAt: Date.now(),
       updatedAt: Date.now(),
       fireAndForget: options?.fireAndForget,
+      onComplete: options?.onComplete,
       groupId: options?.groupId,
       taskId: options?.taskId,
       cwd,

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -31,7 +31,7 @@ const REBUILD_INTERVAL_MS = 30 * 60 * 1000;
 
 export function registerDreaming(
   pi: ExtensionAPI,
-  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: any[], options?: { fireAndForget?: boolean; name?: string }) => { id: string; error?: string },
+  spawnAsyncAgent: (agentName: string, task: string, cwd: string, agents: any[], options?: { fireAndForget?: boolean; name?: string; onComplete?: () => void }) => { id: string; error?: string },
 ): void {
   // Only the orchestrator (top-level pi) runs dreaming — skip in subagent children
   if (process.env.PI_SUBAGENT_CHILD === "1") return;
@@ -42,7 +42,6 @@ export function registerDreaming(
   let lastCtx: any = null;
 
   let dreamInFlight = false;
-  let activePollInterval: ReturnType<typeof setInterval> | null = null;
 
   function updateDreamStatus() {
     try {
@@ -109,41 +108,19 @@ export function registerDreaming(
       `9. Memory rules: one line per entry, max ~100 chars, specific and actionable, no fluff.`,
       cwd,
       agents,
-      { fireAndForget: true, name: "Dream" },
+      {
+        fireAndForget: true,
+        name: "Dream",
+        onComplete: () => {
+          dreamInFlight = false;
+          updateDreamStatus();
+          try { rebuildAndOrganize(cwd); } catch (e: any) { console.debug("[dreaming] rebuildAndOrganize failed:", e?.message || e); }
+        },
+      },
     );
-    // Poll the async agent status file until dream completes
-    if (id) {
-      // Scan project dir for the worker's status file
-      const projectDir = getProjectTmpDir(cwd);
-      const statusPath = path.join(projectDir, id, "status.json");
-      const pollStart = Date.now();
-      const POLL_TIMEOUT_MS = 30 * 60 * 1000; // 30 min max
-      if (activePollInterval) clearInterval(activePollInterval);
-      const pollInterval = setInterval(() => {
-        try {
-          // Timeout guard — don't poll forever
-          if (Date.now() - pollStart > POLL_TIMEOUT_MS) {
-            clearInterval(pollInterval);
-            activePollInterval = null;
-            dreamInFlight = false;
-            updateDreamStatus();
-            console.debug("[dreaming] poll timed out after 30 min");
-            return;
-          }
-          if (!fs.existsSync(statusPath)) return;
-          const status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
-          if (status.state === "complete" || status.state === "failed") {
-            clearInterval(pollInterval);
-            activePollInterval = null;
-            dreamInFlight = false;
-            updateDreamStatus();
-            try { rebuildAndOrganize(cwd); } catch (e: any) { console.debug("[dreaming] rebuildAndOrganize failed:", e?.message || e); }
-          }
-        } catch { /* poll is best-effort */ }
-      }, 15_000); // Check every 15 seconds
-      if (pollInterval.unref) pollInterval.unref();
-      activePollInterval = pollInterval;
-    } else {
+    // Dream runs as fireAndForget async agent.
+    // onComplete callback triggers rebuildAndOrganize when dream finishes.
+    if (!id) {
       dreamInFlight = false;
       updateDreamStatus();
     }
@@ -245,7 +222,6 @@ export function registerDreaming(
   pi.on("session_start", (_event, ctx) => {
     lastCwd = ctx.cwd;
     lastCtx = ctx;
-    if (activePollInterval) { clearInterval(activePollInterval); activePollInterval = null; }
     dreamInFlight = false; // Reset — previous session's dream state doesn't carry over
     // Skip dreaming in one-shot modes (print/json)
     if (ctx.mode === "print" || ctx.mode === "json") return;

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -42,6 +42,7 @@ export function registerDreaming(
   let lastCtx: any = null;
 
   let dreamInFlight = false;
+  let currentDreamId = "";
 
   function updateDreamStatus() {
     try {
@@ -58,6 +59,7 @@ export function registerDreaming(
     if (dreamInFlight) return; // Prevent concurrent dreams
     dreamInFlight = true;
     updateDreamStatus();
+    currentDreamId = "";  // Reset until we get the ID from spawnAsyncAgent
     const { agents } = discoverAgents(cwd, "user");
     const topicsDir = path.join(cwd, ".pi", "memory", "topics");
     const { id } = spawnAsyncAgent(
@@ -120,14 +122,17 @@ export function registerDreaming(
     );
     // Dream runs as fireAndForget async agent.
     // onComplete callback triggers rebuildAndOrganize when dream finishes.
+    currentDreamId = id;
     if (!id) {
       dreamInFlight = false;
       updateDreamStatus();
     } else {
       // Safety fallback: if onComplete never fires (runner crash/hang),
       // reset dreamInFlight after 30 min so future dreams aren't blocked.
+      // Capture the current dream ID to avoid cross-run races.
+      const dreamId = id;
       const fallbackTimer = setTimeout(() => {
-        if (dreamInFlight) {
+        if (dreamInFlight && currentDreamId === dreamId) {
           dreamInFlight = false;
           updateDreamStatus();
           console.debug("[dreaming] fallback: reset dreamInFlight after 30 min (onComplete never fired)");

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -123,6 +123,17 @@ export function registerDreaming(
     if (!id) {
       dreamInFlight = false;
       updateDreamStatus();
+    } else {
+      // Safety fallback: if onComplete never fires (runner crash/hang),
+      // reset dreamInFlight after 30 min so future dreams aren't blocked.
+      const fallbackTimer = setTimeout(() => {
+        if (dreamInFlight) {
+          dreamInFlight = false;
+          updateDreamStatus();
+          console.debug("[dreaming] fallback: reset dreamInFlight after 30 min (onComplete never fired)");
+        }
+      }, 30 * 60 * 1000);
+      if (fallbackTimer.unref) fallbackTimer.unref();
     }
   }
 

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -93,8 +93,9 @@ export function isReadOnlyStatement(stmt: string): boolean {
 const RM_PATTERN = /\brm\s+(?:-[a-zA-Z]+\s+)*(-[a-zA-Z]*r[a-zA-Z]*|--recursive)/i;
 
 /**
- * Check if a dangerous rm command only targets paths within .pi/tmp/.
+ * Check if a dangerous rm command only targets paths within .pi/tmp/ or /tmp/<something>.
  * Returns true if the command should be silently allowed.
+ * Note: bare /tmp (without subpath) is NOT allowed — only /tmp/<file-or-folder>.
  */
 export function isRmInProjectTmp(stmt: string, cwd: string): boolean {
   // Only applies to direct rm commands, not find/xargs variants
@@ -129,11 +130,11 @@ export function isRmInProjectTmp(stmt: string, cwd: string): boolean {
 
   // Resolve and substitute PROJECT_TMP_DIR env var
   const projectTmpDir = path.join(cwd, ".pi", "tmp");
-  let resolvedCwd: string;
+  let resolvedCwd: string | null;
   try {
     resolvedCwd = realpathSync(cwd);
   } catch {
-    return false;
+    resolvedCwd = null; // cwd doesn't exist — project tmp checks will all fail
   }
 
   for (const p of paths) {
@@ -144,17 +145,27 @@ export function isRmInProjectTmp(stmt: string, cwd: string): boolean {
       // Use realpathSync to resolve symlinks — prevents symlink traversal attacks
       resolved = realpathSync(path.resolve(cwd, expanded));
     } catch {
-      // Path doesn't exist — non-existent paths can't be symlink escapes,
-      // but also can't be verified as safe. Fall through to normal prompt.
-      return false;
+      // Path doesn't exist. For explicit /tmp/<something> paths, use lexical resolution
+      // (no symlink risk since the target doesn't exist). Only when the original path
+      // explicitly starts with /tmp/ — not paths that resolve there via traversal.
+      const lexical = path.resolve(cwd, expanded);
+      if (expanded.startsWith("/tmp/") && lexical.startsWith("/tmp/") && lexical !== "/tmp" && lexical.length > 5) {
+        resolved = lexical;
+      } else {
+        return false;
+      }
     }
 
-    // Both conditions required:
-    // 1. Path is within the project (starts with cwd)
-    // 2. Path goes through .pi/tmp/ (our designated temp directory)
-    if (!resolved.startsWith(resolvedCwd + path.sep) && resolved !== resolvedCwd) return false;
-    if (!resolved.includes(`${path.sep}.pi${path.sep}tmp${path.sep}`) &&
-        !resolved.endsWith(`${path.sep}.pi${path.sep}tmp`)) return false;
+    // Check if path is in an allowed temp location:
+    // A) Project .pi/tmp/ — path within project AND goes through .pi/tmp/
+    // B) System /tmp/<something> — path under /tmp/ but NOT /tmp itself
+    const inProjectTmp = resolvedCwd !== null &&
+      (resolved.startsWith(resolvedCwd + path.sep) || resolved === resolvedCwd) &&
+      (resolved.includes(`${path.sep}.pi${path.sep}tmp${path.sep}`) ||
+       resolved.endsWith(`${path.sep}.pi${path.sep}tmp`));
+    const inSystemTmp = resolved.startsWith("/tmp/") && resolved !== "/tmp" && resolved.length > 5;
+
+    if (!inProjectTmp && !inSystemTmp) return false;
   }
 
   return true;

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -162,7 +162,7 @@ export function isRmInProjectTmp(stmt: string, cwd: string): boolean {
         const parentDir = path.dirname(lexical);
         try {
           const resolvedParent = realpathSync(parentDir);
-          if (!resolvedParent.startsWith("/tmp")) {
+          if (!resolvedParent.startsWith("/tmp/") && resolvedParent !== "/tmp") {
             return false; // Parent symlinks outside /tmp
           }
         } catch {

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -101,6 +101,10 @@ export function isRmInProjectTmp(stmt: string, cwd: string): boolean {
   // Only applies to direct rm commands, not find/xargs variants
   if (!RM_PATTERN.test(stmt)) return false;
 
+  // Ensure rm is the actual command, not an argument to another command (e.g., xargs rm)
+  const firstWord = stmt.trim().split(/\s+/)[0];
+  if (firstWord !== "rm" && !firstWord?.endsWith("/rm")) return false;
+
   // Don't silently allow if the statement also matches other DANGEROUS patterns
   // (e.g., sudo rm -rf .pi/tmp/foo — sudo should still trigger confirmation)
   if (/\bsudo\b/i.test(stmt)) return false;
@@ -145,11 +149,25 @@ export function isRmInProjectTmp(stmt: string, cwd: string): boolean {
       // Use realpathSync to resolve symlinks — prevents symlink traversal attacks
       resolved = realpathSync(path.resolve(cwd, expanded));
     } catch {
-      // Path doesn't exist. For explicit /tmp/<something> paths, use lexical resolution
-      // (no symlink risk since the target doesn't exist). Only when the original path
-      // explicitly starts with /tmp/ — not paths that resolve there via traversal.
+      // Path doesn't exist. For /tmp paths, validate the existing parent via realpathSync
+      // to catch symlinked parents (e.g., /tmp/evil-link -> / where evil-link exists).
       const lexical = path.resolve(cwd, expanded);
-      if (expanded.startsWith("/tmp/") && lexical.startsWith("/tmp/") && lexical !== "/tmp" && lexical.length > 5) {
+      if (lexical.startsWith("/tmp/") && lexical !== "/tmp" && lexical.length > 5) {
+        // Block paths containing traversal sequences — even if they resolve under /tmp/,
+        // they may have escaped and re-entered via ..
+        if (expanded.includes("..")) {
+          return false;
+        }
+        // Validate that the existing parent resolves under /tmp
+        const parentDir = path.dirname(lexical);
+        try {
+          const resolvedParent = realpathSync(parentDir);
+          if (!resolvedParent.startsWith("/tmp")) {
+            return false; // Parent symlinks outside /tmp
+          }
+        } catch {
+          // Parent also doesn't exist — safe (entire path is non-existent)
+        }
         resolved = lexical;
       } else {
         return false;

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -162,7 +162,10 @@ export function isRmInProjectTmp(stmt: string, cwd: string): boolean {
         const parentDir = path.dirname(lexical);
         try {
           const resolvedParent = realpathSync(parentDir);
-          if (!resolvedParent.startsWith("/tmp/") && resolvedParent !== "/tmp") {
+          // Resolve /tmp itself to handle systems where /tmp is a symlink (e.g., /private/tmp on macOS)
+          let resolvedTmp: string;
+          try { resolvedTmp = realpathSync("/tmp"); } catch { resolvedTmp = "/tmp"; }
+          if (!resolvedParent.startsWith(resolvedTmp + "/") && resolvedParent !== resolvedTmp) {
             return false; // Parent symlinks outside /tmp
           }
         } catch {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -97,9 +97,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     // Set comment signature env var for CLI tools to read
     if (getSetting(ctx.cwd, "comment_signature")) {
       const modelId = (ctx as any).model?.id || "unknown";
-      process.env.PI_COMMENT_SIGNATURE_LINE = `Assisted-by: PI (${modelId})`;
+      process.env.PI_COMMENT_SIGNATURE = `Assisted-by: PI (${modelId})`;
     } else {
-      delete process.env.PI_COMMENT_SIGNATURE_LINE;
+      delete process.env.PI_COMMENT_SIGNATURE;
     }
   });
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -97,9 +97,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     // Set comment signature env var for CLI tools to read
     if (getSetting(ctx.cwd, "comment_signature")) {
       const modelId = (ctx as any).model?.id || "unknown";
-      process.env.PI_COMMENT_SIGNATURE = `Assisted-by: PI (${modelId})`;
+      process.env.PI_COMMENT_SIGNATURE_LINE = `Assisted-by: PI (${modelId})`;
     } else {
-      delete process.env.PI_COMMENT_SIGNATURE;
+      delete process.env.PI_COMMENT_SIGNATURE_LINE;
     }
   });
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -92,8 +92,15 @@ function resolveEffectiveCwd(command: string, sessionCwd: string): string {
 
 export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): void {
 
-  pi.on("session_start", () => {
+  pi.on("session_start", (_event, ctx) => {
     cachedTrailerSelection = null;
+    // Set comment signature env var for CLI tools to read
+    if (getSetting(ctx.cwd, "comment_signature")) {
+      const modelId = (ctx as any).model?.id || "unknown";
+      process.env.PI_COMMENT_SIGNATURE = `Assisted-by: PI (${modelId})`;
+    } else {
+      delete process.env.PI_COMMENT_SIGNATURE;
+    }
   });
 
   pi.on("tool_call", async (event, ctx) => {

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -169,8 +169,6 @@ export function getSetting(cwd: string, key: string): boolean | string | number 
     }
     case "comment_signature": {
       if (settings.comment_signature !== undefined) return settings.comment_signature;
-      const env = parseBoolEnv("PI_COMMENT_SIGNATURE");
-      if (env !== undefined) return env;
       return false; // default: disabled
     }
     default:

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -20,6 +20,7 @@ interface ProjectSettings {
   use_worktrees?: boolean;
   dream_interval_hours?: number;
   dco?: boolean;
+  comment_signature?: boolean;
 }
 
 const SETTINGS_FILENAME = "pi-config-settings.json";
@@ -41,6 +42,7 @@ function parseSettingsFile(filePath: string): ProjectSettings {
       result.dream_interval_hours = raw.dream_interval_hours;
     }
     if (typeof raw.dco === "boolean") result.dco = raw.dco;
+    if (typeof raw.comment_signature === "boolean") result.comment_signature = raw.comment_signature;
     return result;
   } catch (e: any) {
     console.debug(`[project-settings] failed to parse ${filePath}:`, e?.message?.slice(0, 100));
@@ -126,6 +128,7 @@ export function getSetting(cwd: string, key: "allow_push_to_protected_branches")
 export function getSetting(cwd: string, key: "use_worktrees"): boolean;
 export function getSetting(cwd: string, key: "dream_interval_hours"): number;
 export function getSetting(cwd: string, key: "dco"): boolean;
+export function getSetting(cwd: string, key: "comment_signature"): boolean;
 export function getSetting(cwd: string, key: string): boolean | string | number {
   const settings = getSettings(cwd);
 
@@ -161,6 +164,12 @@ export function getSetting(cwd: string, key: string): boolean | string | number 
     case "dco": {
       if (settings.dco !== undefined) return settings.dco;
       const env = parseBoolEnv("PI_DCO");
+      if (env !== undefined) return env;
+      return false; // default: disabled
+    }
+    case "comment_signature": {
+      if (settings.comment_signature !== undefined) return settings.comment_signature;
+      const env = parseBoolEnv("PI_COMMENT_SIGNATURE");
       if (env !== undefined) return env;
       return false; // default: disabled
     }

--- a/myk_pi_tools/comment_signature.py
+++ b/myk_pi_tools/comment_signature.py
@@ -10,7 +10,7 @@ import os
 
 
 def append_signature(body: str) -> str:
-    """Append AI signature to a comment body if PI_COMMENT_SIGNATURE_LINE is set.
+    """Append AI signature to a comment body if PI_COMMENT_SIGNATURE is set.
 
     Idempotent — checks for existing signature before appending to prevent
     duplicate signatures on retries/updates.

--- a/myk_pi_tools/comment_signature.py
+++ b/myk_pi_tools/comment_signature.py
@@ -1,6 +1,6 @@
 """Comment signature injection for AI-posted PR comments.
 
-Reads PI_COMMENT_SIGNATURE_LINE env var (set by the pi extension on session_start)
+Reads PI_COMMENT_SIGNATURE env var (set by the pi extension on session_start)
 and appends a signature line to comment bodies.
 """
 
@@ -22,7 +22,7 @@ def append_signature(body: str) -> str:
         Body with signature appended, or unchanged if env var is not set
         or signature already present.
     """
-    signature = os.environ.get("PI_COMMENT_SIGNATURE_LINE")
+    signature = os.environ.get("PI_COMMENT_SIGNATURE")
     if not signature:
         return body
     # Check if signature is already present (idempotent — prevents duplicates on retry)

--- a/myk_pi_tools/comment_signature.py
+++ b/myk_pi_tools/comment_signature.py
@@ -1,0 +1,24 @@
+"""Comment signature injection for AI-posted PR comments.
+
+Reads PI_COMMENT_SIGNATURE env var (set by the pi extension on session_start)
+and appends a signature line to comment bodies.
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def append_signature(body: str) -> str:
+    """Append AI signature to a comment body if PI_COMMENT_SIGNATURE is set.
+
+    Args:
+        body: Original comment body.
+
+    Returns:
+        Body with signature appended, or unchanged if env var is not set.
+    """
+    signature = os.environ.get("PI_COMMENT_SIGNATURE")
+    if not signature:
+        return body
+    return f"{body}\n\n---\n*{signature}*"

--- a/myk_pi_tools/comment_signature.py
+++ b/myk_pi_tools/comment_signature.py
@@ -1,6 +1,6 @@
 """Comment signature injection for AI-posted PR comments.
 
-Reads PI_COMMENT_SIGNATURE env var (set by the pi extension on session_start)
+Reads PI_COMMENT_SIGNATURE_LINE env var (set by the pi extension on session_start)
 and appends a signature line to comment bodies.
 """
 
@@ -10,15 +10,23 @@ import os
 
 
 def append_signature(body: str) -> str:
-    """Append AI signature to a comment body if PI_COMMENT_SIGNATURE is set.
+    """Append AI signature to a comment body if PI_COMMENT_SIGNATURE_LINE is set.
+
+    Idempotent — checks for existing signature before appending to prevent
+    duplicate signatures on retries/updates.
 
     Args:
         body: Original comment body.
 
     Returns:
-        Body with signature appended, or unchanged if env var is not set.
+        Body with signature appended, or unchanged if env var is not set
+        or signature already present.
     """
-    signature = os.environ.get("PI_COMMENT_SIGNATURE")
+    signature = os.environ.get("PI_COMMENT_SIGNATURE_LINE")
     if not signature:
         return body
-    return f"{body}\n\n---\n*{signature}*"
+    # Check if signature is already present (idempotent — prevents duplicates on retry)
+    signature_line = f"*{signature}*"
+    if signature_line in body:
+        return body
+    return f"{body}\n\n---\n{signature_line}"

--- a/myk_pi_tools/pr/commands.py
+++ b/myk_pi_tools/pr/commands.py
@@ -81,3 +81,20 @@ def pr_store_review(json_file: str) -> None:
 
     exit_code = run_store(json_file)
     sys.exit(exit_code)
+
+
+@pr.command("info")
+@click.argument("args", nargs=-1)
+def pr_info(args: tuple[str, ...]) -> None:
+    """Fetch PR information as structured JSON.
+
+    Returns author, head SHA, base ref, title, state, labels, assignees.
+
+    Usage:
+        pr info <owner/repo> <pr_number>
+        pr info https://github.com/owner/repo/pull/123
+        pr info <pr_number>
+    """
+    from myk_pi_tools.pr.info import run
+
+    run(list(args))

--- a/myk_pi_tools/pr/info.py
+++ b/myk_pi_tools/pr/info.py
@@ -54,6 +54,12 @@ def fetch_pr_info(pr_info: PRInfo) -> dict[str, Any]:
             timeout=60,
         )
         return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(
+            f"Error: Invalid JSON response from GitHub API for {pr_info.repo_full_name}#{pr_info.pr_number}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
     except FileNotFoundError:
         print(
             "Error: GitHub CLI (gh) not found. Install gh to fetch PR info.",

--- a/myk_pi_tools/pr/info.py
+++ b/myk_pi_tools/pr/info.py
@@ -1,0 +1,118 @@
+"""Fetch PR information as structured JSON.
+
+Usage:
+    myk-pi-tools pr info <owner/repo> <pr_number>
+    myk-pi-tools pr info https://github.com/owner/repo/pull/123
+    myk-pi-tools pr info <pr_number>
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any
+
+from myk_pi_tools.pr.common import PRInfo
+from myk_pi_tools.pr.common import parse_args as _parse_args
+
+
+def parse_args(args: list[str]) -> PRInfo:
+    """Parse command arguments for pr info.
+
+    Args:
+        args: Command line arguments.
+
+    Returns:
+        PRInfo with owner, repo, and pr_number.
+    """
+    return _parse_args(args, command_name="info", docstring=__doc__)
+
+
+def fetch_pr_info(pr_info: PRInfo) -> dict[str, Any]:
+    """Fetch PR information from GitHub API.
+
+    Args:
+        pr_info: Parsed PR information.
+
+    Returns:
+        PR data dictionary from GitHub API.
+
+    Raises:
+        SystemExit: If API call fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"/repos/{pr_info.owner}/{pr_info.repo}/pulls/{pr_info.pr_number}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=60,
+        )
+        return json.loads(result.stdout)
+    except FileNotFoundError:
+        print(
+            "Error: GitHub CLI (gh) not found. Install gh to fetch PR info.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print(
+            f"Error: Timed out fetching PR info for {pr_info.repo_full_name}#{pr_info.pr_number}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        print(
+            f"Error: Failed to fetch PR info for {pr_info.repo_full_name}#{pr_info.pr_number}",
+            file=sys.stderr,
+        )
+        print(e.stderr, file=sys.stderr)
+        sys.exit(1)
+
+
+def run(args: list[str]) -> None:
+    """Run the pr info command.
+
+    Args:
+        args: Command line arguments.
+    """
+    pr_info = parse_args(args)
+    data = fetch_pr_info(pr_info)
+
+    author = data.get("user", {}).get("login", "")
+    head_sha = data.get("head", {}).get("sha", "")
+    base_ref = data.get("base", {}).get("ref", "")
+    title = data.get("title", "")
+    state = data.get("state", "")
+    body = data.get("body", "") or ""
+    labels = [label.get("name", "") for label in data.get("labels", [])]
+    assignees = [a.get("login", "") for a in data.get("assignees", [])]
+
+    # Detect if PR is from a fork
+    head_repo = data.get("head", {}).get("repo", {}) or {}
+    base_repo = data.get("base", {}).get("repo", {}) or {}
+    is_fork = head_repo.get("full_name", "") != base_repo.get("full_name", "")
+    head_repo_full = head_repo.get("full_name", "")
+
+    output = {
+        "owner": pr_info.owner,
+        "repo": pr_info.repo,
+        "pr_number": pr_info.pr_number,
+        "author": author,
+        "head_sha": head_sha,
+        "base_ref": base_ref,
+        "title": title,
+        "state": state,
+        "labels": labels,
+        "assignees": assignees,
+        "is_fork": is_fork,
+        "head_repo": head_repo_full,
+        "body": body,
+    }
+
+    print(json.dumps(output, indent=2))

--- a/myk_pi_tools/pr/post_comment.py
+++ b/myk_pi_tools/pr/post_comment.py
@@ -276,7 +276,9 @@ def post_review(
     Returns:
         ReviewResult with status and details.
     """
-    review_body = generate_review_body(comments)
+    from myk_pi_tools.comment_signature import append_signature
+
+    review_body = append_signature(generate_review_body(comments))
 
     # Build review payload
     payload = {
@@ -287,7 +289,7 @@ def post_review(
             {
                 "path": c.path,
                 "line": c.line,
-                "body": c.body,
+                "body": append_signature(c.body),
                 "side": "RIGHT",
             }
             for c in comments

--- a/myk_pi_tools/reviews/ask_qodo.py
+++ b/myk_pi_tools/reviews/ask_qodo.py
@@ -1,0 +1,149 @@
+"""Ask Qodo a question and wait for reply.
+
+Posts a comment mentioning @qodo-code-review with the question,
+then waits up to 10 minutes for Qodo's reply.
+
+Usage:
+    myk-pi-tools reviews ask-qodo <question>
+    myk-pi-tools reviews ask-qodo --pr <owner/repo> <pr_number> <question>
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+
+from myk_pi_tools.reviews.fetch import get_pr_info, print_stderr, run_gh_api
+
+
+def post_and_wait_for_qodo_reply(
+    owner: str,
+    repo: str,
+    pr_number: str,
+    message: str,
+    match_lines: list[str],
+    timeout: int = 600,
+    poll_interval: int = 30,
+    label: str = "ask-qodo",
+) -> str:
+    """Post a comment mentioning @qodo-code-review and wait for reply.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: PR number.
+        message: Full message body to post (should include @qodo-code-review).
+        match_lines: Lines to match in Qodo's reply (it quotes our message).
+        timeout: Max wait time in seconds (default 600 = 10 min).
+        poll_interval: Seconds between checks (default 30).
+        label: Label for log messages.
+
+    Returns:
+        Qodo's reply body text, or empty string on timeout/failure.
+    """
+    post_time = datetime.now(UTC).isoformat()
+
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "api",
+                f"/repos/{owner}/{repo}/issues/{pr_number}/comments",
+                "-X",
+                "POST",
+                "-f",
+                f"body={message}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        print_stderr(f"[{label}] Posted comment to @qodo-code-review.")
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip() if e.stderr else ""
+        print_stderr(f"[{label}] Failed to post comment (rc={e.returncode}): {stderr}")
+        return ""
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print_stderr(f"[{label}] Failed to post comment: {e}")
+        return ""
+
+    print_stderr(f"[{label}] Waiting for Qodo reply (up to {timeout // 60} min)...")
+    start = time.time()
+    while time.time() - start < timeout:
+        time.sleep(poll_interval)
+        try:
+            endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+            comments = run_gh_api(endpoint, paginate=True)
+            if not comments or not isinstance(comments, list):
+                continue
+
+            for comment in comments:
+                author = comment.get("user", {}).get("login") if comment.get("user") else None
+                if author != "qodo-code-review[bot]":
+                    continue
+                created = comment.get("created_at", "")
+                if created <= post_time:
+                    continue
+                body = comment.get("body", "")
+                if all(line in body for line in match_lines):
+                    print_stderr(f"[{label}] Received Qodo reply.")
+                    return body
+        except Exception as e:
+            print_stderr(f"[{label}] Error checking for reply: {e}")
+
+    print_stderr(f"[{label}] Timeout waiting for Qodo reply ({timeout // 60} min).")
+    return ""
+
+
+def ask_qodo(owner: str, repo: str, pr_number: str, question: str) -> str:
+    """Post a question to Qodo and wait for reply."""
+    message = f"@qodo-code-review\n\n{question}"
+    match_lines = [line.strip() for line in question.strip().splitlines() if line.strip()]
+    return post_and_wait_for_qodo_reply(
+        owner,
+        repo,
+        pr_number,
+        message,
+        match_lines,
+        label="ask-qodo",
+    )
+
+
+def run(args: list[str]) -> None:
+    """Run the ask-qodo command.
+
+    Args:
+        args: Command line arguments. Last arg is the question.
+              Optional: --pr owner/repo pr_number before the question.
+    """
+    if not args or args[0] in ("-h", "--help"):
+        print(__doc__ or "", file=sys.stderr)
+        sys.exit(0)
+
+    # Parse args
+    if "--pr" in args:
+        pr_idx = args.index("--pr")
+        if pr_idx + 2 >= len(args):
+            print("Error: --pr requires <owner/repo> <pr_number>", file=sys.stderr)
+            sys.exit(1)
+        owner_repo = args[pr_idx + 1]
+        pr_number = args[pr_idx + 2]
+        owner, repo = owner_repo.split("/", 1)
+        # Question is everything except --pr and its args
+        question_parts = args[:pr_idx] + args[pr_idx + 3 :]
+        question = " ".join(question_parts)
+    else:
+        # Auto-detect PR from current branch
+        owner, repo, pr_number = get_pr_info("")
+        question = " ".join(args)
+
+    if not question.strip():
+        print("Error: question is required", file=sys.stderr)
+        sys.exit(1)
+
+    reply = ask_qodo(owner, repo, pr_number, question)
+    print(reply)
+    sys.exit(0 if reply else 1)

--- a/myk_pi_tools/reviews/ask_qodo.py
+++ b/myk_pi_tools/reviews/ask_qodo.py
@@ -17,6 +17,8 @@ from datetime import UTC, datetime
 
 from myk_pi_tools.reviews.fetch import get_pr_info, print_stderr, run_gh_api
 
+_QODO_AUTHORS = {"qodo-code-review[bot]", "qodo-code-review"}
+
 
 def post_and_wait_for_qodo_reply(
     owner: str,
@@ -82,10 +84,17 @@ def post_and_wait_for_qodo_reply(
 
             for comment in comments:
                 author = comment.get("user", {}).get("login") if comment.get("user") else None
-                if author != "qodo-code-review[bot]":
+                if author not in _QODO_AUTHORS:
                     continue
                 created = comment.get("created_at", "")
-                if created <= post_time:
+                if not created:
+                    continue
+                try:
+                    created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                    post_dt = datetime.fromisoformat(post_time.replace("Z", "+00:00"))
+                    if created_dt <= post_dt:
+                        continue
+                except (ValueError, TypeError):
                     continue
                 body = comment.get("body", "")
                 if all(line in body for line in match_lines):

--- a/myk_pi_tools/reviews/commands.py
+++ b/myk_pi_tools/reviews/commands.py
@@ -132,6 +132,22 @@ def reviews_status(pr: int | None, output_dir: str) -> None:
     run(pr_number=pr, output_dir=output_dir)
 
 
+@reviews.command("ask-qodo")
+@click.argument("args", nargs=-1)
+def reviews_ask_qodo(args: tuple[str, ...]) -> None:
+    """Ask Qodo a question about the current PR and wait for reply.
+
+    Posts @qodo-code-review comment with your question, waits up to 10 min for reply.
+
+    Usage:
+        reviews ask-qodo "What specific edge cases are missing for finding 11?"
+        reviews ask-qodo --pr owner/repo 559 "What edge cases are missing?"
+    """
+    from myk_pi_tools.reviews.ask_qodo import run
+
+    run(list(args))
+
+
 @reviews.command("store")
 @click.argument("json_path")
 def reviews_store(json_path: str) -> None:

--- a/myk_pi_tools/reviews/commands.py
+++ b/myk_pi_tools/reviews/commands.py
@@ -28,10 +28,16 @@ def reviews_fetch(review_url: str, include_resolved: bool, user: str | None, out
     REVIEW_URL: Optional specific review URL for context
     (e.g., #pullrequestreview-XXX or #discussion_rXXX)
     """
+    import json
+
     from myk_pi_tools.reviews.fetch import run
 
-    exit_code = run(review_url, include_resolved=include_resolved, user=user, output_dir=output_dir)
-    sys.exit(exit_code)
+    result = run(review_url, include_resolved=include_resolved, user=user, output_dir=output_dir)
+    if isinstance(result, dict):
+        print(json.dumps(result, indent=2))
+        sys.exit(0)
+    else:
+        sys.exit(result)
 
 
 @reviews.command("poll")

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1532,6 +1532,7 @@ def run(
             "qodo": categorized["qodo"],
             "coderabbit": categorized["coderabbit"],
             "approved": _is_approved,
+            "qodo_cleanup_response": "",
         }
 
         # Save to file atomically

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1253,7 +1253,13 @@ def fetch_review_body(owner: str, repo: str, pr_number: str, review_id: str) -> 
     return result if isinstance(result, dict) else None
 
 
-def run(review_url: str = "", include_resolved: bool = False, user: str | None = None, *, output_dir: str) -> int:
+def run(
+    review_url: str = "",
+    include_resolved: bool = False,
+    user: str | None = None,
+    *,
+    output_dir: str,
+) -> dict[str, Any] | int:
     """Main entry point.
 
     Args:
@@ -1433,10 +1439,7 @@ def run(review_url: str = "", include_resolved: bool = False, user: str | None =
         if auto_skipped:
             print_stderr(f"Auto-skipped {auto_skipped} previously dismissed comment(s)")
 
-        # Output to stdout
-        print(json.dumps(final_output, indent=2))
-
-        return 0
+        return final_output
 
     finally:
         cleanup()

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1268,8 +1268,7 @@ def is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | Non
     - reason: str ("all_resolved")
     - total_findings: int (total in sticky, resolved + unresolved)
     - resolved_count: int (resolved/dismissed by Qodo)
-    - unresolved_count: int (still open in sticky)
-    - findings: list of dicts with title, status, reply (from DB for already-replied)
+    - unresolved_count: int (0 when approved)
     """
     from myk_pi_tools.reviews.qodo_parser import is_qodo_sticky_comment, parse_qodo_sticky_comment
 

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1362,7 +1362,7 @@ def is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | Non
                     finding_code_diff = finding.get("code_diff") or ""
                     key = (sticky_id, finding_body, finding_code_diff)
                     db_record = replied_map.get(key)
-                    if db_record:
+                    if db_record and db_record.get("status") == "addressed":
                         findings_summary.append({
                             "title": finding.get("title", ""),
                             "finding_type": finding.get("finding_type", ""),
@@ -1497,6 +1497,7 @@ def run(
 
         # Skip bot comment fetching when filtering by specific user
         qodo_replies: list[dict[str, Any]] | None = None
+        issue_comments: list[dict[str, Any]] | None = None
         if not user:
             # Fetch CodeRabbit body-embedded comments from review bodies
             print_stderr("Fetching CodeRabbit body-embedded comments...")
@@ -1601,7 +1602,7 @@ def run(
         auto_skip_replied_findings(categorized.get("qodo", []))
 
         # Check Qodo approval status
-        _approval = is_qodo_approved(owner, repo, str(pr_number))
+        _approval = is_qodo_approved(owner, repo, str(pr_number), comments=issue_comments)
         _is_approved = bool(_approval and _approval.get("approved"))
 
         # Build final output

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1253,6 +1253,208 @@ def fetch_review_body(owner: str, repo: str, pr_number: str, review_id: str) -> 
     return result if isinstance(result, dict) else None
 
 
+def is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | None = None) -> dict | None:
+    """Check if Qodo has approved the PR.
+
+    Returns a summary dict if approved, None if not approved.
+
+    Approved when:
+    1. Sticky comment has 0 unresolved findings (or all unresolved are already replied to)
+    2. Sticky has at least one resolved/dismissed finding (not empty)
+    3. Sticky updated_at is AFTER PR head commit date (Qodo finished reviewing latest)
+
+    Returns dict with keys:
+    - approved: True
+    - reason: str ("all_resolved" or "stale_sticky")
+    - total_findings: int (total in sticky, resolved + unresolved)
+    - resolved_count: int (resolved/dismissed by Qodo)
+    - unresolved_count: int (still open in sticky)
+    - findings: list of dicts with title, status, reply (from DB for already-replied)
+    """
+    from myk_pi_tools.reviews.qodo_parser import is_qodo_sticky_comment, parse_qodo_sticky_comment
+
+    # Get PR head SHA
+    pr_endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}"
+    pr_data = run_gh_api(pr_endpoint)
+    if not isinstance(pr_data, dict):
+        return None
+    head_sha = pr_data.get("head", {}).get("sha", "")
+    if not head_sha:
+        return None
+
+    # Get commit date for PR HEAD
+    commit_endpoint = f"/repos/{owner}/{repo}/commits/{head_sha}"
+    commit_data = run_gh_api(commit_endpoint)
+    if not isinstance(commit_data, dict):
+        return None
+    commit_date = commit_data.get("commit", {}).get("committer", {}).get("date", "")
+    if not commit_date:
+        return None
+
+    # Find the Qodo sticky comment
+    if comments is None:
+        endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
+        comments = run_gh_api(endpoint, paginate=True)
+    if not comments or not isinstance(comments, list):
+        return None
+
+    _QODO_USERS = {"qodo-code-review[bot]", "qodo-code-review"}
+
+    for comment in comments:
+        author = comment.get("user", {}).get("login") if comment.get("user") else None
+        if author not in _QODO_USERS:
+            continue
+
+        body = comment.get("body", "")
+        if not is_qodo_sticky_comment(body):
+            continue
+
+        # Check sticky was updated AFTER the commit
+        sticky_updated = comment.get("updated_at", "")
+        if not sticky_updated or sticky_updated < commit_date:
+            print_stderr(f"[poll] Sticky updated {sticky_updated} but commit at {commit_date} — not yet reviewed.")
+            return None
+
+        # Parse for unresolved findings
+        unresolved = parse_qodo_sticky_comment(body)
+
+        # Count resolved findings from the sticky body
+        import re as _re
+
+        _prev_re = _re.compile(r"^\s*<!-- FOLDED_SECTION_START -->\s*$", _re.MULTILINE)
+        _prev_match = _prev_re.search(body)
+        current_body = body[: _prev_match.start()] if _prev_match else body
+        resolved_count = current_body.count("Resolved</code>") + current_body.count("Dismissed</code>")
+        total_findings = resolved_count + len(unresolved)
+
+        if len(unresolved) > 0:
+            # Check if all unresolved findings were already replied to (stale sticky)
+            try:
+                from myk_pi_tools.db.query import ReviewDB as _ReviewDB
+
+                db = _ReviewDB(db_path=None)
+                replied = db.get_replied_sticky_findings(owner, repo, int(pr_number))
+
+                # Build lookup: (comment_id, body, code_diff) -> DB record
+                replied_map: dict[tuple[int, str, str], dict] = {}
+                for r in replied:
+                    cid = r.get("comment_id")
+                    rbody = r.get("body") or ""
+                    rcode_diff = r.get("code_diff") or ""
+                    if cid is not None:
+                        key = (int(cid), rbody, rcode_diff)
+                        existing = replied_map.get(key)
+                        if existing is None:
+                            replied_map[key] = r
+                        else:
+                            # Prefer records with meaningful replies over dedup artifacts
+                            existing_reply = existing.get("reply") or ""
+                            new_reply = r.get("reply") or ""
+                            if "Already replied" in existing_reply and "Already replied" not in new_reply and new_reply:
+                                replied_map[key] = r
+
+                # Check each unresolved finding
+                sticky_id = int(comment.get("id", 0))
+                all_replied = True
+                findings_summary = []
+                for finding in unresolved:
+                    finding_body = f"**{finding.get('title', '')}**\n\n{finding.get('description', '')}"
+                    finding_code_diff = finding.get("code_diff") or ""
+                    key = (sticky_id, finding_body, finding_code_diff)
+                    db_record = replied_map.get(key)
+                    if db_record:
+                        findings_summary.append({
+                            "title": finding.get("title", ""),
+                            "finding_type": finding.get("finding_type", ""),
+                            "status": db_record.get("status", "unknown"),
+                            "reply": db_record.get("reply", ""),
+                        })
+                    else:
+                        all_replied = False
+                        break
+
+                if all_replied:
+                    print_stderr(
+                        f"[poll] Sticky has {len(unresolved)} unresolved finding(s),"
+                        f" but all already replied to (stale sticky)."
+                    )
+                    print_stderr("[poll] Treating stale sticky as approved.")
+                    return {
+                        "approved": True,
+                        "reason": "stale_sticky",
+                        "total_findings": total_findings,
+                        "resolved_count": resolved_count,
+                        "unresolved_count": len(unresolved),
+                        "findings": findings_summary,
+                    }
+            except Exception as e:
+                print_stderr(f"[poll] Warning: Could not check replied sticky findings: {e}")
+
+            print_stderr(f"[poll] Sticky has {len(unresolved)} unresolved finding(s).")
+            return None
+
+        # Check at least one resolved/dismissed finding exists
+        has_resolved = (
+            "✓ Resolved" in current_body
+            or "Resolved</code>" in current_body
+            or "✗ Dismissed" in current_body
+            or "Dismissed</code>" in current_body
+        )
+        if not has_resolved:
+            print_stderr("[poll] Sticky has no resolved findings — empty review.")
+            return None
+
+        # All checks passed — fully approved by Qodo
+        return {
+            "approved": True,
+            "reason": "all_resolved",
+            "total_findings": total_findings,
+            "resolved_count": resolved_count,
+            "unresolved_count": 0,
+            "findings": [],
+        }
+
+    # No sticky comment found
+    return None
+
+
+def print_approval_summary(approval: dict) -> None:
+    """Print a summary of the Qodo approval status."""
+    reason = approval.get("reason", "unknown")
+    total = approval.get("total_findings", 0)
+    resolved = approval.get("resolved_count", 0)
+    unresolved = approval.get("unresolved_count", 0)
+    findings = approval.get("findings", [])
+
+    print_stderr("")
+    print_stderr("[poll] === Qodo Approval Summary ===")
+    print_stderr(f"  Total findings: {total} ({resolved} resolved by Qodo, {unresolved} still in sticky)")
+
+    if reason == "all_resolved":
+        print_stderr("  Status: All findings resolved/dismissed by Qodo ✅")
+    elif reason == "stale_sticky":
+        print_stderr("  Status: Stale sticky — all unresolved findings already replied to")
+        if findings:
+            print_stderr("")
+            print_stderr("  Unresolved findings (already replied):")
+            for i, f in enumerate(findings, 1):
+                title = f.get("title", "unknown")
+                status = f.get("status", "unknown")
+                finding_type = f.get("finding_type", "")
+                reply = f.get("reply", "")
+                status_icon = {"addressed": "✅", "not_addressed": "⚠️", "skipped": "⏭️"}.get(status, "❓")
+                type_tag = f" [{finding_type}]" if finding_type else ""
+                print_stderr(f"    {i}. {status_icon} [{status}]{type_tag} {title}")
+                if reply:
+                    # Show first line of reply, truncated
+                    reason_line = reply.split("\n")[0].strip()
+                    if len(reason_line) > 100:
+                        reason_line = reason_line[:97] + "..."
+                    print_stderr(f"       Reply: {reason_line}")
+
+    print_stderr("")
+
+
 def run(
     review_url: str = "",
     include_resolved: bool = False,
@@ -1398,6 +1600,10 @@ def run(
         # Post-enrichment: auto-skip already-replied sticky findings where Qodo didn't push back
         auto_skip_replied_findings(categorized.get("qodo", []))
 
+        # Check Qodo approval status
+        _approval = is_qodo_approved(owner, repo, str(pr_number))
+        _is_approved = bool(_approval and _approval.get("approved"))
+
         # Build final output
         final_output = {
             "metadata": {
@@ -1409,6 +1615,7 @@ def run(
             "human": categorized["human"],
             "qodo": categorized["qodo"],
             "coderabbit": categorized["coderabbit"],
+            "approved": _is_approved,
         }
 
         # Save to file atomically
@@ -1430,9 +1637,9 @@ def run(
         print_stderr(f"Saved to: {json_path}")
 
         # Count by category
-        human_count = len(final_output["human"])
-        qodo_count = len(final_output["qodo"])
-        coderabbit_count = len(final_output["coderabbit"])
+        human_count = len(categorized["human"])
+        qodo_count = len(categorized["qodo"])
+        coderabbit_count = len(categorized["coderabbit"])
         print_stderr(f"Categories: human={human_count}, qodo={qodo_count}, coderabbit={coderabbit_count}")
 
         # Count auto-skipped comments

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1269,7 +1269,8 @@ def run(
         output_dir: Directory for output JSON file.
 
     Returns:
-        Exit code (0 for success, 1 for error).
+        dict with keys (metadata, human, qodo, coderabbit) on success,
+        or int exit code (1) on error.
     """
     try:
         check_dependencies()

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1259,13 +1259,13 @@ def is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | Non
     Returns a summary dict if approved, None if not approved.
 
     Approved when:
-    1. Sticky comment has 0 unresolved findings (or all unresolved are already replied to)
+    1. Sticky comment has 0 unresolved findings (literal 0 from Qodo)
     2. Sticky has at least one resolved/dismissed finding (not empty)
     3. Sticky updated_at is AFTER PR head commit date (Qodo finished reviewing latest)
 
     Returns dict with keys:
     - approved: True
-    - reason: str ("all_resolved" or "stale_sticky")
+    - reason: str ("all_resolved")
     - total_findings: int (total in sticky, resolved + unresolved)
     - resolved_count: int (resolved/dismissed by Qodo)
     - unresolved_count: int (still open in sticky)
@@ -1328,68 +1328,6 @@ def is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | Non
         total_findings = resolved_count + len(unresolved)
 
         if len(unresolved) > 0:
-            # Check if all unresolved findings were already replied to (stale sticky)
-            try:
-                from myk_pi_tools.db.query import ReviewDB as _ReviewDB
-
-                db = _ReviewDB(db_path=None)
-                replied = db.get_replied_sticky_findings(owner, repo, int(pr_number))
-
-                # Build lookup: (comment_id, body, code_diff) -> DB record
-                replied_map: dict[tuple[int, str, str], dict] = {}
-                for r in replied:
-                    cid = r.get("comment_id")
-                    rbody = r.get("body") or ""
-                    rcode_diff = r.get("code_diff") or ""
-                    if cid is not None:
-                        key = (int(cid), rbody, rcode_diff)
-                        existing = replied_map.get(key)
-                        if existing is None:
-                            replied_map[key] = r
-                        else:
-                            # Prefer records with meaningful replies over dedup artifacts
-                            existing_reply = existing.get("reply") or ""
-                            new_reply = r.get("reply") or ""
-                            if "Already replied" in existing_reply and "Already replied" not in new_reply and new_reply:
-                                replied_map[key] = r
-
-                # Check each unresolved finding
-                sticky_id = int(comment.get("id", 0))
-                all_replied = True
-                findings_summary = []
-                for finding in unresolved:
-                    finding_body = f"**{finding.get('title', '')}**\n\n{finding.get('description', '')}"
-                    finding_code_diff = finding.get("code_diff") or ""
-                    key = (sticky_id, finding_body, finding_code_diff)
-                    db_record = replied_map.get(key)
-                    if db_record and db_record.get("status") == "addressed":
-                        findings_summary.append({
-                            "title": finding.get("title", ""),
-                            "finding_type": finding.get("finding_type", ""),
-                            "status": db_record.get("status", "unknown"),
-                            "reply": db_record.get("reply", ""),
-                        })
-                    else:
-                        all_replied = False
-                        break
-
-                if all_replied:
-                    print_stderr(
-                        f"[poll] Sticky has {len(unresolved)} unresolved finding(s),"
-                        f" but all already replied to (stale sticky)."
-                    )
-                    print_stderr("[poll] Treating stale sticky as approved.")
-                    return {
-                        "approved": True,
-                        "reason": "stale_sticky",
-                        "total_findings": total_findings,
-                        "resolved_count": resolved_count,
-                        "unresolved_count": len(unresolved),
-                        "findings": findings_summary,
-                    }
-            except Exception as e:
-                print_stderr(f"[poll] Warning: Could not check replied sticky findings: {e}")
-
             print_stderr(f"[poll] Sticky has {len(unresolved)} unresolved finding(s).")
             return None
 
@@ -1411,7 +1349,6 @@ def is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | Non
             "total_findings": total_findings,
             "resolved_count": resolved_count,
             "unresolved_count": 0,
-            "findings": [],
         }
 
     # No sticky comment found
@@ -1424,33 +1361,12 @@ def print_approval_summary(approval: dict) -> None:
     total = approval.get("total_findings", 0)
     resolved = approval.get("resolved_count", 0)
     unresolved = approval.get("unresolved_count", 0)
-    findings = approval.get("findings", [])
-
     print_stderr("")
     print_stderr("[poll] === Qodo Approval Summary ===")
     print_stderr(f"  Total findings: {total} ({resolved} resolved by Qodo, {unresolved} still in sticky)")
 
     if reason == "all_resolved":
         print_stderr("  Status: All findings resolved/dismissed by Qodo ✅")
-    elif reason == "stale_sticky":
-        print_stderr("  Status: Stale sticky — all unresolved findings already replied to")
-        if findings:
-            print_stderr("")
-            print_stderr("  Unresolved findings (already replied):")
-            for i, f in enumerate(findings, 1):
-                title = f.get("title", "unknown")
-                status = f.get("status", "unknown")
-                finding_type = f.get("finding_type", "")
-                reply = f.get("reply", "")
-                status_icon = {"addressed": "✅", "not_addressed": "⚠️", "skipped": "⏭️"}.get(status, "❓")
-                type_tag = f" [{finding_type}]" if finding_type else ""
-                print_stderr(f"    {i}. {status_icon} [{status}]{type_tag} {title}")
-                if reply:
-                    # Show first line of reply, truncated
-                    reason_line = reply.split("\n")[0].strip()
-                    if len(reason_line) > 100:
-                        reason_line = reason_line[:97] + "..."
-                    print_stderr(f"       Reply: {reason_line}")
 
     print_stderr("")
 

--- a/myk_pi_tools/reviews/pending_update.py
+++ b/myk_pi_tools/reviews/pending_update.py
@@ -153,9 +153,11 @@ def update_comment_body(node_id: str | None, refined_body: str) -> str:
         print_stderr("Error: node_id is required")
         return "error"
 
+    from myk_pi_tools.comment_signature import append_signature
+
     payload = json.dumps({
         "query": _UPDATE_COMMENT_MUTATION,
-        "variables": {"id": node_id, "body": refined_body},
+        "variables": {"id": node_id, "body": append_signature(refined_body)},
     })
 
     try:

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -208,7 +208,11 @@ def _retrigger_qodo_review(owner: str, repo: str, pr_number: str) -> bool:
         )
         print_stderr("[poll] Posted /agentic_review to re-trigger stuck Qodo review.")
         return True
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip() if e.stderr else ""
+        print_stderr(f"[poll] Failed to post /agentic_review (rc={e.returncode}): {stderr}")
+        return False
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
         print_stderr(f"[poll] Failed to post /agentic_review: {e}")
         return False
 
@@ -246,7 +250,11 @@ def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> bool:
         )
         print_stderr("[poll] Posted sticky cleanup request to @qodo-code-review.")
         return True
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+    except subprocess.CalledProcessError as e:
+        stderr = e.stderr.strip() if e.stderr else ""
+        print_stderr(f"[poll] Failed to post sticky cleanup request (rc={e.returncode}): {stderr}")
+        return False
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
         print_stderr(f"[poll] Failed to post sticky cleanup request: {e}")
         return False
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -30,6 +30,7 @@ from myk_pi_tools.coderabbit.rate_limit import (
     run_trigger,
 )
 from myk_pi_tools.coderabbit.utils import find_summary_comment
+from myk_pi_tools.reviews.ask_qodo import post_and_wait_for_qodo_reply
 from myk_pi_tools.reviews.fetch import get_pr_info, is_qodo_approved, print_approval_summary, print_stderr, run_gh_api
 from myk_pi_tools.reviews.fetch import run as fetch_run
 
@@ -217,46 +218,29 @@ def _retrigger_qodo_review(owner: str, repo: str, pr_number: str) -> bool:
         return False
 
 
-def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> bool:
-    """Ask Qodo to re-evaluate sticky findings and remove resolved ones.
+_CLEANUP_REQUEST_TEXT = (
+    "Please re-evaluate all remaining sticky findings against the current code.\n"
+    "For each finding, check if the referenced code has been fixed in subsequent commits.\n"
+    "Remove findings that are fully addressed. "
+    "Keep any findings where the issue is still present in the code."
+)
 
-    Posts a comment asking @qodo-code-review to check each remaining sticky
-    finding against the current code and remove only those that are fully addressed.
 
-    Returns True if the comment was posted successfully.
+def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> str:
+    """Ask Qodo to re-evaluate sticky findings and wait for reply.
+
+    Returns Qodo's reply body text, or empty string on timeout/failure.
     """
-    body = (
-        "@qodo-code-review\n\n"
-        "Please re-evaluate all remaining sticky findings against the current code.\n"
-        "For each finding, check if the referenced code has been fixed in subsequent commits.\n"
-        "Remove findings that are fully addressed. "
-        "Keep any findings where the issue is still present in the code."
+    message = f"@qodo-code-review\n\n{_CLEANUP_REQUEST_TEXT}"
+    match_lines = [line.strip() for line in _CLEANUP_REQUEST_TEXT.strip().splitlines() if line.strip()]
+    return post_and_wait_for_qodo_reply(
+        owner,
+        repo,
+        pr_number,
+        message,
+        match_lines,
+        label="poll",
     )
-    try:
-        subprocess.run(
-            [
-                "gh",
-                "api",
-                f"/repos/{owner}/{repo}/issues/{pr_number}/comments",
-                "-X",
-                "POST",
-                "-f",
-                f"body={body}",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=30,
-        )
-        print_stderr("[poll] Posted sticky cleanup request to @qodo-code-review.")
-        return True
-    except subprocess.CalledProcessError as e:
-        stderr = e.stderr.strip() if e.stderr else ""
-        print_stderr(f"[poll] Failed to post sticky cleanup request (rc={e.returncode}): {stderr}")
-        return False
-    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        print_stderr(f"[poll] Failed to post sticky cleanup request: {e}")
-        return False
 
 
 def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, output_dir: str) -> int:
@@ -270,6 +254,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
     owner_repo = f"{owner}/{repo}"
     _qodo_reviewing_since: float | None = None  # Track when "Looking for bugs" first appeared
     _cleanup_requested = False  # Track if we already asked Qodo to clean up stickies
+    _cleanup_response = ""  # Qodo's reply to our cleanup request
     cycle = 0
 
     while True:
@@ -287,6 +272,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
             if has_actionable:
                 assert isinstance(fetch_result, dict)
                 fetch_result["approved"] = False
+                fetch_result["qodo_cleanup_response"] = _cleanup_response
                 print_stderr("[poll] Found actionable Qodo comments.")
                 print(json.dumps(fetch_result, indent=2))
                 return 0
@@ -322,6 +308,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                 _approval_detail = is_qodo_approved(owner, repo, pr_number, comments=_pr_comments)
                 if _approval_detail:
                     print_approval_summary(_approval_detail)
+                fetch_result["qodo_cleanup_response"] = _cleanup_response
                 print(json.dumps(fetch_result, indent=2))
                 return 0
             else:
@@ -338,8 +325,18 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                             )
                             if _has_stale:
                                 print_stderr("[poll] Stale sticky findings detected — requesting Qodo cleanup.")
-                                if _request_qodo_sticky_cleanup(owner, repo, pr_number):
-                                    _cleanup_requested = True
+                                _cleanup_reply = _request_qodo_sticky_cleanup(owner, repo, pr_number)
+                                _cleanup_requested = True
+                                if _cleanup_reply:
+                                    _cleanup_response = _cleanup_reply
+                                if _cleanup_response:
+                                    # Re-fetch to get fresh data
+                                    _fresh = fetch_run(review_url, output_dir=output_dir)
+                                    if isinstance(_fresh, dict):
+                                        _fresh["qodo_cleanup_response"] = _cleanup_response
+                                        _fresh["approved"] = False
+                                        print(json.dumps(_fresh, indent=2))
+                                        return 0
                         except Exception:
                             pass
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -108,9 +108,13 @@ def _has_actionable_comments(pr_number: str, output_dir: str) -> bool:
 def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
     """Check if fetched reviews have actionable Qodo comments.
 
-    Sticky findings are ALWAYS actionable — already_replied is context only.
-    Only is_auto_skipped items are skipped (qodo_reply threads).
-    Note: dismissal-based auto-skip does not apply to qodo sources.
+    A comment is actionable if:
+    - Not auto-skipped AND not already replied (new finding), OR
+    - Not auto-skipped AND already replied AND qodo_response contains
+      pushback keywords (Qodo disagrees with our previous fix)
+
+    Already-replied findings WITHOUT pushback are not actionable in the poll
+    — Qodo's silence or confirmation means the finding is resolved.
     """
     import json
     from pathlib import Path
@@ -127,7 +131,16 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
         return True
 
     for comment in data.get("qodo", []):
-        if not comment.get("is_auto_skipped"):
+        if comment.get("is_auto_skipped"):
+            continue
+
+        # New finding — not yet replied to
+        if not comment.get("already_replied"):
+            return True
+
+        # Already replied — only actionable if Qodo pushed back
+        qodo_response = comment.get("qodo_response", "")
+        if qodo_response and _PUSHBACK_KEYWORDS.search(qodo_response):
             return True
 
     return False

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -30,7 +30,7 @@ from myk_pi_tools.coderabbit.rate_limit import (
     run_trigger,
 )
 from myk_pi_tools.coderabbit.utils import find_summary_comment
-from myk_pi_tools.reviews.fetch import get_pr_info, print_stderr, run_gh_api
+from myk_pi_tools.reviews.fetch import get_pr_info, is_qodo_approved, print_approval_summary, print_stderr, run_gh_api
 from myk_pi_tools.reviews.fetch import run as fetch_run
 
 _RATE_LIMIT_BUFFER_SECONDS = 30
@@ -176,7 +176,9 @@ def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | N
         if author != "qodo-code-review[bot]":
             continue
         body = comment.get("body", "")
-        if any(marker in body for marker in _QODO_REVIEWING_MARKERS):
+        # Only match transient review comments — they start with <h3> heading.
+        # Don't match reply comments that quote the phrase in prose text.
+        if any(f"<h3>{marker}</h3>" in body or body.strip().startswith(marker) for marker in _QODO_REVIEWING_MARKERS):
             print_stderr("[poll] Qodo review in progress (Looking for bugs).")
             return True
 
@@ -249,208 +251,6 @@ def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> bool:
         return False
 
 
-def _is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | None = None) -> dict | None:
-    """Check if Qodo has approved the PR.
-
-    Returns a summary dict if approved, None if not approved.
-
-    Approved when:
-    1. Sticky comment has 0 unresolved findings (or all unresolved are already replied to)
-    2. Sticky has at least one resolved/dismissed finding (not empty)
-    3. Sticky updated_at is AFTER PR head commit date (Qodo finished reviewing latest)
-
-    Returns dict with keys:
-    - approved: True
-    - reason: str ("all_resolved" or "stale_sticky")
-    - total_findings: int (total in sticky, resolved + unresolved)
-    - resolved_count: int (resolved/dismissed by Qodo)
-    - unresolved_count: int (still open in sticky)
-    - findings: list of dicts with title, status, reply (from DB for already-replied)
-    """
-    from myk_pi_tools.reviews.qodo_parser import is_qodo_sticky_comment, parse_qodo_sticky_comment
-
-    # Get PR head SHA
-    pr_endpoint = f"/repos/{owner}/{repo}/pulls/{pr_number}"
-    pr_data = run_gh_api(pr_endpoint)
-    if not isinstance(pr_data, dict):
-        return None
-    head_sha = pr_data.get("head", {}).get("sha", "")
-    if not head_sha:
-        return None
-
-    # Get commit date for PR HEAD
-    commit_endpoint = f"/repos/{owner}/{repo}/commits/{head_sha}"
-    commit_data = run_gh_api(commit_endpoint)
-    if not isinstance(commit_data, dict):
-        return None
-    commit_date = commit_data.get("commit", {}).get("committer", {}).get("date", "")
-    if not commit_date:
-        return None
-
-    # Find the Qodo sticky comment
-    if comments is None:
-        endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
-        comments = run_gh_api(endpoint, paginate=True)
-    if not comments or not isinstance(comments, list):
-        return None
-
-    QODO_USERS = {"qodo-code-review[bot]", "qodo-code-review"}
-
-    for comment in comments:
-        author = comment.get("user", {}).get("login") if comment.get("user") else None
-        if author not in QODO_USERS:
-            continue
-
-        body = comment.get("body", "")
-        if not is_qodo_sticky_comment(body):
-            continue
-
-        # Check sticky was updated AFTER the commit
-        sticky_updated = comment.get("updated_at", "")
-        if not sticky_updated or sticky_updated < commit_date:
-            print_stderr(f"[poll] Sticky updated {sticky_updated} but commit at {commit_date} — not yet reviewed.")
-            return None
-
-        # Parse for unresolved findings
-        unresolved = parse_qodo_sticky_comment(body)
-
-        # Count resolved findings from the sticky body
-        import re as _re
-
-        _prev_re = _re.compile(r"^\s*<!-- FOLDED_SECTION_START -->\s*$", _re.MULTILINE)
-        _prev_match = _prev_re.search(body)
-        current_body = body[: _prev_match.start()] if _prev_match else body
-        resolved_count = current_body.count("Resolved</code>") + current_body.count("Dismissed</code>")
-        total_findings = resolved_count + len(unresolved)
-
-        if len(unresolved) > 0:
-            # Check if all unresolved findings were already replied to (stale sticky)
-            try:
-                from myk_pi_tools.db.query import ReviewDB
-
-                db = ReviewDB(db_path=None)
-                replied = db.get_replied_sticky_findings(owner, repo, int(pr_number))
-
-                # Build lookup: (comment_id, body, code_diff) -> DB record
-                replied_map: dict[tuple[int, str, str], dict] = {}
-                for r in replied:
-                    cid = r.get("comment_id")
-                    rbody = r.get("body") or ""
-                    rcode_diff = r.get("code_diff") or ""
-                    if cid is not None:
-                        key = (int(cid), rbody, rcode_diff)
-                        existing = replied_map.get(key)
-                        if existing is None:
-                            replied_map[key] = r
-                        else:
-                            # Prefer records with meaningful replies over dedup artifacts
-                            existing_reply = existing.get("reply") or ""
-                            new_reply = r.get("reply") or ""
-                            if "Already replied" in existing_reply and "Already replied" not in new_reply and new_reply:
-                                replied_map[key] = r
-
-                # Check each unresolved finding
-                sticky_id = int(comment.get("id", 0))
-                all_replied = True
-                findings_summary = []
-                for finding in unresolved:
-                    finding_body = f"**{finding.get('title', '')}**\n\n{finding.get('description', '')}"
-                    finding_code_diff = finding.get("code_diff") or ""
-                    key = (sticky_id, finding_body, finding_code_diff)
-                    db_record = replied_map.get(key)
-                    if db_record:
-                        findings_summary.append({
-                            "title": finding.get("title", ""),
-                            "finding_type": finding.get("finding_type", ""),
-                            "status": db_record.get("status", "unknown"),
-                            "reply": db_record.get("reply", ""),
-                        })
-                    else:
-                        all_replied = False
-                        break
-
-                if all_replied:
-                    print_stderr(
-                        f"[poll] Sticky has {len(unresolved)} unresolved finding(s),"
-                        f" but all already replied to (stale sticky)."
-                    )
-                    print_stderr("[poll] Treating stale sticky as approved.")
-                    return {
-                        "approved": True,
-                        "reason": "stale_sticky",
-                        "total_findings": total_findings,
-                        "resolved_count": resolved_count,
-                        "unresolved_count": len(unresolved),
-                        "findings": findings_summary,
-                    }
-            except Exception as e:
-                print_stderr(f"[poll] Warning: Could not check replied sticky findings: {e}")
-
-            print_stderr(f"[poll] Sticky has {len(unresolved)} unresolved finding(s).")
-            return None
-
-        # Check at least one resolved/dismissed finding exists
-        has_resolved = (
-            "✓ Resolved" in current_body
-            or "Resolved</code>" in current_body
-            or "✗ Dismissed" in current_body
-            or "Dismissed</code>" in current_body
-        )
-        if not has_resolved:
-            print_stderr("[poll] Sticky has no resolved findings — empty review.")
-            return None
-
-        # All checks passed — fully approved by Qodo
-        return {
-            "approved": True,
-            "reason": "all_resolved",
-            "total_findings": total_findings,
-            "resolved_count": resolved_count,
-            "unresolved_count": 0,
-            "findings": [],
-        }
-
-    # No sticky comment found
-    return None
-
-
-def _print_approval_summary(approval: dict) -> None:
-    """Print a summary of the Qodo approval status."""
-    reason = approval.get("reason", "unknown")
-    total = approval.get("total_findings", 0)
-    resolved = approval.get("resolved_count", 0)
-    unresolved = approval.get("unresolved_count", 0)
-    findings = approval.get("findings", [])
-
-    print_stderr("")
-    print_stderr("[poll] === Qodo Approval Summary ===")
-    print_stderr(f"  Total findings: {total} ({resolved} resolved by Qodo, {unresolved} still in sticky)")
-
-    if reason == "all_resolved":
-        print_stderr("  Status: All findings resolved/dismissed by Qodo ✅")
-    elif reason == "stale_sticky":
-        print_stderr("  Status: Stale sticky — all unresolved findings already replied to")
-        if findings:
-            print_stderr("")
-            print_stderr("  Unresolved findings (already replied):")
-            for i, f in enumerate(findings, 1):
-                title = f.get("title", "unknown")
-                status = f.get("status", "unknown")
-                finding_type = f.get("finding_type", "")
-                reply = f.get("reply", "")
-                status_icon = {"addressed": "✅", "not_addressed": "⚠️", "skipped": "⏭️"}.get(status, "❓")
-                type_tag = f" [{finding_type}]" if finding_type else ""
-                print_stderr(f"    {i}. {status_icon} [{status}]{type_tag} {title}")
-                if reply:
-                    # Show first line of reply, truncated
-                    reason_line = reply.split("\n")[0].strip()
-                    if len(reason_line) > 100:
-                        reason_line = reason_line[:97] + "..."
-                    print_stderr(f"       Reply: {reason_line}")
-
-    print_stderr("")
-
-
 def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, output_dir: str) -> int:
     """Poll for Qodo reviews in a loop until approved or new comments.
 
@@ -477,79 +277,48 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
             _print_poll_summary(pr_number, output_dir)
             has_actionable = _has_actionable_qodo_comments(pr_number, output_dir)
             if has_actionable:
-                # Before returning, check if Qodo is mid-review — if so, wait for it to finish
-                _comments_endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
-                _pr_comments = run_gh_api(_comments_endpoint, paginate=True)
-                if _is_qodo_reviewing(owner, repo, pr_number, comments=_pr_comments):
-                    if _qodo_reviewing_since is None:
-                        _qodo_reviewing_since = time.time()
-                    elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
-                        print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
-                        if _retrigger_qodo_review(owner, repo, pr_number):
-                            _qodo_reviewing_since = time.time()  # Reset timer on success
-                        else:
-                            # Cooldown: retry after ~30 min (shift timer to 30 min before threshold)
-                            _qodo_reviewing_since = (
-                                time.time() - _QODO_STUCK_TIMEOUT_SECONDS + _QODO_RETRIGGER_COOLDOWN_SECONDS
-                            )
-                    print_stderr(
-                        "[poll] Qodo is currently reviewing —"
-                        " waiting for review to complete before processing findings."
-                    )
-                else:
-                    _qodo_reviewing_since = None  # Reset — Qodo finished reviewing
-                    print_stderr("[poll] Found actionable Qodo comments.")
-                    assert isinstance(fetch_result, dict)
-                    fetch_result["approved"] = False
-                    print(json.dumps(fetch_result, indent=2))
-                    return 0
+                assert isinstance(fetch_result, dict)
+                fetch_result["approved"] = False
+                print_stderr("[poll] Found actionable Qodo comments.")
+                print(json.dumps(fetch_result, indent=2))
+                return 0
             else:
                 print_stderr("[poll] No actionable Qodo comments (all auto-skipped or none found).")
         else:
             print_stderr(f"[poll] Fetch failed (exit code {fetch_result}). Will retry in {_POLL_SLEEP_SECONDS}s...")
 
-        # Step 2: Only check approval AFTER confirming 0 new comments
-        # This prevents approving before processing new findings
+        # Step 2: Check approval and handle stuck reviews
         if fetch_ok:
-            # Fetch PR comments once — reused by mid-review and approval checks
+            # Check for stuck Qodo reviews (mid-review detection)
             _comments_endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
             _pr_comments = run_gh_api(_comments_endpoint, paginate=True)
-            # Don't check approval if Qodo is mid-review — sticky is about to change
             if _is_qodo_reviewing(owner, repo, pr_number, comments=_pr_comments):
                 if _qodo_reviewing_since is None:
                     _qodo_reviewing_since = time.time()
                 elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
                     print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
                     if _retrigger_qodo_review(owner, repo, pr_number):
-                        _qodo_reviewing_since = time.time()  # Reset timer on success
+                        _qodo_reviewing_since = time.time()
                     else:
-                        # Cooldown: retry after ~30 min (shift timer to 30 min before threshold)
                         _qodo_reviewing_since = (
                             time.time() - _QODO_STUCK_TIMEOUT_SECONDS + _QODO_RETRIGGER_COOLDOWN_SECONDS
                         )
                 print_stderr(
                     "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
                 )
-            else:
-                _qodo_reviewing_since = None  # Reset — Qodo finished reviewing
+            elif isinstance(fetch_result, dict) and fetch_result.get("approved"):
+                _qodo_reviewing_since = None
                 print_stderr("[poll] Checking Qodo approval...")
-                approval = _is_qodo_approved(owner, repo, pr_number, comments=_pr_comments)
-                if approval:
-                    reason = approval.get("reason", "unknown")
-                    if reason == "all_resolved":
-                        print_stderr("[poll] Qodo approved — all findings resolved.")
-                    elif reason == "stale_sticky":
-                        print_stderr("[poll] Qodo approved — stale sticky, all unresolved findings already replied to.")
-                    else:
-                        print_stderr(f"[poll] Qodo approved — {reason}.")
-                    # Print approval summary
-                    _print_approval_summary(approval)
-                    assert isinstance(fetch_result, dict)
-                    fetch_result["approved"] = True
-                    print(json.dumps(fetch_result, indent=2))
-                    return 0
-
-                # Approval not granted — check for stale sticky findings
+                print_stderr("[poll] Qodo approved — all findings resolved.")
+                # Get approval details for summary
+                _approval_detail = is_qodo_approved(owner, repo, pr_number, comments=_pr_comments)
+                if _approval_detail:
+                    print_approval_summary(_approval_detail)
+                print(json.dumps(fetch_result, indent=2))
+                return 0
+            else:
+                _qodo_reviewing_since = None
+                # Check for stale sticky findings and request cleanup
                 if not _cleanup_requested and not has_actionable:
                     _review_path = Path(output_dir) / f"pr-{pr_number}-reviews.json"
                     if _review_path.exists():

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 from datetime import UTC, datetime
 from pathlib import Path
@@ -256,9 +258,11 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
     _cleanup_requested = False  # Track if we already asked Qodo to clean up stickies
     _cleanup_response = ""  # Qodo's reply to our cleanup request
     cycle = 0
+    _result: dict | None = None
 
     while True:
         cycle += 1
+        has_actionable = False
         print_stderr(f"[poll] Cycle {cycle} for {owner_repo}#{pr_number} (source: qodo)...")
 
         # Step 1: Fetch reviews first
@@ -274,8 +278,8 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                 fetch_result["approved"] = False
                 fetch_result["qodo_cleanup_response"] = _cleanup_response
                 print_stderr("[poll] Found actionable Qodo comments.")
-                print(json.dumps(fetch_result, indent=2))
-                return 0
+                _result = fetch_result
+                break
             else:
                 print_stderr("[poll] No actionable Qodo comments (all auto-skipped or none found).")
         else:
@@ -309,8 +313,8 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                 if _approval_detail:
                     print_approval_summary(_approval_detail)
                 fetch_result["qodo_cleanup_response"] = ""  # Clear — stale when approved
-                print(json.dumps(fetch_result, indent=2))
-                return 0
+                _result = fetch_result
+                break
             else:
                 _qodo_reviewing_since = None
                 # Check for stale sticky findings and request cleanup
@@ -335,14 +339,33 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                                     if isinstance(_fresh, dict):
                                         _fresh["qodo_cleanup_response"] = _cleanup_response
                                         _fresh["approved"] = False
-                                        print(json.dumps(_fresh, indent=2))
-                                        return 0
-                        except Exception:
-                            pass
+                                        _result = _fresh
+                                        break
+                        except Exception as e:
+                            print_stderr(f"[poll] Cleanup check failed: {e}")
+
+        if _result is not None:
+            break
 
         # No actionable result — sleep and loop
         print_stderr(f"[poll] No new Qodo comments. Sleeping {_POLL_SLEEP_SECONDS}s before next cycle...")
         time.sleep(_POLL_SLEEP_SECONDS)
+
+    # Single exit path — re-write file and print to stdout
+    _json_path = Path(output_dir) / f"pr-{_result['metadata']['pr_number']}-reviews.json"
+    _fd, _tmp_path = tempfile.mkstemp(
+        prefix=f"pr-{_result['metadata']['pr_number']}-reviews.json.",
+        dir=str(Path(output_dir)),
+    )
+    try:
+        with os.fdopen(_fd, "w") as f:
+            json.dump(_result, f, indent=2)
+        os.replace(_tmp_path, _json_path)
+    except Exception:
+        Path(_tmp_path).unlink(missing_ok=True)
+        raise
+    print(json.dumps(_result, indent=2))
+    return 0
 
 
 def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) -> int:

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import time
 from datetime import UTC, datetime
+from pathlib import Path
 
 from myk_pi_tools.coderabbit.approved import is_approved
 from myk_pi_tools.coderabbit.rate_limit import (
@@ -207,6 +208,44 @@ def _retrigger_qodo_review(owner: str, repo: str, pr_number: str) -> bool:
         return True
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
         print_stderr(f"[poll] Failed to post /agentic_review: {e}")
+        return False
+
+
+def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> bool:
+    """Ask Qodo to re-evaluate sticky findings and remove resolved ones.
+
+    Posts a comment asking @qodo-code-review to check each remaining sticky
+    finding against the current code and remove only those that are fully addressed.
+
+    Returns True if the comment was posted successfully.
+    """
+    body = (
+        "@qodo-code-review\n\n"
+        "Please re-evaluate all remaining sticky findings against the current code.\n"
+        "For each finding, check if the referenced code has been fixed in subsequent commits.\n"
+        "Remove findings that are fully addressed. "
+        "Keep any findings where the issue is still present in the code."
+    )
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "api",
+                f"/repos/{owner}/{repo}/issues/{pr_number}/comments",
+                "-X",
+                "POST",
+                "-f",
+                f"body={body}",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        print_stderr("[poll] Posted sticky cleanup request to @qodo-code-review.")
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print_stderr(f"[poll] Failed to post sticky cleanup request: {e}")
         return False
 
 
@@ -422,6 +461,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
     """
     owner_repo = f"{owner}/{repo}"
     _qodo_reviewing_since: float | None = None  # Track when "Looking for bugs" first appeared
+    _cleanup_requested = False  # Track if we already asked Qodo to clean up stickies
     cycle = 0
 
     while True:
@@ -508,6 +548,23 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                     fetch_result["approved"] = True
                     print(json.dumps(fetch_result, indent=2))
                     return 0
+
+                # Approval not granted — check for stale sticky findings
+                if not _cleanup_requested and not has_actionable:
+                    _review_path = Path(output_dir) / f"pr-{pr_number}-reviews.json"
+                    if _review_path.exists():
+                        try:
+                            _review_data = json.loads(_review_path.read_text())
+                            _has_stale = any(
+                                f.get("is_auto_skipped") and f.get("already_replied")
+                                for f in _review_data.get("qodo", [])
+                            )
+                            if _has_stale:
+                                print_stderr("[poll] Stale sticky findings detected — requesting Qodo cleanup.")
+                                if _request_qodo_sticky_cleanup(owner, repo, pr_number):
+                                    _cleanup_requested = True
+                        except Exception:
+                            pass
 
         # No actionable result — sleep and loop
         print_stderr(f"[poll] No new Qodo comments. Sleeping {_POLL_SLEEP_SECONDS}s before next cycle...")

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -443,7 +443,10 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                     elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
                         print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
                         if _retrigger_qodo_review(owner, repo, pr_number):
-                            _qodo_reviewing_since = time.time()  # Reset timer only on success
+                            _qodo_reviewing_since = time.time()  # Reset timer on success
+                        else:
+                            # Cooldown: shift timer forward by 30 min to avoid retrying every cycle
+                            _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1800
                     print_stderr(
                         "[poll] Qodo is currently reviewing —"
                         " waiting for review to complete before processing findings."
@@ -470,7 +473,10 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                 elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
                     print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
                     if _retrigger_qodo_review(owner, repo, pr_number):
-                        _qodo_reviewing_since = time.time()  # Reset timer only on success
+                        _qodo_reviewing_since = time.time()  # Reset timer on success
+                    else:
+                        # Cooldown: shift timer forward by 30 min to avoid retrying every cycle
+                        _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1800
                 print_stderr(
                     "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
                 )

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import contextlib
 import re
+import subprocess
 import sys
 import time
 from datetime import UTC, datetime
@@ -151,6 +152,8 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
 # Do NOT add broad markers — they false-positive against PR summary/description text.
 _QODO_REVIEWING_MARKERS = ("Looking for bugs?",)
 
+_QODO_STUCK_TIMEOUT_SECONDS = 3600  # 1 hour — if "Looking for bugs" persists, Qodo is stuck
+
 
 def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | None = None) -> bool:
     """Check if Qodo is currently reviewing the PR.
@@ -175,6 +178,34 @@ def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | N
             return True
 
     return False
+
+
+def _retrigger_qodo_review(owner: str, repo: str, pr_number: str) -> bool:
+    """Post /agentic_review comment to re-trigger a stuck Qodo review.
+
+    Returns True if the comment was posted successfully.
+    """
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "api",
+                f"/repos/{owner}/{repo}/issues/{pr_number}/comments",
+                "-X",
+                "POST",
+                "-f",
+                "body=/agentic_review",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+        print_stderr("[poll] Posted /agentic_review to re-trigger stuck Qodo review.")
+        return True
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print_stderr(f"[poll] Failed to post /agentic_review: {e}")
+        return False
 
 
 def _is_qodo_approved(owner: str, repo: str, pr_number: str, comments: list | None = None) -> dict | None:
@@ -388,6 +419,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
     3. If not approved, sleep and retry
     """
     owner_repo = f"{owner}/{repo}"
+    _qodo_reviewing_since: float | None = None  # Track when "Looking for bugs" first appeared
     cycle = 0
 
     while True:
@@ -406,11 +438,18 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                 _comments_endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
                 _pr_comments = run_gh_api(_comments_endpoint, paginate=True)
                 if _is_qodo_reviewing(owner, repo, pr_number, comments=_pr_comments):
+                    if _qodo_reviewing_since is None:
+                        _qodo_reviewing_since = time.time()
+                    elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
+                        print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
+                        _retrigger_qodo_review(owner, repo, pr_number)
+                        _qodo_reviewing_since = time.time()  # Reset timer after re-trigger
                     print_stderr(
                         "[poll] Qodo is currently reviewing —"
                         " waiting for review to complete before processing findings."
                     )
                 else:
+                    _qodo_reviewing_since = None  # Reset — Qodo finished reviewing
                     print_stderr("[poll] Found actionable Qodo comments.")
                     return 0
             else:
@@ -426,10 +465,17 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
             _pr_comments = run_gh_api(_comments_endpoint, paginate=True)
             # Don't check approval if Qodo is mid-review — sticky is about to change
             if _is_qodo_reviewing(owner, repo, pr_number, comments=_pr_comments):
+                if _qodo_reviewing_since is None:
+                    _qodo_reviewing_since = time.time()
+                elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
+                    print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
+                    _retrigger_qodo_review(owner, repo, pr_number)
+                    _qodo_reviewing_since = time.time()  # Reset timer after re-trigger
                 print_stderr(
                     "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
                 )
             else:
+                _qodo_reviewing_since = None  # Reset — Qodo finished reviewing
                 print_stderr("[poll] Checking Qodo approval...")
                 approval = _is_qodo_approved(owner, repo, pr_number, comments=_pr_comments)
                 if approval:

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -11,6 +11,7 @@ on "no new comments" -- sleeps and retries.
 from __future__ import annotations
 
 import contextlib
+import json
 import re
 import subprocess
 import sys
@@ -430,8 +431,9 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
         # Step 1: Fetch reviews first
         print_stderr("[poll] Fetching reviews...")
         fetch_result = fetch_run(review_url, output_dir=output_dir)
+        fetch_ok = isinstance(fetch_result, dict)
 
-        if fetch_result == 0:
+        if fetch_ok:
             _print_poll_summary(pr_number, output_dir)
             has_actionable = _has_actionable_qodo_comments(pr_number, output_dir)
             if has_actionable:
@@ -457,15 +459,18 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                 else:
                     _qodo_reviewing_since = None  # Reset — Qodo finished reviewing
                     print_stderr("[poll] Found actionable Qodo comments.")
+                    assert isinstance(fetch_result, dict)
+                    fetch_result["approved"] = False
+                    print(json.dumps(fetch_result, indent=2))
                     return 0
             else:
                 print_stderr("[poll] No actionable Qodo comments (all auto-skipped or none found).")
         else:
-            print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
+            print_stderr(f"[poll] Fetch failed (exit code {fetch_result}). Will retry in {_POLL_SLEEP_SECONDS}s...")
 
         # Step 2: Only check approval AFTER confirming 0 new comments
         # This prevents approving before processing new findings
-        if fetch_result == 0:
+        if fetch_ok:
             # Fetch PR comments once — reused by mid-review and approval checks
             _comments_endpoint = f"/repos/{owner}/{repo}/issues/{pr_number}/comments?per_page=100"
             _pr_comments = run_gh_api(_comments_endpoint, paginate=True)
@@ -499,7 +504,9 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                         print_stderr(f"[poll] Qodo approved — {reason}.")
                     # Print approval summary
                     _print_approval_summary(approval)
-                    print('{"approved": true}')
+                    assert isinstance(fetch_result, dict)
+                    fetch_result["approved"] = True
+                    print(json.dumps(fetch_result, indent=2))
                     return 0
 
         # No actionable result — sleep and loop
@@ -538,24 +545,34 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
         print_stderr("[poll] Checking CodeRabbit approval...")
         if is_approved(owner_repo, int(pr_number)):
             print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
-            print('{"approved": true}')
+            # Fetch reviews data for the approval output
+            _approval_data = fetch_run(review_url, output_dir=output_dir)
+            if isinstance(_approval_data, dict):
+                _approval_data["approved"] = True
+                print(json.dumps(_approval_data, indent=2))
+            else:
+                print(json.dumps({"approved": True}, indent=2))
             return 0
 
         # Step 3: Fetch reviews — get actionable comments before waiting on rate limit
         print_stderr("[poll] Fetching reviews...")
         fetch_result = fetch_run(review_url, output_dir=output_dir)
+        fetch_ok = isinstance(fetch_result, dict)
 
-        if fetch_result == 0:
+        if fetch_ok:
             _print_poll_summary(pr_number, output_dir)
             # Check if there are actionable (non-auto-skipped) comments
             # fetch_run saves JSON to a predictable path
             has_actionable = _has_actionable_comments(pr_number, output_dir)
             if has_actionable:
+                assert isinstance(fetch_result, dict)
+                fetch_result["approved"] = False
+                print(json.dumps(fetch_result, indent=2))
                 return 0
             print_stderr("[poll] All fetched comments are auto-skipped (previously addressed). No new comments.")
         else:
             # Fetch failed -- log and retry
-            print_stderr(f"[poll] Fetch failed with exit code {fetch_result}. Will retry in {_POLL_SLEEP_SECONDS}s...")
+            print_stderr(f"[poll] Fetch failed (exit code {fetch_result}). Will retry in {_POLL_SLEEP_SECONDS}s...")
 
         # Step 4: Check CodeRabbit rate limit
         print_stderr("[poll] Checking CodeRabbit rate limit...")
@@ -595,7 +612,12 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
             print_stderr("[poll] Re-checking approval after rate limit trigger...")
             if is_approved(owner_repo, int(pr_number)):
                 print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
-                print('{"approved": true}')
+                _approval_data = fetch_run(review_url, output_dir=output_dir)
+                if isinstance(_approval_data, dict):
+                    _approval_data["approved"] = True
+                    print(json.dumps(_approval_data, indent=2))
+                else:
+                    print(json.dumps({"approved": True}, indent=2))
                 return 0
 
         elif (
@@ -632,7 +654,12 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
                     print_stderr("[poll] Re-checking approval after resume trigger...")
                     if is_approved(owner_repo, int(pr_number)):
                         print_stderr("[poll] CodeRabbit approved — no actionable comments.")
-                        print('{"approved": true}')
+                        _approval_data = fetch_run(review_url, output_dir=output_dir)
+                        if isinstance(_approval_data, dict):
+                            _approval_data["approved"] = True
+                            print(json.dumps(_approval_data, indent=2))
+                        else:
+                            print(json.dumps({"approved": True}, indent=2))
                         return 0
                 else:
                     print_stderr("[poll] Warning: Failed to post resume trigger. Will retry next cycle.")

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -445,8 +445,8 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                         if _retrigger_qodo_review(owner, repo, pr_number):
                             _qodo_reviewing_since = time.time()  # Reset timer on success
                         else:
-                            # Cooldown: shift timer forward by 30 min to avoid retrying every cycle
-                            _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1800
+                            # Cooldown: retry after ~30 min (shift timer to 30 min before threshold)
+                            _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1801
                     print_stderr(
                         "[poll] Qodo is currently reviewing —"
                         " waiting for review to complete before processing findings."
@@ -475,8 +475,8 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                     if _retrigger_qodo_review(owner, repo, pr_number):
                         _qodo_reviewing_since = time.time()  # Reset timer on success
                     else:
-                        # Cooldown: shift timer forward by 30 min to avoid retrying every cycle
-                        _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1800
+                        # Cooldown: retry after ~30 min (shift timer to 30 min before threshold)
+                        _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1801
                 print_stderr(
                     "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
                 )

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -548,16 +548,14 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
             # Fetch reviews data for the approval output
             _approval_data = fetch_run(review_url, output_dir=output_dir)
             if not isinstance(_approval_data, dict):
-                # Retry once — fetch must succeed for complete approval output
+                # Retry once
                 _approval_data = fetch_run(review_url, output_dir=output_dir)
             if isinstance(_approval_data, dict):
                 _approval_data["approved"] = True
                 print(json.dumps(_approval_data, indent=2))
-            else:
-                # Last resort — emit minimal approval so poll exits
-                print_stderr("[poll] Warning: fetch failed on approval — emitting minimal JSON")
-                print(json.dumps({"approved": True}, indent=2))
-            return 0
+                return 0
+            # Fetch failed — do NOT approve without data, keep polling
+            print_stderr("[poll] Warning: approval detected but fetch failed — will retry next cycle")
 
         # Step 3: Fetch reviews — get actionable comments before waiting on rate limit
         print_stderr("[poll] Fetching reviews...")
@@ -619,16 +617,14 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
                 print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
                 _approval_data = fetch_run(review_url, output_dir=output_dir)
                 if not isinstance(_approval_data, dict):
-                    # Retry once — fetch must succeed for complete approval output
+                    # Retry once
                     _approval_data = fetch_run(review_url, output_dir=output_dir)
                 if isinstance(_approval_data, dict):
                     _approval_data["approved"] = True
                     print(json.dumps(_approval_data, indent=2))
-                else:
-                    # Last resort — emit minimal approval so poll exits
-                    print_stderr("[poll] Warning: fetch failed on approval — emitting minimal JSON")
-                    print(json.dumps({"approved": True}, indent=2))
-                return 0
+                    return 0
+                # Fetch failed — do NOT approve without data, keep polling
+                print_stderr("[poll] Warning: approval detected but fetch failed — will retry next cycle")
 
         elif (
             comment_id is not None
@@ -666,16 +662,14 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
                         print_stderr("[poll] CodeRabbit approved — no actionable comments.")
                         _approval_data = fetch_run(review_url, output_dir=output_dir)
                         if not isinstance(_approval_data, dict):
-                            # Retry once — fetch must succeed for complete approval output
+                            # Retry once
                             _approval_data = fetch_run(review_url, output_dir=output_dir)
                         if isinstance(_approval_data, dict):
                             _approval_data["approved"] = True
                             print(json.dumps(_approval_data, indent=2))
-                        else:
-                            # Last resort — emit minimal approval so poll exits
-                            print_stderr("[poll] Warning: fetch failed on approval — emitting minimal JSON")
-                            print(json.dumps({"approved": True}, indent=2))
-                        return 0
+                            return 0
+                        # Fetch failed — do NOT approve without data, keep polling
+                        print_stderr("[poll] Warning: approval detected but fetch failed — will retry next cycle")
                 else:
                     print_stderr("[poll] Warning: Failed to post resume trigger. Will retry next cycle.")
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -547,10 +547,15 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
             print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
             # Fetch reviews data for the approval output
             _approval_data = fetch_run(review_url, output_dir=output_dir)
+            if not isinstance(_approval_data, dict):
+                # Retry once — fetch must succeed for complete approval output
+                _approval_data = fetch_run(review_url, output_dir=output_dir)
             if isinstance(_approval_data, dict):
                 _approval_data["approved"] = True
                 print(json.dumps(_approval_data, indent=2))
             else:
+                # Last resort — emit minimal approval so poll exits
+                print_stderr("[poll] Warning: fetch failed on approval — emitting minimal JSON")
                 print(json.dumps({"approved": True}, indent=2))
             return 0
 
@@ -613,10 +618,15 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
             if is_approved(owner_repo, int(pr_number)):
                 print_stderr("[poll] CodeRabbit approved \u2014 no actionable comments.")
                 _approval_data = fetch_run(review_url, output_dir=output_dir)
+                if not isinstance(_approval_data, dict):
+                    # Retry once — fetch must succeed for complete approval output
+                    _approval_data = fetch_run(review_url, output_dir=output_dir)
                 if isinstance(_approval_data, dict):
                     _approval_data["approved"] = True
                     print(json.dumps(_approval_data, indent=2))
                 else:
+                    # Last resort — emit minimal approval so poll exits
+                    print_stderr("[poll] Warning: fetch failed on approval — emitting minimal JSON")
                     print(json.dumps({"approved": True}, indent=2))
                 return 0
 
@@ -655,10 +665,15 @@ def run(review_url: str = "", source: str = "coderabbit", *, output_dir: str) ->
                     if is_approved(owner_repo, int(pr_number)):
                         print_stderr("[poll] CodeRabbit approved — no actionable comments.")
                         _approval_data = fetch_run(review_url, output_dir=output_dir)
+                        if not isinstance(_approval_data, dict):
+                            # Retry once — fetch must succeed for complete approval output
+                            _approval_data = fetch_run(review_url, output_dir=output_dir)
                         if isinstance(_approval_data, dict):
                             _approval_data["approved"] = True
                             print(json.dumps(_approval_data, indent=2))
                         else:
+                            # Last resort — emit minimal approval so poll exits
+                            print_stderr("[poll] Warning: fetch failed on approval — emitting minimal JSON")
                             print(json.dumps({"approved": True}, indent=2))
                         return 0
                 else:

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -308,7 +308,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                 _approval_detail = is_qodo_approved(owner, repo, pr_number, comments=_pr_comments)
                 if _approval_detail:
                     print_approval_summary(_approval_detail)
-                fetch_result["qodo_cleanup_response"] = _cleanup_response
+                fetch_result["qodo_cleanup_response"] = ""  # Clear — stale when approved
                 print(json.dumps(fetch_result, indent=2))
                 return 0
             else:

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -153,6 +153,7 @@ def _has_actionable_qodo_comments(pr_number: str, output_dir: str) -> bool:
 _QODO_REVIEWING_MARKERS = ("Looking for bugs?",)
 
 _QODO_STUCK_TIMEOUT_SECONDS = 3600  # 1 hour — if "Looking for bugs" persists, Qodo is stuck
+_QODO_RETRIGGER_COOLDOWN_SECONDS = 1801  # ~30 min cooldown between re-trigger attempts (+1s for strict > comparison)
 
 
 def _is_qodo_reviewing(owner: str, repo: str, pr_number: str, comments: list | None = None) -> bool:
@@ -446,7 +447,9 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                             _qodo_reviewing_since = time.time()  # Reset timer on success
                         else:
                             # Cooldown: retry after ~30 min (shift timer to 30 min before threshold)
-                            _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1801
+                            _qodo_reviewing_since = (
+                                time.time() - _QODO_STUCK_TIMEOUT_SECONDS + _QODO_RETRIGGER_COOLDOWN_SECONDS
+                            )
                     print_stderr(
                         "[poll] Qodo is currently reviewing —"
                         " waiting for review to complete before processing findings."
@@ -476,7 +479,9 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                         _qodo_reviewing_since = time.time()  # Reset timer on success
                     else:
                         # Cooldown: retry after ~30 min (shift timer to 30 min before threshold)
-                        _qodo_reviewing_since = time.time() - _QODO_STUCK_TIMEOUT_SECONDS + 1801
+                        _qodo_reviewing_since = (
+                            time.time() - _QODO_STUCK_TIMEOUT_SECONDS + _QODO_RETRIGGER_COOLDOWN_SECONDS
+                        )
                 print_stderr(
                     "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
                 )

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -442,8 +442,8 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                         _qodo_reviewing_since = time.time()
                     elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
                         print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
-                        _retrigger_qodo_review(owner, repo, pr_number)
-                        _qodo_reviewing_since = time.time()  # Reset timer after re-trigger
+                        if _retrigger_qodo_review(owner, repo, pr_number):
+                            _qodo_reviewing_since = time.time()  # Reset timer only on success
                     print_stderr(
                         "[poll] Qodo is currently reviewing —"
                         " waiting for review to complete before processing findings."
@@ -469,8 +469,8 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                     _qodo_reviewing_since = time.time()
                 elif time.time() - _qodo_reviewing_since > _QODO_STUCK_TIMEOUT_SECONDS:
                     print_stderr("[poll] Qodo has been reviewing for over 1 hour — likely stuck.")
-                    _retrigger_qodo_review(owner, repo, pr_number)
-                    _qodo_reviewing_since = time.time()  # Reset timer after re-trigger
+                    if _retrigger_qodo_review(owner, repo, pr_number):
+                        _qodo_reviewing_since = time.time()  # Reset timer only on success
                 print_stderr(
                     "[poll] Qodo is currently reviewing — skipping approval check, waiting for review to complete."
                 )

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -151,6 +151,9 @@ def post_thread_reply(thread_id: str, body: str) -> bool:
 
     Returns True on success, False on failure.
     """
+    from myk_pi_tools.comment_signature import append_signature
+
+    body = append_signature(body)
     # GitHub comment bodies have a size limit (~65KB); truncate to avoid failures
     max_len = 60000
     if len(body) > max_len:
@@ -401,7 +404,9 @@ def _post_chunk(
         Tuple of (success, list of posted_at update dicts).
     """
     truncated_suffix = "\n...[truncated]"
-    chunk_body = header + "".join(text for text, _ in chunk).strip()
+    from myk_pi_tools.comment_signature import append_signature
+
+    chunk_body = append_signature(header + "".join(text for text, _ in chunk).strip())
     if total_chunks > 1:
         chunk_body = f"(Part {chunk_idx + 1}/{total_chunks})\n\n" + chunk_body
 

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -44,25 +44,6 @@ _FENCED_DIFF_RE = re.compile(r"```diff\n(.*?)```", re.DOTALL)
 # Pattern to extract fenced code blocks (``` ... ```)
 _FENCED_CODE_RE = re.compile(r"```(?!\w)\n(.*?)```", re.DOTALL)
 
-# Finding type keywords from Qodo sticky <code> tags
-_FINDING_TYPES = (
-    "Bug",
-    "Rule violation",
-    "Requirement gap",
-    "UX issue",
-    "Cross-repo conflict",
-)
-
-# Finding category keywords from Qodo sticky <code> tags
-_FINDING_CATEGORIES = (
-    "Correctness",
-    "Security",
-    "Reliability",
-    "Performance",
-    "Maintainability",
-    "Observability",
-)
-
 
 def _strip_blockquote_prefix(text: str) -> str:
     """Strip leading `> ` or `>` markdown blockquote prefix from each line."""
@@ -177,10 +158,14 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
                     is_resolved = True
                 elif "Dismissed" in text:
                     is_dismissed = True
-                elif any(t in text for t in _FINDING_TYPES):
-                    finding_type = re.sub(r"[^\w\s-]", "", text).strip()
-                elif any(c in text for c in _FINDING_CATEGORIES):
-                    category = re.sub(r"[^\w\s]", "", text).strip()
+                else:
+                    # Dynamic: first non-status tag is type, second is category
+                    cleaned = re.sub(r"[^\w\s-]", "", text).strip()
+                    if cleaned:
+                        if not finding_type:
+                            finding_type = cleaned
+                        elif not category:
+                            category = cleaned
 
         if strikethrough_title is not None:
             title = strikethrough_title

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -170,11 +170,14 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
                     _has_type_emoji = any(e in text for e in _type_emojis)
                     if _has_type_emoji and not finding_type:
                         finding_type = cleaned
-                    elif not _has_type_emoji and not category:
+                    elif not _has_type_emoji and finding_type and not category:
+                        # Known type already found; non-type-emoji tag is category
                         category = cleaned
                     elif not finding_type:
+                        # Positional fallback: first unassigned tag → type
                         finding_type = cleaned
                     elif not category:
+                        # Positional fallback: second unassigned tag → category
                         category = cleaned
 
         if strikethrough_title is not None:

--- a/myk_pi_tools/reviews/qodo_parser.py
+++ b/myk_pi_tools/reviews/qodo_parser.py
@@ -159,13 +159,23 @@ def parse_qodo_sticky_comment(body: str) -> list[dict[str, Any]]:
                 elif "Dismissed" in text:
                     is_dismissed = True
                 else:
-                    # Dynamic: first non-status tag is type, second is category
+                    # Dynamic: type tags have known emoji prefixes (🐞📘📎📜),
+                    # category tags have other emoji prefixes (≡⛨☼➹⚙◔▣✧).
+                    # Fall back to positional assignment if no emoji detected.
                     cleaned = re.sub(r"[^\w\s-]", "", text).strip()
-                    if cleaned:
-                        if not finding_type:
-                            finding_type = cleaned
-                        elif not category:
-                            category = cleaned
+                    if not cleaned:
+                        continue
+                    # Check for type-indicator emojis in raw text
+                    _type_emojis = ("🐞", "📘", "📎", "📜", "⚠")
+                    _has_type_emoji = any(e in text for e in _type_emojis)
+                    if _has_type_emoji and not finding_type:
+                        finding_type = cleaned
+                    elif not _has_type_emoji and not category:
+                        category = cleaned
+                    elif not finding_type:
+                        finding_type = cleaned
+                    elif not category:
+                        category = cleaned
 
         if strikethrough_title is not None:
             title = strikethrough_title

--- a/pi-config-settings.example.json
+++ b/pi-config-settings.example.json
@@ -3,5 +3,6 @@
   "allow_push_to_protected_branches": false,
   "use_worktrees": false,
   "dream_interval_hours": 3,
-  "dco": false
+  "dco": false,
+  "comment_signature": false
 }

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -139,61 +139,35 @@ Mark Task 1 as `in_progress`.
 
 If the raw arguments are empty:
 
-1. Detect PR from current branch:
+1. If the raw arguments do NOT contain a PR number or URL, detect from current branch:
 
    ```bash
-   gh pr view --json number,headRefOid
+   myk-pi-tools pr info $(gh pr view --json number --jq '.number')
    ```
 
-2. Get base repository context (where PR targets):
-
-   The base repository (where the PR is opened) is determined by the current working directory context.
-   When you run `gh pr view` from a cloned repository, it operates in that repository's context.
-
-   To get `owner` and `repo`:
+2. Fetch PR metadata using the CLI:
 
    ```bash
-   gh repo view --json owner,name
+   myk-pi-tools pr info <cleaned_arguments>
    ```
 
-   This returns the base repository information regardless of whether the PR comes from a fork.
+   This returns JSON with all needed fields: `owner`, `repo`, `pr_number`, `author`,
+   `head_sha`, `base_ref`, `title`, `state`, `labels`, `assignees`, `is_fork`, `head_repo`, `body`.
 
-   **Note:** `baseRepository` is NOT available in `gh pr view --json`. For fork PRs, `headRepository` would incorrectly point to the fork, not the target repository.
-
-3. Extract and store:
-
-   - `pr_number` from the PR JSON response
-   - `owner` from `gh repo view` → `owner.login`
-   - `repo` from `gh repo view` → `name`
-   - `head_sha` from `headRefOid`
-
-4. Use `{pr_number}` for subsequent CLI commands
+3. Extract and store all fields from the JSON output — these are used by Phase 1c and Phase 5.
 
 If the raw arguments contain a PR number or URL:
 
-1. If the argument is a URL (contains `github.com`):
-   - Extract `owner`, `repo`, and `pr_number` directly from the URL pattern
-     `https://github.com/{owner}/{repo}/pull/{pr_number}`
-   - Get `head_sha`:
+1. Fetch PR metadata using the CLI:
 
-     ```bash
-     gh pr view {pr_number} --repo {owner}/{repo} --json headRefOid --jq '.headRefOid'
-     ```
+   ```bash
+   myk-pi-tools pr info <cleaned_arguments>
+   ```
 
-1. If the argument is a bare PR number:
-   - Get `owner` and `repo` from the current repository context:
+   This returns JSON with all needed fields: `owner`, `repo`, `pr_number`, `author`,
+   `head_sha`, `base_ref`, `title`, `state`, `labels`, `assignees`, `is_fork`, `head_repo`, `body`.
 
-     ```bash
-     gh repo view --json owner,name
-     ```
-
-   - Get `head_sha`:
-
-     ```bash
-     gh pr view {pr_number} --json headRefOid --jq '.headRefOid'
-     ```
-
-1. Store `owner`, `repo`, `pr_number`, and `head_sha` — these are used by Phase 1c and Phase 5.
+2. Extract and store all fields from the JSON output — these are used by Phase 1c and Phase 5.
 
 Mark Task 1 as `completed`.
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -575,24 +575,25 @@ Check the poll JSON output — it always contains an `approved` key:
   - **Why remaining** = the status + reason (from the reply field)
   - If zero remaining findings: show `## Remaining Findings (0)` with "All findings resolved."
   - This is the ONLY user-facing output on exit — no per-cycle summaries, no fix history
-- If `"qodo_cleanup_response"` is not empty in the JSON: **MUST be addressed.**
-  This is Qodo's reply to our sticky cleanup request — it lists which findings
-  are fixed and which are still open.
 
-  **For each item Qodo listed:**
-  - Qodo says "fixed" / "looks fixed" / "addressed" → no code change needed
-  - Qodo says "still open" / "still relevant" / "still actionable" → MUST fix the code, commit, push
-  - If you don't understand what Qodo wants for a specific finding → use
-    `myk-pi-tools reviews ask-qodo "<question>"` to ask Qodo directly.
-    The command posts the question to @qodo-code-review and waits up to 10 minutes
-    for Qodo's reply. Read the reply and act on it.
+- If `"approved": false`: **Process ALL actionable items in the JSON.**
 
-  **Every item in `qodo_cleanup_response` MUST be addressed. No skipping.**
-  After fixing all still-open items, commit and push, then re-spawn the poll.
+  🚨 **MANDATORY: Process EVERY actionable item — review thread comments, sticky findings,
+  AND cleanup response. Do NOT cherry-pick one type and skip others. Do NOT treat the
+  checks below as mutually exclusive — they ALL apply in the same cycle.**
 
-- If **new comments found from auto-approved sources**: Run Phases 2-8 again with
-  auto-approve behavior for the relevant sources.
-  After completing, spawn another async worker (go to 9a+9b again).
+  1. **Review thread comments** (items with `thread_id`): Run Phases 2-8 for each.
+  2. **Sticky findings** (items without `thread_id`, type starts with `qodo_`): Run Phases 2-8 for each.
+  3. **`qodo_cleanup_response`** (if not empty): Address every item Qodo listed:
+     - Qodo says "fixed" / "looks fixed" / "addressed" → no code change needed
+     - Qodo says "still open" / "still relevant" / "still actionable" → MUST fix the code, commit, push
+     - If you don't understand what Qodo wants for a specific finding → use
+       `myk-pi-tools reviews ask-qodo "<question>"` to ask Qodo directly.
+       The command posts the question to @qodo-code-review and waits up to 10 minutes
+       for Qodo's reply. Read the reply and act on it.
+     - Every item in `qodo_cleanup_response` MUST be addressed. No skipping.
+
+  After fixing ALL items, commit and push, then re-spawn the poll.
 
 #### 9c: Exit Conditions (MANDATORY)
 

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -575,6 +575,21 @@ Check the poll JSON output — it always contains an `approved` key:
   - **Why remaining** = the status + reason (from the reply field)
   - If zero remaining findings: show `## Remaining Findings (0)` with "All findings resolved."
   - This is the ONLY user-facing output on exit — no per-cycle summaries, no fix history
+- If `"qodo_cleanup_response"` is not empty in the JSON: **MUST be addressed.**
+  This is Qodo's reply to our sticky cleanup request — it lists which findings
+  are fixed and which are still open.
+
+  **For each item Qodo listed:**
+  - Qodo says "fixed" / "looks fixed" / "addressed" → no code change needed
+  - Qodo says "still open" / "still relevant" / "still actionable" → MUST fix the code, commit, push
+  - If you don't understand what Qodo wants for a specific finding → use
+    `myk-pi-tools reviews ask-qodo "<question>"` to ask Qodo directly.
+    The command posts the question to @qodo-code-review and waits up to 10 minutes
+    for Qodo's reply. Read the reply and act on it.
+
+  **Every item in `qodo_cleanup_response` MUST be addressed. No skipping.**
+  After fixing all still-open items, commit and push, then re-spawn the poll.
+
 - If **new comments found from auto-approved sources**: Run Phases 2-8 again with
   auto-approve behavior for the relevant sources.
   After completing, spawn another async worker (go to 9a+9b again).

--- a/prompts/review-handler.md
+++ b/prompts/review-handler.md
@@ -546,19 +546,16 @@ The other agent keeps running independently.
 **While waiting for the async result**, the session remains interactive — the user
 can continue working. When the result surfaces, process it:
 
-Check the poll RAW output (not the worker's summary — look for the exact JSON string):
+Check the poll JSON output — it always contains an `approved` key:
 
-- If output contains the EXACT string `"approved": true`: **EXIT the loop**.
-  **CRITICAL:** Only exit on the literal JSON `{"approved": true}` from the CLI output.
-  Do NOT exit because the worker says "approved" or "0 comments" in its summary.
+- If `"approved": true` in the JSON: **EXIT the loop**.
+  The JSON contains both the approval status AND the reviews data
+  (metadata, human, qodo, coderabbit) — no separate fetch needed.
 
   **On exit, display the Remaining Findings Summary (MANDATORY):**
 
-  The `{"approved": true}` response does NOT contain finding details.
-  Instead, read the last saved reviews JSON file — its path was in the
-  `metadata.json_path` field from the most recent `reviews fetch` or `reviews poll` output.
-  If the JSON file was already deleted by `reviews store`, re-fetch with:
-  `myk-pi-tools reviews fetch --output-dir ${PROJECT_TMP_DIR}` (passing the same arguments used in Phase 1, if any)
+  The approval JSON includes the reviews data directly — use it for the summary.
+  The `metadata.json_path` field contains the path to the saved JSON file.
 
   Display remaining findings in a table:
 
@@ -586,7 +583,7 @@ Check the poll RAW output (not the worker's summary — look for the exact JSON 
 
 **The loop MUST run until one of these conditions is met:**
 
-1. **All auto-approved reviewers approved** — `reviews poll` returns `{"approved": true}`. Exit and notify the user.
+1. **All auto-approved reviewers approved** — `reviews poll` returns JSON with `"approved": true`. Exit and notify the user.
 2. **User explicitly stops** — user presses `Ctrl+C` or sends "stop", "exit", "done", or "quit".
 
 **No other reason is valid to exit the loop.**

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -124,11 +124,17 @@ describe("isRmInProjectTmp", () => {
 
   // Create a real temp dir structure for realpathSync to work
   before(() => {
+    // Use a subdirectory structure that doesn't start with /tmp to avoid
+    // interference with the /tmp/<something> allowlist
     testDir = mkdtempSync(join(tmpdir(), "enforcement-test-"));
     tmpPath = join(testDir, ".pi", "tmp");
     mkdirSync(tmpPath, { recursive: true });
     mkdirSync(join(tmpPath, "worker-123"), { recursive: true });
     writeFileSync(join(tmpPath, "worker-123", "output.log"), "test");
+    // Create worktree structure for worktree test
+    const worktreeTmp = join(testDir, ".worktrees", "pr-42", ".pi", "tmp", "worker-1");
+    mkdirSync(worktreeTmp, { recursive: true });
+    writeFileSync(join(worktreeTmp, "output.log"), "test");
   });
 
   after(() => {
@@ -156,8 +162,8 @@ describe("isRmInProjectTmp", () => {
     assert.ok(isRmInProjectTmp("rm -rf /tmp/something", testDir));
   });
 
-  it("blocks rm -rf on non-existent paths (can't verify safety)", () => {
-    assert.ok(!isRmInProjectTmp("rm -rf .pi/tmp/nonexistent-dir", testDir));
+  it("blocks rm -rf on non-existent paths outside allowed locations", () => {
+    assert.ok(!isRmInProjectTmp("rm -rf /var/nonexistent-dir", testDir));
   });
 
   it("blocks when no path arguments (vacuous truth guard)", () => {
@@ -190,8 +196,6 @@ describe("isRmInProjectTmp", () => {
   it("allows rm -rf targeting .pi/tmp/ inside worktree path", () => {
     // Simulates worktree: cwd is project root, path goes through .worktrees/pr-42/.pi/tmp/
     const worktreeTmp = join(testDir, ".worktrees", "pr-42", ".pi", "tmp", "worker-1");
-    mkdirSync(worktreeTmp, { recursive: true });
-    writeFileSync(join(worktreeTmp, "output.log"), "test");
     assert.ok(isRmInProjectTmp(`rm -rf ${worktreeTmp}`, testDir));
   });
 

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -152,8 +152,8 @@ describe("isRmInProjectTmp", () => {
     assert.ok(!isRmInProjectTmp("rm -rf .pi/tmp/../../etc/passwd", testDir));
   });
 
-  it("blocks rm -rf targeting paths outside project", () => {
-    assert.ok(!isRmInProjectTmp("rm -rf /tmp/something", testDir));
+  it("allows rm -rf targeting /tmp/<something>", () => {
+    assert.ok(isRmInProjectTmp("rm -rf /tmp/something", testDir));
   });
 
   it("blocks rm -rf on non-existent paths (can't verify safety)", () => {
@@ -201,6 +201,18 @@ describe("isRmInProjectTmp", () => {
 
   it("blocks sudo rm -rf even when targeting .pi/tmp/", () => {
     assert.ok(!isRmInProjectTmp(`sudo rm -rf ${join(tmpPath, "worker-123")}`, testDir));
+  });
+
+  it("allows rm -rf /tmp/somefile", () => {
+    assert.ok(isRmInProjectTmp("rm -rf /tmp/test-output-123", "/repo"));
+  });
+
+  it("blocks rm -rf /tmp (bare /tmp without subpath)", () => {
+    assert.ok(!isRmInProjectTmp("rm -rf /tmp", "/repo"));
+  });
+
+  it("allows rm -rf /tmp/nested/path", () => {
+    assert.ok(isRmInProjectTmp("rm -rf /tmp/pi-test/output.log", "/repo"));
   });
 
   it("allows rm -rf with quoted path in .pi/tmp/", () => {

--- a/tests/python/test_actionable_qodo.py
+++ b/tests/python/test_actionable_qodo.py
@@ -1,0 +1,179 @@
+"""Tests for _has_actionable_qodo_comments — pushback detection in poll loop."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from myk_pi_tools.reviews.poll import _has_actionable_qodo_comments
+
+
+@pytest.fixture
+def reviews_dir(tmp_path: Path) -> Path:
+    """Provide a temp directory for review JSON files."""
+    return tmp_path
+
+
+def _write_reviews(reviews_dir: Path, pr_number: str, qodo_comments: list[dict[str, Any]]) -> None:
+    """Write a reviews JSON file with the given Qodo comments."""
+    data = {
+        "metadata": {"owner": "test", "repo": "test", "pr_number": int(pr_number)},
+        "human": [],
+        "qodo": qodo_comments,
+        "coderabbit": [],
+    }
+    json_path = reviews_dir / f"pr-{pr_number}-reviews.json"
+    json_path.write_text(json.dumps(data))
+
+
+class TestHasActionableQodoComments:
+    """Test pushback detection in _has_actionable_qodo_comments."""
+
+    def test_new_finding_is_actionable(self, reviews_dir: Path) -> None:
+        """New finding (not already_replied) → actionable."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {"status": "pending", "body": "New finding"},
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is True
+
+    def test_already_replied_no_response_not_actionable(self, reviews_dir: Path) -> None:
+        """already_replied + no qodo_response → not actionable (Qodo silent = resolved)."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {"already_replied": True, "status": "pending", "body": "Replied finding"},
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is False
+
+    def test_already_replied_confirmed_resolved_not_actionable(self, reviews_dir: Path) -> None:
+        """already_replied + qodo_response confirms resolution → not actionable."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {
+                    "already_replied": True,
+                    "qodo_response": "Yes — finding 9 is addressed. Thanks for the fix.",
+                    "status": "pending",
+                    "body": "Confirmed resolved",
+                },
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is False
+
+    def test_already_replied_with_pushback_is_actionable(self, reviews_dir: Path) -> None:
+        """already_replied + pushback in qodo_response → actionable."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {
+                    "already_replied": True,
+                    "qodo_response": "The issue is still present in the code.",
+                    "status": "pending",
+                    "body": "Pushback finding",
+                },
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is True
+
+    def test_already_replied_disagree_pushback_is_actionable(self, reviews_dir: Path) -> None:
+        """already_replied + 'disagree' in qodo_response → actionable."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {
+                    "already_replied": True,
+                    "qodo_response": "I disagree with this approach.",
+                    "status": "pending",
+                    "body": "Disagree finding",
+                },
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is True
+
+    def test_already_replied_not_fixed_pushback_is_actionable(self, reviews_dir: Path) -> None:
+        """already_replied + 'not fixed' in qodo_response → actionable."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {
+                    "already_replied": True,
+                    "qodo_response": "This bug is not fixed.",
+                    "status": "pending",
+                    "body": "Not fixed finding",
+                },
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is True
+
+    def test_auto_skipped_not_actionable(self, reviews_dir: Path) -> None:
+        """is_auto_skipped → not actionable regardless of other fields."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {"is_auto_skipped": True, "status": "skipped", "body": "Auto-skipped"},
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is False
+
+    def test_empty_qodo_list_not_actionable(self, reviews_dir: Path) -> None:
+        """No Qodo comments → not actionable."""
+        _write_reviews(reviews_dir, "99", [])
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is False
+
+    def test_missing_json_file_is_actionable(self, reviews_dir: Path) -> None:
+        """Missing JSON file → assume actionable (safe default)."""
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is True
+
+    def test_mixed_findings(self, reviews_dir: Path) -> None:
+        """Mix: auto-skipped + resolved + new → actionable (new finding present)."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {"is_auto_skipped": True, "status": "skipped", "body": "Skipped"},
+                {"already_replied": True, "status": "pending", "body": "Resolved silently"},
+                {"status": "pending", "body": "New finding"},
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is True
+
+    def test_only_resolved_findings_not_actionable(self, reviews_dir: Path) -> None:
+        """All already_replied with no pushback → not actionable."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {"already_replied": True, "status": "pending", "body": "Resolved 1"},
+                {
+                    "already_replied": True,
+                    "qodo_response": "Looks good, addressed.",
+                    "status": "pending",
+                    "body": "Resolved 2",
+                },
+                {"is_auto_skipped": True, "status": "skipped", "body": "Skipped"},
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is False
+
+    def test_empty_qodo_response_not_actionable(self, reviews_dir: Path) -> None:
+        """already_replied + empty qodo_response → not actionable (empty = no pushback)."""
+        _write_reviews(
+            reviews_dir,
+            "99",
+            [
+                {"already_replied": True, "qodo_response": "", "status": "pending", "body": "Empty response"},
+            ],
+        )
+        assert _has_actionable_qodo_comments("99", str(reviews_dir)) is False

--- a/tests/python/test_ask_qodo.py
+++ b/tests/python/test_ask_qodo.py
@@ -1,0 +1,287 @@
+"""Tests for ask_qodo — post question to Qodo and wait for reply."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from myk_pi_tools.reviews.ask_qodo import ask_qodo, run
+
+
+class TestAskQodo:
+    """Test the ask_qodo() function."""
+
+    def test_success_returns_reply_body(self) -> None:
+        """Posts comment, receives matching Qodo reply → returns reply body."""
+        question = "What does this function do?"
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api") as mock_api,
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+        ):
+            mock_run.return_value.returncode = 0
+            mock_api.return_value = [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "created_at": "2099-01-01T00:00:00Z",
+                    "body": (
+                        "> What does this function do?\n\nThis function processes input data and returns a result."
+                    ),
+                }
+            ]
+            result = ask_qodo("org", "repo", "42", question)
+
+        assert "This function processes input data" in result
+        assert "What does this function do?" in result
+
+    def test_multiline_question_match(self) -> None:
+        """All non-empty stripped lines from question must appear in reply body."""
+        question = "Line one\nLine two\n\nLine three"
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api") as mock_api,
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+        ):
+            mock_run.return_value.returncode = 0
+            # Reply contains all lines
+            mock_api.return_value = [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "created_at": "2099-01-01T00:00:00Z",
+                    "body": "> Line one\n> Line two\n> Line three\n\nHere is my answer.",
+                }
+            ]
+            result = ask_qodo("org", "repo", "42", question)
+
+        assert "Here is my answer." in result
+
+    def test_partial_match_skipped(self) -> None:
+        """Reply missing some match lines is not accepted → timeout."""
+        question = "Line one\nLine two"
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api") as mock_api,
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+            patch("myk_pi_tools.reviews.ask_qodo.time.time") as mock_time,
+        ):
+            mock_run.return_value.returncode = 0
+            # Reply only contains Line one, not Line two
+            mock_api.return_value = [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "created_at": "2099-01-01T00:00:00Z",
+                    "body": "> Line one\n\nSome answer without line two.",
+                }
+            ]
+            mock_time.side_effect = [0, 0, 700]
+            result = ask_qodo("org", "repo", "42", question)
+
+        assert result == ""
+
+    def test_timeout_returns_empty_string(self) -> None:
+        """No matching reply within timeout → returns empty string."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api", return_value=[]),
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+            patch("myk_pi_tools.reviews.ask_qodo.time.time") as mock_time,
+        ):
+            mock_run.return_value.returncode = 0
+            # first call = start, loop: enter check + exit check exceed timeout
+            mock_time.side_effect = [0, 0, 700]
+            result = ask_qodo("org", "repo", "42", "Hello?")
+
+        assert result == ""
+
+    def test_post_failure_called_process_error(self) -> None:
+        """gh api post fails with CalledProcessError → returns empty string."""
+        with patch(
+            "myk_pi_tools.reviews.ask_qodo.subprocess.run",
+            side_effect=subprocess.CalledProcessError(1, "gh", stderr="forbidden"),
+        ):
+            result = ask_qodo("org", "repo", "42", "Hello?")
+
+        assert result == ""
+
+    def test_post_failure_timeout_expired(self) -> None:
+        """gh api post times out → returns empty string."""
+        with patch(
+            "myk_pi_tools.reviews.ask_qodo.subprocess.run",
+            side_effect=subprocess.TimeoutExpired("gh", 30),
+        ):
+            result = ask_qodo("org", "repo", "42", "Hello?")
+
+        assert result == ""
+
+    def test_post_failure_file_not_found(self) -> None:
+        """gh binary not found → returns empty string."""
+        with patch(
+            "myk_pi_tools.reviews.ask_qodo.subprocess.run",
+            side_effect=FileNotFoundError,
+        ):
+            result = ask_qodo("org", "repo", "42", "Hello?")
+
+        assert result == ""
+
+    def test_ignores_non_qodo_comments(self) -> None:
+        """Comments from other users are ignored."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api") as mock_api,
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+            patch("myk_pi_tools.reviews.ask_qodo.time.time") as mock_time,
+        ):
+            mock_run.return_value.returncode = 0
+            mock_api.return_value = [
+                {
+                    "user": {"login": "some-other-bot"},
+                    "created_at": "2099-01-01T00:00:00Z",
+                    "body": "Hello?",
+                }
+            ]
+            mock_time.side_effect = [0, 0, 700]
+            result = ask_qodo("org", "repo", "42", "Hello?")
+
+        assert result == ""
+
+    def test_ignores_old_qodo_comments(self) -> None:
+        """Qodo comments created before the post time are ignored."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api") as mock_api,
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+            patch("myk_pi_tools.reviews.ask_qodo.time.time") as mock_time,
+        ):
+            mock_run.return_value.returncode = 0
+            # Comment created far in the past
+            mock_api.return_value = [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "created_at": "2000-01-01T00:00:00Z",
+                    "body": "Hello?",
+                }
+            ]
+            mock_time.side_effect = [0, 0, 700]
+            result = ask_qodo("org", "repo", "42", "Hello?")
+
+        assert result == ""
+
+    def test_accepts_qodo_code_review_login(self) -> None:
+        """Accepts replies from 'qodo-code-review' (without [bot] suffix)."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api") as mock_api,
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+        ):
+            mock_run.return_value.returncode = 0
+            mock_api.return_value = [
+                {
+                    "user": {"login": "qodo-code-review"},
+                    "created_at": "2099-01-01T00:00:00Z",
+                    "body": "My question\n\nQodo reply here.",
+                }
+            ]
+            result = ask_qodo("org", "repo", "42", "My question")
+
+        assert "Qodo reply here." in result
+
+
+class TestRun:
+    """Test the run() CLI entry point."""
+
+    def test_pr_flag_calls_ask_qodo_with_correct_args(self) -> None:
+        """--pr owner/repo 123 'question' → calls ask_qodo with correct args, prints reply."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.ask_qodo", return_value="Qodo says hi") as mock_ask,
+            patch("builtins.print") as mock_print,
+        ):
+            try:
+                run(["--pr", "myorg/myrepo", "99", "What is this?"])
+            except SystemExit as e:
+                assert e.code == 0
+
+        mock_ask.assert_called_once_with("myorg", "myrepo", "99", "What is this?")
+        mock_print.assert_called_once_with("Qodo says hi")
+
+    def test_pr_flag_question_before_flag(self) -> None:
+        """Question parts before --pr are joined with parts after."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.ask_qodo", return_value="reply") as mock_ask,
+            patch("builtins.print"),
+        ):
+            try:
+                run(["part1", "--pr", "o/r", "1", "part2"])
+            except SystemExit as e:
+                assert e.code == 0
+
+        mock_ask.assert_called_once_with("o", "r", "1", "part1 part2")
+
+    def test_auto_detect_without_pr_flag(self) -> None:
+        """Without --pr, calls get_pr_info then ask_qodo."""
+        with (
+            patch(
+                "myk_pi_tools.reviews.ask_qodo.get_pr_info",
+                return_value=("auto-owner", "auto-repo", "55"),
+            ) as mock_info,
+            patch("myk_pi_tools.reviews.ask_qodo.ask_qodo", return_value="auto reply") as mock_ask,
+            patch("builtins.print") as mock_print,
+        ):
+            try:
+                run(["How does this work?"])
+            except SystemExit as e:
+                assert e.code == 0
+
+        mock_info.assert_called_once_with("")
+        mock_ask.assert_called_once_with("auto-owner", "auto-repo", "55", "How does this work?")
+        mock_print.assert_called_once_with("auto reply")
+
+    def test_empty_question_exits_1(self) -> None:
+        """Empty question → sys.exit(1)."""
+        with patch("myk_pi_tools.reviews.ask_qodo.get_pr_info", return_value=("o", "r", "1")):
+            try:
+                run([""])
+            except SystemExit as e:
+                assert e.code == 1
+
+    def test_no_reply_exits_1(self) -> None:
+        """ask_qodo returns empty string (timeout) → sys.exit(1)."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.ask_qodo", return_value=""),
+            patch("builtins.print"),
+        ):
+            try:
+                run(["--pr", "o/r", "1", "question"])
+            except SystemExit as e:
+                assert e.code == 1
+
+    def test_success_exits_0(self) -> None:
+        """ask_qodo returns non-empty reply → sys.exit(0)."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.ask_qodo", return_value="got it"),
+            patch("builtins.print"),
+        ):
+            try:
+                run(["--pr", "o/r", "1", "question"])
+            except SystemExit as e:
+                assert e.code == 0
+
+    def test_help_exits_0(self) -> None:
+        """--help → sys.exit(0)."""
+        try:
+            run(["--help"])
+        except SystemExit as e:
+            assert e.code == 0
+
+    def test_no_args_exits_0(self) -> None:
+        """No args → sys.exit(0) (shows help)."""
+        try:
+            run([])
+        except SystemExit as e:
+            assert e.code == 0
+
+    def test_pr_flag_missing_args_exits_1(self) -> None:
+        """--pr without enough arguments → sys.exit(1)."""
+        try:
+            run(["--pr", "o/r"])
+        except SystemExit as e:
+            assert e.code == 1

--- a/tests/python/test_comment_signature.py
+++ b/tests/python/test_comment_signature.py
@@ -1,0 +1,50 @@
+"""Tests for comment signature injection."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from myk_pi_tools.comment_signature import append_signature
+
+
+class TestAppendSignature:
+    """Test append_signature function."""
+
+    def test_appends_when_env_set(self) -> None:
+        """Signature appended when PI_COMMENT_SIGNATURE is set."""
+        with patch.dict("os.environ", {"PI_COMMENT_SIGNATURE": "Assisted-by: PI (test-model)"}):
+            result = append_signature("Hello world")
+        assert result == "Hello world\n\n---\n*Assisted-by: PI (test-model)*"
+
+    def test_no_change_when_env_unset(self) -> None:
+        """Body unchanged when PI_COMMENT_SIGNATURE is not set."""
+        with patch.dict("os.environ", {}, clear=True):
+            result = append_signature("Hello world")
+        assert result == "Hello world"
+
+    def test_no_change_when_env_empty(self) -> None:
+        """Body unchanged when PI_COMMENT_SIGNATURE is empty string."""
+        with patch.dict("os.environ", {"PI_COMMENT_SIGNATURE": ""}):
+            result = append_signature("Hello world")
+        assert result == "Hello world"
+
+    def test_idempotent_no_duplicate(self) -> None:
+        """Calling twice does not duplicate the signature."""
+        with patch.dict("os.environ", {"PI_COMMENT_SIGNATURE": "Assisted-by: PI (test-model)"}):
+            first = append_signature("Hello world")
+            second = append_signature(first)
+        assert first == second
+        assert second.count("Assisted-by") == 1
+
+    def test_empty_body(self) -> None:
+        """Works with empty body."""
+        with patch.dict("os.environ", {"PI_COMMENT_SIGNATURE": "Assisted-by: PI (model)"}):
+            result = append_signature("")
+        assert result == "\n\n---\n*Assisted-by: PI (model)*"
+
+    def test_body_with_existing_different_signature(self) -> None:
+        """Different signature content is appended (not idempotent across models)."""
+        body = "Hello\n\n---\n*Assisted-by: PI (old-model)*"
+        with patch.dict("os.environ", {"PI_COMMENT_SIGNATURE": "Assisted-by: PI (new-model)"}):
+            result = append_signature(body)
+        assert result.count("Assisted-by") == 2

--- a/tests/python/test_fetch_approved.py
+++ b/tests/python/test_fetch_approved.py
@@ -1,0 +1,112 @@
+"""Tests for approved key in reviews fetch output."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from myk_pi_tools.reviews.fetch import is_qodo_approved
+
+
+class TestIsQodoApproved:
+    """Test is_qodo_approved function."""
+
+    def _mock_api(self, responses: dict[str, Any]) -> Any:
+        """Create a mock for run_gh_api that returns different data per endpoint."""
+
+        def mock_fn(endpoint: str, **_kwargs: Any) -> Any:
+            for key, val in responses.items():
+                if key in endpoint:
+                    return val
+            return None
+
+        return mock_fn
+
+    def test_approved_when_no_unresolved_findings(self) -> None:
+        """Returns approved dict when sticky has 0 unresolved findings."""
+        sticky_body = (
+            "<h3>Code Review by Qodo</h3>\n"
+            "<details><summary>Findings</summary>\n"
+            "<code>🐞 Bugs (0)</code>\n"
+            "<!-- QODO_CODE_REVIEW_STICKY -->\n"
+            "finding 1 Resolved</code>\n"
+            "✓ Resolved\n"
+            "</details>\n"
+        )
+        responses = {
+            "/pulls/": {"head": {"sha": "abc123"}},
+            "/commits/": {"commit": {"committer": {"date": "2026-01-01T00:00:00Z"}}},
+            "/comments": [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "body": sticky_body,
+                    "updated_at": "2026-01-02T00:00:00Z",
+                    "id": 123,
+                }
+            ],
+        }
+        with patch("myk_pi_tools.reviews.fetch.run_gh_api", side_effect=self._mock_api(responses)):
+            result = is_qodo_approved("org", "repo", "1")
+        assert result is not None
+        assert result["approved"] is True
+        assert result["reason"] == "all_resolved"
+
+    def test_not_approved_when_unresolved_findings(self) -> None:
+        """Returns None when sticky has unresolved findings."""
+        sticky_body = (
+            "<h3>Code Review by Qodo</h3>\n"
+            "<!-- QODO_CODE_REVIEW_STICKY -->\n"
+            "<details><summary>🐞 <b>Bug title</b></summary>\n"
+            "description\n</details>\n"
+        )
+        responses = {
+            "/pulls/": {"head": {"sha": "abc123"}},
+            "/commits/": {"commit": {"committer": {"date": "2026-01-01T00:00:00Z"}}},
+            "/comments": [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "body": sticky_body,
+                    "updated_at": "2026-01-02T00:00:00Z",
+                    "id": 123,
+                }
+            ],
+        }
+        with patch("myk_pi_tools.reviews.fetch.run_gh_api", side_effect=self._mock_api(responses)):
+            result = is_qodo_approved("org", "repo", "1")
+        assert result is None
+
+    def test_not_approved_when_no_sticky_comment(self) -> None:
+        """Returns None when no Qodo sticky comment found."""
+        responses = {
+            "/pulls/": {"head": {"sha": "abc123"}},
+            "/commits/": {"commit": {"committer": {"date": "2026-01-01T00:00:00Z"}}},
+            "/comments": [],
+        }
+        with patch("myk_pi_tools.reviews.fetch.run_gh_api", side_effect=self._mock_api(responses)):
+            result = is_qodo_approved("org", "repo", "1")
+        assert result is None
+
+    def test_not_approved_when_sticky_not_updated_after_commit(self) -> None:
+        """Returns None when sticky was updated BEFORE the latest commit."""
+        sticky_body = "<h3>Code Review by Qodo</h3>\n<!-- QODO_CODE_REVIEW_STICKY -->\nResolved</code>\n✓ Resolved\n"
+        responses = {
+            "/pulls/": {"head": {"sha": "abc123"}},
+            "/commits/": {"commit": {"committer": {"date": "2026-01-02T00:00:00Z"}}},
+            "/comments": [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "body": sticky_body,
+                    "updated_at": "2026-01-01T00:00:00Z",
+                    "id": 123,
+                }
+            ],
+        }
+        with patch("myk_pi_tools.reviews.fetch.run_gh_api", side_effect=self._mock_api(responses)):
+            result = is_qodo_approved("org", "repo", "1")
+        assert result is None
+
+    def test_not_approved_when_api_fails(self) -> None:
+        """Returns None when API call fails."""
+        with patch("myk_pi_tools.reviews.fetch.run_gh_api", return_value=None):
+            result = is_qodo_approved("org", "repo", "1")
+        assert result is None

--- a/tests/python/test_pr_info.py
+++ b/tests/python/test_pr_info.py
@@ -52,17 +52,19 @@ class TestFetchPrInfo:
 class TestRun:
     """Test the run function output."""
 
-    def test_output_contains_author(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Output JSON contains author field from user.login."""
-        mock_api_response = (
+    @staticmethod
+    def _fork_api_response() -> str:
+        return (
             '{"user": {"login": "Chenli-Hu"}, "head": {"sha": "abc",'
             ' "repo": {"full_name": "Chenli-Hu/repo"}}, "base": {"ref": "main",'
             ' "repo": {"full_name": "RedHatQE/repo"}}, "title": "test PR",'
             ' "state": "open", "body": "", "labels": [], "assignees": []}'
         )
 
+    def test_output_contains_author(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Output JSON contains author field from user.login."""
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value.stdout = mock_api_response
+            mock_run.return_value.stdout = self._fork_api_response()
             mock_run.return_value.returncode = 0
 
             run(["RedHatQE/repo", "503"])
@@ -71,7 +73,31 @@ class TestRun:
 
         output = json.loads(capsys.readouterr().out)
         assert output["author"] == "Chenli-Hu"
+
+    def test_output_contains_owner(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Output JSON contains owner extracted from base repo."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = self._fork_api_response()
+            mock_run.return_value.returncode = 0
+
+            run(["RedHatQE/repo", "503"])
+
+        import json
+
+        output = json.loads(capsys.readouterr().out)
         assert output["owner"] == "RedHatQE"
+
+    def test_output_detects_fork(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """is_fork is True when head and base repos differ."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = self._fork_api_response()
+            mock_run.return_value.returncode = 0
+
+            run(["RedHatQE/repo", "503"])
+
+        import json
+
+        output = json.loads(capsys.readouterr().out)
         assert output["is_fork"] is True
 
     def test_output_detects_non_fork(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/python/test_pr_info.py
+++ b/tests/python/test_pr_info.py
@@ -1,0 +1,95 @@
+"""Tests for myk-pi-tools pr info command."""
+
+from unittest.mock import patch
+
+import pytest
+
+from myk_pi_tools.pr.common import PRInfo
+from myk_pi_tools.pr.info import fetch_pr_info, run
+
+
+class TestFetchPrInfo:
+    """Test fetch_pr_info function."""
+
+    def test_successful_fetch(self) -> None:
+        """Successfully fetch PR info from GitHub API."""
+        mock_api_response = (
+            '{"user": {"login": "testuser"}, "head": {"sha": "abc123",'
+            ' "repo": {"full_name": "fork/repo"}}, "base": {"ref": "main",'
+            ' "repo": {"full_name": "org/repo"}}, "title": "Test PR",'
+            ' "state": "open", "body": "PR body",'
+            ' "labels": [{"name": "bug"}],'
+            ' "assignees": [{"login": "reviewer"}]}'
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = mock_api_response
+            mock_run.return_value.returncode = 0
+
+            result = fetch_pr_info(PRInfo(owner="org", repo="repo", pr_number="1"))
+
+        assert result["user"]["login"] == "testuser"
+        assert result["head"]["sha"] == "abc123"
+
+    def test_invalid_json_exits(self) -> None:
+        """Invalid JSON response causes sys.exit(1)."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = "not json"
+            mock_run.return_value.returncode = 0
+
+            with pytest.raises(SystemExit) as exc_info:
+                fetch_pr_info(PRInfo(owner="org", repo="repo", pr_number="1"))
+            assert exc_info.value.code == 1
+
+    def test_gh_not_found_exits(self) -> None:
+        """Missing gh CLI causes sys.exit(1)."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(SystemExit) as exc_info:
+                fetch_pr_info(PRInfo(owner="org", repo="repo", pr_number="1"))
+            assert exc_info.value.code == 1
+
+
+class TestRun:
+    """Test the run function output."""
+
+    def test_output_contains_author(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Output JSON contains author field from user.login."""
+        mock_api_response = (
+            '{"user": {"login": "Chenli-Hu"}, "head": {"sha": "abc",'
+            ' "repo": {"full_name": "Chenli-Hu/repo"}}, "base": {"ref": "main",'
+            ' "repo": {"full_name": "RedHatQE/repo"}}, "title": "test PR",'
+            ' "state": "open", "body": "", "labels": [], "assignees": []}'
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = mock_api_response
+            mock_run.return_value.returncode = 0
+
+            run(["RedHatQE/repo", "503"])
+
+        import json
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["author"] == "Chenli-Hu"
+        assert output["owner"] == "RedHatQE"
+        assert output["is_fork"] is True
+
+    def test_output_detects_non_fork(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """is_fork is False when head and base repos match."""
+        mock_api_response = (
+            '{"user": {"login": "dev"}, "head": {"sha": "abc",'
+            ' "repo": {"full_name": "org/repo"}}, "base": {"ref": "main",'
+            ' "repo": {"full_name": "org/repo"}}, "title": "test",'
+            ' "state": "open", "body": "", "labels": [], "assignees": []}'
+        )
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.stdout = mock_api_response
+            mock_run.return_value.returncode = 0
+
+            run(["org/repo", "1"])
+
+        import json
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["is_fork"] is False

--- a/tests/python/test_qodo_parser.py
+++ b/tests/python/test_qodo_parser.py
@@ -136,6 +136,16 @@ class TestParseQodoStickyComment:
         assert findings[0]["finding_type"] == "Requirement gap"
         assert findings[0]["category"] == "Quality"
 
+    def test_single_category_tag_no_type_emoji(self) -> None:
+        """Single non-type-emoji code tag is assigned as type (positional fallback)."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> <code>≡ Correctness</code></summary>\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Correctness"
+        assert findings[0]["category"] == ""
+
     def test_reverse_order_no_emoji_fallback(self) -> None:
         """When category tag appears before type tag with no emojis, positional assignment still works."""
         html = self._make_sticky(

--- a/tests/python/test_qodo_parser.py
+++ b/tests/python/test_qodo_parser.py
@@ -91,3 +91,60 @@ class TestParseQodoStickyComment:
         assert len(findings) == 1
         assert findings[0]["finding_type"] == "Bug"
         assert findings[0]["category"] == "Correctness"
+
+    def test_unknown_emoji_falls_back_to_positional(self) -> None:
+        """Code tags with unrecognized emojis use positional assignment."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>🔥 New category</code> <code>⚡ Performance</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "New category"
+        assert findings[0]["category"] == "Performance"
+
+    def test_no_emoji_falls_back_to_positional(self) -> None:
+        """Code tags without any emoji use positional assignment."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>Custom type</code> <code>Custom category</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Custom type"
+        assert findings[0]["category"] == "Custom category"
+
+    def test_single_code_tag_sets_type_only(self) -> None:
+        """Only one non-status code tag sets type, category remains empty."""
+        html = self._make_sticky("<details><summary>  1.  <b>Title</b> <code>🐞 Bug</code></summary>\ndesc\n</details>")
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Bug"
+        assert findings[0]["category"] == ""
+
+    def test_type_emoji_with_unknown_category_emoji(self) -> None:
+        """Known type emoji + unknown category emoji both parsed correctly."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>📎 Requirement gap</code> <code>🌟 Quality</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Requirement gap"
+        assert findings[0]["category"] == "Quality"
+
+    def test_reverse_order_no_emoji_fallback(self) -> None:
+        """When category tag appears before type tag with no emojis, positional assignment still works."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>Testability</code> <code>Skill insight</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        # Positional: first = type, second = category (even if semantically reversed)
+        assert findings[0]["finding_type"] == "Testability"
+        assert findings[0]["category"] == "Skill insight"

--- a/tests/python/test_qodo_parser.py
+++ b/tests/python/test_qodo_parser.py
@@ -1,0 +1,93 @@
+"""Tests for qodo_parser dynamic type/category detection."""
+
+from __future__ import annotations
+
+from myk_pi_tools.reviews.qodo_parser import parse_qodo_sticky_comment
+
+
+class TestParseQodoStickyComment:
+    """Test dynamic finding type/category parsing."""
+
+    def _make_sticky(self, findings_html: str) -> str:
+        """Wrap findings HTML in a valid Qodo sticky comment structure."""
+        return f"<h3>Code Review by Qodo</h3>\n{findings_html}"
+
+    def test_bug_type_parsed(self) -> None:
+        """Bug finding type is correctly identified."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>🐞 Bug</code> <code>≡ Correctness</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Bug"
+        assert findings[0]["category"] == "Correctness"
+
+    def test_skill_insight_type_parsed(self) -> None:
+        """Skill insight type is correctly identified."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>📜 Skill insight</code> <code>▣ Testability</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Skill insight"
+        assert findings[0]["category"] == "Testability"
+
+    def test_rule_violation_type_parsed(self) -> None:
+        """Rule violation type is correctly identified."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>📘 Rule violation</code> <code>⛨ Security</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Rule violation"
+        assert findings[0]["category"] == "Security"
+
+    def test_requirement_gap_type_parsed(self) -> None:
+        """Requirement gap type is correctly identified."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>📎 Requirement gap</code> <code>☼ Reliability</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Requirement gap"
+        assert findings[0]["category"] == "Reliability"
+
+    def test_resolved_finding_not_returned(self) -> None:
+        """Resolved findings are excluded from results."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <s>Title</s> "
+            "<code>✓ Resolved</code> <code>🐞 Bug</code> <code>≡ Correctness</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 0
+
+    def test_dismissed_finding_not_returned(self) -> None:
+        """Dismissed findings are excluded from results."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <s>Title</s> "
+            "<code>✗ Dismissed</code> <code>📜 Skill insight</code> <code>▣ Testability</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 0
+
+    def test_extra_code_tags_dont_shift_type(self) -> None:
+        """Extra code tags (like severity) don't corrupt type/category."""
+        html = self._make_sticky(
+            "<details><summary>  1.  <b>Title</b> "
+            "<code>🐞 Bug</code> <code>≡ Correctness</code> <code>HIGH</code></summary>"
+            "\ndesc\n</details>"
+        )
+        findings = parse_qodo_sticky_comment(html)
+        assert len(findings) == 1
+        assert findings[0]["finding_type"] == "Bug"
+        assert findings[0]["category"] == "Correctness"

--- a/tests/python/test_retrigger_qodo.py
+++ b/tests/python/test_retrigger_qodo.py
@@ -43,7 +43,7 @@ class TestRetriggerQodoReview:
 class TestRequestQodoStickyCleanup:
     """Test the sticky cleanup request helper."""
 
-    def test_posts_comment_and_returns_reply(self) -> None:
+    def test_returns_reply_on_successful_cleanup(self) -> None:
         """Returns reply body when Qodo responds to cleanup request."""
         with (
             patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,

--- a/tests/python/test_retrigger_qodo.py
+++ b/tests/python/test_retrigger_qodo.py
@@ -17,10 +17,6 @@ class TestRetriggerQodoReview:
             mock_run.return_value.returncode = 0
             result = _retrigger_qodo_review("org", "repo", "123")
         assert result is True
-        mock_run.assert_called_once()
-        # Verify the command posts /agentic_review
-        call_args = mock_run.call_args
-        assert "/agentic_review" in str(call_args)
 
     def test_api_failure_returns_false(self) -> None:
         """Returns False when gh api call fails."""

--- a/tests/python/test_retrigger_qodo.py
+++ b/tests/python/test_retrigger_qodo.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import subprocess
-import time
 from unittest.mock import patch
 
 from myk_pi_tools.reviews.poll import (
-    _QODO_RETRIGGER_COOLDOWN_SECONDS,
-    _QODO_STUCK_TIMEOUT_SECONDS,
+    _request_qodo_sticky_cleanup,
     _retrigger_qodo_review,
 )
 
@@ -42,38 +40,51 @@ class TestRetriggerQodoReview:
         assert result is False
 
 
-class TestStuckReviewConstants:
-    """Test stuck review detection constants and timer math."""
+class TestRequestQodoStickyCleanup:
+    """Test the sticky cleanup request helper."""
 
-    def test_stuck_timeout_is_one_hour(self) -> None:
-        """Stuck timeout is 3600 seconds (1 hour)."""
-        assert _QODO_STUCK_TIMEOUT_SECONDS == 3600
+    def test_posts_comment_and_returns_reply(self) -> None:
+        """Returns reply body when Qodo responds to cleanup request."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api") as mock_api,
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+        ):
+            mock_run.return_value.returncode = 0
+            # Simulate Qodo's reply containing our quoted cleanup text
+            mock_api.return_value = [
+                {
+                    "user": {"login": "qodo-code-review[bot]"},
+                    "created_at": "2099-01-01T00:00:00Z",
+                    "body": (
+                        "> Please re-evaluate all remaining sticky findings against the current code.\n"
+                        "> For each finding, check if the referenced code has been fixed in subsequent commits.\n"
+                        "> Remove findings that are fully addressed."
+                        " Keep any findings where the issue is still present in the code.\n\n"
+                        "finding 1: fixed\nfinding 2: still open"
+                    ),
+                }
+            ]
+            result = _request_qodo_sticky_cleanup("org", "repo", "1")
+        assert "finding 1: fixed" in result
+        assert "finding 2: still open" in result
 
-    def test_cooldown_exceeds_half_timeout(self) -> None:
-        """Cooldown is roughly half the timeout (~30 min) so retries aren't too frequent."""
-        assert _QODO_RETRIGGER_COOLDOWN_SECONDS > _QODO_STUCK_TIMEOUT_SECONDS / 2 - 100
-        assert _QODO_RETRIGGER_COOLDOWN_SECONDS < _QODO_STUCK_TIMEOUT_SECONDS
+    def test_returns_empty_on_post_failure(self) -> None:
+        """Returns empty string when comment post fails."""
+        with patch("myk_pi_tools.reviews.ask_qodo.subprocess.run", side_effect=subprocess.CalledProcessError(1, "gh")):
+            result = _request_qodo_sticky_cleanup("org", "repo", "1")
+        assert result == ""
 
-    def test_cooldown_accounts_for_strict_comparison(self) -> None:
-        """Cooldown is > 1800 to account for strict > comparison in stuck check."""
-        assert _QODO_RETRIGGER_COOLDOWN_SECONDS > 1800
-
-    def test_failed_retrigger_timer_math(self) -> None:
-        """On failed re-trigger, timer shifts forward so next retry is in ~30 min."""
-        now = time.time()
-        # Simulate: reviewing_since was set 1 hour ago, re-trigger failed
-        shifted = now - _QODO_STUCK_TIMEOUT_SECONDS + _QODO_RETRIGGER_COOLDOWN_SECONDS
-        # Time until next trigger: timeout - (now - shifted)
-        elapsed = now - shifted
-        remaining = _QODO_STUCK_TIMEOUT_SECONDS - elapsed
-        # Should be approximately cooldown seconds from now
-        assert abs(remaining - _QODO_RETRIGGER_COOLDOWN_SECONDS) < 1
-
-    def test_successful_retrigger_resets_fully(self) -> None:
-        """On successful re-trigger, timer resets to now — next trigger in 1 full hour."""
-        now = time.time()
-        # Simulate: reset to now
-        reset_time = now
-        elapsed = now - reset_time
-        remaining = _QODO_STUCK_TIMEOUT_SECONDS - elapsed
-        assert abs(remaining - _QODO_STUCK_TIMEOUT_SECONDS) < 1
+    def test_returns_empty_on_timeout(self) -> None:
+        """Returns empty string when no reply within timeout."""
+        with (
+            patch("myk_pi_tools.reviews.ask_qodo.subprocess.run") as mock_run,
+            patch("myk_pi_tools.reviews.ask_qodo.run_gh_api", return_value=[]),
+            patch("myk_pi_tools.reviews.ask_qodo.time.sleep"),
+            patch("myk_pi_tools.reviews.ask_qodo.time.time") as mock_time,
+        ):
+            mock_run.return_value.returncode = 0
+            # Simulate timeout: first call returns start time, subsequent calls exceed timeout
+            mock_time.side_effect = [0, 0, 700]
+            result = _request_qodo_sticky_cleanup("org", "repo", "1")
+        assert result == ""

--- a/tests/python/test_retrigger_qodo.py
+++ b/tests/python/test_retrigger_qodo.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import subprocess
+import time
 from unittest.mock import patch
 
-from myk_pi_tools.reviews.poll import _retrigger_qodo_review
+from myk_pi_tools.reviews.poll import (
+    _QODO_RETRIGGER_COOLDOWN_SECONDS,
+    _QODO_STUCK_TIMEOUT_SECONDS,
+    _retrigger_qodo_review,
+)
 
 
 class TestRetriggerQodoReview:
@@ -35,3 +40,40 @@ class TestRetriggerQodoReview:
         with patch("subprocess.run", side_effect=FileNotFoundError):
             result = _retrigger_qodo_review("org", "repo", "123")
         assert result is False
+
+
+class TestStuckReviewConstants:
+    """Test stuck review detection constants and timer math."""
+
+    def test_stuck_timeout_is_one_hour(self) -> None:
+        """Stuck timeout is 3600 seconds (1 hour)."""
+        assert _QODO_STUCK_TIMEOUT_SECONDS == 3600
+
+    def test_cooldown_exceeds_half_timeout(self) -> None:
+        """Cooldown is roughly half the timeout (~30 min) so retries aren't too frequent."""
+        assert _QODO_RETRIGGER_COOLDOWN_SECONDS > _QODO_STUCK_TIMEOUT_SECONDS / 2 - 100
+        assert _QODO_RETRIGGER_COOLDOWN_SECONDS < _QODO_STUCK_TIMEOUT_SECONDS
+
+    def test_cooldown_accounts_for_strict_comparison(self) -> None:
+        """Cooldown is > 1800 to account for strict > comparison in stuck check."""
+        assert _QODO_RETRIGGER_COOLDOWN_SECONDS > 1800
+
+    def test_failed_retrigger_timer_math(self) -> None:
+        """On failed re-trigger, timer shifts forward so next retry is in ~30 min."""
+        now = time.time()
+        # Simulate: reviewing_since was set 1 hour ago, re-trigger failed
+        shifted = now - _QODO_STUCK_TIMEOUT_SECONDS + _QODO_RETRIGGER_COOLDOWN_SECONDS
+        # Time until next trigger: timeout - (now - shifted)
+        elapsed = now - shifted
+        remaining = _QODO_STUCK_TIMEOUT_SECONDS - elapsed
+        # Should be approximately cooldown seconds from now
+        assert abs(remaining - _QODO_RETRIGGER_COOLDOWN_SECONDS) < 1
+
+    def test_successful_retrigger_resets_fully(self) -> None:
+        """On successful re-trigger, timer resets to now — next trigger in 1 full hour."""
+        now = time.time()
+        # Simulate: reset to now
+        reset_time = now
+        elapsed = now - reset_time
+        remaining = _QODO_STUCK_TIMEOUT_SECONDS - elapsed
+        assert abs(remaining - _QODO_STUCK_TIMEOUT_SECONDS) < 1

--- a/tests/python/test_retrigger_qodo.py
+++ b/tests/python/test_retrigger_qodo.py
@@ -1,0 +1,41 @@
+"""Tests for _retrigger_qodo_review — stuck Qodo review re-trigger."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from myk_pi_tools.reviews.poll import _retrigger_qodo_review
+
+
+class TestRetriggerQodoReview:
+    """Test the stuck Qodo review re-trigger helper."""
+
+    def test_success_returns_true(self) -> None:
+        """Returns True when gh api call succeeds."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = _retrigger_qodo_review("org", "repo", "123")
+        assert result is True
+        mock_run.assert_called_once()
+        # Verify the command posts /agentic_review
+        call_args = mock_run.call_args
+        assert "/agentic_review" in str(call_args)
+
+    def test_api_failure_returns_false(self) -> None:
+        """Returns False when gh api call fails."""
+        with patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "gh")):
+            result = _retrigger_qodo_review("org", "repo", "123")
+        assert result is False
+
+    def test_timeout_returns_false(self) -> None:
+        """Returns False on timeout."""
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("gh", 30)):
+            result = _retrigger_qodo_review("org", "repo", "123")
+        assert result is False
+
+    def test_gh_not_found_returns_false(self) -> None:
+        """Returns False when gh binary not found."""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = _retrigger_qodo_review("org", "repo", "123")
+        assert result is False

--- a/tests/python/test_stale_sticky_cleanup.py
+++ b/tests/python/test_stale_sticky_cleanup.py
@@ -1,0 +1,205 @@
+"""Tests for stale-sticky cleanup branch in _run_qodo_poll."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from myk_pi_tools.reviews.poll import _run_qodo_poll
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+_OWNER = "test-org"
+_REPO = "test-repo"
+_PR = "42"
+_REVIEW_URL = "https://example.com/review"
+
+_PATCH_PREFIX = "myk_pi_tools.reviews.poll"
+
+
+def _base_fetch_result(*, approved: bool = False) -> dict[str, object]:
+    """Return a minimal fetch_run result dict."""
+    return {
+        "approved": approved,
+        "metadata": {"pr_number": _PR},
+        "qodo": [],
+    }
+
+
+def _write_reviews_json(output_dir: Path, findings: list[dict[str, object]]) -> None:
+    """Write a pr-{number}-reviews.json file with the given Qodo findings."""
+    path = output_dir / f"pr-{_PR}-reviews.json"
+    data = {"metadata": {"pr_number": _PR}, "qodo": findings}
+    path.write_text(json.dumps(data))
+
+
+def _stale_findings() -> list[dict[str, object]]:
+    """Findings that are auto-skipped AND already replied → stale sticky."""
+    return [
+        {"id": "1", "is_auto_skipped": True, "already_replied": True, "body": "old finding"},
+        {"id": "2", "is_auto_skipped": True, "already_replied": True, "body": "another old finding"},
+    ]
+
+
+def _fresh_findings() -> list[dict[str, object]]:
+    """Findings that are NOT auto-skipped and NOT already replied → actionable."""
+    return [
+        {"id": "3", "is_auto_skipped": False, "already_replied": False, "body": "new issue"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStaleCleanupTriggersAndReturnsResponse:
+    """Full happy path: stale findings → cleanup → reply → re-fetch → result."""
+
+    def test_stale_cleanup_triggers_and_returns_response(self, tmp_path: Path) -> None:
+        _write_reviews_json(tmp_path, _stale_findings())
+
+        fetch_result = _base_fetch_result(approved=False)
+        fresh_result = _base_fetch_result(approved=False)
+        cleanup_reply = "finding 1: fixed\nfinding 2: still open"
+
+        with (
+            patch(f"{_PATCH_PREFIX}.fetch_run", side_effect=[fetch_result, fresh_result]) as mock_fetch,
+            patch(f"{_PATCH_PREFIX}._has_actionable_qodo_comments", return_value=False),
+            patch(f"{_PATCH_PREFIX}._is_qodo_reviewing", return_value=False),
+            patch(f"{_PATCH_PREFIX}._request_qodo_sticky_cleanup", return_value=cleanup_reply) as mock_cleanup,
+            patch(f"{_PATCH_PREFIX}._print_poll_summary"),
+            patch(f"{_PATCH_PREFIX}.run_gh_api", return_value=[]),
+            patch(f"{_PATCH_PREFIX}.is_qodo_approved", return_value=None),
+            patch(f"{_PATCH_PREFIX}.time.sleep"),
+            patch("builtins.print") as mock_print,
+        ):
+            rc = _run_qodo_poll(_REVIEW_URL, _OWNER, _REPO, _PR, str(tmp_path))
+
+        assert rc == 0
+        mock_cleanup.assert_called_once_with(_OWNER, _REPO, _PR)
+
+        # Verify the JSON written to stdout
+        printed = mock_print.call_args[0][0]
+        result = json.loads(printed)
+        assert result["approved"] is False
+        assert result["qodo_cleanup_response"] == cleanup_reply
+
+        # Two fetch calls: initial + re-fetch after cleanup
+        assert mock_fetch.call_count == 2
+
+        # Verify on-disk JSON file matches
+        disk_path = tmp_path / f"pr-{_PR}-reviews.json"
+        assert disk_path.exists()
+        disk_data = json.loads(disk_path.read_text())
+        assert disk_data["qodo_cleanup_response"] == cleanup_reply
+        assert disk_data["approved"] is False
+
+
+class TestStaleCleanupOnlyRunsOnce:
+    """_cleanup_requested flag prevents requesting cleanup twice."""
+
+    def test_stale_cleanup_only_runs_once(self, tmp_path: Path) -> None:
+        _write_reviews_json(tmp_path, _stale_findings())
+
+        # First cycle: cleanup requested but reply is empty → loop continues
+        # Second cycle: has actionable comments → breaks out
+        fetch_results = [
+            _base_fetch_result(approved=False),  # cycle 1
+            _base_fetch_result(approved=False),  # cycle 2
+        ]
+
+        actionable_returns = [False, True]  # cycle 1: no actionable, cycle 2: actionable → break
+
+        with (
+            patch(f"{_PATCH_PREFIX}.fetch_run", side_effect=fetch_results),
+            patch(f"{_PATCH_PREFIX}._has_actionable_qodo_comments", side_effect=actionable_returns),
+            patch(f"{_PATCH_PREFIX}._is_qodo_reviewing", return_value=False),
+            patch(f"{_PATCH_PREFIX}._request_qodo_sticky_cleanup", return_value="") as mock_cleanup,
+            patch(f"{_PATCH_PREFIX}._print_poll_summary"),
+            patch(f"{_PATCH_PREFIX}.run_gh_api", return_value=[]),
+            patch(f"{_PATCH_PREFIX}.is_qodo_approved", return_value=None),
+            patch(f"{_PATCH_PREFIX}.time.sleep"),
+            patch("builtins.print"),
+        ):
+            rc = _run_qodo_poll(_REVIEW_URL, _OWNER, _REPO, _PR, str(tmp_path))
+
+        assert rc == 0
+        # Cleanup was requested exactly once (cycle 1), NOT again in cycle 2
+        mock_cleanup.assert_called_once()
+
+
+class TestStaleCleanupSkippedWhenNoStaleFindings:
+    """No auto-skipped findings → cleanup NOT requested."""
+
+    def test_stale_cleanup_skipped_when_no_stale_findings(self, tmp_path: Path) -> None:
+        # Write findings that are NOT stale (not auto-skipped)
+        _write_reviews_json(tmp_path, _fresh_findings())
+
+        # fetch returns not-approved, _has_actionable returns True on cycle 1 → breaks immediately
+        # But we need to reach the else branch first to test cleanup skipping.
+        # So: actionable=False on cycle 1 (enters else), then actionable=True on cycle 2 (breaks).
+        fetch_results = [
+            _base_fetch_result(approved=False),  # cycle 1
+            _base_fetch_result(approved=False),  # cycle 2
+        ]
+        actionable_returns = [False, True]
+
+        with (
+            patch(f"{_PATCH_PREFIX}.fetch_run", side_effect=fetch_results),
+            patch(f"{_PATCH_PREFIX}._has_actionable_qodo_comments", side_effect=actionable_returns),
+            patch(f"{_PATCH_PREFIX}._is_qodo_reviewing", return_value=False),
+            patch(f"{_PATCH_PREFIX}._request_qodo_sticky_cleanup") as mock_cleanup,
+            patch(f"{_PATCH_PREFIX}._print_poll_summary"),
+            patch(f"{_PATCH_PREFIX}.run_gh_api", return_value=[]),
+            patch(f"{_PATCH_PREFIX}.is_qodo_approved", return_value=None),
+            patch(f"{_PATCH_PREFIX}.time.sleep"),
+            patch("builtins.print"),
+        ):
+            rc = _run_qodo_poll(_REVIEW_URL, _OWNER, _REPO, _PR, str(tmp_path))
+
+        assert rc == 0
+        mock_cleanup.assert_not_called()
+
+
+class TestStaleCleanupEmptyReplyContinuesLoop:
+    """Cleanup requested but Qodo doesn't reply → loop continues."""
+
+    def test_stale_cleanup_empty_reply_continues_loop(self, tmp_path: Path) -> None:
+        _write_reviews_json(tmp_path, _stale_findings())
+
+        # Cycle 1: stale detected, cleanup requested, empty reply → no break, sleeps
+        # Cycle 2: Qodo now has actionable comments → breaks
+        fetch_results = [
+            _base_fetch_result(approved=False),  # cycle 1
+            _base_fetch_result(approved=False),  # cycle 2
+        ]
+        actionable_returns = [False, True]
+
+        with (
+            patch(f"{_PATCH_PREFIX}.fetch_run", side_effect=fetch_results),
+            patch(f"{_PATCH_PREFIX}._has_actionable_qodo_comments", side_effect=actionable_returns),
+            patch(f"{_PATCH_PREFIX}._is_qodo_reviewing", return_value=False),
+            patch(f"{_PATCH_PREFIX}._request_qodo_sticky_cleanup", return_value="") as mock_cleanup,
+            patch(f"{_PATCH_PREFIX}._print_poll_summary"),
+            patch(f"{_PATCH_PREFIX}.run_gh_api", return_value=[]),
+            patch(f"{_PATCH_PREFIX}.is_qodo_approved", return_value=None),
+            patch(f"{_PATCH_PREFIX}.time.sleep") as mock_sleep,
+            patch("builtins.print") as mock_print,
+        ):
+            rc = _run_qodo_poll(_REVIEW_URL, _OWNER, _REPO, _PR, str(tmp_path))
+
+        assert rc == 0
+        # Cleanup was attempted
+        mock_cleanup.assert_called_once()
+        # Sleep was called (loop continued after empty reply)
+        mock_sleep.assert_called()
+        # Final result should NOT contain qodo_cleanup_response (it came from actionable path)
+        printed = mock_print.call_args[0][0]
+        result = json.loads(printed)
+        # The actionable-comments branch sets qodo_cleanup_response to _cleanup_response
+        # which is still "" since cleanup reply was empty
+        assert result["qodo_cleanup_response"] == ""


### PR DESCRIPTION
## Summary

Nine changes in one PR:

### 1. Restore pushback detection in poll loop (fixes #558)

The autoqodo polling loop was stuck in an infinite loop because `_has_actionable_qodo_comments()` treated ALL non-auto-skipped Qodo entries as actionable — even when Qodo confirmed a finding was resolved.

**Fix:** Restore three-tier logic: new findings → actionable, already replied + pushback → actionable, already replied + no pushback → not actionable.

### 2. Add `myk-pi-tools pr info` command

New CLI command returning PR metadata as structured JSON (author, head_sha, base_ref, title, state, labels, assignees, is_fork). Updated `pr-review.md` to use it instead of manual `gh` calls.

### 3. Allow `rm -rf /tmp/<something>` without confirmation

Extends enforcement allowlist. Uses `realpathSync` for parent validation, blocks `..` traversal, handles symlinked `/tmp` (macOS).

### 4. Dreaming: replace 30-min poll with onComplete callback

Added `onComplete` callback to async agent infrastructure. Dreaming uses it for immediate `rebuildAndOrganize()` on completion. 30-min fallback timer prevents stale `dreamInFlight` if callback never fires.

### 5. Comment signature injection

New `comment_signature` project setting (boolean). When enabled, appends `*Assisted-by: PI (<model>)*` to all AI-posted PR comments. Injected via `PI_COMMENT_SIGNATURE` env var set by extension on session_start, read by CLI post commands. Idempotent — no duplicate signatures on retry.

### 6. Auto re-trigger stuck Qodo reviews

If "Looking for bugs" persists for over 1 hour during autoqodo polling, posts `/agentic_review` comment to re-trigger a stuck Qodo review. Timer resets after re-trigger or when Qodo finishes.

### 7. Single JSON output from poll/fetch

Fixed bug where `reviews poll` printed two JSONs to stdout (fetch data + approval signal), causing the AI to miss the approval. Now `fetch.run()` returns a dict, the poll adds `"approved": true/false` to it, and prints one JSON. The `approved` key is always present in both `reviews fetch` and `reviews poll` output.

### 8. Approval check moved to fetch

Moved `is_qodo_approved` from `poll.py` to `fetch.py`. The `approved: true/false` key is now always present in the `reviews fetch` output JSON. Poll reads it from the fetch result instead of running a separate check. Simplified poll loop significantly.

### 9. Fix _is_qodo_reviewing false positive

Fixed false match on "Looking for bugs?" in Qodo reply prose text. Now only matches `<h3>Looking for bugs?</h3>` heading or body starting with the marker — not substring matches in long replies.

## Changes

- `myk_pi_tools/reviews/poll.py` — pushback detection + stuck Qodo re-trigger
- `myk_pi_tools/pr/info.py` + `commands.py` — new `pr info` command
- `myk_pi_tools/comment_signature.py` — signature injection helper
- `myk_pi_tools/reviews/post.py` — signature in thread replies + consolidated comments
- `myk_pi_tools/pr/post_comment.py` — signature in review comments
- `myk_pi_tools/reviews/pending_update.py` — signature in refined comments
- `extensions/orchestrator/enforcement-helpers.ts` — `/tmp/<something>` allowlist
- `extensions/orchestrator/async-agents.ts` — `onComplete` callback
- `extensions/orchestrator/dreaming.ts` — poll removal + onComplete + fallback timer
- `extensions/orchestrator/enforcement.ts` — set PI_COMMENT_SIGNATURE env var
- `extensions/orchestrator/project-settings.ts` — comment_signature setting
- `prompts/pr-review.md` — use `myk-pi-tools pr info`
- `myk_pi_tools/reviews/fetch.py` — `run()` returns dict instead of printing JSON
- `myk_pi_tools/reviews/commands.py` — CLI prints the JSON from `run()` return
- `prompts/review-handler.md` — updated for single JSON with `approved` key
- `AGENTS.md` — enforcement docs, async-agents, settings table
- `tests/python/test_fetch_approved.py` — 5 tests for is_qodo_approved

## Testing

- 97 Python tests pass (18 new)
- 51 Node tests pass (6 new)
- Comment signature manually verified via `myk-pi-tools reviews post`

Closes #558

