### PR TITLE
fix(memory): don't memorize rejected/abandoned ideas

### DIFF
--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -152,6 +152,10 @@ Background async agent that reads the session, extracts things worth remembering
 Triggered by `/dream` (manual) or session shutdown (automatic).
 **ALWAYS run as async + fireAndForget** — never block the session.
 
+**Dreaming follows the same NEVER memorize rules as per-turn self-improvement:**
+do NOT extract rejected/abandoned ideas, unfinished conversations, or unimplemented requirements.
+Only extract outcomes, not intentions.
+
 ---
 
 ## Skill Creation (Procedural Memory)

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -124,6 +124,14 @@ The situation report header shows usage: `# Project Memory [72% — 1,224/1,700 
 | Something failed or took multiple attempts | `memory_add` as `mistake` |
 | PR merged / technical decision made / non-obvious pattern found | `memory_add` as `done` / `decision` / `pattern` |
 
+**NEVER memorize:**
+
+- Ideas or requests the user rejected, abandoned, or said "nevermind" to
+- Unfinished conversations where no conclusion was reached
+- User requirements that were never implemented
+
+Only memorize **outcomes** (what happened), not **intentions** (what was discussed but dropped).
+
 **Save immediately — do NOT wait for `/dream` or session shutdown.**
 
 ---


### PR DESCRIPTION
## Problem

The per-turn self-improvement rule in `rules/35-memory.md` was too broad. It said to check after every response if something is worth remembering, including "non-obvious patterns found." This caused the AI to memorize ideas/requests that the user rejected or abandoned (e.g., user says "nevermind, I'll figure it out" and the AI still saves the dropped idea as a pattern).

## Fix

Added an explicit **NEVER memorize** guard to the per-turn self-improvement section:

- Ideas or requests the user rejected, abandoned, or said "nevermind" to
- Unfinished conversations where no conclusion was reached
- User requirements that were never implemented

Rule: only memorize **outcomes** (what happened), not **intentions** (what was discussed but dropped).

## Done

- [x] Add NEVER memorize guard to per-turn self-improvement rules