### PR TITLE
refactor(rules): compress orchestrator rules from 1658 to 890 lines (46% reduction)

### DIFF
--- a/rules/00-orchestrator-core.md
+++ b/rules/00-orchestrator-core.md
@@ -16,6 +16,8 @@ The orchestrator delegates — never implements directly.
 **Allowed direct actions:** read files, run `mcpl`, ask questions, analyze, plan,
 route to agents via `subagent`, execute slash commands AND all their internal operations.
 
+Never use edit, write, or bash directly — delegate to specialists. Exception: `mcpl` via bash for MCP discovery.
+
 **Always delegate via `subagent`:**
 
 - Code changes (edit/write) → language specialist

--- a/rules/00-orchestrator-core.md
+++ b/rules/00-orchestrator-core.md
@@ -16,7 +16,7 @@ The orchestrator delegates — never implements directly.
 **Allowed direct actions:** read files, run `mcpl`, ask questions, analyze, plan,
 route to agents via `subagent`, execute slash commands AND all their internal operations.
 
-Never use edit, write, or bash directly (except `mcpl`) — delegate to specialists.
+Outside slash commands, never use edit, write, or bash directly (except `mcpl`) — delegate to specialists.
 
 **Always delegate via `subagent`:**
 

--- a/rules/00-orchestrator-core.md
+++ b/rules/00-orchestrator-core.md
@@ -16,7 +16,7 @@ The orchestrator delegates — never implements directly.
 **Allowed direct actions:** read files, run `mcpl`, ask questions, analyze, plan,
 route to agents via `subagent`, execute slash commands AND all their internal operations.
 
-Never use edit, write, or bash directly — delegate to specialists. Exception: `mcpl` via bash for MCP discovery.
+Never use edit, write, or bash directly (except `mcpl`) — delegate to specialists.
 
 **Always delegate via `subagent`:**
 

--- a/rules/00-orchestrator-core.md
+++ b/rules/00-orchestrator-core.md
@@ -8,33 +8,22 @@
 
 ---
 
-## Forbidden Actions - Read Every Response
+## Delegation Model
 
-❌ **NEVER** use: edit, write, bash (except `mcpl`) directly — delegate to specialists instead
-❌ **NEVER** delegate slash commands (`/command`) OR their internal operations - see slash command rules
-✅ **ALWAYS** delegate other work to specialist agents via the `subagent` tool
-⚠️ Pi does not enforce these restrictions — you SHOULD NOT violate them
+The orchestrator delegates — never implements directly.
+⚠️ Pi does not enforce these restrictions — you SHOULD NOT violate them.
 
-## Allowed Direct Actions
+**Allowed direct actions:** read files, run `mcpl`, ask questions, analyze, plan,
+route to agents via `subagent`, execute slash commands AND all their internal operations.
 
-✅ **ALLOWED** direct actions:
+**Always delegate via `subagent`:**
 
-- Read files (read tool for single files)
-- Run `mcpl` (via bash) for MCP server discovery only
-- Ask clarifying questions
-- Analyze and plan
-- Route tasks to agents via `subagent` tool
-- Execute slash commands AND all their internal operations directly (see slash command rules)
+- Code changes (edit/write) → language specialist
+- Git commands → git-expert
+- MCP tools → manager agents
+- Multi-file exploration → worker
 
----
-
-## Critical Reminder
-
-❌ edit/write → delegate to language specialist via `subagent`
-❌ Git commands → delegate to git-expert via `subagent`
-❌ MCP tools → delegate to manager agents via `subagent`
-❌ Multi-file exploration → delegate to worker agent via `subagent`
-❌ Delegating slash commands → execute them AND their internal operations DIRECTLY (see slash command rules)
+**Never delegate:** slash commands — execute them directly (see slash command rules).
 
 ---
 
@@ -42,7 +31,7 @@
 
 Before ANY code changes, run the pre-implementation checklist:
 
-→ **See the "Pre-Implementation Checklist" section below** - Do NOT skip this step.
+→ **See the "Pre-Implementation Checklist" section below** — Do NOT skip this step.
 
 **Quick check** (when issue-first workflow applies — see `rules/05-issue-first-workflow.md` for skip conditions):
 

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -11,7 +11,7 @@
 
 Before ANY code changes, complete this checklist:
 
-1. **Should this workflow be skipped?** (see "SKIP this workflow for" list below)
+1. **Should this workflow be skipped?** (see "SKIP" list below)
    - YES → Do directly, skip remaining steps
    - NO → Continue checklist
 
@@ -49,95 +49,35 @@ An issue without root cause analysis is a TODO, not a useful issue.
 
 ## When This Workflow Applies
 
-**USE this workflow for:**
+**USE for:**
 
-- New features or enhancements
-- Bug fixes that require code changes
+- New features, enhancements, bug fixes requiring code changes
 - Refactoring tasks
-- Any request that will modify multiple files
-- Tasks that benefit from tracking and documentation
+- Multi-file modifications
+- Tasks benefiting from tracking/documentation
 
-**SKIP this workflow for:**
+**SKIP for:**
 
 - Trivial fixes (typos, single-line changes)
-- Questions or explanations (no code changes)
-- Exploration or research tasks
-- When user explicitly says "just do it" or "quick fix"
-- Urgent hotfixes where user indicates time pressure
-
----
-
-## Workflow
-
-```text
-User Request
-     ↓
-Analyze and understand the request
-     ↓
-Should skip workflow? ──YES──→ Do it directly (skip workflow)
-     │
-    NO
-     ↓
-Investigate root cause:
-  - Read relevant source code
-  - Identify affected files/functions
-  - Understand current behavior
-  - Form conceptual fix approach
-     ↓
-Delegate to github-expert to create issue with:
-  - Type (fix/feat/refactor/docs)
-  - Problem/feature description
-  - Root cause analysis (for bugs/fixes — affected files, functions, why)
-  - Proposed fix approach
-  - Requirements
-  - Deliverables checklist
-     ↓
-Ask: "Issue #N created. Do you want to work on it now?"
-     ↓
-     │
-  ┌──┴──┐
- YES    NO
-  │      │
-  ↓      └──→ Done (user triggers later)
-Fetch main & create issue branch
-     ↓
-Work on the issue
-  - Check off items as completed
-  - Follow code review loop
-     ↓
-All items done → Close issue
-```
+- Questions, explanations, exploration (no code changes)
+- User says "just do it" / "quick fix"
+- Urgent hotfixes with time pressure
 
 ---
 
 ## Branch Workflow
 
-When user confirms they want to work on the issue, **delegate to git-expert**:
+When user confirms, **delegate to git-expert**: fetch main (`git fetch origin main`), create branch (`git checkout -b <type>/issue-<N>-<short-desc> origin/main`).
 
-1. **Fetch main**: `git fetch origin main`
-2. **Create issue branch**: `git checkout -b <type>/issue-<number>-<short-description> origin/main`
-
-**Branch naming:**
-
-- `feat/issue-70-issue-first-workflow`
-- `fix/issue-42-memory-leak`
-- `refactor/issue-99-cleanup-utils`
-- `docs/issue-15-update-readme`
+Branch types: `feat/`, `fix/`, `refactor/`, `docs/` — always prefixed with `issue-<N>-`.
 
 ---
 
 ## Issue Format
 
-The `github-expert` agent handles issue formatting. When delegating issue creation, provide:
+Delegate to `github-expert` with: type (fix/feat/refactor/docs), problem description, root cause analysis (affected files, functions, why), proposed fix, and requirements.
 
-- Type (fix/feat/refactor/docs)
-- Problem/feature description
-- Root cause analysis (for bugs/fixes) — affected files, functions, lines, and why it happens
-- Proposed fix approach
-- Requirements list
-- **Deliverables checklist (MANDATORY)** — every issue MUST have a `## Done` section with checkboxes
-
-**Every issue MUST include a `## Done` section with checkboxes** that define what "done" means:
+**Every issue MUST include a `## Done` section with checkboxes** — the contract for when the issue can be closed:
 
 ```markdown
 ## Done
@@ -147,82 +87,29 @@ The `github-expert` agent handles issue formatting. When delegating issue creati
 - [ ] Deliverable 3
 ```
 
-These checkboxes are the **contract** for when the issue can be closed.
-
 ---
 
 ## Tracking Progress
 
-**As you work on the issue:**
-
-1. **Check off deliverables** - Update the issue to mark completed items
-2. **Follow code review loop** - All code changes go through the review loop (see `rules/20-code-review-loop.md`)
-3. **Update issue with progress** - Add comments if significant updates occur
-
-**When all deliverables are complete:**
-
-1. **Verify ALL checkboxes in the `## Done` section are checked** — if any are unchecked, the issue MUST NOT be closed
-2. Ensure code review passed
-3. Ensure tests pass (if applicable)
-4. Close the issue with a summary comment
-
-🚨 **NEVER close an issue with unchecked deliverables.** An issue with unchecked boxes is NOT done.
-If deliverables are no longer needed, explicitly remove them or mark as N/A before closing.
+Check off deliverables in the issue as you complete them.
+All code changes go through the review loop (see `rules/20-code-review-loop.md`).
+When all deliverables are complete, verify all `## Done` checkboxes are checked, ensure reviews/tests pass, then close with a summary comment.
+🚨 **NEVER close an issue with unchecked deliverables** — remove or mark N/A first if no longer needed.
 
 ---
 
 ## Integration with Code Review Loop
 
-The issue-first workflow integrates with the existing code review loop:
-
-```text
-Issue created & branch ready
-          ↓
-    ┌─────────────────────────────────┐
-    │     CODE REVIEW LOOP            │
-    │  (from 20-code-review-loop.md)  │
-    │                                 │
-    │  Write code → Review → Fix     │
-    │       ↓                         │
-    │  Tests pass?                    │
-    │       ↓                         │
-    │     YES                         │
-    └─────────────────────────────────┘
-          ↓
-Check off deliverable in issue
-          ↓
-More deliverables? ──YES──→ Next item (loop)
-          │
-         NO
-          ↓
-Close issue
-```
-
----
-
-## Asking User to Work on Issue
-
-After creating the issue, always ask:
-
-> **Issue #N created: [title]**
->
-> URL: [issue URL]
->
-> Do you want to work on it now?
-
-Wait for explicit confirmation before:
-
-- Creating the branch
-- Starting any implementation work
+Each deliverable follows the code review loop defined in `rules/20-code-review-loop.md`; once all deliverables pass review, close the issue.
 
 ---
 
 ## Edge Cases
 
-| Scenario                           | Behavior                                     |
-|------------------------------------|----------------------------------------------|
-| User says "just fix it"            | Skip workflow, do directly                   |
-| User provides partial requirements | Ask clarifying questions, then create issue  |
-| Issue already exists               | Ask if user wants to continue existing issue |
-| Urgent/hotfix request              | Skip workflow, note in commit message        |
-| Multiple unrelated requests        | Create separate issues for each              |
+| Scenario | Behavior |
+|---|---|
+| User says "just fix it" | Skip workflow, do directly |
+| Partial requirements | Ask clarifying questions, then create issue |
+| Issue already exists | Ask to continue existing issue |
+| Urgent/hotfix | Skip workflow, note in commit message |
+| Multiple unrelated requests | Create separate issues for each |

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -78,7 +78,8 @@ After creating the issue, present the issue number, title, and URL, then ask:
 
 ## Issue Format
 
-Delegate to `github-expert` with: type (fix/feat/refactor/docs), problem description, root cause analysis (affected files, functions, lines, and why), proposed fix, and requirements.
+Delegate to `github-expert` with: type (fix/feat/refactor/docs), problem description, root cause analysis for bugs/fixes
+(affected files, functions, lines, and why), proposed approach, and requirements.
 
 **Every issue MUST include a `## Done` section with checkboxes** — the contract for when the issue can be closed:
 

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -71,6 +71,9 @@ When user confirms, **delegate to git-expert**: fetch main (`git fetch origin ma
 
 Branch types: `feat/`, `fix/`, `refactor/`, `docs/` — always prefixed with `issue-<N>-`.
 
+After creating the issue, present the issue number, title, and URL, then ask:
+'Do you want to work on it now?' Wait for explicit confirmation before creating the branch or starting implementation.
+
 ---
 
 ## Issue Format

--- a/rules/05-issue-first-workflow.md
+++ b/rules/05-issue-first-workflow.md
@@ -78,7 +78,7 @@ After creating the issue, present the issue number, title, and URL, then ask:
 
 ## Issue Format
 
-Delegate to `github-expert` with: type (fix/feat/refactor/docs), problem description, root cause analysis (affected files, functions, why), proposed fix, and requirements.
+Delegate to `github-expert` with: type (fix/feat/refactor/docs), problem description, root cause analysis (affected files, functions, lines, and why), proposed fix, and requirements.
 
 **Every issue MUST include a `## Done` section with checkboxes** — the contract for when the issue can be closed:
 

--- a/rules/10-agent-routing.md
+++ b/rules/10-agent-routing.md
@@ -2,118 +2,48 @@
 
 ## Routing Table
 
-| Domain/Tool                                                  | Agent                            |
-|--------------------------------------------------------------|----------------------------------|
-| **Languages (by file type)**                                 |                                  |
-| Python (.py)                                                 | `python-expert`                  |
-| Go (.go)                                                     | `go-expert`                      |
-| Frontend (JS/TS/React/Vue/Angular)                           | `ts-expert`                      |
-| Java (.java)                                                 | `java-expert`                    |
-| Shell scripts (.sh)                                          | `bash-expert`                    |
-| Markdown (.md)                                               | `technical-documentation-writer` |
-| **Infrastructure**                                           |                                  |
-| Docker                                                       | `docker-expert`                  |
-| Kubernetes/OpenShift                                         | `kubernetes-expert`              |
-| Jenkins/CI/Groovy                                            | `jenkins-expert`                 |
-| **Development**                                              |                                  |
-| Git operations (local)                                       | `git-expert`                     |
-| GitHub (PRs, issues, releases, workflows)                    | `github-expert`                  |
-| Tests                                                        | `test-automator`                 |
-| Debugging                                                    | `debugger`                       |
-| API docs                                                     | `api-documenter`                 |
-| External repo security audit                                 | `security-auditor`                     |
-| External AI agents (cursor, codex, gemini, claude, copilot, etc.) | `/acpx-prompt`               |
-| External library/framework docs (React, FastAPI, Django, etc.) | `docs-fetcher`                 |
+| Domain/Tool | Agent |
+|---|---|
+| Python (.py) | `python-expert` |
+| Go (.go) | `go-expert` |
+| Frontend (JS/TS/React/Vue/Angular) | `ts-expert` |
+| Java (.java) | `java-expert` |
+| Shell scripts (.sh) | `bash-expert` |
+| Markdown (.md) | `technical-documentation-writer` |
+| Docker | `docker-expert` |
+| Kubernetes/OpenShift | `kubernetes-expert` |
+| Jenkins/CI/Groovy | `jenkins-expert` |
+| Git operations (local) | `git-expert` |
+| GitHub (PRs, issues, releases, workflows) | `github-expert` |
+| Tests | `test-automator` |
+| Debugging | `debugger` |
+| API docs | `api-documenter` |
+| External repo security audit | `security-auditor` |
+| External AI agents (cursor, codex, gemini, claude, copilot, etc.) | `/acpx-prompt` |
+| External library/framework docs (React, FastAPI, Django, etc.) | `docs-fetcher` |
 
 ## Routing by Intent, Not Tool
 
-**Important:** Route based on the task intent, not just the tool being used.
-
-Examples:
+Route based on the task intent, not just the tool being used.
 
 - Running Python tests? → `python-expert` (not bash-expert)
 - Editing Python files? → `python-expert` (even with sed/awk)
-- Shell script creation? → `bash-expert`
 - Creating a PR? → `github-expert` (not git-expert)
-- Committing changes? → `git-expert` (local git)
-- Viewing GitHub issue? → `github-expert`
-- React documentation? → `docs-fetcher`
-- FastAPI documentation? → `docs-fetcher`
+- External library docs? → `docs-fetcher` (not direct fetch)
 
 ## Documentation Routing (MANDATORY)
 
-### docs-fetcher (External Docs)
+The orchestrator MUST NEVER fetch external docs directly — always delegate to `docs-fetcher`, which tries `llms.txt` first and extracts only relevant sections.
 
-**Use for ALL external library/framework documentation:**
+**Spawn `docs-fetcher` when:**
 
-- React, Vue, Angular, FastAPI, Django, etc.
-- Third-party tools (Oh My Posh, Starship, etc.)
-- Any external documentation
+- Fetching library/framework docs (React, FastAPI, Django, etc.)
+- Looking up config guides or API references for external tools
 
-### Rule: NEVER Fetch Docs Directly
-
-**The orchestrator MUST NEVER fetch documentation directly.**
-
-❌ **FORBIDDEN** - Orchestrator using fetch_content for external docs:
-
-```text
-fetch_content(https://react.dev/...)
-fetch_content(https://fastapi.tiangolo.com/...)
-fetch_content(https://ohmyposh.dev/...)
-```
-
-✅ **REQUIRED** - Delegate to the appropriate agent:
-
-```text
-# For external library docs:
-subagent(agent="docs-fetcher", task="Fetch Oh My Posh configuration docs...")
-
-# For React docs:
-subagent(agent="docs-fetcher", task="Fetch React hooks documentation...")
-```
-
-### Why This Matters
-
-- `docs-fetcher` tries `llms.txt` first (optimized for LLMs)
-- `docs-fetcher` extracts only relevant sections
-- Direct fetch_content wastes tokens on full HTML pages
-
-### When to Spawn docs-fetcher
-
-**Use `docs-fetcher` when:**
-
-- Fetching library/framework documentation (React, FastAPI, Django, etc.)
-- Looking up configuration guides for external tools
-- Getting API references for third-party services
-- User asks about external tool documentation
-
-**Exceptions - Skip when:**
+**Skip when:**
 
 - Standard library only (no external dependencies)
-- User explicitly says "skip docs" or "I know the API"
-- Simple operations with obvious patterns
 - Already fetched docs in current conversation
-
-### Workflow
-
-```text
-Need documentation?
-       ↓
-  Is it an external library/framework/tool?
-       │
-   ┌───┴───┐
-  YES      NO
-   │        │
-   ↓        ↓
-┌──────────────────┐  ┌──────────────────┐
-│   docs-fetcher   │  │  No agent needed │
-│  (web fetching)  │  │  (standard lib)  │
-└──────────────────┘  └──────────────────┘
-       │                      │
-       └──────────┬───────────┘
-                  ↓
-       Use context for implementation
-```
 
 ## Fallback
 

--- a/rules/15-mcp-launchpad.md
+++ b/rules/15-mcp-launchpad.md
@@ -1,9 +1,8 @@
 # MCP Launchpad (mcpl)
 
 Use the `mcpl` command for all MCP server interactions.
-
-MCP Launchpad is a unified CLI for discovering and executing tools from multiple MCP servers.
-If a task requires functionality outside current capabilities, always check `mcpl` for available tools.
+If a task requires functionality outside current capabilities, check `mcpl` for available tools.
+Orchestrator discovers tools via `mcpl search`/`mcpl list` and delegates execution to agents.
 
 ---
 
@@ -20,78 +19,28 @@ If a task requires functionality outside current capabilities, always check `mcp
 | `mcpl inspect <server> <tool> --example`     | Get schema + example call                           |
 | `mcpl call <server> <tool> '{}'`             | Execute tool (no arguments)                         |
 | `mcpl call <server> <tool> '{"param": "v"}'` | Execute tool with arguments                         |
+| `mcpl call <server> <tool> '{}' --no-daemon` | Bypass daemon for debugging                         |
 | `mcpl verify`                                | Test all server connections                         |
+| `mcpl session status`                        | Check daemon and server connection status           |
+| `mcpl session stop`                          | Restart daemon (stops current, auto-restarts)       |
+| `mcpl config`                                | Show current configuration                          |
 
 ---
 
 ## Workflow
 
-**Never guess tool names** - always discover them first.
+**Never guess tool names** — always discover first.
 
-1. **Search first** to find the right tool:
-
-   ```bash
-   mcpl search "list projects"
-   ```
-
-2. **Get example** for complex tools:
-
-   ```bash
-   mcpl inspect sentry search_issues --example
-   ```
-
-3. **Call with required params**:
-
-   ```bash
-   mcpl call vercel list_projects '{"teamId": "team_xxx"}'
-   ```
-
-### Alternative: List Server Tools
-
-If you know which server to use but not the tool name:
-
-```bash
-mcpl list vercel    # Shows all tools with required params
-```
+1. **Search** → `mcpl search "list projects"` (or `mcpl list <server>` if you know the server)
+2. **Inspect** → `mcpl inspect sentry search_issues --example` (for complex tools)
+3. **Call** → `mcpl call vercel list_projects '{"teamId": "team_xxx"}'`
 
 ---
 
 ## Error Recovery
 
-If a tool call fails, mcpl provides helpful suggestions:
-
-- **Tool not found**: Shows similar tool names from that server
-- **Missing parameters**: Shows required params and an example call
-- **Validation errors**: Shows expected parameter types
-
----
+On failure, mcpl suggests fixes: similar tool names (not found), required params + example (missing params), or expected types (validation errors).
 
 ## Troubleshooting
 
-| Command                                      | Purpose                                             |
-|----------------------------------------------|-----------------------------------------------------|
-| `mcpl verify`                                | Test all server connections                         |
-| `mcpl session status`                        | Check daemon and server connection status           |
-| `mcpl session stop`                          | Restart daemon (stops current, auto-restarts)       |
-| `mcpl config`                                | Show current configuration                          |
-| `mcpl call <server> <tool> '{}' --no-daemon` | Bypass daemon for debugging                         |
-
-### Common Issues
-
-- **Server not connecting**: Run `mcpl verify` to test connections
-- **Stale connections**: Run `mcpl session stop` then retry
-- **Timeout errors**: Increase with `MCPL_CONNECTION_TIMEOUT=120`
-
----
-
-## For Orchestrator
-
-- Use `mcpl search` or `mcpl list` for discovery
-- Delegate actual MCP tool execution to agents
-- When delegating, tell agents that MCP servers are available via `mcpl`
-
-## For Agents
-
-- Use the full mcpl workflow above
-- Always search or list before calling unknown tools
-- Execute tools as needed for your task
+- **Server not connecting**: `mcpl verify` → **Stale connections**: `mcpl session stop` then retry → **Timeouts**: set `MCPL_CONNECTION_TIMEOUT=120`

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -3,31 +3,16 @@
 After ANY code change, follow this loop:
 
 ```text
-┌───────────────────────────────────────────────────────────────────┐
-│  1. Specialist writes/fixes code                                 │
-│              ↓                                                   │
-│  2. Send to ALL 3 review agents IN PARALLEL:                     │
-│     - `code-reviewer-quality`                                    │
-│     - `code-reviewer-guidelines`                                 │
-│     - `code-reviewer-security`                                   │
-│              ↓                                                   │
-│  3. Merge findings from all 3 reviewers                          │
-│              ↓                                                   │
-│  4. Has comments from ANY reviewer? ──YES──→ Fix code (go to 2)  │
-│              │                                                   │
-│             NO                                                   │
-│              ↓                                                   │
-│  5. Run `test-automator`                                         │
-│              ↓                                                   │
-│  6. Tests pass? ──NO──→ Fix code                                 │
-│              │              ↓                                    │
-│              │         Minor fix (test/config only)?             │
-│              │           YES → re-run tests (go to 5)           │
-│              │           NO  → full re-review (go to 2)         │
-│             YES                                                  │
-│              ↓                                                   │
-│  ✅ DONE                                                         │
-└───────────────────────────────────────────────────────────────────┘
+1. Specialist writes/fixes code
+2. Send to ALL 3 review agents IN PARALLEL (async)
+3. Merge & deduplicate findings
+4. Has comments? ──YES──→ Fix code → go to 2
+                    NO ↓
+5. Run test-automator
+6. Tests pass? ──NO──→ Minor fix? re-run tests (go to 5)
+                        Substantive change? full re-review (go to 2)
+               YES ↓
+✅ DONE
 ```
 
 ## Review Agents
@@ -41,38 +26,24 @@ Three agents review code in parallel for comprehensive coverage:
 | `code-reviewer-security` | Bugs, logic errors, and security vulnerabilities |
 
 **All 3 MUST be invoked as async subagents (`async: true`) in the same assistant turn.
-Do NOT block waiting for reviews — continue working while they run.
-Results surface automatically when complete.**
+Do NOT block waiting for reviews — continue working while they run.**
 
-**Note:** The overlapping scope between reviewers is intentional. Multiple reviewers examining similar areas
-ensures comprehensive coverage and reduces the chance of missed issues.
-Step 3's deduplication (see below) handles any duplicate findings.
+Overlapping scope is intentional for comprehensive coverage; step 3's deduplication handles duplicates.
 
 ## Deduplication Criteria
 
-When merging findings from all 3 reviewers (step 3), apply these rules:
-
-- **Same file/line range + same issue type or root cause** = duplicate. Keep the most actionable version.
-- **Conflicting suggestions** = follow priority order: security > correctness > performance > style. If still ambiguous, escalate to the user.
-- **Complementary findings on the same code** (different issue types) = keep both.
+Same file/line + same issue or root cause = duplicate — keep the most actionable version.
+Conflicts follow priority: security > correctness > performance > style; complementary findings on the same code are kept.
 
 ## Key Rules
 
-**Never skip code review. Loop until all reviewers approve.**
-
-The process is iterative:
-
-1. Code is written or modified by a specialist
-2. All 3 review agents run in parallel
-3. Merge and deduplicate findings from all reviewers (see "Deduplication Criteria" above)
-4. If there are comments, fix the code and repeat from step 2
-5. Once approved, run tests
-6. If tests fail, fix the code. Minor test/config-only fixes can skip re-review and go to step 5. Substantive code changes require full re-review from step 2
-7. Only complete when all reviewers approve AND tests pass
+Never skip code review — loop until all reviewers approve AND tests pass.
+If there are comments, fix and re-review from step 2; once approved, run tests.
+Minor test/config-only fixes skip re-review (go to step 5); substantive code changes require full re-review.
 
 ## Baseline Test Comparison (Step 5)
 
-Before declaring test failures as blockers, compare against the baseline:
+Compare against baseline before declaring test failures as blockers:
 
 ```bash
 BASELINE_DIR="${PROJECT_TMP_DIR}"
@@ -84,11 +55,9 @@ git ls-files --others --exclude-standard > "$BASELINE_DIR/untracked.list"
 
 # 2. Reset to clean state
 git reset --hard HEAD
-# Remove untracked files listed (if any)
 xargs -r -d '\n' rm -f < "$BASELINE_DIR/untracked.list" 2>/dev/null || true
 
 # 3. Run tests → record baseline failure count
-# <run tests here>
 
 # 4. Restore changes
 git apply "$BASELINE_DIR/baseline.patch" \
@@ -98,45 +67,19 @@ git apply "$BASELINE_DIR/baseline.patch" \
 rm -f "$BASELINE_DIR/baseline.patch" "$BASELINE_DIR/untracked.list"
 
 # 6. Run tests → record current failure count
-# <run tests here>
 ```
 
-- **Only NEW failures** (current minus baseline) block the review
-- Pre-existing failures are noted in the review but do not block
-- If both `git apply` and `git apply --3way` fail, skip baseline comparison
-  and note "baseline comparison unavailable" — do NOT block on all failures
-- Untracked files are saved/restored separately since `git diff` doesn't capture them
-
-This prevents blocking on test failures that existed before the PR.
+Only **new failures** (current minus baseline) block the review; pre-existing failures are noted but don't block.
+If both `git apply` methods fail, skip baseline comparison and note "baseline comparison unavailable" — do NOT block on all failures.
 
 ## Staged Review Mode (Automated Workflows)
 
-For automated review flows (autorabbit, autoqodo), use **two-stage review order**
-instead of parallel review:
+For automated review flows (autorabbit, autoqodo), use **two-stage order** instead of parallel:
 
-```text
-┌─────────────────────────────────────────────────────────────────┐
-│  Stage 1: Spec Compliance                                       │
-│  - Does the code meet the requirements/spec?                    │
-│  - Are all deliverables implemented?                            │
-│  - No scope creep?                                              │
-│              ↓                                                  │
-│  Stage 1 passed?  ──NO──→ Fix spec issues first (loop Stage 1)  │
-│              │                                                  │
-│             YES                                                 │
-│              ↓                                                  │
-│  Stage 2: Code Quality                                          │
-│  - Code quality and maintainability                             │
-│  - Security and bugs                                            │
-│  - Project guidelines adherence                                 │
-│              ↓                                                  │
-│  Stage 2 passed?  ──NO──→ Fix quality issues (loop Stage 2)     │
-│              │                                                  │
-│             YES                                                 │
-│              ↓                                                  │
-│  ✅ DONE                                                         │
-└─────────────────────────────────────────────────────────────────┘
-```
+1. **Stage 1 — Spec Compliance:** Does code meet requirements? All deliverables implemented? No scope creep?
+   Loop Stage 1 until passed.
+2. **Stage 2 — Code Quality:** Quality, security, guidelines adherence.
+   Loop Stage 2 until passed.
 
-**Why staged?** Don't polish code that doesn't meet spec — it wastes work.
-The parallel mode (all 3 reviewers at once) remains the default for manual reviews.
+Don't polish code that doesn't meet spec — it wastes work.
+Parallel mode (all 3 reviewers at once) remains default for manual reviews.

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -3,8 +3,6 @@
 Scored, topic-organized memory system with stability-based decay.
 Memories are scored, prioritized, and injected into the system prompt via situation reports.
 
-**CLI:** `uv run myk-pi-tools memory <command>`
-
 ---
 
 ## Memory Tools (MANDATORY)
@@ -21,57 +19,27 @@ Three mechanisms automatically inject relevant context into your system prompt �
 
 **Ground Truth:** All injected memories are authoritative. Use them directly —
 do not re-discover or re-verify information already in your context window.
-If you see a memory about how something works, trust it. Only verify against terminal output if actively debugging.
 
-**Social closer gate:** Trivial messages ("ok", "thanks", "yes", "👍", messages < 6 chars) skip vector/session search — no wasted computation.
+**Social closer gate:** Trivial messages ("ok", "thanks", "👍", < 6 chars) skip vector/session search.
 
 ### `memory_search` — Search Before Answering
 
-**MANDATORY:** Before answering questions about prior sessions, user preferences,
-past decisions, recurring patterns, or anything the user mentioned before —
-call `memory_search` first.
-
-```text
-memory_search(query: "docker")           # Search by keyword
-memory_search(query: "PR", category: "lesson")  # Filter by category
-```
+**MANDATORY:** Before answering questions about prior sessions, user preferences, past decisions, or anything mentioned before —
+call `memory_search` first. Supports keyword and category-filtered queries.
 
 ### `memory_reinforce` — Reinforce When Relevant
 
-**MANDATORY:** When you notice a memory is relevant to the current task,
-call `memory_reinforce` to bump its evidence count. This prevents useful
-memories from decaying.
-
-```text
-memory_reinforce(entryText: "...", category: "lesson")
-```
+**MANDATORY:** When a memory is relevant to the current task, call `memory_reinforce` to bump its evidence count and prevent decay.
 
 ### `memory_add` — Add New Memories Proactively
 
-**MANDATORY:** When you learn something worth remembering — user preferences,
-environment facts, corrections, conventions, completed work — add it immediately.
-Don't wait for dreaming or CLI. You own your memory.
-
-```text
-memory_add(text: "Always use --admin for gate-blocked PRs", category: "lesson")
-memory_add(text: "User prefers concise responses", category: "preference", pinned: true)
-```
-
-**Rules:**
-
-- Keep entries short (one line, ~100 chars max)
-- Be specific and actionable — not vague observations
-- Use `pinned: true` ONLY when the user explicitly says "remember this"
-- If the entry already exists, it's automatically reinforced instead
+**MANDATORY:** When you learn something worth remembering — preferences, corrections, conventions, completed work — add it immediately.
+Keep entries short (~100 chars), specific, actionable.
+Use `pinned: true` ONLY when user explicitly says "remember this". Duplicates are auto-reinforced.
 
 ### `memory_remove` — Remove Outdated Memories
 
-Remove entries that are no longer accurate or relevant. Use when information
-is outdated, wrong, or superseded by a newer entry.
-
-```text
-memory_remove(text: "Project uses Python 3.11", category: "lesson")
-```
+Remove entries that are no longer accurate, relevant, or superseded by newer entries.
 
 ### `memory_topics` — Inspect Topic Organization
 
@@ -79,20 +47,11 @@ List all memory topic files with hotness scores and entry counts.
 
 ### `session_search` — Recall Past Conversations
 
-Search past conversation summaries. Use when the user references something
-from a previous session, or when you need to recall what was discussed before.
-Returns matching snippets at zero LLM cost — no summarization, no token usage.
-
-```text
-session_search(query: "docker container build")
-session_search(query: "coderabbit review", limit: 5)
-```
+Search past conversation summaries for references to previous sessions. Returns matching snippets at zero LLM cost.
 
 ---
 
 ## Memory Storage
-
-Memories are stored in topic files under `.pi/memory/topics/`:
 
 ```text
 .pi/memory/
@@ -106,15 +65,6 @@ Memories are stored in topic files under `.pi/memory/topics/`:
     └── mistakes.md        # [mistake] entries
 ```
 
-Each topic file uses this format:
-
-```markdown
-# TopicName
-
-- [category] entry text *(pinned)*
-- [category] entry text
-```
-
 **Pinned** — user explicitly said "remember this". Dream must NEVER remove these.
 **Learned** — auto-extracted by dreaming. Dream can reorganize, deduplicate, remove.
 
@@ -122,47 +72,32 @@ Each topic file uses this format:
 
 ## Scoring System
 
-Every memory has a stability score that decays over time:
-
 ```text
 stability = cue_weight × exp(-Δt / half_life) × ln(1 + evidence_count)
 ```
 
-- **Reinforcing** a memory (via `memory_reinforce`) bumps its evidence count and resets decay
-- **Pinned** entries have score = 9999 (never decay)
-- **Forgotten** entries have score = 0 (always dropped)
-- Entries below the eviction threshold are dropped automatically
-
-**Lifecycle:** active → provisional → candidate → dropped
+- Reinforcing bumps evidence count and resets decay. Pinned = 9999 (never decay). Forgotten = 0.
+- **Lifecycle:** active → provisional → candidate → dropped
 
 ---
 
 ## Capacity Signal
 
-The situation report header shows current memory usage:
-
-```text
-# Project Memory [72% — 1,224/1,700 tokens]
-```
+The situation report header shows usage: `# Project Memory [72% — 1,224/1,700 tokens]`
 
 - **Below 80%** — add freely
-- **Above 80%** — consolidate before adding: merge related entries, remove outdated ones using `memory_remove`
-- The system warns you when capacity is high
+- **Above 80%** — consolidate before adding: merge related entries, remove outdated ones
 
 ---
 
 ## Memory Quality Rules (CRITICAL)
 
-- **One line only** — entries MUST be a single short sentence, max ~100 chars
-- **Specific and actionable** — not vague observations, but concrete "do X" or "don't do Y"
-- **No fluff** — no context, no background, no explanation. Just the fact.
-
-### Good vs Bad
+- **One line only** — max ~100 chars, single short sentence
+- **Specific and actionable** — concrete "do X" or "don't do Y", no fluff
 
 | ❌ Bad | ✅ Good |
 |--------|---------|
-| "We had issues with buildah and Docker caching and tried several approaches before finding the right one" | "buildah chown -R breaks cache mounts — use --mount=type=cache with correct uid instead" |
-| "The memory system was implemented but the integration was incomplete" | "Never close issues with unchecked deliverables in Done section" |
+| "We had issues with buildah and Docker caching and tried several approaches" | "buildah chown -R breaks cache mounts — use --mount=type=cache with correct uid" |
 | "User prefers a certain approach to handling processes" | "Attach child processes to pi (no detached:true) — kills on exit" |
 
 ---
@@ -177,40 +112,26 @@ The situation report header shows current memory usage:
 | Multiple fix attempts | `mistake` | Learned |
 | User states a preference | `preference` | Learned |
 
-**Use `memory_add` tool directly** — don't delegate to CLI or wait for dreaming.
-You are the curator of your own memory.
-
 ---
 
 ## Per-Turn Self-Improvement (MANDATORY)
 
-**After EVERY response, ask yourself:** "Did this turn contain something worth remembering?"
-
-Check for these triggers and act IMMEDIATELY — don't wait for dreaming:
+**After EVERY response, ask:** "Did this turn contain something worth remembering?"
 
 | What happened | Action |
 |---------------|--------|
-| User corrected you | `memory_add(text: "...", category: "lesson")` |
-| You tried something that failed | `memory_add(text: "...", category: "mistake")` |
-| User said "don't do X" or "always do Y" | `memory_add(text: "...", category: "preference")` |
-| A PR was merged | `memory_add(text: "...", category: "done")` |
-| You discovered a non-obvious pattern | `memory_add(text: "...", category: "pattern")` |
-| A technical decision was made | `memory_add(text: "...", category: "decision")` |
+| User corrected you / said "don't do X" / "always do Y" | `memory_add` as `lesson` or `preference` |
+| Something failed or took multiple attempts | `memory_add` as `mistake` |
+| PR merged / technical decision made / non-obvious pattern found | `memory_add` as `done` / `decision` / `pattern` |
 
-**Do NOT wait for `/dream` or session shutdown.** Save immediately when you notice it.
-The difference between a useful memory system and a useless one is whether you actually write to it.
+**Save immediately — do NOT wait for `/dream` or session shutdown.**
 
 ---
 
 ## CLI
 
 ```bash
-uv run myk-pi-tools memory add -c <category> -s "summary"             # Add to Learned
-uv run myk-pi-tools memory add -c <category> -s "summary" --pinned    # Add to Pinned
-uv run myk-pi-tools memory forget -c <category> -s "summary"          # Remove an entry
-uv run myk-pi-tools memory show                                       # Show memory file
-uv run myk-pi-tools memory migrate                                    # One-time DB→md migration
-uv run myk-pi-tools memory path                                       # Print file path
+uv run myk-pi-tools memory <command>   # Commands: add, forget, show, migrate, path
 ```
 
 **Categories:** `lesson`, `decision`, `mistake`, `pattern`, `done`, `preference`
@@ -219,52 +140,14 @@ uv run myk-pi-tools memory path                                       # Print fi
 
 ## Dreaming (Background Consolidation)
 
-Inspired by [OpenClaw's dreaming system](https://docs.openclaw.ai/concepts/dreaming).
-
-Memory consolidation runs as a **background async agent** — never blocking the session.
-
-### Triggers
-
-- `/dream` command — manual trigger
-- Session shutdown — automatic lightweight pass
-
-### What it does
-
-Dreaming is a **self-contained action** — the LLM worker:
-
-1. **Reads** the session file and extracts things worth remembering
-2. **Adds** new entries to the Learned section
-3. **Reorganizes** the memory file — deduplicates, removes stale entries
-4. **Writes** updated topic files under .pi/memory/topics/
-5. **NEVER** removes or modifies Pinned entries
-
-### Rules
-
-- **ALWAYS run dreaming as async + fireAndForget** — never block the session, never inject results into conversation
-- Tell the user: "Running memory consolidation in background..."
+Background async agent that reads the session, extracts things worth remembering, adds/deduplicates/reorganizes topic files, and removes stale entries. **NEVER removes Pinned entries.**
+Triggered by `/dream` (manual) or session shutdown (automatic).
+**ALWAYS run as async + fireAndForget** — never block the session.
 
 ---
 
 ## Skill Creation (Procedural Memory)
 
-Memory stores facts. **Skills store procedures.**
-
-When you complete a multi-step workflow, save it as a skill using `/create-skill <name>`.
-Skills are reusable — next time the same task comes up, the skill provides the exact steps.
-
-**Auto-create skills when:**
-
-- A workflow took 3+ steps and involved trial-and-error or non-obvious commands
-- You notice you're doing the same multi-step task for the second time
-- A debugging session revealed a non-obvious root cause + fix pattern
-- A build/deploy/integration required specific steps that aren't documented
-
-**Do NOT create skills for:**
-
-- Simple one-step tasks
-- Standard workflows already covered by existing skills
-- Tasks that are unlikely to recur
-
-**How:** Run `/create-skill <name>` — it extracts the workflow from the current
-conversation and saves it as `~/.agents/skills/<name>/SKILL.md`.
-The skill is available in the next pi session.
+Memory stores facts; **skills store procedures.**
+When you complete a multi-step workflow (3+ steps, trial-and-error, or non-obvious commands), save it as a skill via `/create-skill <name>`.
+Don't create skills for simple one-step tasks or standard workflows already covered by existing skills.

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -149,5 +149,6 @@ Triggered by `/dream` (manual) or session shutdown (automatic).
 ## Skill Creation (Procedural Memory)
 
 Memory stores facts; **skills store procedures.**
-When you complete a multi-step workflow (3+ steps, trial-and-error, or non-obvious commands), save it as a skill via `/create-skill <name>`.
+When you complete a multi-step workflow (3+ steps, or doing the same multi-step task for the second time,
+trial-and-error, or non-obvious commands), save it as a skill via `/create-skill <name>`.
 Don't create skills for simple one-step tasks or standard workflows already covered by existing skills.

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -1,274 +1,119 @@
 # Critical Rules
 
-## Questions Are Not Instructions (MANDATORY)
+## Questions Are Not Instructions
 
-**When the user asks a question, ONLY answer the question.**
-
-- ❌ **DO NOT** modify files, create files, or delete files
-- ❌ **DO NOT** run commands that change state (git commit, git push, rm, write, edit)
-- ❌ **DO NOT** create branches, open PRs, open issues, or merge anything
-- ❌ **DO NOT** "fix" something you noticed while answering
-- ❌ **DO NOT** take ANY action beyond reading/searching to formulate the answer
-- ✅ **DO** answer the question
-- ✅ **DO** use read-only commands (read, bash with grep/cat/ls/rg, memory_search) to find the answer
-- ✅ **DO** ask for confirmation before taking action if the answer implies something should be done
-
-**A question mark (?) means ANSWER ONLY.** The user will explicitly tell you to act when they want action.
+When the user asks a question, ONLY answer it. Do not modify files, run state-changing commands,
+create branches/PRs/issues, or take any action beyond reading/searching.
+A question mark means answer only — the user will tell you when to act.
 
 ---
 
-## Task Focus (MANDATORY)
+## Task Focus
 
-**When executing a multi-step workflow** (e.g., implement → review → commit → push → PR):
-
-- **NEVER abandon the workflow** when the user asks a side question
-- Answer the side question, then **IMMEDIATELY resume** the original workflow from where you left off
-- Side questions, async agent results, and interruptions do NOT end the current task
-- The workflow is complete ONLY when all steps are done (e.g., PR created, issue closed)
-
-❌ **WRONG:** User asks a question mid-workflow → answer → stop (forget the workflow)
-✅ **RIGHT:** User asks a question mid-workflow → answer → resume workflow from the next pending step
-
-**After EVERY response, ask yourself:** "Was I in the middle of a workflow? If yes, what's the next step?"
-
-## Parallel Execution (MANDATORY)
-
-**Before EVERY response:** Can operations run in parallel?
-
-- **YES** → Execute ALL in ONE message
-- **NO** → PROVE dependency
-
-### Parallel Execution Examples
-
-❌ **WRONG:** Agent1 → wait → Agent2 → wait → Agent3
-✅ **RIGHT:** Agent1 + Agent2 + Agent3 in ONE message
-
-Always maximize parallelism. Only execute sequentially when there's a proven dependency between operations.
-
-### Async Agents (MANDATORY)
-
-**ALWAYS use `async: true`** for independent tasks that can run in parallel —
-code reviews, opening issues, research, analysis, polling, monitoring,
-waiting for builds/CI, and any task where you don't need the result immediately.
-Only use sync (default) when the **very next step** depends on this agent's output.
-
-❌ **WRONG:** Spawn 3 sync reviewers → wait for all → respond
-✅ **RIGHT:** Spawn 3 async reviewers → end turn → results arrive as follow-up
-
-❌ **WRONG:** `sleep 60 && check status` — blocks the session
-✅ **RIGHT:** Spawn async agent → end turn → system delivers result automatically
-
-**After spawning async agents, END YOUR TURN.** Do NOT write bash loops, sleep commands,
-or poll for results. The system delivers async results automatically as a follow-up message
-that starts a new LLM turn. Your only job is to spawn the agent and stop.
-(`fireAndForget: true` agents are silent — no follow-up message is delivered.)
-
-❌ **WRONG:** Spawn async agent → `while true; do sleep 30; check status; done`
-❌ **WRONG:** Spawn async agent → `bash("sleep 60 && cat result.json")`
-❌ **WRONG:** Spawn async agent → keep talking / checking / waiting in the same turn
-✅ **RIGHT:** Spawn async agent → end turn → result arrives as follow-up → process it then
-
-**Kill async agents when their result is no longer needed.**
-Don't let them run to completion wasting resources. Use `asyncKill` immediately.
-
-❌ **WRONG:** Re-dispatch to correct cwd → old agent keeps running in the background
-✅ **RIGHT:** Kill the old agent → then dispatch the replacement
-
-### Sync Agent Time Estimates (MANDATORY)
-
-**ALWAYS provide `estimatedSeconds`** when spawning sync subagents (single, parallel, or chain).
-If the estimated time is **30 seconds or more**, you **MUST use `async: true`** instead.
-
-- **Single sync**: `estimatedSeconds` on the top-level params
-- **Parallel sync**: `estimatedSeconds` on each task — max must be < 30s
-- **Chain sync**: `estimatedSeconds` on each step — sum must be < 30s
-- **Async**: Not required (async agents don't block the session)
-
-The tool enforces this — calls without `estimatedSeconds` or ≥ 30s are rejected.
-
-### Subagent cwd (MANDATORY)
-
-**ALWAYS pass `cwd`** when delegating to subagents — in ALL modes (single, parallel, chain, async).
-
-- Use the project directory when working in the current repo
-- Use the target repo path when working in external repos (e.g., `${PROJECT_TMP_DIR}/...`)
-
-❌ **WRONG:** Omit cwd (subagent inherits session cwd, enforcement checks wrong repo)
-✅ **RIGHT:** Always pass explicit cwd
+When executing a multi-step workflow, never abandon it for a side question. Answer the question,
+then immediately resume the workflow from where you left off. After every response, ask yourself:
+was I in a workflow? If yes, what's the next step?
 
 ---
 
-## Multi-PR / Multi-Branch Work (MANDATORY)
+## Parallel Execution
 
-**When working on multiple PRs or branches simultaneously:**
+Before every response, identify operations that can run in parallel and execute them all in one message.
 
-- ❌ **NEVER** switch branches in the main worktree — other agents may be running there
-- ✅ **ALWAYS** use `git worktree` for each PR/branch when handling more than one
+- Spawn independent agents simultaneously, not sequentially.
+- Only execute sequentially when there's a proven data dependency between operations.
+
+### Async Agents
+
+Use `async: true` for independent tasks (reviews, research, polling, monitoring, CI checks) — any task where you don't need the result immediately.
+After spawning async agents, end your turn — results arrive automatically as a follow-up message.
+
+Do NOT write bash loops, sleep commands, or poll for results after spawning async agents.
+
+❌ Spawn async agent → write bash sleep/poll loop in the same turn
+✅ Spawn async agent → end your turn — results arrive as follow-up automatically
+
+Kill async agents with `asyncKill` when their result is no longer needed.
+
+### Sync Agent Time Estimates
+
+Provide `estimatedSeconds` when spawning sync subagents (single, parallel, or chain).
+If the estimated time is 30 seconds or more, use `async: true` instead — the tool enforces this.
+Single: `estimatedSeconds` on top-level. Parallel: per-task (max <30s). Chain: per-step (sum <30s).
+
+### Subagent cwd
+
+Always pass `cwd` when delegating to subagents in all modes — omitting it causes enforcement to check the wrong repo.
+
+---
+
+## Multi-PR / Multi-Branch Work
+
+**NEVER switch branches in the main worktree** when working on multiple PRs — other agents may be running there.
+Use `git worktree` for each concurrent branch:
 
 ```bash
-# Create a worktree for each PR (inside the repo)
 git worktree add .worktrees/pr-42 origin/fix/issue-42
-git worktree add .worktrees/pr-43 origin/feat/issue-43
-
-# Work in each directory independently
-# When done, clean up
-git worktree remove .worktrees/pr-42
+git worktree remove .worktrees/pr-42  # when done
 ```
 
-**Why:** Branch switching in the main worktree corrupts parallel agent work.
-Agent A switches to branch X, Agent B thinks it's still on branch Y —
-wrong diffs, wrong commits, wrong everything.
-Worktrees give each branch its own directory, fully isolated.
+---
+
+## User Interaction
+
+When you need user input (approvals, selections, confirmations), always use the `ask_user` tool — never ask via plain text in your response.
 
 ---
 
-## User Interaction (MANDATORY)
+## Technical Honesty
 
-**When you need user input** (approvals, selections, confirmations):
-
-- ✅ **ALWAYS** use the `ask_user` tool
-- ❌ **NEVER** ask questions via plain text in your response
-
-Provide clear, concise options. Include a 'no' or 'cancel' option when appropriate.
-
----
-
-## Technical Honesty (MANDATORY)
-
-**When the user proposes an idea, approach, or solution:**
-
-- ✅ **Evaluate it critically** — consider if there's a better technical alternative
-- ✅ **Present alternatives first** — if you know a better way, say so with clear reasoning before proceeding
-- ✅ **Show tradeoffs** — explain pros/cons of the user's approach vs alternatives
-- ✅ **Let the user decide** — after presenting alternatives, the user makes the final call
-- ❌ **NEVER agree blindly** — "you're right" without evaluation is not helpful
-- ❌ **NEVER disagree blindly** — push back only when you have concrete technical reasoning
-
-The user's idea may be the best option — but they should hear alternatives if they exist.
+When the user proposes an approach, evaluate it critically — if a better technical alternative exists, present it with tradeoffs before proceeding.
 After presenting your analysis, respect the user's decision.
 
 ---
 
-## Web Access (MANDATORY)
+## Web Access
 
-**When accessing the web:**
-
-- ✅ Use `web_search` tool for research and search queries
-- ✅ Use `fetch_content` tool for extracting content from URLs, YouTube, GitHub repos
-- ✅ Use `agent-browser` CLI for interactive pages requiring clicks, forms, screenshots
-- ❌ **NEVER** use `curl` for reading web pages
-- ❌ **NEVER** use SearXNG MCP
+- Use `web_search` for research and search queries.
+- Use `fetch_content` for extracting content from URLs, YouTube, GitHub repos.
+- Use `agent-browser` CLI for interactive pages requiring clicks, forms, screenshots.
+- **NEVER** use `curl` for reading web pages or SearXNG MCP.
 
 ---
 
-## External Code Security Audit (MANDATORY)
+## External Code Security Audit
 
-**Before adopting any external code from an untrusted source:**
+Before adopting external code from an untrusted source, delegate a full security audit to `security-auditor` and only proceed if the verdict is safe.
 
-1. Obtain the source code (clone repo, download package source, inspect skill files)
-2. Delegate a full security audit to `security-auditor`
-3. Only proceed if the audit verdict is ✅ SAFE or ⚠️ CAUTION with acceptable risks
-4. If ❌ UNSAFE — do not use, inform the user with findings
+| Source | Audit approach |
+| --------------- | --------------------------------------------------------------------------- |
+| **Git repos** | Clone to `${PROJECT_TMP_DIR}/`, run `security-auditor` |
+| **Pi skills** | Clone/download source to `${PROJECT_TMP_DIR}/`, run `security-auditor` |
+| **PyPI packages** | Clone source repo from PyPI metadata, check install hooks, scan code |
+| **npm packages** | Download source, check `postinstall` scripts, scan code |
+| **MCP servers** | Audit server source code before adding config |
+| **Docker images** | Inspect Dockerfile source, check base image provenance |
+| **Remote scripts** | **ALWAYS block** `curl \| bash` — download first, audit, then run if safe |
 
-### What triggers an audit
-
-| Source | Trigger | Audit approach |
-|--------|---------|----------------|
-| **Git repos** | Adopting external repo/tool/library | Clone to `${PROJECT_TMP_DIR}/`, run `security-auditor` |
-| **Pi skills** | `pi skill install`, adding skill files | Clone/download source to `${PROJECT_TMP_DIR}/`, run `security-auditor` |
-| **PyPI packages** | `uv add <unknown-pkg>`, `uv run --with <unknown-pkg>` | Clone source repo from PyPI metadata, check install hooks, scan code |
-| **npm packages** | `npm install <unknown-pkg>` | Download source, check `postinstall` scripts, scan code |
-| **MCP servers** | Adding new server to `mcp.json` | Audit the server source code before adding config |
-| **Docker images** | `FROM unknown-registry/image` in Dockerfile | Inspect Dockerfile source, check base image provenance |
-| **Remote scripts** | `curl \| bash`, `wget \| sh` | **ALWAYS block** — download first, audit, then run if safe |
-
-### Skip when
-
-- User explicitly says "skip audit" or "I already reviewed it"
-- The tool/package is from a trusted source the user has previously approved
-- Well-known, widely-used packages (e.g., `requests`, `flask`, `react`, `lodash`)
+Skip when the user explicitly says "skip audit", has previously approved the source, or it's a well-known package (e.g., `requests`, `react`, `lodash`).
 
 ---
 
 ## Temp Files
 
-**ALL temp files MUST go to the project temp dir** (`getProjectTmpDir(cwd)` → `<cwd>/.pi/tmp/`).
-
-- The `.pi/` directory is already gitignored — no risk of committing temp files
-
-NEVER create temp files directly in the project tree — always use `.pi/tmp/` via `getProjectTmpDir()`.
+All temp files go to `.pi/tmp/` via `getProjectTmpDir(cwd)` — NEVER create temp files directly in the project tree.
 
 ---
 
 ## Python Execution with uv
 
-**MANDATORY** - When running arbitrary Python files:
-
-- **ONLY** use `uv run --with <package>` syntax
-- **FORBIDDEN** - `uv run pip install` - NEVER use this
-
-### Python uv Examples
-
-✅ **Correct:**
-
-```bash
-uv run --with requests script.py
-uv run --with requests --with pandas script.py
-```
-
-❌ **Wrong:**
-
-```bash
-uv run pip install requests
-```
-
-The `--with` syntax ensures dependencies are managed per-execution without modifying the environment.
+Use `uv run --with <package>` for arbitrary Python files with dependencies.
+**NEVER** use `uv run pip install` — the `--with` syntax manages dependencies per-execution without modifying the environment.
 
 ---
 
 ## External Git Repository Exploration
 
-**When exploring external Git repositories, clone locally first.**
-
-Clone to `${PROJECT_TMP_DIR}/` and explore using read/bash (find, rg, grep) - NOT via web fetching.
-
-### Clone the Bare Minimum
-
-- ✅ Use `--depth 1` for shallow clone (no history)
-- ✅ Use sparse checkout if only specific directories are needed
-- ✅ Delete the clone when done if not needed
-
-### Git Clone Examples
-
-✅ **Correct:**
-
-```bash
-# Shallow clone to temp directory
-git clone --depth 1 https://github.com/org/repo.git ${PROJECT_TMP_DIR}/repo
-
-# Sparse checkout for specific directory only
-git clone --depth 1 --filter=blob:none --sparse https://github.com/org/repo.git ${PROJECT_TMP_DIR}/repo
-cd ${PROJECT_TMP_DIR}/repo && git sparse-checkout set src/utils
-
-# Clean up when done
-rm -rf ${PROJECT_TMP_DIR}/repo
-```
-
-❌ **Wrong:**
-
-```bash
-# Full clone with history
-git clone https://github.com/org/repo.git ${PROJECT_TMP_DIR}/repo
-
-# Using web fetch to browse repository files
-fetch_content(https://github.com/org/repo/blob/main/src/file.py)
-```
-
-### Private Repositories
-
-For private repositories, ensure authentication is configured:
-
-- **SSH**: `git clone --depth 1 git@github.com:org/private-repo.git ${PROJECT_TMP_DIR}/repo`
-- **Credential helper**: Ensure `git config --global credential.helper` is set
-
-Local exploration is faster, more reliable, and provides full file access without web scraping limitations.
+Clone external repos to `${PROJECT_TMP_DIR}/` with `--depth 1` and explore locally using read/bash — not via web fetching.
+Use sparse checkout (`--filter=blob:none --sparse`) when only specific directories are needed.
+For private repos, use SSH or ensure `git config --global credential.helper` is set.

--- a/rules/40-critical-rules.md
+++ b/rules/40-critical-rules.md
@@ -1,6 +1,6 @@
 # Critical Rules
 
-## Questions Are Not Instructions
+## Questions Are Not Instructions (MANDATORY)
 
 When the user asks a question, ONLY answer it. Do not modify files, run state-changing commands,
 create branches/PRs/issues, or take any action beyond reading/searching.
@@ -8,7 +8,7 @@ A question mark means answer only — the user will tell you when to act.
 
 ---
 
-## Task Focus
+## Task Focus (MANDATORY)
 
 When executing a multi-step workflow, never abandon it for a side question. Answer the question,
 then immediately resume the workflow from where you left off. After every response, ask yourself:
@@ -16,7 +16,7 @@ was I in a workflow? If yes, what's the next step?
 
 ---
 
-## Parallel Execution
+## Parallel Execution (MANDATORY)
 
 Before every response, identify operations that can run in parallel and execute them all in one message.
 
@@ -26,7 +26,9 @@ Before every response, identify operations that can run in parallel and execute 
 ### Async Agents
 
 Use `async: true` for independent tasks (reviews, research, polling, monitoring, CI checks) — any task where you don't need the result immediately.
+Only use sync when the very next step depends on this agent's output.
 After spawning async agents, end your turn — results arrive automatically as a follow-up message.
+(`fireAndForget: true` agents are silent — no follow-up.)
 
 Do NOT write bash loops, sleep commands, or poll for results after spawning async agents.
 
@@ -62,6 +64,7 @@ git worktree remove .worktrees/pr-42  # when done
 ## User Interaction
 
 When you need user input (approvals, selections, confirmations), always use the `ask_user` tool — never ask via plain text in your response.
+Provide clear options; include 'no'/'cancel' when appropriate.
 
 ---
 
@@ -83,7 +86,9 @@ After presenting your analysis, respect the user's decision.
 
 ## External Code Security Audit
 
-Before adopting external code from an untrusted source, delegate a full security audit to `security-auditor` and only proceed if the verdict is safe.
+Before adopting external code from an untrusted source, delegate a full security audit to `security-auditor`
+and only proceed if verdict is ✅ SAFE or ⚠️ CAUTION with acceptable risks.
+If ❌ UNSAFE — do not use, inform the user with findings.
 
 | Source | Audit approach |
 | --------------- | --------------------------------------------------------------------------- |

--- a/rules/50-agent-bug-reporting.md
+++ b/rules/50-agent-bug-reporting.md
@@ -5,8 +5,6 @@
 > **If you are a SPECIALIST AGENT:**
 > IGNORE this rule. This is for the ORCHESTRATOR only.
 
----
-
 When the orchestrator discovers a logic flaw or bug in an agent's configuration or instructions, follow this workflow.
 
 ## Agents Covered by This Rule
@@ -40,60 +38,20 @@ This rule applies ONLY to agents defined in this repository (`agents/` directory
 
 **NOT covered:** Built-in pi agents or agents from other sources.
 
----
-
 ## When to Trigger
 
-**Trigger this process when you discover:**
-
-- Flawed logic in an agent's instructions (in `agents/` directory - see scope list above)
-- An agent producing incorrect results due to its configuration
-- An agent's behavior contradicting its intended purpose
-- Agent instructions that cause systematic errors
-
-**DO NOT trigger for:**
-
-- Runtime errors (network failures, missing files, etc.)
-- External tool failures
-- User code bugs (those are normal review feedback)
-- Expected behavior that user disagrees with
-- Bugs in built-in pi agents (not in this repository)
-
----
+**Trigger** when you find flawed logic, incorrect results, contradictory behavior, or systematic errors in an agent's instructions (in `agents/` directory — see scope list above).
+**Do NOT trigger** for runtime/external failures, user code bugs, expected behavior the user disagrees with, or bugs in built-in pi agents.
 
 ## Workflow
 
-```text
-┌─────────────────────────────────────────────────┐
-│  Orchestrator discovers agent logic bug         │
-│                    ↓                            │
-│  ASK USER: "I found a logic bug in [agent].     │
-│             Do you want me to create a          │
-│             GitHub issue for this?"             │
-│                    ↓                            │
-│          User responds YES/NO                   │
-│                    │                            │
-│           ┌────────┴────────┐                   │
-│          YES              NO                    │
-│           │                 │                   │
-│           ↓                 ↓                   │
-│  Delegate to github-expert  │                   │
-│  to create issue            │                   │
-│           │                 │                   │
-│           └────────┬────────┘                   │
-│                    ↓                            │
-│  Continue with original task                    │
-│  (fix bug or apply workaround)                  │
-└─────────────────────────────────────────────────┘
-```
-
----
+1. **Ask user:** "I found a logic bug in [agent]. Do you want me to create a GitHub issue for this?"
+2. **If yes:** Delegate to `github-expert` to create the issue in `myk-org/pi-config`.
+3. **Continue** with the original task (fix bug or apply workaround) regardless of the answer.
 
 ## Issue Creation Format
 
-**Repository:** `myk-org/pi-config`
-
-**Title format:** `bug(agents): [agent-name] - brief description`
+**Title:** `bug(agents): [agent-name] - brief description`
 
 **Body template:**
 
@@ -102,50 +60,23 @@ This rule applies ONLY to agents defined in this repository (`agents/` directory
 [Agent name from agents/ directory]
 
 ## Bug Description
-[Clear description of the logic flaw in the agent's instructions]
+[Clear description of the logic flaw]
 
 ## Expected Behavior
-[What the agent should do according to its purpose]
+[What the agent should do]
 
 ## Actual Behavior
-[What the agent actually does due to the flawed logic]
+[What the agent actually does]
+
+## Suggested Fix
+[Proposed change, if known]
 
 ## Impact
 [How this affects users/workflows]
-
-## Suggested Fix
-[Proposed change to agent instructions, if known]
-
-## Context
-[Any additional context about when/how the bug was discovered]
 ```
-
----
-
-## Example Interaction
-
-```text
-Orchestrator: "I found a logic bug in git-expert. The merged branch
-check incorrectly flags fresh branches as 'already merged' when the
-branch HEAD equals main HEAD, even though the branch has never been
-merged.
-
-Do you want me to create a GitHub issue for this?"
-
-User: "yes"
-
-Orchestrator: [Delegates to github-expert with issue details]
-Orchestrator: "Issue #42 created: bug(agents): git-expert - false
-positive on merged branch detection. Now let me fix the bug with a
-workaround..."
-```
-
----
 
 ## Key Rules
 
-1. **Always ask first** - Never auto-create issues without user confirmation
-2. **Use github-expert** - Delegate issue creation to github-expert agent (don't use gh commands directly)
-3. **Continue working** - After issue creation (or skip), continue with the original task
-4. **Be specific** - Clearly identify which agent and which part of its logic is flawed
-5. **Suggest fixes** - If you know how to fix the agent's instructions, include it in the issue
+Always ask user before creating an issue — never auto-create.
+Delegate issue creation to `github-expert` (don't use `gh` commands directly).
+Be specific about which agent and which logic is flawed, and suggest a fix if you know one.

--- a/rules/50-agent-bug-reporting.md
+++ b/rules/50-agent-bug-reporting.md
@@ -73,6 +73,9 @@ This rule applies ONLY to agents defined in this repository (`agents/` directory
 
 ## Impact
 [How this affects users/workflows]
+
+## Context
+[Any additional context about when/how the bug was discovered]
 ```
 
 ## Key Rules

--- a/rules/55-coms-protocol.md
+++ b/rules/55-coms-protocol.md
@@ -13,25 +13,10 @@ Both systems can be active. When asked to list peers, send messages, or interact
 **try both** `coms_list` and `coms_net_list`. If one fails, use the other.
 Don't assume which system is active.
 
----
-
 ## Activation
 
-Tools are unavailable until the user activates a system:
-
-```text
-/coms start        # Start P2P communication
-/coms-net start    # Start networked communication
-```
-
-To see connected peers:
-
-```text
-coms_list          # P2P peers
-coms_net_list      # Networked peers
-```
-
----
+Tools are unavailable until the user runs `/coms start` (P2P) or `/coms-net start` (networked).
+Use `coms_list` / `coms_net_list` to see connected peers.
 
 ## Tool Reference
 
@@ -41,74 +26,25 @@ coms_net_list      # Networked peers
 | Send message | `coms_send` | `coms_net_send` |
 | Poll for response | `coms_get` | `coms_net_get` |
 
----
-
 ## Inbound Messages — How to Reply
 
-When you receive an inbound message, it appears as:
+Inbound messages appear as `[from <peer> @ <cwd>] <message>`. Your assistant text IS the reply — the `agent_end` hook captures it and sends it back automatically.
 
-```text
-[from <peer> @ <cwd>] <message content>
-```
-
-**Your assistant text IS the reply.** The `agent_end` hook automatically captures your final assistant message and sends it back to the peer. You do NOT need to call any send tool.
-
-❌ **WRONG:** Receive inbound → call `coms_send` to reply
-
-```text
-# This creates a NEW outbound conversation instead of replying.
-# The response never reaches the original peer.
-# The send call blocks waiting for a reply to this new message.
-```
-
-✅ **RIGHT:** Receive inbound → write your answer as normal assistant text
-
-```text
-# The hook captures your response and delivers it to the peer automatically.
-# No tool calls needed — just answer the question.
-```
-
----
+❌ **Never call `coms_send` to reply** — that starts a new outbound conversation instead of replying.
 
 ## Outbound Messages — How to Initiate
 
-To START a new conversation with a peer, use the send tool then **end your turn**. The response auto-delivers as a followUp message when the peer replies — no polling or blocking needed.
+To start a conversation: call the send tool, then **end your turn**.
+The peer's response auto-delivers as a followUp message — no polling needed.
+Use `coms_get` / `coms_net_get` only for non-blocking status checks.
 
-### Example: Outbound conversation (P2P)
+## Message Queue
 
-```text
-1. coms_list                          # Find available peers
-2. coms_send(peer="pi-2", msg="...")  # Send the question
-3. (end turn)                         # Response arrives as followUp automatically
-```
-
-### Example: Outbound conversation (Networked)
-
-```text
-1. coms_net_list                          # Find available peers
-2. coms_net_send(peer="pi-2", msg="...")  # Send the question
-3. (end turn)                             # Response arrives as followUp automatically
-```
-
-Use `coms_get` / `coms_net_get` for non-blocking status checks if needed.
-
----
-
-## Message Queue Behavior
-
-Inbound messages are processed in **FIFO order** (oldest first). When multiple messages arrive while the peer is busy:
-
-1. First message is processed immediately
-2. Subsequent messages are **queued** — not lost, not superseded
-3. After responding to the current message, the next queued message is automatically injected
-4. Each message gets its own dedicated turn and response
-5. The sender receives a response for every message sent — nothing is dropped
-
----
+Inbound messages process in FIFO order. If multiple arrive while the peer is busy, they queue — each gets its own turn and response, nothing is dropped.
 
 ## Structured Task Delegation
 
-Send structured tasks alongside messages using the `tasks` parameter. Tasks appear in the peer's task widget (requires `@tintinweb/pi-tasks`).
+Use the `tasks` parameter to delegate structured work items alongside messages. Tasks appear in the peer's task widget (requires `@tintinweb/pi-tasks`):
 
 ```text
 coms_send(target="coder", prompt="Implement these features", tasks=[
@@ -117,15 +53,11 @@ coms_send(target="coder", prompt="Implement these features", tasks=[
 ])
 ```
 
-The peer sees the tasks in their task widget and can track progress. Tasks are created immediately — even if the message itself is queued.
-
----
-
 ## Key Rules
 
-1. **Responses auto-deliver** — after `coms_send` / `coms_net_send`, end your turn. The peer's response arrives as a followUp message automatically.
+1. **Responses auto-deliver** — after send, end your turn; the reply arrives as a followUp
 2. **Never call send tools to reply** to inbound messages — your assistant text is the reply
-3. **Always check peers first** — use list tools before sending to verify the peer exists
-4. **Try both systems** — when asked to interact with peers without specifying which system, try `coms_` first, then `coms_net_` if it fails (or vice versa)
-5. **Messages are never lost** — if the peer is busy, messages queue and process in order
-6. **Use tasks for structured work** — when delegating multiple items, use the `tasks` parameter instead of listing them in prose
+3. **Always check peers first** — use list tools before sending
+4. **Try both systems** — try `coms_` and `coms_net_` when system isn't specified
+5. **Messages are never lost** — busy peers queue messages in FIFO order
+6. **Use tasks for structured work** — use `tasks` parameter instead of prose lists

--- a/rules/60-task-tracking.md
+++ b/rules/60-task-tracking.md
@@ -11,20 +11,11 @@
 
 **BEFORE starting any multi-step workflow (3+ steps)**, use `TaskCreate` to list ALL steps first.
 
-**Use tasks for:**
+**Use tasks for:** feature implementation, bug fixes with multiple files,
+workflows from `rules/05-issue-first-workflow.md` or `rules/20-code-review-loop.md`,
+multi-file refactoring, or any work involving more than 2 actions.
 
-- Feature implementation (investigate → issue → branch → implement → review → commit → push → PR)
-- Bug fixes with multiple files or steps
-- Any workflow from `rules/05-issue-first-workflow.md` or `rules/20-code-review-loop.md`
-- Refactoring across multiple files
-- Any work the user requests that involves more than 2 actions
-
-**Skip tasks for:**
-
-- Single-step actions (one edit, one command)
-- Questions or explanations (no code changes)
-- `/btw` side questions
-- Trivial fixes (typos, single-line changes)
+**Skip tasks for:** single-step actions, questions/explanations, `/btw` side questions, or trivial fixes.
 
 ---
 
@@ -32,100 +23,44 @@
 
 Tasks MUST be **detailed and specific** — not high-level summaries.
 
-❌ **BAD** (too vague):
-
-```text
-- Implement the fix
-- Review code
-- Create PR
-```
-
-✅ **GOOD** (specific and actionable):
-
-```text
-- Investigate root cause in extensions/orchestrator/utils.ts
-- Create GitHub issue with root cause analysis
-- Create branch fix/issue-N-description from origin/main
-- Edit extensions/orchestrator/utils.ts — add timeout parameter to fetchData()
-- Run code review loop (3 async reviewers)
-- Fix review findings (if any)
-- Run test-automator
-- Commit changes (git add specific files, commit with message)
-- Push branch to origin
-- Create PR with description
-```
+- ❌ BAD: `Implement the fix` / `Review code` / `Create PR`
+- ✅ GOOD: `Edit extensions/orchestrator/utils.ts — add timeout parameter to fetchData()` / `Run code review loop (3 async reviewers)` / `Create PR with description`
 
 ---
 
 ## Task Lifecycle (MANDATORY)
 
-1. **Create all tasks BEFORE starting work** — use `TaskCreate` for each step
-2. **Mark `in_progress`** via `TaskUpdate` BEFORE starting each task
-3. **Mark `completed`** via `TaskUpdate` IMMEDIATELY after finishing each task
-4. **Do NOT skip tasks** — work through them in order
-5. **Do NOT start new work** while unchecked tasks exist (unless user explicitly pivots)
+Create all tasks BEFORE starting work via `TaskCreate`.
+Mark each `in_progress` before starting and `completed` immediately after finishing via `TaskUpdate`.
+Work through tasks in order — do not skip tasks or start new work while unchecked tasks exist (unless user explicitly pivots).
 
 ---
 
-## Side Questions During Workflow
+## Side Questions
 
-When the user asks a side question while tasks are active:
-
-1. Answer the question
-2. **Resume the next unchecked task immediately** — the task list tells you exactly where you left off
-
-This is the entire point of task tracking — you cannot "forget" what you were doing because the tasks are persistent and injected into every turn.
+Answer the question, then resume the next unchecked task immediately — the persistent task list tells you exactly where you left off.
 
 ---
 
-## Integration with Existing Rules
+## Integration & Key Rules
 
-Task tracking works alongside — not instead of — existing workflow rules:
-
-- **Issue-first workflow** (`05-issue-first-workflow.md`): Create tasks for the full issue workflow
-- **Code review loop** (`20-code-review-loop.md`): Include review steps as individual tasks
-- **Documentation updates** (`25-documentation-updates.md`): Include doc updates as tasks when applicable
-
----
-
-## Key Rules
-
-- **Tasks are code-enforced** — the extension injects reminders if you ignore tasks for 4+ turns
-- **Never abandon tasks** — if scope changes, use `TaskUpdate` with `status: "deleted"` to remove obsolete tasks
-- **The task list is your contract** — complete every task or explicitly remove it
+Task tracking works alongside existing workflow rules — include issue-first, code review, and documentation steps as individual tasks.
+Tasks are code-enforced (reminders after 4+ ignored turns).
+Never abandon tasks — if scope changes, use `TaskUpdate` with `status: "deleted"` to remove obsolete tasks; the task list is your contract.
 
 ---
 
 ## Async Agent taskId (MANDATORY — code-enforced)
 
-**Every async agent call MUST include `taskId`.** This is enforced by the subagent tool —
-calls without `taskId` are rejected.
-
-- If the agent is working on a task: pass the task ID (e.g., `taskId: "5"`)
-- If the agent is NOT linked to any task: pass `taskId: "-1"`
-
-When `taskId` is a real task ID, the task auto-completes when the agent finishes successfully.
-No manual `TaskUpdate` needed — the system handles it.
+**Every async agent call MUST include `taskId`.** Enforced — calls without it are rejected.
+Pass the task ID (e.g., `"5"`) when linked to a task, or `"-1"` when not.
+Linked tasks auto-complete on agent success — no manual `TaskUpdate` needed.
 
 ```text
-# Async agent linked to task 5 — auto-completes on success
-subagent(agent="code-reviewer-quality", task="...", cwd="...", async=true, name="Review Quality", taskId="5")
-
-# Async agent NOT linked to any task
+subagent(agent="code-reviewer-quality", task="...", cwd="...", async=true, name="Review", taskId="5")
 subagent(agent="worker", task="...", cwd="...", async=true, name="Qodo Poll", taskId="-1")
-
-# Parallel async agents linked to tasks
-subagent(tasks=[
-  {agent: "code-reviewer-quality", task: "...", cwd: "...", name: "Review Quality", taskId: "5"},
-  {agent: "code-reviewer-guidelines", task: "...", cwd: "...", name: "Review Guidelines", taskId: "6"},
-  {agent: "code-reviewer-security", task: "...", cwd: "...", name: "Review Security", taskId: "7"},
-])
 ```
 
-**Rules:**
-
-- ✅ **ALWAYS** pass `taskId` — the tool rejects async calls without it
-- ✅ Pass `"-1"` when the agent is not linked to any task
-- ✅ The task auto-completes on success, stays `in_progress` on failure
-- ❌ **NEVER** manually `TaskUpdate` a task to `completed` if it has an async agent — the agent handles it
-- ❌ **NEVER** omit `taskId` — the call will fail with a clear error
+- ✅ **ALWAYS** pass `taskId` — auto-completes on success, stays `in_progress` on failure
+- ❌ **NEVER** manually `TaskUpdate` a task to `completed` if it has an async agent
+- ❌ **NEVER** omit `taskId` — the call will fail


### PR DESCRIPTION
Compression-only refactor of orchestrator rule files. No rules added, removed, or moved between files.

## Stats
- **Lines:** 1658 → 890 (46% reduction)
- **Enforcement markers:** 74 → 35 (53% reduction)
- **Files changed:** 10 rule files in `rules/`
- **No files outside `rules/` touched**

## Approach
- One sentence, one concept (inspired by Claude Code system prompt patterns)
- Removed redundant ❌/✅ example lists where rules are unambiguous
- Removed ASCII flowcharts where text descriptions exist
- Merged related sub-sections within same files
- Kept critical anti-pattern examples (async polling)
- Preserved all security audit verdict tiers, fireAndForget notes, issue templates

## What was NOT changed
- No rules added, removed, or moved between files
- No behavior changes — only wording compressed
- No files outside rules/ folder touched
- Rule loading order unchanged

Closes #565