### PR TITLE
fix(pr-review): auto-repost unresolved previous findings

### DIFF
--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -369,14 +369,20 @@ findings are **automatically included** in the post list — they are the user's
 comments that remain unaddressed and MUST be re-raised. Do NOT ask the user to select these.
 Show them in the list marked as "(auto-post)" so the user knows they'll be re-raised.
 
+**Numbering:** Display two separate numbered sections. First, previous findings with their
+own numbering (P1, P2, ...) marked "(auto-post)". Second, new findings with their own
+numbering (1, 2, ...) for user selection. This avoids ambiguity — user selections always
+refer to the `[NEW]` numbering.
+
 **User selects from `[NEW]` findings only:**
 
-- 'all' = Post all new findings
+- 'all' = Post all new findings (previous findings are always auto-posted regardless)
 - 'none' = Skip posting new findings (previous findings are still auto-posted)
-- Specific numbers = Post only those new findings
+- Specific numbers = Post only those new findings (numbers refer to the `[NEW]` list)
 
-If there are ZERO `[NEW]` findings, skip user selection entirely — just auto-post the
-previous findings and proceed to Phase 5
+If there are ZERO `[NEW]` findings, skip user selection entirely — auto-post the
+previous findings and proceed directly to Phase 5 (the auto-post path still generates
+the comments JSON and posts them — see Phase 5)
 
 Mark Task 9 as `completed`.
 
@@ -384,7 +390,9 @@ Mark Task 9 as `completed`.
 
 Mark Task 10 as `in_progress`.
 
-If user selected findings, write JSON to temp file:
+Write JSON to temp file for ALL findings to be posted — this includes both user-selected
+`[NEW]` findings AND auto-posted `[PREV-*]` findings. If only `[PREV-*]` findings exist
+(zero `[NEW]` findings, selection was skipped), still generate the JSON for the auto-posted items:
 
 Use the `owner`, `repo`, `pr_number`, and `head_sha` from Phase 0 or Phase 1a metadata:
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -364,11 +364,19 @@ Each finding shows its source:
 - `[PREV-NO-FIX]` — resolved without code change or valid response
 - `[NEW]` — new finding from current code analysis
 
-Ask which to post:
+**Auto-post previous findings:** `[PREV-UNRESOLVED]`, `[PREV-BAD-FIX]`, and `[PREV-NO-FIX]`
+findings are **automatically included** in the post list — they are the user's own prior
+comments that remain unaddressed and MUST be re-raised. Do NOT ask the user to select these.
+Show them in the list marked as "(auto-post)" so the user knows they'll be re-raised.
 
-- 'all' = Post all
-- 'none' = Skip posting
-- Specific numbers = Post only those
+**User selects from `[NEW]` findings only:**
+
+- 'all' = Post all new findings
+- 'none' = Skip posting new findings (previous findings are still auto-posted)
+- Specific numbers = Post only those new findings
+
+If there are ZERO `[NEW]` findings, skip user selection entirely — just auto-post the
+previous findings and proceed to Phase 5
 
 Mark Task 9 as `completed`.
 


### PR DESCRIPTION
## Problem

When running `/pr-review` on a PR with unresolved findings from a previous review cycle, the `[PREV-UNRESOLVED]`, `[PREV-BAD-FIX]`, and `[PREV-NO-FIX]` findings were mixed into the user selection list alongside `[NEW]` findings. The user had to manually select them for re-posting each cycle, even though they are the user's own prior comments that remain unaddressed.

## Fix

Phase 4 (User Selection) now splits behavior:

- **Previous findings** (`PREV-*`) → **automatically included** in the post list. Shown as "(auto-post)" so the user knows they'll be re-raised. No manual selection needed.
- **New findings** (`[NEW]`) → user selects which to post (unchanged behavior).
- If there are zero new findings, user selection is skipped entirely — previous findings are auto-posted and the workflow proceeds to Phase 5.

## Done

- [x] Auto-post `PREV-UNRESOLVED`, `PREV-BAD-FIX`, `PREV-NO-FIX` findings without user selection
- [x] User selection applies only to `[NEW]` findings
- [x] Skip selection entirely when zero new findings exist