### PR TITLE
feat(pr-review): persist skipped findings + learned review guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,6 +353,13 @@ Storage: `.pi/memory/embeddings.json`. Embeds on write with dedup
 indexed on shutdown, auto-injected for relevant sessions. Storage: `.pi/data/session-search.json`.
 
 **PR Review Store** (`myk_pi_tools/pr/pr_review_store.py`): Tracks PR review comments in SQLite (`.pi/data/pr-reviews.db`).
+Stores both posted and skipped findings with status/skip_reason columns.
+Skipped findings are auto-matched in subsequent review cycles to avoid re-raising dismissed items.
+
+**Learned Review Preferences** (`.pi/data/review-guidelines.md`): Per-repo review guidelines
+learned from user skip decisions. When a user skips a finding for a generalizable reason
+(project convention, intentional pattern), the AI appends a one-line guideline to this file.
+All 3 code-reviewer agents read this file before reviewing and suppress matching findings.
 
 **Capacity Signal** (`situation-report.ts`): Header shows usage % (e.g. `[72% — 1,224/1,700 tokens]`), consolidation warning at >80%.
 

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -52,6 +52,13 @@ Additionally:
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Learned Review Preferences
+
+After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.
+If it does, read it — these are learned review preferences for this project
+(patterns the reviewer has previously evaluated and dismissed).
+Do NOT raise findings that contradict these guidelines.
+
 ## Output Format
 
 For each finding:

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -33,6 +33,13 @@ conventions, patterns, or rules as findings.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Learned Review Preferences
+
+After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.
+If it does, read it — these are learned review preferences for this project
+(patterns the reviewer has previously evaluated and dismissed).
+Do NOT raise findings that contradict these guidelines.
+
 ## Review Focus
 
 - Code readability and clarity

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -50,6 +50,13 @@ and conventions.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Learned Review Preferences
+
+After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.
+If it does, read it — these are learned review preferences for this project
+(patterns the reviewer has previously evaluated and dismissed).
+Do NOT raise findings that contradict these guidelines.
+
 ## Approach
 
 1. Read project guidelines (see above)

--- a/myk_pi_tools/pr/commands.py
+++ b/myk_pi_tools/pr/commands.py
@@ -83,6 +83,26 @@ def pr_store_review(json_file: str) -> None:
     sys.exit(exit_code)
 
 
+@pr.command("get-skipped-comments")
+@click.argument("owner")
+@click.argument("repo")
+@click.argument("pr_number", type=int)
+def pr_get_skipped(owner: str, repo: str, pr_number: int) -> None:
+    """Get previously skipped review comments for a PR.
+
+    Outputs JSON array of skipped comments with path, line, body,
+    severity, skip_reason, and head_sha.
+    """
+    import json
+    import sys
+
+    from myk_pi_tools.pr.pr_review_store import get_skipped_comments
+
+    results = get_skipped_comments(owner, repo, pr_number)
+    print(json.dumps(results, indent=2))
+    sys.exit(0)
+
+
 @pr.command("info")
 @click.argument("args", nargs=-1)
 def pr_info(args: tuple[str, ...]) -> None:

--- a/myk_pi_tools/pr/commands.py
+++ b/myk_pi_tools/pr/commands.py
@@ -98,7 +98,11 @@ def pr_get_skipped(owner: str, repo: str, pr_number: int) -> None:
 
     from myk_pi_tools.pr.pr_review_store import get_skipped_comments
 
-    results = get_skipped_comments(owner, repo, pr_number)
+    try:
+        results = get_skipped_comments(owner, repo, pr_number)
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
     print(json.dumps(results, indent=2))
     sys.exit(0)
 

--- a/myk_pi_tools/pr/pr_review_store.py
+++ b/myk_pi_tools/pr/pr_review_store.py
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS pr_reviews (
     repo TEXT NOT NULL,
     pr_number INTEGER NOT NULL,
     head_sha TEXT NOT NULL,
+    author TEXT,
     created_at TEXT NOT NULL
 );
 
@@ -36,13 +37,24 @@ CREATE TABLE IF NOT EXISTS pr_comments (
     line INTEGER,
     body TEXT,
     severity TEXT,
-    posted_at TEXT
+    posted_at TEXT,
+    status TEXT DEFAULT 'posted',
+    skip_reason TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_pr_comments_review_id ON pr_comments(review_id);
 CREATE INDEX IF NOT EXISTS idx_pr_reviews_pr ON pr_reviews(owner, repo, pr_number);
 CREATE INDEX IF NOT EXISTS idx_pr_comments_posted_at ON pr_comments(posted_at);
 """
+
+# Migration for existing databases that lack the new columns
+_MIGRATIONS = [
+    # pr_comments migrations
+    ("pr_comments", "status", "ALTER TABLE pr_comments ADD COLUMN status TEXT DEFAULT 'posted'"),
+    ("pr_comments", "skip_reason", "ALTER TABLE pr_comments ADD COLUMN skip_reason TEXT"),
+    # pr_reviews migrations
+    ("pr_reviews", "author", "ALTER TABLE pr_reviews ADD COLUMN author TEXT"),
+]
 
 
 def log(message: str) -> None:
@@ -84,23 +96,49 @@ def _get_db_path() -> Path:
     return project_root / ".pi" / "data" / "pr-reviews.db"
 
 
+def _run_migrations(conn: sqlite3.Connection) -> None:
+    """Apply schema migrations for existing databases."""
+    # Cache column info per table
+    table_columns: dict[str, set[str]] = {}
+
+    for table, col_name, sql in _MIGRATIONS:
+        if table not in table_columns:
+            cursor = conn.execute(f"PRAGMA table_info({table})")
+            table_columns[table] = {row[1] for row in cursor.fetchall()}
+
+        if col_name not in table_columns[table]:
+            try:
+                conn.execute(sql)
+                table_columns[table].add(col_name)
+                log(f"Schema migration: added '{col_name}' column to {table}")
+            except sqlite3.OperationalError as e:
+                if "duplicate column" not in str(e).lower():
+                    raise
+
+
 def store_pr_review(
     owner: str,
     repo: str,
     pr_number: int,
     comments: list[dict[str, Any]],
     head_sha: str | None = None,
+    author: str | None = None,
 ) -> None:
-    """Store posted PR review comments to the database.
+    """Store PR review comments to the database.
+
+    Stores both posted and skipped findings. Each comment dict may include:
+    - status: 'posted' (default) or 'skipped'
+    - skip_reason: reason for skipping (only when status='skipped')
 
     Args:
         owner: Repository owner.
         repo: Repository name.
         pr_number: PR number.
         comments: List of comment dicts with keys: thread_id, comment_id,
-                  path, line, body, severity, posted_at.
+                  path, line, body, severity, posted_at, status, skip_reason.
         head_sha: Git commit SHA for the reviewed code. Auto-detected
                   from local git HEAD if not provided.
+        author: PR author login (e.g., 'username').
     """
     db_path = _get_db_path()
     # Ensure directory exists
@@ -124,23 +162,32 @@ def store_pr_review(
     conn = sqlite3.connect(str(db_path))
     try:
         conn.executescript(SCHEMA)
+        _run_migrations(conn)
         conn.execute("PRAGMA foreign_keys=ON")
 
         cursor = conn.cursor()
         cursor.execute(
-            "INSERT INTO pr_reviews (owner, repo, pr_number, head_sha, created_at) VALUES (?, ?, ?, ?, ?)",
-            (owner, repo, pr_number, head_sha, created_at),
+            "INSERT INTO pr_reviews (owner, repo, pr_number, head_sha, author, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            (owner, repo, pr_number, head_sha, author, created_at),
         )
         review_id = cursor.lastrowid
         if not review_id:
             raise RuntimeError("Failed to insert pr_reviews record")
 
+        posted_count = 0
+        skipped_count = 0
         for comment in comments:
+            status = comment.get("status", "posted")
+            if status == "skipped":
+                skipped_count += 1
+            else:
+                posted_count += 1
             cursor.execute(
                 """
                 INSERT INTO pr_comments (
-                    review_id, thread_id, comment_id, path, line, body, severity, posted_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    review_id, thread_id, comment_id, path, line, body, severity,
+                    posted_at, status, skip_reason
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     review_id,
@@ -151,11 +198,16 @@ def store_pr_review(
                     comment.get("body"),
                     comment.get("severity"),
                     comment.get("posted_at"),
+                    status,
+                    comment.get("skip_reason"),
                 ),
             )
 
         conn.commit()
-        log(f"Stored {len(comments)} comment(s) (commit: {head_sha[:7]})")
+        parts = [f"{posted_count} posted"]
+        if skipped_count:
+            parts.append(f"{skipped_count} skipped")
+        log(f"Stored {len(comments)} comment(s) ({', '.join(parts)}) (commit: {head_sha[:7]})")
 
     except sqlite3.Error as e:
         conn.rollback()
@@ -164,12 +216,53 @@ def store_pr_review(
         conn.close()
 
 
+def get_skipped_comments(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    db_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Get previously skipped comments for a PR.
+
+    Returns:
+        List of dicts with keys: path, line, body, severity, skip_reason, head_sha.
+    """
+    if db_path is None:
+        db_path = _get_db_path()
+
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        _run_migrations(conn)
+        cursor = conn.execute(
+            """
+            SELECT c.path, c.line, c.body, c.severity, c.skip_reason, r.head_sha
+            FROM pr_comments c
+            JOIN pr_reviews r ON c.review_id = r.id
+            WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
+              AND c.status = 'skipped'
+            ORDER BY c.id
+            """,
+            (owner, repo, pr_number),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+    except sqlite3.Error as e:
+        log(f"Warning: Failed to query skipped comments: {e}")
+        return []
+    finally:
+        conn.close()
+
+
 def run_store(json_path: str) -> int:
     """Store PR review comments from a JSON file.
 
     The JSON file should have:
-    - metadata: {owner, repo, pr_number}
-    - comments: [{thread_id, comment_id, path, line, body, severity, posted_at}, ...]
+    - metadata: {owner, repo, pr_number, author (optional)}
+    - comments: [{thread_id, comment_id, path, line, body, severity, posted_at,
+                  status (optional), skip_reason (optional)}, ...]
 
     Args:
         json_path: Path to the JSON file.
@@ -223,9 +316,10 @@ def run_store(json_path: str) -> int:
             return 1
 
     head_sha = metadata.get("head_sha") or metadata.get("commit_sha")
+    author = metadata.get("author")
 
     try:
-        store_pr_review(owner, repo, pr_number, comments, head_sha=head_sha)
+        store_pr_review(owner, repo, pr_number, comments, head_sha=head_sha, author=author)
     except RuntimeError as e:
         log(f"Error: {e}")
         return 1

--- a/myk_pi_tools/pr/pr_review_store.py
+++ b/myk_pi_tools/pr/pr_review_store.py
@@ -105,6 +105,7 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
 
     for table, col_name, sql in _MIGRATIONS:
         if table not in table_columns:
+            # table names come from hardcoded _MIGRATIONS — safe, PRAGMA can't be parameterized
             cursor = conn.execute(f"PRAGMA table_info({table})")
             table_columns[table] = {row[1] for row in cursor.fetchall()}
 
@@ -158,6 +159,15 @@ def store_pr_review(
         head_sha = _get_current_commit_sha(cwd=project_root)
     created_at = datetime.now(UTC).isoformat()
 
+    # Validate all comments before touching the database
+    for i, comment in enumerate(comments):
+        status = comment.get("status", "posted")
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Invalid status '{status}' in comment[{i}], must be one of {VALID_STATUSES}")
+        skip_reason = comment.get("skip_reason", "").strip()
+        if status == "skipped" and not skip_reason:
+            raise ValueError("status='skipped' requires a non-empty skip_reason")
+
     log(f"Storing {len(comments)} PR review comment(s) for {owner}/{repo}#{pr_number}...")
     log(f"Database: {db_path}")
 
@@ -180,8 +190,6 @@ def store_pr_review(
         skipped_count = 0
         for comment in comments:
             status = comment.get("status", "posted")
-            if status not in VALID_STATUSES:
-                raise ValueError(f"Invalid status '{status}', must be one of {VALID_STATUSES}")
             if status == "skipped":
                 skipped_count += 1
             else:
@@ -241,6 +249,7 @@ def get_skipped_comments(
     conn.row_factory = sqlite3.Row
     try:
         _run_migrations(conn)
+        conn.commit()
         cursor = conn.execute(
             """
             SELECT c.path, c.line, c.body, c.severity, c.skip_reason, r.head_sha
@@ -254,8 +263,7 @@ def get_skipped_comments(
         )
         return [dict(row) for row in cursor.fetchall()]
     except sqlite3.Error as e:
-        log(f"Warning: Failed to query skipped comments: {e}")
-        return []
+        raise RuntimeError(f"Failed to query skipped comments: {e}") from e
     finally:
         conn.close()
 
@@ -324,7 +332,7 @@ def run_store(json_path: str) -> int:
 
     try:
         store_pr_review(owner, repo, pr_number, comments, head_sha=head_sha, author=author)
-    except RuntimeError as e:
+    except (RuntimeError, ValueError) as e:
         log(f"Error: {e}")
         return 1
     return 0

--- a/myk_pi_tools/pr/pr_review_store.py
+++ b/myk_pi_tools/pr/pr_review_store.py
@@ -17,6 +17,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+VALID_STATUSES = {"posted", "skipped"}
+
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS pr_reviews (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -178,6 +180,8 @@ def store_pr_review(
         skipped_count = 0
         for comment in comments:
             status = comment.get("status", "posted")
+            if status not in VALID_STATUSES:
+                raise ValueError(f"Invalid status '{status}', must be one of {VALID_STATUSES}")
             if status == "skipped":
                 skipped_count += 1
             else:

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1419,6 +1419,8 @@ def run(
         author_data = run_gh_api(f"/repos/{owner}/{repo}/pulls/{pr_number}")
         if isinstance(author_data, dict):
             pr_author = author_data.get("user", {}).get("login") if author_data.get("user") else None
+        else:
+            print_stderr(f"Warning: Could not fetch PR author (API returned {type(author_data).__name__})")
 
         # Ensure output directory exists
         out_dir = Path(output_dir)

--- a/myk_pi_tools/reviews/fetch.py
+++ b/myk_pi_tools/reviews/fetch.py
@@ -1414,6 +1414,12 @@ def run(
 
         print_stderr(f"Repository: {owner}/{repo}, PR: {pr_number}")
 
+        # Fetch PR author
+        pr_author: str | None = None
+        author_data = run_gh_api(f"/repos/{owner}/{repo}/pulls/{pr_number}")
+        if isinstance(author_data, dict):
+            pr_author = author_data.get("user", {}).get("login") if author_data.get("user") else None
+
         # Ensure output directory exists
         out_dir = Path(output_dir)
         out_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -1542,6 +1548,7 @@ def run(
                 "owner": owner,
                 "repo": repo,
                 "pr_number": int(pr_number),
+                "author": pr_author,
                 "json_path": str(json_path),
             },
             "human": categorized["human"],

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -360,6 +360,18 @@ existing unresolved comment.
 > comments that naturally appear in the all-unresolved list — removing them would lose
 > tracking of unresolved prior findings. Dedup applies ONLY to `[NEW]` findings.
 
+**Previously skipped findings dedup:** Also check the PR review database for findings
+the user previously skipped on this same PR. Run:
+
+```bash
+myk-pi-tools db query "SELECT path, line, body, severity, skip_reason FROM pr_comments c JOIN pr_reviews r ON c.review_id = r.id WHERE r.owner='{owner}' AND r.repo='{repo}' AND r.pr_number={pr_number} AND c.status='skipped'" --json --db-path .pi/data/pr-reviews.db
+```
+
+For each `[NEW]` finding, compare against the skipped list using path + body similarity
+(same file and similar description = match). Matched findings are auto-skipped with
+`"Auto-skipped (previously dismissed): <skip_reason>"`. The user still sees them in the
+Phase 4 table and can override by selecting them explicitly.
+
 Mark Task 8 as `completed`.
 
 ### Phase 4: User Selection — Task 9
@@ -397,7 +409,41 @@ refer to the `[NEW]` numbering.
 
 If there are ZERO `[NEW]` findings, skip user selection entirely — auto-post the
 previous findings and proceed directly to Phase 5 (the auto-post path still generates
-the comments JSON and posts them — see Phase 5)
+the comments JSON and posts them — see Phase 5).
+
+**Skip reason collection (MANDATORY when findings are skipped):**
+
+After the user selects which findings to post, derive the skipped set (total findings
+minus posted findings). If the skipped set is non-empty:
+
+1. Ask the user for skip reasons via `ask_user`:
+
+   ```text
+   You skipped findings 2, 4, 5. Why?
+   Give one reason for all, or per-finding (e.g., "2: not relevant, 4 and 5: style only")
+   ```
+
+2. AI refines each reason — make it concise, technical, and useful for future reference:
+   - User: "don't care" → "Style-only finding — no functional impact"
+   - User: "we do it this way" → "Intentional pattern — project convention"
+   - User: "already covered" → "Already validated by existing test coverage"
+
+3. AI classifies each refined reason (no user interaction):
+   - **Finding-specific** — references specific code, line, variable, or one-off context.
+     Store in DB only (same-PR dedup).
+   - **Generalizable** — references a project-wide pattern, convention, or category of
+     findings (e.g., "don't flag snake_case", "print() is intentional in CLI modules").
+     Store in DB AND append to `.pi/data/review-guidelines.md`.
+
+4. For generalizable reasons, append one line per finding to `.pi/data/review-guidelines.md`
+   (create the file if it doesn't exist). Format:
+
+   ```markdown
+   - Do not flag <finding type> — <refined reason>
+   ```
+
+   This file is read by all 3 reviewer agents before reviewing, so the same class of
+   finding won't be raised again on future PRs in this repo.
 
 Mark Task 9 as `completed`.
 
@@ -421,14 +467,15 @@ Mark Task 10 as `completed`.
 
 Mark Task 11 as `in_progress`.
 
-After posting comments, store them in the PR review database for future cycle tracking:
+After posting comments, store ALL findings (posted AND skipped) in the PR review database
+for future cycle tracking and same-PR dedup of skipped findings.
 
-1. Write a JSON file with the posted comments:
+1. Write a JSON file with ALL findings:
 
 ```bash
 cat > ${PROJECT_TMP_DIR}/pr-review-store.json << 'EOF'
 {
-  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}"},
+  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}", "author": "{author}"},
   "comments": [
     {
       "thread_id": null,
@@ -437,12 +484,26 @@ cat > ${PROJECT_TMP_DIR}/pr-review-store.json << 'EOF'
       "line": 42,
       "body": "Comment body as posted",
       "severity": "WARNING",
-      "posted_at": "<ISO timestamp>"
+      "posted_at": "<ISO timestamp>",
+      "status": "posted"
+    },
+    {
+      "thread_id": null,
+      "comment_id": null,
+      "path": "file.py",
+      "line": 99,
+      "body": "Finding description that was skipped",
+      "severity": "SUGGESTION",
+      "posted_at": null,
+      "status": "skipped",
+      "skip_reason": "Refined skip reason from Phase 4"
     }
   ]
 }
 EOF
 ```
+
+Use `{author}` from Phase 0 (`myk-pi-tools pr info` returns `author` field).
 
 1. Store to database:
 
@@ -451,7 +512,8 @@ myk-pi-tools pr store-pr-review ${PROJECT_TMP_DIR}/pr-review-store.json
 ```
 
 **This step is MANDATORY — never skip it.** The database is used by future `/pr-review`
-runs to track which comments were posted and verify they were addressed.
+runs to track which comments were posted, verify they were addressed, and auto-skip
+previously dismissed findings.
 
 Mark Task 11 as `completed`.
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -364,8 +364,11 @@ existing unresolved comment.
 the user previously skipped on this same PR. Run:
 
 ```bash
-myk-pi-tools db query "SELECT path, line, body, severity, skip_reason FROM pr_comments c JOIN pr_reviews r ON c.review_id = r.id WHERE r.owner='{owner}' AND r.repo='{repo}' AND r.pr_number={pr_number} AND c.status='skipped'" --json --db-path .pi/data/pr-reviews.db
+myk-pi-tools pr get-skipped-comments {owner} {repo} {pr_number}
 ```
+
+This returns a JSON array of previously skipped comments with `path`, `line`, `body`,
+`severity`, `skip_reason`, and `head_sha`.
 
 For each `[NEW]` finding, compare against the skipped list using path + body similarity
 (same file and similar description = match). Matched findings are auto-skipped with

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -57,7 +57,7 @@ The command saves the review data to a JSON file and outputs the file path to st
 
 The JSON file contains:
 
-- `metadata`: owner, repo, pr_number, review_id, username, json_path
+- `metadata`: owner, repo, pr_number, review_id, username, author, json_path
 - `comments`: array of pending review comments with id, path, line, body, diff_hunk
 - `diff`: PR diff text for context
 

--- a/prompts/refine-review.md
+++ b/prompts/refine-review.md
@@ -165,7 +165,7 @@ for future `/pr-review` cycle tracking:
 ```bash
 cat > ${PROJECT_TMP_DIR}/pr-review-store.json << 'EOF'
 {
-  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}"},
+  "metadata": {"owner": "{owner}", "repo": "{repo}", "pr_number": {pr_number}, "head_sha": "{head_sha}", "author": "{author}"},
   "comments": [
     {
       "thread_id": null,

--- a/tests/python/test_pr_review_store.py
+++ b/tests/python/test_pr_review_store.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from myk_pi_tools.pr.commands import pr
 from myk_pi_tools.pr.pr_review_store import (
     get_skipped_comments,
+    run_store,
     store_pr_review,
 )
 
@@ -246,3 +250,71 @@ def test_schema_migration(db_path: Path) -> None:
     assert reviews[1]["author"] == "migrator"
 
     conn.close()
+
+
+def test_store_invalid_status_raises(db_path: Path) -> None:
+    """Passing an invalid status raises ValueError before any DB write."""
+    comments = [{"path": "a.py", "line": 1, "body": "bad", "status": "invalid"}]
+    with pytest.raises(ValueError, match="Invalid status 'invalid'"):
+        store_pr_review("org", "repo", 1, comments, head_sha="sha1")
+
+    # DB should not have been created or written to
+    assert not db_path.exists()
+
+
+def test_store_skipped_without_reason_raises(db_path: Path) -> None:  # noqa: ARG001
+    """Passing status='skipped' without skip_reason raises ValueError."""
+    comments = [{"path": "a.py", "line": 1, "body": "needs reason", "status": "skipped"}]
+    with pytest.raises(ValueError, match="requires a non-empty skip_reason"):
+        store_pr_review("org", "repo", 1, comments, head_sha="sha1")
+
+    # Also test with empty / whitespace-only skip_reason
+    comments_ws = [{"path": "a.py", "line": 1, "body": "needs reason", "status": "skipped", "skip_reason": "  "}]
+    with pytest.raises(ValueError, match="requires a non-empty skip_reason"):
+        store_pr_review("org", "repo", 2, comments_ws, head_sha="sha2")
+
+
+def test_cli_get_skipped(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG001
+    """CLI get-skipped-comments returns JSON output with exit code 0."""
+    comments = [
+        {
+            "path": "x.py",
+            "line": 1,
+            "body": "skip me",
+            "severity": "nitpick",
+            "status": "skipped",
+            "skip_reason": "dup",
+        },
+    ]
+    store_pr_review("org", "repo", 55, comments, head_sha="bbb2222")
+
+    runner = CliRunner()
+    result = runner.invoke(pr, ["get-skipped-comments", "org", "repo", "55"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 1
+    assert data[0]["path"] == "x.py"
+    assert data[0]["skip_reason"] == "dup"
+
+
+def test_run_store_with_author(db_path: Path, tmp_path: Path) -> None:
+    """run_store() reads author from metadata and stores it in pr_reviews."""
+    json_data = {
+        "metadata": {
+            "owner": "org",
+            "repo": "repo",
+            "pr_number": 10,
+            "head_sha": "abc123",
+            "author": "janedoe",
+        },
+        "comments": [{"path": "f.py", "line": 1, "body": "ok", "severity": "info"}],
+    }
+    json_file = tmp_path / "review.json"
+    json_file.write_text(json.dumps(json_data))
+
+    exit_code = run_store(str(json_file))
+    assert exit_code == 0
+
+    reviews = _query_all(db_path, "pr_reviews")
+    assert len(reviews) == 1
+    assert reviews[0]["author"] == "janedoe"

--- a/tests/python/test_pr_review_store.py
+++ b/tests/python/test_pr_review_store.py
@@ -1,0 +1,248 @@
+"""Tests for the PR review store module."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from myk_pi_tools.pr.pr_review_store import (
+    get_skipped_comments,
+    store_pr_review,
+)
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Provide a temp DB path and patch _get_db_path to return it."""
+    path = tmp_path / "pr-reviews.db"
+    monkeypatch.setattr("myk_pi_tools.pr.pr_review_store._get_db_path", lambda: path)
+    return path
+
+
+def _query_all(db_path: Path, table: str) -> list[sqlite3.Row]:
+    """Helper: fetch all rows from a table as dicts."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(f"SELECT * FROM {table}").fetchall()  # noqa: S608
+    conn.close()
+    return rows
+
+
+def test_store_posted_comments(db_path: Path) -> None:
+    """Store comments with default status='posted', verify in DB."""
+    comments = [
+        {"path": "src/main.py", "line": 10, "body": "Fix this", "severity": "warning"},
+        {"path": "src/utils.py", "line": 20, "body": "Refactor", "severity": "suggestion"},
+    ]
+    store_pr_review("myorg", "myrepo", 42, comments, head_sha="abc1234")
+
+    reviews = _query_all(db_path, "pr_reviews")
+    assert len(reviews) == 1
+    assert reviews[0]["owner"] == "myorg"
+    assert reviews[0]["repo"] == "myrepo"
+    assert reviews[0]["pr_number"] == 42
+    assert reviews[0]["head_sha"] == "abc1234"
+
+    stored = _query_all(db_path, "pr_comments")
+    assert len(stored) == 2
+    assert stored[0]["path"] == "src/main.py"
+    assert stored[0]["status"] == "posted"
+    assert stored[0]["skip_reason"] is None
+    assert stored[1]["path"] == "src/utils.py"
+    assert stored[1]["status"] == "posted"
+
+
+def test_store_skipped_comments(db_path: Path) -> None:
+    """Store comments with status='skipped' and skip_reason, verify both fields."""
+    comments = [
+        {
+            "path": "src/api.py",
+            "line": 5,
+            "body": "Unused import",
+            "severity": "nitpick",
+            "status": "skipped",
+            "skip_reason": "duplicate of existing comment",
+        },
+    ]
+    store_pr_review("org", "repo", 7, comments, head_sha="def5678")
+
+    stored = _query_all(db_path, "pr_comments")
+    assert len(stored) == 1
+    assert stored[0]["status"] == "skipped"
+    assert stored[0]["skip_reason"] == "duplicate of existing comment"
+    assert stored[0]["body"] == "Unused import"
+
+
+def test_store_mixed_comments(db_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Store mix of posted and skipped comments, verify counts in log output."""
+    comments = [
+        {"path": "a.py", "line": 1, "body": "posted1", "status": "posted"},
+        {"path": "b.py", "line": 2, "body": "skipped1", "status": "skipped", "skip_reason": "dup"},
+        {"path": "c.py", "line": 3, "body": "posted2"},  # default = posted
+        {"path": "d.py", "line": 4, "body": "skipped2", "status": "skipped", "skip_reason": "low severity"},
+    ]
+    store_pr_review("org", "repo", 10, comments, head_sha="aaa1111")
+
+    stderr = capsys.readouterr().err
+    assert "2 posted" in stderr
+    assert "2 skipped" in stderr
+
+    stored = _query_all(db_path, "pr_comments")
+    assert len(stored) == 4
+    posted = [r for r in stored if r["status"] == "posted"]
+    skipped = [r for r in stored if r["status"] == "skipped"]
+    assert len(posted) == 2
+    assert len(skipped) == 2
+
+
+def test_store_with_author(db_path: Path) -> None:
+    """Store with author field, verify saved in pr_reviews."""
+    store_pr_review("org", "repo", 1, [{"body": "test"}], head_sha="sha1", author="janedoe")
+
+    reviews = _query_all(db_path, "pr_reviews")
+    assert len(reviews) == 1
+    assert reviews[0]["author"] == "janedoe"
+
+
+def test_store_without_author(db_path: Path) -> None:
+    """Store without author, verify NULL in pr_reviews.author."""
+    store_pr_review("org", "repo", 2, [{"body": "test"}], head_sha="sha2")
+
+    reviews = _query_all(db_path, "pr_reviews")
+    assert len(reviews) == 1
+    assert reviews[0]["author"] is None
+
+
+def test_get_skipped_comments(db_path: Path) -> None:
+    """Store skipped comments then query with get_skipped_comments()."""
+    comments = [
+        {
+            "path": "x.py",
+            "line": 1,
+            "body": "skip me",
+            "severity": "nitpick",
+            "status": "skipped",
+            "skip_reason": "dup",
+        },
+        {
+            "path": "y.py",
+            "line": 2,
+            "body": "post me",
+            "severity": "warning",
+            "status": "posted",
+        },
+        {
+            "path": "z.py",
+            "line": 3,
+            "body": "skip too",
+            "severity": "info",
+            "status": "skipped",
+            "skip_reason": "low prio",
+        },
+    ]
+    store_pr_review("org", "repo", 55, comments, head_sha="bbb2222")
+
+    result = get_skipped_comments("org", "repo", 55, db_path=db_path)
+    assert len(result) == 2
+    assert result[0]["path"] == "x.py"
+    assert result[0]["skip_reason"] == "dup"
+    assert result[0]["head_sha"] == "bbb2222"
+    assert result[1]["path"] == "z.py"
+    assert result[1]["skip_reason"] == "low prio"
+
+
+def test_get_skipped_comments_empty(db_path: Path) -> None:
+    """Query when no skipped comments exist returns empty list."""
+    # Store only posted comments
+    store_pr_review("org", "repo", 99, [{"body": "posted", "status": "posted"}], head_sha="ccc3333")
+
+    result = get_skipped_comments("org", "repo", 99, db_path=db_path)
+    assert result == []
+
+
+def test_get_skipped_comments_no_db(tmp_path: Path) -> None:
+    """Query when DB file doesn't exist returns empty list."""
+    nonexistent = tmp_path / "does-not-exist.db"
+    result = get_skipped_comments("org", "repo", 1, db_path=nonexistent)
+    assert result == []
+
+
+def test_schema_migration(db_path: Path) -> None:
+    """Create DB with old schema (no status/skip_reason/author), verify migration adds columns."""
+    # Create old-schema DB without status, skip_reason, and author columns
+    old_schema = """
+    CREATE TABLE IF NOT EXISTS pr_reviews (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        pr_number INTEGER NOT NULL,
+        head_sha TEXT NOT NULL,
+        created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS pr_comments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        review_id INTEGER NOT NULL REFERENCES pr_reviews(id) ON DELETE CASCADE,
+        thread_id TEXT,
+        comment_id INTEGER,
+        path TEXT,
+        line INTEGER,
+        body TEXT,
+        severity TEXT,
+        posted_at TEXT
+    );
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(old_schema)
+    # Insert a legacy row without the new columns
+    conn.execute(
+        "INSERT INTO pr_reviews (owner, repo, pr_number, head_sha, created_at) VALUES (?, ?, ?, ?, ?)",
+        ("org", "repo", 1, "old_sha", "2025-01-01T00:00:00"),
+    )
+    conn.execute(
+        "INSERT INTO pr_comments"
+        " (review_id, thread_id, path, line, body, severity, posted_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (1, "t1", "old.py", 5, "old comment", "warning", "2025-01-01T00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    # Now store via the normal API — this triggers migration
+    comments = [
+        {
+            "path": "new.py",
+            "line": 10,
+            "body": "new comment",
+            "severity": "error",
+            "status": "skipped",
+            "skip_reason": "test reason",
+        },
+    ]
+    store_pr_review("org", "repo", 2, comments, head_sha="new_sha", author="migrator")
+
+    # Verify migration added the columns and data is correct
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+
+    # Old comment should have default status='posted', NULL skip_reason
+    old_comments = conn.execute("SELECT * FROM pr_comments WHERE review_id = 1").fetchall()
+    assert len(old_comments) == 1
+    assert old_comments[0]["status"] == "posted"  # default from migration
+    assert old_comments[0]["skip_reason"] is None
+
+    # New comment should have the explicitly set values
+    new_comments = conn.execute("SELECT * FROM pr_comments WHERE review_id = 2").fetchall()
+    assert len(new_comments) == 1
+    assert new_comments[0]["status"] == "skipped"
+    assert new_comments[0]["skip_reason"] == "test reason"
+
+    # Old review should have NULL author, new review should have 'migrator'
+    reviews = conn.execute("SELECT * FROM pr_reviews ORDER BY id").fetchall()
+    assert len(reviews) == 2
+    assert reviews[0]["author"] is None
+    assert reviews[1]["author"] == "migrator"
+
+    conn.close()

--- a/tests/python/test_pr_review_store.py
+++ b/tests/python/test_pr_review_store.py
@@ -268,10 +268,12 @@ def test_store_skipped_without_reason_raises(db_path: Path) -> None:  # noqa: AR
     with pytest.raises(ValueError, match="requires a non-empty skip_reason"):
         store_pr_review("org", "repo", 1, comments, head_sha="sha1")
 
-    # Also test with empty / whitespace-only skip_reason
-    comments_ws = [{"path": "a.py", "line": 1, "body": "needs reason", "status": "skipped", "skip_reason": "  "}]
+
+def test_store_skipped_whitespace_reason_raises(db_path: Path) -> None:  # noqa: ARG001
+    """Passing status='skipped' with whitespace-only skip_reason raises ValueError."""
+    comments = [{"path": "a.py", "line": 1, "body": "needs reason", "status": "skipped", "skip_reason": "  "}]
     with pytest.raises(ValueError, match="requires a non-empty skip_reason"):
-        store_pr_review("org", "repo", 2, comments_ws, head_sha="sha2")
+        store_pr_review("org", "repo", 2, comments, head_sha="sha2")
 
 
 def test_cli_get_skipped(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG001

--- a/tests/python/test_pr_review_store.py
+++ b/tests/python/test_pr_review_store.py
@@ -255,7 +255,7 @@ def test_schema_migration(db_path: Path) -> None:
 def test_store_invalid_status_raises(db_path: Path) -> None:
     """Passing an invalid status raises ValueError before any DB write."""
     comments = [{"path": "a.py", "line": 1, "body": "bad", "status": "invalid"}]
-    with pytest.raises(ValueError, match="Invalid status 'invalid'"):
+    with pytest.raises(ValueError):
         store_pr_review("org", "repo", 1, comments, head_sha="sha1")
 
     # DB should not have been created or written to
@@ -265,14 +265,16 @@ def test_store_invalid_status_raises(db_path: Path) -> None:
 def test_store_skipped_without_reason_raises(db_path: Path) -> None:  # noqa: ARG001
     """Passing status='skipped' without skip_reason raises ValueError."""
     comments = [{"path": "a.py", "line": 1, "body": "needs reason", "status": "skipped"}]
-    with pytest.raises(ValueError, match="requires a non-empty skip_reason"):
+    with pytest.raises(ValueError):
         store_pr_review("org", "repo", 1, comments, head_sha="sha1")
 
 
 def test_store_skipped_whitespace_reason_raises(db_path: Path) -> None:  # noqa: ARG001
     """Passing status='skipped' with whitespace-only skip_reason raises ValueError."""
-    comments = [{"path": "a.py", "line": 1, "body": "needs reason", "status": "skipped", "skip_reason": "  "}]
-    with pytest.raises(ValueError, match="requires a non-empty skip_reason"):
+    comments = [
+        {"path": "a.py", "line": 1, "body": "needs reason", "status": "skipped", "skip_reason": "  "},
+    ]
+    with pytest.raises(ValueError):
         store_pr_review("org", "repo", 2, comments, head_sha="sha2")
 
 


### PR DESCRIPTION
## Summary

Closes #575

When using `/pr-review`, skipped findings are now persisted in the database and used for same-PR dedup in subsequent cycles. Additionally, generalizable skip reasons are written to `.pi/data/review-guidelines.md` — a per-repo, gitignored file that all 3 reviewer agents read before reviewing, preventing the same class of finding from being raised again.

## Changes

### Python (`myk_pi_tools/pr/`)

- **`pr_review_store.py`** — Added `status` + `skip_reason` columns to `pr_comments` table and `author` column to `pr_reviews` table, with schema migration for existing DBs. Added `get_skipped_comments()` query. Added `VALID_STATUSES` validation.
- **`commands.py`** — Added `myk-pi-tools pr get-skipped-comments {owner} {repo} {pr_number}` CLI subcommand.

### Prompts

- **`pr-review.md`** — Phase 4: derive skipped set → ask reason → AI refines → classify (finding-specific vs generalizable) → write to guidelines file. Phase 5b: store ALL findings (posted + skipped) with author. Phase 8: query and auto-skip previously dismissed findings via CLI.
- **`refine-review.md`** — Added `author` field to store metadata.

### Agents

- **All 3 code-reviewer agents** — Added "Learned Review Preferences" section: check `.pi/data/review-guidelines.md` before reviewing.

### Docs & Tests

- **`AGENTS.md`** — Documented PR Review Store changes and Learned Review Preferences.
- **`tests/python/test_pr_review_store.py`** — 9 tests covering store, query, migration, validation.

## Done

- [x] Add `status` + `skip_reason` columns with migration
- [x] Add `author` column with migration
- [x] Add `get_skipped_comments()` query + CLI subcommand
- [x] Add status validation
- [x] Update Phase 4: derive skipped set → ask reason → refine → classify
- [x] Update Phase 5b: store all findings (posted + skipped) with author
- [x] Update Phase 8: query and auto-skip previously dismissed findings
- [x] Write generalizable dismissals to `.pi/data/review-guidelines.md`
- [x] Add review-guidelines check to all 3 reviewer agents
- [x] Write tests (9 passing)
- [x] Update AGENTS.md