### PR TITLE
fix: add skills directory to pi package config for skill discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     ],
     "prompts": [
       "./prompts"
+    ],
+    "skills": [
+      "./skills"
     ]
   }
 }


### PR DESCRIPTION
The `pi` section in `package.json` declared `extensions` and `prompts` directories but not `skills`. Skills under `skills/` (like `update-agents-md`) were not discoverable by pi.

Fix: add `"skills": ["./skills"]` to the `pi` config section.