### PR TITLE
refactor(async-agents): extract command handlers from registerAsyncAgents

### DIFF
--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -671,215 +671,218 @@ export function registerAsyncAgents(
     if (asyncState.watcher) { asyncState.watcher.close(); asyncState.watcher = null; }
   });
 
+  // /async-status handler — extracted for readability (closure access preserved)
+  async function handleAsyncStatus(ctx: any): Promise<void> {
+    const jobs = Array.from(asyncState.jobs.values());
+    if (jobs.length === 0) {
+      ctx.ui.notify("No async agents running or recently completed.", "info");
+      return;
+    }
+
+    // If only completed agents, show static summary
+    const running = jobs.filter(j => j.status === "running" || j.status === "queued");
+    if (running.length === 0) {
+      const lines: string[] = ["All agents completed:\n"];
+      for (const job of jobs) {
+        const dur = job.durationMs ? formatDuration(job.durationMs) : formatDuration(Date.now() - job.startedAt);
+        const icon = job.status === "complete" ? "✅" : "❌";
+        lines.push(`${icon} ${job.name || job.agent} (${dur}) — ${job.task.slice(0, 60)}`);
+      }
+      ctx.ui.notify(lines.join("\n"), "info");
+      return;
+    }
+
+    // Build selection list — append short ID to ensure uniqueness
+    const options = running.map((j) => {
+      const duration = formatDuration(Date.now() - j.startedAt);
+      const taskPreview = j.task.length > 60 ? j.task.slice(0, 60) + "..." : j.task;
+      const shortId = j.id.slice(-6);
+      return `${j.name || j.agent} (${duration}) [${shortId}] — ${taskPreview}`;
+    });
+
+    const selected = await ctx.ui.select("View async agent output:", options);
+    if (!selected) return;
+
+    // Extract short ID from selection to find the exact job (avoids indexOf collision on duplicate labels)
+    const idMatch = selected.match(/\[(\w{6})\] —/);
+    const job = idMatch ? running.find(j => j.id.endsWith(idMatch[1])) : running[options.indexOf(selected)];
+    if (!job) return;
+    const outputPath = path.join(job.workerDir, "output.log");
+
+    // Create a live output viewer as an overlay
+    await ctx.ui.custom<void>((tui, _theme, _kb, done) => {
+      const lines: string[] = [];
+      let scrollOffset = 0;
+      let maxScroll = 0;
+      let following = true; // auto-scroll to bottom
+      let closed = false;
+      let cachedWidth: number | undefined;
+      let cachedLines: string[] | undefined;
+
+      // Parse a JSON line from the output log into a display string
+      function parseLine(raw: string): string | null {
+        try {
+          const ev = JSON.parse(raw);
+          if (ev.type === "message_update" && ev.assistantMessageEvent) {
+            const ae = ev.assistantMessageEvent;
+            if (ae.type === "text_delta" && ae.delta) return ae.delta;
+            if (ae.type === "thinking_delta" && ae.delta) return null;
+            if (ae.type === "toolcall_delta" && ae.content) return null;
+            return null;
+          }
+          if (ev.type === "tool_execution_start") {
+            const name = ev.toolName || "tool";
+            const cmd = ev.args?.command ? ` ${ev.args.command.slice(0, 80)}` : "";
+            return `\n🔧 ${name}${cmd}`;
+          }
+          if (ev.type === "tool_execution_end") {
+            const text = ev.result?.content?.[0]?.text || "";
+            const prefix = ev.isError ? "✗" : "✓";
+            return `\n${prefix} ${text.slice(0, 200)}`;
+          }
+          if (ev.type === "agent_end") return "\n--- Agent finished ---";
+          return null;
+        } catch {
+          return null;
+        }
+      }
+
+      // Read existing output and watch for new content
+      let filePos = 0;
+      let textBuffer = "";
+      let lastLoggedError = "";
+
+      function readNewContent() {
+        if (closed) return;
+        try {
+          const content = fs.readFileSync(outputPath, "utf-8");
+          if (content.length > filePos) {
+            const newContent = content.slice(filePos);
+            filePos = content.length;
+            textBuffer += newContent;
+
+            // Process complete lines
+            const parts = textBuffer.split("\n");
+            textBuffer = parts.pop() || "";
+            for (const part of parts) {
+              if (!part.trim()) continue;
+              const parsed = parseLine(part);
+              if (parsed !== null) {
+                for (const l of parsed.split("\n")) {
+                  if (l) lines.push(l);
+                  else lines.push("");
+                }
+              }
+            }
+            cachedWidth = undefined;
+            cachedLines = undefined;
+            tui.requestRender();
+          }
+        } catch (e: any) {
+          if (e?.code === "ENOENT") return;
+          const msg = e?.message || String(e);
+          if (msg !== lastLoggedError) {
+            lastLoggedError = msg;
+            console.debug("[async-agents] live output read failed:", msg);
+          }
+        }
+      }
+
+      // Poll for new content every 500ms
+      const poller = setInterval(readNewContent, 500);
+      readNewContent();
+
+      return {
+        handleInput(data: string) {
+          if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+            closed = true;
+            clearInterval(poller);
+            done(undefined);
+            return;
+          }
+          if (matchesKey(data, Key.up)) {
+            if (scrollOffset > 0) { scrollOffset--; following = false; cachedWidth = undefined; tui.requestRender(); }
+            return;
+          }
+          if (matchesKey(data, Key.down)) {
+            if (scrollOffset < maxScroll) { scrollOffset++; cachedWidth = undefined; tui.requestRender(); }
+            if (scrollOffset >= maxScroll) following = true;
+            return;
+          }
+          if (matchesKey(data, Key.pageUp)) {
+            scrollOffset = Math.max(0, scrollOffset - 10); following = false; cachedWidth = undefined; tui.requestRender();
+            return;
+          }
+          if (matchesKey(data, Key.pageDown)) {
+            scrollOffset = Math.min(maxScroll, scrollOffset + 10);
+            if (scrollOffset >= maxScroll) following = true;
+            cachedWidth = undefined; tui.requestRender();
+            return;
+          }
+          if (matchesKey(data, Key.home)) {
+            scrollOffset = 0; following = false; cachedWidth = undefined; tui.requestRender();
+            return;
+          }
+          if (matchesKey(data, Key.end)) {
+            scrollOffset = maxScroll; following = true; cachedWidth = undefined; tui.requestRender();
+            return;
+          }
+        },
+
+        invalidate() { cachedWidth = undefined; cachedLines = undefined; },
+
+        render(width: number): string[] {
+          if (cachedLines && cachedWidth === width) return cachedLines;
+
+          const headerWidth = width - 2;
+          const dur = formatDuration(Date.now() - job.startedAt);
+          const status = readAsyncStatus(job.workerDir);
+          const state = status?.state || job.status;
+          const stateIcon = state === "complete" ? "✅" : state === "failed" ? "❌" : "⏳";
+          const header = truncateToWidth(`${stateIcon} ${job.name || job.agent} — ${dur} — ${job.task.slice(0, 40)}`, headerWidth);
+          const footer = truncateToWidth("↑↓ scroll  PgUp/PgDn  Home/End  Esc close", headerWidth);
+          const sep = "─".repeat(Math.min(width, headerWidth));
+
+          // Wrap all lines to fit width
+          const wrapped: string[] = [];
+          for (const line of lines) {
+            const w = wrapTextWithAnsi(line, width - 2);
+            for (const wl of w) {
+              wrapped.push(truncateToWidth(wl, width - 2));
+            }
+          }
+
+          // Calculate visible area
+          const viewHeight = Math.max(5, Math.min(30, ((tui as any).height ?? 24) - 8));
+          maxScroll = Math.max(0, wrapped.length - viewHeight);
+
+          // Auto-scroll to bottom
+          if (following) {
+            scrollOffset = maxScroll;
+          }
+
+          const visible = wrapped.slice(scrollOffset, scrollOffset + viewHeight);
+
+          // Pad to viewHeight
+          while (visible.length < viewHeight) visible.push("");
+
+          cachedLines = [header, sep, ...visible, sep, footer];
+          cachedWidth = width;
+          return cachedLines;
+        },
+
+        dispose() {
+          closed = true;
+          clearInterval(poller);
+        },
+      };
+    });
+  }
+
   // /async-status command
   pi.registerCommand("async-status", {
     description: "Show status of background async agents — select one to view live output",
-    handler: async (_args, ctx) => {
-      const jobs = Array.from(asyncState.jobs.values());
-      if (jobs.length === 0) {
-        ctx.ui.notify("No async agents running or recently completed.", "info");
-        return;
-      }
-
-      // If only completed agents, show static summary
-      const running = jobs.filter(j => j.status === "running" || j.status === "queued");
-      if (running.length === 0) {
-        const lines: string[] = ["All agents completed:\n"];
-        for (const job of jobs) {
-          const dur = job.durationMs ? formatDuration(job.durationMs) : formatDuration(Date.now() - job.startedAt);
-          const icon = job.status === "complete" ? "✅" : "❌";
-          lines.push(`${icon} ${job.name || job.agent} (${dur}) — ${job.task.slice(0, 60)}`);
-        }
-        ctx.ui.notify(lines.join("\n"), "info");
-        return;
-      }
-
-      // Build selection list — append short ID to ensure uniqueness
-      const options = running.map((j) => {
-        const duration = formatDuration(Date.now() - j.startedAt);
-        const taskPreview = j.task.length > 60 ? j.task.slice(0, 60) + "..." : j.task;
-        const shortId = j.id.slice(-6);
-        return `${j.name || j.agent} (${duration}) [${shortId}] — ${taskPreview}`;
-      });
-
-      const selected = await ctx.ui.select("View async agent output:", options);
-      if (!selected) return;
-
-      // Extract short ID from selection to find the exact job (avoids indexOf collision on duplicate labels)
-      const idMatch = selected.match(/\[(\w{6})\] —/);
-      const job = idMatch ? running.find(j => j.id.endsWith(idMatch[1])) : running[options.indexOf(selected)];
-      if (!job) return;
-      const outputPath = path.join(job.workerDir, "output.log");
-
-      // Create a live output viewer as an overlay
-      await ctx.ui.custom<void>((tui, _theme, _kb, done) => {
-        const lines: string[] = [];
-        let scrollOffset = 0;
-        let maxScroll = 0;
-        let following = true; // auto-scroll to bottom
-        let closed = false;
-        let cachedWidth: number | undefined;
-        let cachedLines: string[] | undefined;
-
-        // Parse a JSON line from the output log into a display string
-        function parseLine(raw: string): string | null {
-          try {
-            const ev = JSON.parse(raw);
-            if (ev.type === "message_update" && ev.assistantMessageEvent) {
-              const ae = ev.assistantMessageEvent;
-              if (ae.type === "text_delta" && ae.delta) return ae.delta;
-              if (ae.type === "thinking_delta" && ae.delta) return null;
-              if (ae.type === "toolcall_delta" && ae.content) return null;
-              return null;
-            }
-            if (ev.type === "tool_execution_start") {
-              const name = ev.toolName || "tool";
-              const cmd = ev.args?.command ? ` ${ev.args.command.slice(0, 80)}` : "";
-              return `\n🔧 ${name}${cmd}`;
-            }
-            if (ev.type === "tool_execution_end") {
-              const text = ev.result?.content?.[0]?.text || "";
-              const prefix = ev.isError ? "✗" : "✓";
-              return `\n${prefix} ${text.slice(0, 200)}`;
-            }
-            if (ev.type === "agent_end") return "\n--- Agent finished ---";
-            return null;
-          } catch {
-            return null;
-          }
-        }
-
-        // Read existing output and watch for new content
-        let filePos = 0;
-        let textBuffer = "";
-        let lastLoggedError = "";
-
-        function readNewContent() {
-          if (closed) return;
-          try {
-            const content = fs.readFileSync(outputPath, "utf-8");
-            if (content.length > filePos) {
-              const newContent = content.slice(filePos);
-              filePos = content.length;
-              textBuffer += newContent;
-
-              // Process complete lines
-              const parts = textBuffer.split("\n");
-              textBuffer = parts.pop() || "";
-              for (const part of parts) {
-                if (!part.trim()) continue;
-                const parsed = parseLine(part);
-                if (parsed !== null) {
-                  for (const l of parsed.split("\n")) {
-                    if (l) lines.push(l);
-                    else lines.push("");
-                  }
-                }
-              }
-              cachedWidth = undefined;
-              cachedLines = undefined;
-              tui.requestRender();
-            }
-          } catch (e: any) {
-            if (e?.code === "ENOENT") return;
-            const msg = e?.message || String(e);
-            if (msg !== lastLoggedError) {
-              lastLoggedError = msg;
-              console.debug("[async-agents] live output read failed:", msg);
-            }
-          }
-        }
-
-        // Poll for new content every 500ms
-        const poller = setInterval(readNewContent, 500);
-        readNewContent();
-
-        return {
-          handleInput(data: string) {
-            if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
-              closed = true;
-              clearInterval(poller);
-              done(undefined);
-              return;
-            }
-            if (matchesKey(data, Key.up)) {
-              if (scrollOffset > 0) { scrollOffset--; following = false; cachedWidth = undefined; tui.requestRender(); }
-              return;
-            }
-            if (matchesKey(data, Key.down)) {
-              if (scrollOffset < maxScroll) { scrollOffset++; cachedWidth = undefined; tui.requestRender(); }
-              if (scrollOffset >= maxScroll) following = true;
-              return;
-            }
-            if (matchesKey(data, Key.pageUp)) {
-              scrollOffset = Math.max(0, scrollOffset - 10); following = false; cachedWidth = undefined; tui.requestRender();
-              return;
-            }
-            if (matchesKey(data, Key.pageDown)) {
-              scrollOffset = Math.min(maxScroll, scrollOffset + 10);
-              if (scrollOffset >= maxScroll) following = true;
-              cachedWidth = undefined; tui.requestRender();
-              return;
-            }
-            if (matchesKey(data, Key.home)) {
-              scrollOffset = 0; following = false; cachedWidth = undefined; tui.requestRender();
-              return;
-            }
-            if (matchesKey(data, Key.end)) {
-              scrollOffset = maxScroll; following = true; cachedWidth = undefined; tui.requestRender();
-              return;
-            }
-          },
-
-          invalidate() { cachedWidth = undefined; cachedLines = undefined; },
-
-          render(width: number): string[] {
-            if (cachedLines && cachedWidth === width) return cachedLines;
-
-            const headerWidth = width - 2;
-            const dur = formatDuration(Date.now() - job.startedAt);
-            const status = readAsyncStatus(job.workerDir);
-            const state = status?.state || job.status;
-            const stateIcon = state === "complete" ? "✅" : state === "failed" ? "❌" : "⏳";
-            const header = truncateToWidth(`${stateIcon} ${job.name || job.agent} — ${dur} — ${job.task.slice(0, 40)}`, headerWidth);
-            const footer = truncateToWidth("↑↓ scroll  PgUp/PgDn  Home/End  Esc close", headerWidth);
-            const sep = "─".repeat(Math.min(width, headerWidth));
-
-            // Wrap all lines to fit width
-            const wrapped: string[] = [];
-            for (const line of lines) {
-              const w = wrapTextWithAnsi(line, width - 2);
-              for (const wl of w) {
-                wrapped.push(truncateToWidth(wl, width - 2));
-              }
-            }
-
-            // Calculate visible area
-            const viewHeight = Math.max(5, Math.min(30, ((tui as any).height ?? 24) - 8));
-            maxScroll = Math.max(0, wrapped.length - viewHeight);
-
-            // Auto-scroll to bottom
-            if (following) {
-              scrollOffset = maxScroll;
-            }
-
-            const visible = wrapped.slice(scrollOffset, scrollOffset + viewHeight);
-
-            // Pad to viewHeight
-            while (visible.length < viewHeight) visible.push("");
-
-            cachedLines = [header, sep, ...visible, sep, footer];
-            cachedWidth = width;
-            return cachedLines;
-          },
-
-          dispose() {
-            closed = true;
-            clearInterval(poller);
-          },
-        };
-      });
-    },
+    handler: async (_args, ctx) => handleAsyncStatus(ctx),
   });
 
   // Kill an async agent by name, id prefix, or "all"
@@ -945,82 +948,83 @@ export function registerAsyncAgents(
     return { killed, errors };
   }
 
+  // /async-kill handler — extracted for readability (closure access preserved)
+  async function handleAsyncKill(args: string, ctx: any): Promise<void> {
+    // If arg provided, kill directly without interactive selection
+    if (args) {
+      const { killed, errors } = killAsyncAgent(args);
+      if (killed.length > 0) {
+        ctx.ui.notify(`Killed: ${killed.join(", ")}`, "info");
+      }
+      if (errors.length > 0) {
+        ctx.ui.notify(errors.join("\n"), "warning");
+      }
+      return;
+    }
+
+    const running = Array.from(asyncState.jobs.values()).filter(
+      (j) => j.status === "running" || j.status === "queued",
+    );
+
+    if (running.length === 0) {
+      ctx.ui.notify("No running async agents.", "info");
+      return;
+    }
+
+    // Build selection list — append short ID to ensure uniqueness
+    const options = running.map((j) => {
+      const duration = formatDuration(Date.now() - j.startedAt);
+      const taskPreview = j.task.length > 60 ? j.task.slice(0, 60) + "..." : j.task;
+      const shortId = j.id.slice(-6);
+      return `${j.name || j.agent} (${duration}) [${shortId}] — ${taskPreview}`;
+    });
+
+    const selected = await ctx.ui.select("Kill which async agent?", options);
+    if (!selected) return;
+
+    // Extract short ID from selection to find the exact job (avoids indexOf collision on duplicate labels)
+    const idMatch = selected.match(/\[(\w{6})\] —/);
+    const job = idMatch ? running.find(j => j.id.endsWith(idMatch[1])) : running[options.indexOf(selected)];
+    if (!job) return;
+
+    // Kill entire process tree
+    const status = readAsyncStatus(job.workerDir);
+    if (status?.pid) {
+      const killLog: string[] = [];
+      try {
+        const tree = execFileSync("pstree", ["-p", String(status.pid)], { encoding: "utf-8", timeout: 3000 });
+        killLog.push(`pstree output: ${tree.trim()}`);
+        const matches = tree.match(/\((\d+)\)/g);
+        const allPids = matches ? [...new Set(matches.map((m: string) => parseInt(m.slice(1, -1), 10)))] : [status.pid];
+        killLog.push(`PIDs to kill: ${allPids.join(", ")}`);
+        for (const pid of allPids) {
+          try { process.kill(pid, "SIGKILL"); killLog.push(`killed ${pid}`); } catch (e: any) { killLog.push(`failed ${pid}: ${e.message}`); }
+        }
+      } catch (e: any) {
+        killLog.push(`pstree failed: ${e.message}`);
+        try { process.kill(status.pid, "SIGKILL"); killLog.push(`killed runner ${status.pid}`); } catch {}
+        if (status.childPid) try { process.kill(status.childPid, "SIGKILL"); killLog.push(`killed child ${status.childPid}`); } catch {}
+      }
+      const logPath = path.join(job.workerDir, "kill.log");
+      fs.writeFileSync(logPath, killLog.join("\n"), "utf-8");
+    }
+
+    job.status = "failed";
+    job.updatedAt = Date.now();
+    updateAsyncWidget();
+    ctx.ui.notify(`Killed: ${job.name || job.agent}`, "info");
+
+    // Clean up after 5s
+    setTimeout(() => {
+      asyncState.jobs.delete(job.id);
+      updateAsyncWidget();
+    }, 5000);
+  }
+
   // /async-kill command — accepts name/id/"all" or interactive selection
   pi.registerCommand("async-kill", {
     description: "Kill async agent(s) — /async-kill <name|id|all>",
-    handler: async (_args, ctx) => {
-      const arg = (_args || "").trim();
-
-      // If arg provided, kill directly without interactive selection
-      if (arg) {
-        const { killed, errors } = killAsyncAgent(arg);
-        if (killed.length > 0) {
-          ctx.ui.notify(`Killed: ${killed.join(", ")}`, "info");
-        }
-        if (errors.length > 0) {
-          ctx.ui.notify(errors.join("\n"), "warning");
-        }
-        return;
-      }
-
-      const running = Array.from(asyncState.jobs.values()).filter(
-        (j) => j.status === "running" || j.status === "queued",
-      );
-
-      if (running.length === 0) {
-        ctx.ui.notify("No running async agents.", "info");
-        return;
-      }
-
-      // Build selection list — append short ID to ensure uniqueness
-      const options = running.map((j) => {
-        const duration = formatDuration(Date.now() - j.startedAt);
-        const taskPreview = j.task.length > 60 ? j.task.slice(0, 60) + "..." : j.task;
-        const shortId = j.id.slice(-6);
-        return `${j.name || j.agent} (${duration}) [${shortId}] — ${taskPreview}`;
-      });
-
-      const selected = await ctx.ui.select("Kill which async agent?", options);
-      if (!selected) return;
-
-      // Extract short ID from selection to find the exact job (avoids indexOf collision on duplicate labels)
-      const idMatch = selected.match(/\[(\w{6})\] —/);
-      const job = idMatch ? running.find(j => j.id.endsWith(idMatch[1])) : running[options.indexOf(selected)];
-      if (!job) return;
-
-      // Kill entire process tree
-      const status = readAsyncStatus(job.workerDir);
-      if (status?.pid) {
-        const killLog: string[] = [];
-        try {
-          const tree = execFileSync("pstree", ["-p", String(status.pid)], { encoding: "utf-8", timeout: 3000 });
-          killLog.push(`pstree output: ${tree.trim()}`);
-          const matches = tree.match(/\((\d+)\)/g);
-          const allPids = matches ? [...new Set(matches.map((m: string) => parseInt(m.slice(1, -1), 10)))] : [status.pid];
-          killLog.push(`PIDs to kill: ${allPids.join(", ")}`);
-          for (const pid of allPids) {
-            try { process.kill(pid, "SIGKILL"); killLog.push(`killed ${pid}`); } catch (e: any) { killLog.push(`failed ${pid}: ${e.message}`); }
-          }
-        } catch (e: any) {
-          killLog.push(`pstree failed: ${e.message}`);
-          try { process.kill(status.pid, "SIGKILL"); killLog.push(`killed runner ${status.pid}`); } catch {}
-          if (status.childPid) try { process.kill(status.childPid, "SIGKILL"); killLog.push(`killed child ${status.childPid}`); } catch {}
-        }
-        const logPath = path.join(job.workerDir, "kill.log");
-        fs.writeFileSync(logPath, killLog.join("\n"), "utf-8");
-      }
-
-      job.status = "failed";
-      job.updatedAt = Date.now();
-      updateAsyncWidget();
-      ctx.ui.notify(`Killed: ${job.name || job.agent}`, "info");
-
-      // Clean up after 5s
-      setTimeout(() => {
-        asyncState.jobs.delete(job.id);
-        updateAsyncWidget();
-      }, 5000);
-    },
+    handler: async (_args, ctx) => handleAsyncKill((_args || "").trim(), ctx),
   });
 
   // Handle async-kill from pidash browser UI


### PR DESCRIPTION
## Summary

Extract `/async-status` and `/async-kill` command handler bodies into named inner functions within `registerAsyncAgents`.

Part of #443 — Closes #585

## Changes

| Function | What it handles |
|---|---|
| `handleAsyncStatus(ctx)` | `/async-status` command — live output viewer with TUI overlay |
| `handleAsyncKill(args, ctx)` | `/async-kill` command — interactive/direct agent kill |

Both functions remain inside `registerAsyncAgents` closure to maintain access to shared state (`asyncState`, `killAsyncAgent`, `updateAsyncWidget`, etc.).

## Constraints
- Zero logic changes — pure mechanical extraction
- No changes to public APIs/exports
- No dependency changes

## Verification
- 169 Node tests pass
- 161 Python tests pass
- pre-commit run --all-files passes