### PR TITLE
feat(pidash,pr-review): leverage pi 0.80.3 APIs + PR review history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Writing effective rules:
 - Memory system: see `dev-docs/memory-architecture.md`
 - Project settings: see `dev-docs/project-settings.md`
 - When adding slash command arguments: update autocomplete in `extended-autocomplete.ts`
+- Memory `*(enforced)*` marker: entries with this marker are hash-keyed — never change their text, only add/remove whole entries
 
 ## When Modifying Docker
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Single extension that provides:
 | Feature | Description |
 |---------|-------------|
 | **Subagent tool** | Delegate tasks to specialist agents (single, parallel, chain, async modes) |
-| **Async background agents** | Spawn agents in background with `async: true` — results surface automatically when complete |
+| **Async background agents** | Spawn agents in background with `async: true` — results surface automatically when complete, deterministic session IDs for provider cache affinity |
 | **`/btw` command** | Quick side questions without polluting conversation history — ephemeral overlay |
 | **`/async-status` command** | Show status of background agents — select one for live output streaming |
 | **`ask_user` tool** | Structured user input with options and free-text — used by workflows |
@@ -24,10 +24,10 @@ Single extension that provides:
 | **Git status** | Live git status in status line with colored icons — updates after every tool call. Last-activity clock `⏱ HH:MM (Xm/Xh ago)` shows time since last response |
 | **Desktop notifications** | Notifies via `notify-send` on task completion, waiting for input, and action required |
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
-| **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching |
-| **Pidiff viewer** | Standalone diff viewer with review comments — branch diffs, file tree, inline comments |
+| **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching, live session name updates, reasoning token display |
+| **Pidiff viewer** | Standalone diff viewer with review comments — branch diffs, file tree, inline comments, git-based ignore rules |
 | **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains topic-based memory |
-| **Memory enforcement** | Code-enforced memory entries — triggers on bash/tool/file events, actions: block, run_after, warn. LLM cannot ignore enforced rules |
+| **Memory enforcement** | Code-enforced memory entries — triggers on bash/tool/file events, actions: block, run_after, warn. LLM cannot ignore enforced rules. Dreaming-safe via *(enforced)* marker |
 | **Upgrade changelog** | Shows release notes on session start after pi-config version upgrade |
 | **Task tracking** | Structured task lists for multi-step workflows — live widget, progress tracking, reminder nudges ([@tintinweb/pi-tasks](https://github.com/tintinweb/pi-tasks)) |
 | **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |
@@ -681,7 +681,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for tips on testing extensions locally, run
 
 ## Prerequisites
 
-- [pi](https://github.com/badlogic/pi-mono)
+- [pi](https://github.com/badlogic/pi-mono) (minimum version: **0.80.3**)
 - `gh` CLI (for GitHub operations)
 - `uv` (for Python execution)
 - `myk-pi-tools` (optional, for `/pr-review` and `/release`)

--- a/README.md
+++ b/README.md
@@ -544,6 +544,25 @@ PI_PIDIFF_ENABLE=false pi
 | `cr` | CodeRabbit CLI — local AI code reviews |
 | `curl` | HTTP requests |
 
+#### `myk-pi-tools` subcommands
+
+| Command | Description |
+|---------|-------------|
+| `myk-pi-tools pr diff` | Fetch PR diff and metadata |
+| `myk-pi-tools pr info` | Fetch PR information as structured JSON |
+| `myk-pi-tools pr post-comment` | Post inline comments to a PR |
+| `myk-pi-tools pr store-pr-review` | Store posted PR review comments to `pr-reviews.db` |
+| `myk-pi-tools pr update-resolution` | Update resolution status for a previously posted review comment. Used by Phase 1c of `/pr-review` to persist LLM evaluation verdicts |
+| `myk-pi-tools pr get-review-history` | Return complete review history for a PR as JSON (posted, skipped, resolved findings). Used by reviewers to avoid re-raising dismissed findings |
+| `myk-pi-tools pr get-skipped-comments` | Get previously skipped review comments for a PR |
+| `myk-pi-tools pr claude-md` | Fetch `CLAUDE.md` and `AGENTS.md` content for a PR's repository |
+| `myk-pi-tools release create` | Create a GitHub release with changelog |
+| `myk-pi-tools db` | Review database query commands |
+| `myk-pi-tools reviews` | Review handling commands |
+| `myk-pi-tools memory` | Project memory commands — persistent per-repo learning |
+| `myk-pi-tools ai-cli` | AI CLI commands (cursor, claude, gemini) |
+| `myk-pi-tools coderabbit` | CodeRabbit commands |
+
 ### What's protected
 
 **Filesystem isolation** — the container cannot access anything outside the mounted volumes:

--- a/dev-docs/async-internals.md
+++ b/dev-docs/async-internals.md
@@ -33,6 +33,11 @@ All async agent temp files live under `.pi/tmp/`:
     └── system-prompt.md                      # Agent system prompt
 ```
 
+**Deterministic session IDs:** Async agents use `--session-id` (hash of agent name + task prefix) alongside `--no-session`.
+This enables provider-side prompt caching for repeated async agent patterns.
+`--no-session` creates an in-memory session (no disk persistence); `--session-id` assigns a stable ID for cache affinity.
+Both flags are compatible: pi uses `SessionManager.inMemory(cwd, { id: sessionId })` when both are set.
+
 **Zombie cleanup:** On `session_start`, checks each agent's `parentPid` + `parentStartTime` against `/proc/PID/stat` — dead parent = zombie = delete.
 
 **Shared helper:** `getProjectTmpDir(cwd)` in `utils.ts` — returns `<cwd>/.pi/tmp/`, creates dir if missing.

--- a/dev-docs/memory-architecture.md
+++ b/dev-docs/memory-architecture.md
@@ -56,6 +56,21 @@ indexed on shutdown, auto-injected for relevant sessions. Storage: `.pi/data/ses
 Stores both posted and skipped findings with status/skip_reason columns.
 Skipped findings are auto-matched in subsequent review cycles to avoid re-raising dismissed items.
 
+**Resolution tracking columns:**
+
+- `resolution_status`: LLM evaluation verdict — one of `resolved_fixed`, `resolved_accepted`, `resolved_bad_fix`, `resolved_no_fix`
+- `author_response`: stores the author's reply or fix context for audit trail
+
+**Key functions:**
+
+- `update_resolution()`: writes LLM evaluation verdicts for resolved review threads back to the store
+- `get_review_history()`: returns ALL past findings (posted, skipped, resolved) — single source of truth for review state
+
+**CLI commands:**
+
+- `myk-pi-tools pr update-resolution` — persist resolution verdicts from resolved threads
+- `myk-pi-tools pr get-review-history` — dump full review history (all statuses)
+
 ## Learned Review Preferences
 
 `.pi/data/review-guidelines.md`: Per-repo review guidelines

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -457,7 +457,7 @@ export function registerAsyncAgents(
 
     // Build pi args
     const piArgs: string[] = ["--mode", "json", "-p", "--no-session", "-nc"];
-    // Deterministic session ID for provider cache affinity.
+    // Deterministic session ID for provider cache affinity (requires pi >= 0.80.3).
     // --no-session creates an in-memory session (no disk persistence).
     // --session-id assigns a stable ID so the provider can reuse cached prompts
     // across runs with the same agent+task pattern. Both flags are compatible:

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -457,6 +457,18 @@ export function registerAsyncAgents(
 
     // Build pi args
     const piArgs: string[] = ["--mode", "json", "-p", "--no-session", "-nc"];
+    // Deterministic session ID for provider cache affinity.
+    // --no-session creates an in-memory session (no disk persistence).
+    // --session-id assigns a stable ID so the provider can reuse cached prompts
+    // across runs with the same agent+task pattern. Both flags are compatible:
+    // pi uses SessionManager.inMemory(cwd, { id: sessionId }) when both are set.
+    const sessionIdSource = agentName + ':' + task.slice(0, 100);
+    let hash = 0;
+    for (let i = 0; i < sessionIdSource.length; i++) {
+      hash = ((hash << 5) - hash + sessionIdSource.charCodeAt(i)) | 0;
+    }
+    const deterministicSessionId = `async-${agentName}-${Math.abs(hash).toString(36)}`;
+    piArgs.push("--session-id", deterministicSessionId);
     const effectiveModel = agent.model || options?.parentModelId;
     if (effectiveModel) piArgs.push("--model", effectiveModel);
     const effectiveProvider = agent.provider || options?.parentProvider;

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -93,11 +93,14 @@ export function registerDreaming(
       `   - Remove stale/useless entries\n` +
       `   - Keep each file at a reasonable size (aim for under 20 entries per topic)\n` +
       `   - NEVER remove or modify entries marked with *(pinned)*\n` +
+      `   - NEVER remove or modify entries marked with *(enforced)* — these have code-enforced triggers/actions that are keyed by text hash. ANY text change destroys the enforcement binding.\n` +
       `6. Write each updated topic file with this format:\n` +
       `   # TopicName\n` +
       `   \n` +
-      `   - [category] summary *(pinned)*    (if pinned)\n` +
-      `   - [category] summary               (if not pinned)\n` +
+      `   - [category] summary *(pinned)*              (if pinned)\n` +
+      `   - [category] summary *(enforced)*            (if enforced)\n` +
+      `   - [category] summary *(pinned)* *(enforced)* (if both)\n` +
+      `   - [category] summary                         (if neither)\n` +
       `7. Auto-generate skills: if you notice a multi-step workflow pattern across entries,\n` +
       `   create a skill file at .pi/skills/<name>/SKILL.md (project-level, NOT global ~/.agents/).\n` +
       `   The SKILL.md MUST start with YAML frontmatter:\n` +

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -313,7 +313,7 @@ function registerMemoryAdd(pi: ExtensionAPI): void {
       // Canonical line (no markers) — used for hashing/scoring
       const canonicalLine = `- [${category}] ${text}`;
       // File line — includes markers for display
-      const isEnforced = !!(params.trigger || params.action || params.verifier);
+      const isEnforced = !!((params.trigger && params.action) || params.verifier);
       let entryLine = canonicalLine;
       if (isPinned && isEnforced) entryLine = `- [${category}] ${text} *(pinned)* *(enforced)*`;
       else if (isPinned) entryLine = `- [${category}] ${text} *(pinned)*`;

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -310,12 +310,14 @@ function registerMemoryAdd(pi: ExtensionAPI): void {
         }
       }
 
-      // Canonical line (no pinned marker) — used for hashing/scoring
+      // Canonical line (no markers) — used for hashing/scoring
       const canonicalLine = `- [${category}] ${text}`;
-      // File line — includes pinned marker for display
-      const entryLine = isPinned
-        ? `- [${category}] ${text} *(pinned)*`
-        : canonicalLine;
+      // File line — includes markers for display
+      const isEnforced = !!(params.trigger || params.action || params.verifier);
+      let entryLine = canonicalLine;
+      if (isPinned && isEnforced) entryLine = `- [${category}] ${text} *(pinned)* *(enforced)*`;
+      else if (isPinned) entryLine = `- [${category}] ${text} *(pinned)*`;
+      else if (isEnforced) entryLine = `- [${category}] ${text} *(enforced)*`;
 
       // Check for duplicates — vector similarity first, then exact match
       const topicEntries = readAllTopicEntries(cwd);
@@ -530,13 +532,15 @@ function registerMemoryRemove(pi: ExtensionAPI): void {
       }
 
       const content = readFileSync(topicPath, "utf-8");
+      const pinnedEnforcedLine = `- [${category}] ${text} *(pinned)* *(enforced)*`;
       const pinnedLine = `- [${category}] ${text} *(pinned)*`;
+      const enforcedLine = `- [${category}] ${text} *(enforced)*`;
       const learnedLine = `- [${category}] ${text}`;
 
       // Find which line matches
       const lines = content.split("\n");
       let removedLine: string | null = null;
-      for (const candidate of [pinnedLine, learnedLine]) {
+      for (const candidate of [pinnedEnforcedLine, pinnedLine, enforcedLine, learnedLine]) {
         if (lines.some(l => l.trimEnd() === candidate)) {
           removedLine = candidate;
           break;
@@ -668,15 +672,20 @@ function registerMemoryEdit(pi: ExtensionAPI): void {
 
       const content = readFileSync(topicPath, "utf-8");
       const oldLine = `- [${category}] ${text}`;
+      const oldLinePinnedEnforced = `- [${category}] ${text} *(pinned)* *(enforced)*`;
       const oldLinePinned = `- [${category}] ${text} *(pinned)*`;
+      const oldLineEnforced = `- [${category}] ${text} *(enforced)*`;
 
       // Find the matching line
       const lines = content.split("\n");
       let matchIndex = -1;
       let wasPinned = false;
+      let wasEnforced = false;
       for (let i = 0; i < lines.length; i++) {
         const trimmed = lines[i].trimEnd();
+        if (trimmed === oldLinePinnedEnforced) { matchIndex = i; wasPinned = true; wasEnforced = true; break; }
         if (trimmed === oldLinePinned) { matchIndex = i; wasPinned = true; break; }
+        if (trimmed === oldLineEnforced) { matchIndex = i; wasEnforced = true; break; }
         if (trimmed === oldLine) { matchIndex = i; break; }
       }
 
@@ -694,13 +703,13 @@ function registerMemoryEdit(pi: ExtensionAPI): void {
         }
         // Check topic size cap
         const currentContent = readFileSync(topicPath, "utf-8");
-        const newContent = currentContent.replace(lines[matchIndex], `- [${category}] ${newText}${wasPinned ? " *(pinned)*" : ""}`);
+        const markers = `${wasPinned ? " *(pinned)*" : ""}${wasEnforced ? " *(enforced)*" : ""}`;
+        const newContent = currentContent.replace(lines[matchIndex], `- [${category}] ${newText}${markers}`);
         if (newContent.length > MAX_TOPIC_CHARS) {
           return { content: [{ type: "text", text: `Update would exceed topic size limit (${newContent.length}/${MAX_TOPIC_CHARS} chars).` }] };
         }
         // Replace the line
-        const pin = wasPinned ? " *(pinned)*" : "";
-        lines[matchIndex] = `- [${category}] ${newText}${pin}`;
+        lines[matchIndex] = `- [${category}] ${newText}${markers}`;
         writeFileSync(topicPath, lines.join("\n"), "utf-8");
 
         // Update scores: transfer old entry's score to new entry

--- a/extensions/orchestrator/memory-tree.ts
+++ b/extensions/orchestrator/memory-tree.ts
@@ -85,8 +85,8 @@ function readTopicFile(path: string): TopicFile {
     for (const line of content.split("\n")) {
       const match = line.match(/^- \[(preference|lesson|pattern|decision|done|mistake)\] (.+)$/);
       if (match) {
-        // Strip *(pinned)* tags from text (may have duplicates from legacy data)
-        const rawText = match[2]!.replace(/\s*\*\(pinned\)\*/g, "").trim();
+        // Strip *(pinned)* and *(enforced)* tags from text (may have duplicates from legacy data)
+        const rawText = match[2]!.replace(/\s*\*\(pinned\)\*/g, "").replace(/\s*\*\(enforced\)\*/g, "").trim();
         entries.push({
           text: rawText,
           category: match[1] as MemoryCategory,

--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -7,6 +7,7 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { checkMinPiVersion } from "./utils.js";
 
 /** Check whether a CLI command is available on PATH. */
 function hasCmd(cmd: string): boolean {
@@ -329,6 +330,19 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
 
   pi.on("session_start", async (_event, ctx) => {
     if (!ctx.hasUI) return;
+
+    // Check minimum pi version
+    const versionCheck = checkMinPiVersion();
+    if (!versionCheck.ok) {
+      if (ctx.hasUI) {
+        ctx.ui.notify(
+          `⚠️ pi ${versionCheck.installed || "unknown"} is below minimum required version ${versionCheck.required}. ` +
+          `Some features (--session-id for async agents, session_info_changed events) will not work. ` +
+          `Update pi: npm install -g @earendil-works/pi-coding-agent`,
+          "warning",
+        );
+      }
+    }
 
     await checkSessionTools(ctx);
 

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -121,10 +121,18 @@ export const MIN_PI_VERSION = "0.80.3";
 /** Get the installed pi version from its package.json. */
 export function getPiVersion(): string | null {
   try {
-    const piPkgPath = require.resolve("@earendil-works/pi-coding-agent/package.json");
-    const pkg = JSON.parse(fs.readFileSync(piPkgPath, "utf-8"));
-    return pkg.version || null;
-  } catch { return null; }
+    // Resolve from pi's own install location (process.argv[1] → dist/cli.js → package root)
+    const piScript = process.argv[1];
+    if (piScript) {
+      const realPath = fs.realpathSync(piScript);
+      const piPkgPath = path.join(path.dirname(path.dirname(realPath)), "package.json");
+      if (fs.existsSync(piPkgPath)) {
+        const pkg = JSON.parse(fs.readFileSync(piPkgPath, "utf-8"));
+        if (pkg.name === "@earendil-works/pi-coding-agent" && pkg.version) return pkg.version;
+      }
+    }
+  } catch {}
+  return null;
 }
 
 /** Compare two semver strings. Returns -1 if a < b, 0 if equal, 1 if a > b. */

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -4,7 +4,10 @@
 
 import { execFile, execFileSync } from "node:child_process";
 import * as fs from "node:fs";
+import { createRequire } from "node:module";
 import * as path from "node:path";
+
+const require = createRequire(import.meta.url);
 
 /** Whether notify-send is available (false = ENOENT, never retry) */
 let notifyAvailable: boolean | undefined;
@@ -110,4 +113,36 @@ export function tryGetSystemPromptOptions(ctx: any): { contextFiles?: any[]; ski
     console.debug("[utils] getSystemPromptOptions failed:", e?.message);
     return null;
   }
+}
+
+/** Minimum pi version required by this pi-config version. */
+export const MIN_PI_VERSION = "0.80.3";
+
+/** Get the installed pi version from its package.json. */
+export function getPiVersion(): string | null {
+  try {
+    const piPkgPath = require.resolve("@earendil-works/pi-coding-agent/package.json");
+    const pkg = JSON.parse(fs.readFileSync(piPkgPath, "utf-8"));
+    return pkg.version || null;
+  } catch { return null; }
+}
+
+/** Compare two semver strings. Returns -1 if a < b, 0 if equal, 1 if a > b. */
+function compareSemver(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+/** Check if installed pi version meets minimum requirement. */
+export function checkMinPiVersion(minVersion: string = MIN_PI_VERSION): { ok: boolean; installed: string | null; required: string } {
+  const installed = getPiVersion();
+  if (!installed) return { ok: false, installed: null, required: minVersion };
+  return { ok: compareSemver(installed, minVersion) >= 0, installed, required: minVersion };
 }

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -136,7 +136,7 @@ export function getPiVersion(): string | null {
 }
 
 /** Compare two semver strings. Returns -1 if a < b, 0 if equal, 1 if a > b. */
-function compareSemver(a: string, b: string): number {
+export function compareSemver(a: string, b: string): number {
   // Strip prerelease/build metadata (e.g., '0.80.4-beta.1' → '0.80.4')
   const pa = a.split("-")[0].split(".").map(Number);
   const pb = b.split("-")[0].split(".").map(Number);

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -137,8 +137,9 @@ export function getPiVersion(): string | null {
 
 /** Compare two semver strings. Returns -1 if a < b, 0 if equal, 1 if a > b. */
 function compareSemver(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
+  // Strip prerelease/build metadata (e.g., '0.80.4-beta.1' → '0.80.4')
+  const pa = a.split("-")[0].split(".").map(Number);
+  const pb = b.split("-")[0].split(".").map(Number);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;

--- a/extensions/pidash/pidash-ui/src/components/InfoBar.tsx
+++ b/extensions/pidash/pidash-ui/src/components/InfoBar.tsx
@@ -203,6 +203,7 @@ export function InfoBar({ session, model, tokens, send, onMessage }: Props) {
         {" "}
         <span className="inline-block min-w-[3.5em] text-right">↓{fk(output)}</span>
         {cache > 0 && <span className="inline-block min-w-[3.5em] text-right"> 📦{fk(cache)}</span>}
+        {(tokens?.reasoning ?? 0) > 0 && <span className="inline-block min-w-[3.5em] text-right"> 🧠{fk(tokens!.reasoning!)}</span>}
       </span>
 
       <span className="text-border">|</span>

--- a/extensions/pidash/pidash-ui/src/components/SessionSidebar.tsx
+++ b/extensions/pidash/pidash-ui/src/components/SessionSidebar.tsx
@@ -167,7 +167,7 @@ export function SessionSidebar({ sessions, activeSessionId, connected, onSelect,
                           <span className="relative inline-flex rounded-full h-2 w-2 bg-green-400" />
                         </span>
                       )}
-                      <span className="truncate">{s.model || "—"}</span>
+                      <span className="truncate">{s.name || s.model || "—"}</span>
                     </div>
                     <div className="flex items-center gap-1.5 mt-0.5 text-[10px] text-muted-foreground">
                       {s.branch && (

--- a/extensions/pidash/pidash-ui/src/hooks/useMessageHandler.ts
+++ b/extensions/pidash/pidash-ui/src/hooks/useMessageHandler.ts
@@ -371,6 +371,12 @@ export function useMessageHandler(
           }
           break;
 
+        case "session_info_changed":
+          if ((ev as any).name !== undefined) {
+            setSession((prev) => prev ? { ...prev, name: (ev as any).name } : prev);
+          }
+          break;
+
         case "commands-list":
           if ((ev as any).commands) setAvailableCommands((ev as any).commands);
           break;

--- a/extensions/pidash/pidash-ui/src/types.ts
+++ b/extensions/pidash/pidash-ui/src/types.ts
@@ -49,6 +49,7 @@ export interface TokenUsage {
   cacheRead?: number;
   cacheWrite?: number;
   totalTokens?: number;
+  reasoning?: number;
 }
 
 export interface NotificationPreferences {

--- a/extensions/pidash/pidash.ts
+++ b/extensions/pidash/pidash.ts
@@ -693,6 +693,7 @@ export function registerPidash(
     forward("tool_execution_end");
     forward("tool_call");
     forward("tool_result");
+    forward("session_info_changed");
 
     pi.on("model_select", (event: any) => {
       if (ws && connected) {

--- a/extensions/shared/types.ts
+++ b/extensions/shared/types.ts
@@ -16,4 +16,5 @@ export interface SessionInfo {
   thinkingLevel?: string;
   diffPort?: number | null;
   working?: boolean;
+  name?: string;
 }

--- a/myk_pi_tools/pr/commands.py
+++ b/myk_pi_tools/pr/commands.py
@@ -121,6 +121,13 @@ def pr_get_skipped(owner: str, repo: str, pr_number: int) -> None:
     help="Resolution status",
 )
 @click.option("--response", "author_response", default=None, help="PR author's reply text")
+@click.option(
+    "--response-file",
+    "response_file",
+    default=None,
+    type=click.Path(exists=True),
+    help="Read author response from file (avoids shell quoting issues)",
+)
 def pr_update_resolution(
     owner: str,
     repo: str,
@@ -129,6 +136,7 @@ def pr_update_resolution(
     line: int | None,
     resolution_status: str,
     author_response: str | None,
+    response_file: str | None,
 ) -> None:
     """Update resolution status for a previously posted review comment.
 
@@ -138,6 +146,12 @@ def pr_update_resolution(
     import sys
 
     from myk_pi_tools.pr.pr_review_store import update_resolution
+
+    # --response-file takes precedence over --response
+    if response_file:
+        from pathlib import Path
+
+        author_response = Path(response_file).read_text(encoding="utf-8").strip()
 
     try:
         updated = update_resolution(owner, repo, pr_number, file_path, line, resolution_status, author_response)

--- a/myk_pi_tools/pr/commands.py
+++ b/myk_pi_tools/pr/commands.py
@@ -125,7 +125,7 @@ def pr_get_skipped(owner: str, repo: str, pr_number: int) -> None:
     "--response-file",
     "response_file",
     default=None,
-    type=click.Path(exists=True),
+    type=click.Path(exists=True, dir_okay=False, readable=True),
     help="Read author response from file (avoids shell quoting issues)",
 )
 def pr_update_resolution(
@@ -151,7 +151,11 @@ def pr_update_resolution(
     if response_file:
         from pathlib import Path
 
-        author_response = Path(response_file).read_text(encoding="utf-8").strip()
+        try:
+            author_response = Path(response_file).read_text(encoding="utf-8").strip()
+        except OSError as e:
+            print(f"Error reading response file: {e}", file=sys.stderr)
+            sys.exit(1)
 
     try:
         updated = update_resolution(owner, repo, pr_number, file_path, line, resolution_status, author_response)

--- a/myk_pi_tools/pr/commands.py
+++ b/myk_pi_tools/pr/commands.py
@@ -107,6 +107,75 @@ def pr_get_skipped(owner: str, repo: str, pr_number: int) -> None:
     sys.exit(0)
 
 
+@pr.command("update-resolution")
+@click.argument("owner")
+@click.argument("repo")
+@click.argument("pr_number", type=int)
+@click.option("--path", "file_path", required=True, help="File path of the comment")
+@click.option("--line", type=int, default=None, help="Line number of the comment")
+@click.option(
+    "--status",
+    "resolution_status",
+    required=True,
+    type=click.Choice(["resolved_fixed", "resolved_accepted", "resolved_bad_fix", "resolved_no_fix"]),
+    help="Resolution status",
+)
+@click.option("--response", "author_response", default=None, help="PR author's reply text")
+def pr_update_resolution(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    file_path: str,
+    line: int | None,
+    resolution_status: str,
+    author_response: str | None,
+) -> None:
+    """Update resolution status for a previously posted review comment.
+
+    Resolution decisions are made by our review LLM (Phase 1c evaluation),
+    not by the PR author. Stores our verdict in the PR review database.
+    """
+    import sys
+
+    from myk_pi_tools.pr.pr_review_store import update_resolution
+
+    try:
+        updated = update_resolution(owner, repo, pr_number, file_path, line, resolution_status, author_response)
+        if updated:
+            print(f"Updated: {file_path}:{line} \u2192 {resolution_status}", file=sys.stderr)
+        else:
+            print(f"No matching comment found for {file_path}:{line}", file=sys.stderr)
+            sys.exit(1)
+    except (RuntimeError, ValueError) as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+
+@pr.command("get-review-history")
+@click.argument("owner")
+@click.argument("repo")
+@click.argument("pr_number", type=int)
+def pr_get_review_history(owner: str, repo: str, pr_number: int) -> None:
+    """Get complete review history for a PR.
+
+    Returns ALL past findings as JSON: posted, skipped (with reason),
+    resolved (with our verdict and author response). This is the single
+    source of truth for reviewers to avoid re-raising dismissed findings.
+    """
+    import json
+    import sys
+
+    from myk_pi_tools.pr.pr_review_store import get_review_history
+
+    try:
+        results = get_review_history(owner, repo, pr_number)
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+    print(json.dumps(results, indent=2))
+    sys.exit(0)
+
+
 @pr.command("info")
 @click.argument("args", nargs=-1)
 def pr_info(args: tuple[str, ...]) -> None:

--- a/myk_pi_tools/pr/pr_review_store.py
+++ b/myk_pi_tools/pr/pr_review_store.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 VALID_STATUSES = {"posted", "skipped"}
+VALID_RESOLUTION_STATUSES = {"resolved_fixed", "resolved_accepted", "resolved_bad_fix", "resolved_no_fix"}
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS pr_reviews (
@@ -56,6 +57,8 @@ _MIGRATIONS = [
     ("pr_comments", "skip_reason", "ALTER TABLE pr_comments ADD COLUMN skip_reason TEXT"),
     # pr_reviews migrations
     ("pr_reviews", "author", "ALTER TABLE pr_reviews ADD COLUMN author TEXT"),
+    ("pr_comments", "resolution_status", "ALTER TABLE pr_comments ADD COLUMN resolution_status TEXT"),
+    ("pr_comments", "author_response", "ALTER TABLE pr_comments ADD COLUMN author_response TEXT"),
 ]
 
 
@@ -264,6 +267,126 @@ def get_skipped_comments(
         return [dict(row) for row in cursor.fetchall()]
     except sqlite3.Error as e:
         raise RuntimeError(f"Failed to query skipped comments: {e}") from e
+    finally:
+        conn.close()
+
+
+def update_resolution(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    file_path: str,
+    line: int | None,
+    resolution_status: str,
+    author_response: str | None = None,
+    db_path: Path | None = None,
+) -> bool:
+    """Update resolution status for a previously posted comment.
+
+    Matches by owner/repo/pr_number/path/line, updates the most recent match.
+    Resolution decisions are made by the reviewing LLM (Phase 1c), not the PR author.
+
+    Args:
+        owner: Repository owner.
+        repo: Repository name.
+        pr_number: PR number.
+        file_path: File path of the comment.
+        line: Line number of the comment (None to match any line in file).
+        resolution_status: One of: resolved_fixed, resolved_accepted, resolved_bad_fix, resolved_no_fix.
+        author_response: The PR author's reply text (why they resolved/dismissed).
+
+    Returns:
+        True if a comment was updated, False if no matching comment found.
+    """
+    if resolution_status not in VALID_RESOLUTION_STATUSES:
+        raise ValueError(f"Invalid resolution_status '{resolution_status}', must be one of {VALID_RESOLUTION_STATUSES}")
+
+    if db_path is None:
+        db_path = _get_db_path()
+
+    if not db_path.exists():
+        return False
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        _run_migrations(conn)
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys=ON")
+
+        # Find the most recent matching posted comment
+        query = """
+            SELECT c.id FROM pr_comments c
+            JOIN pr_reviews r ON c.review_id = r.id
+            WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
+              AND c.path = ? AND c.status = 'posted'
+        """
+        params: list = [owner, repo, pr_number, file_path]
+        if line is not None:
+            query += " AND c.line = ?"
+            params.append(line)
+        query += " ORDER BY c.id DESC LIMIT 1"
+
+        cursor = conn.execute(query, params)
+        row = cursor.fetchone()
+        if not row:
+            return False
+
+        comment_id = row[0]
+        conn.execute(
+            "UPDATE pr_comments SET resolution_status = ?, author_response = ? WHERE id = ?",
+            (resolution_status, author_response, comment_id),
+        )
+        conn.commit()
+        log(f"Updated resolution for {file_path}:{line} \u2192 {resolution_status}")
+        return True
+    except sqlite3.Error as e:
+        raise RuntimeError(f"Failed to update resolution: {e}") from e
+    finally:
+        conn.close()
+
+
+def get_review_history(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    db_path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Get ALL past findings for a PR \u2014 posted, skipped, and resolved.
+
+    Returns a comprehensive history of all review findings across all cycles,
+    including resolution status and author responses. This is the single source
+    of truth for reviewers to avoid re-raising dismissed findings.
+
+    Returns:
+        List of dicts with keys: path, line, body, severity, status,
+        skip_reason, resolution_status, author_response, head_sha, created_at.
+    """
+    if db_path is None:
+        db_path = _get_db_path()
+
+    if not db_path.exists():
+        return []
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        _run_migrations(conn)
+        conn.commit()
+        cursor = conn.execute(
+            """
+            SELECT c.path, c.line, c.body, c.severity, c.status,
+                   c.skip_reason, c.resolution_status, c.author_response,
+                   r.head_sha, r.created_at
+            FROM pr_comments c
+            JOIN pr_reviews r ON c.review_id = r.id
+            WHERE r.owner = ? AND r.repo = ? AND r.pr_number = ?
+            ORDER BY r.created_at, c.id
+            """,
+            (owner, repo, pr_number),
+        )
+        return [dict(row) for row in cursor.fetchall()]
+    except sqlite3.Error as e:
+        raise RuntimeError(f"Failed to query review history: {e}") from e
     finally:
         conn.close()
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -261,9 +261,11 @@ After evaluating each resolved thread, persist YOUR verdict to the PR review dat
 For each resolved thread that was previously posted by us (matched in the `--user` fetch),
 call:
 
-```bash
-myk-pi-tools pr update-resolution {owner} {repo} {pr_number} --path {path} --line {line} --status {resolution_status} --response "{author_response}"
-```
+To store the verdict, write the author's response to a temp file first (to avoid shell quoting issues),
+then run the CLI:
+
+1. Write `{author_response}` text to `${PROJECT_TMP_DIR}/resolution-response.txt` using the `write` tool
+2. Run: `myk-pi-tools pr update-resolution {owner} {repo} {pr_number} --path {path} --line {line} --status {resolution_status} --response-file ${PROJECT_TMP_DIR}/resolution-response.txt`
 
 Where:
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -255,6 +255,28 @@ For the `human` list, categorize each thread:
     - Valid response (by design, wrong assumption, clarification) → mark as "✅ Resolved — response accepted"
     - Invalid/missing response → include in findings as "❌ Resolved without code change or valid response"
 
+**Store resolution verdicts to DB (MANDATORY):**
+
+After evaluating each resolved thread, persist YOUR verdict to the PR review database.
+For each resolved thread that was previously posted by us (matched in the `--user` fetch),
+call:
+
+```bash
+myk-pi-tools pr update-resolution {owner} {repo} {pr_number} --path {path} --line {line} --status {resolution_status} --response "{author_response}"
+```
+
+Where:
+
+- `{resolution_status}` is one of:
+  - `resolved_fixed` (code changed, fix verified)
+  - `resolved_accepted` (response accepted, no code change needed)
+  - `resolved_bad_fix` (code changed but fix is incorrect)
+  - `resolved_no_fix` (resolved without code change or valid response)
+- `{author_response}` is the PR author's reply text (why they resolved/dismissed)
+
+This persists resolution decisions to the DB so future review cycles can query them.
+Resolution decisions are OURS (from this LLM evaluation), not the PR author's click.
+
 **All past comment statuses are included in the combined findings in Phase 4 —
 not presented as a separate summary.**
 
@@ -315,9 +337,9 @@ Then include `EXISTING_COMMENTS`, `PR_DESCRIPTION_VERIFICATION`, and `CODE_SUGGE
 
 ```text
 subagent(tasks=[
-  {agent: "code-reviewer-quality", task: "Review this PR for code quality. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read any files needed for context.\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Quality", taskId: "<task 5 ID>"},
-  {agent: "code-reviewer-guidelines", task: "Review this PR for guideline adherence. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read AGENTS.md and check compliance.\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Guidelines", taskId: "<task 6 ID>"},
-  {agent: "code-reviewer-security", task: "Review this PR for bugs and security. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Trace data flow through changed code.\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Security", taskId: "<task 7 ID>"},
+  {agent: "code-reviewer-quality", task: "Review this PR for code quality. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read any files needed for context.\n\n<review-history>\nMANDATORY — before reviewing any code, run:\nmyk-pi-tools pr get-review-history {owner} {repo} {pr_number}\nReview the output. Do NOT re-raise any finding marked as resolved_accepted, resolved_fixed, or skipped. These have been evaluated and decided in prior review cycles. Only flag a previously resolved finding if the code at that location has materially changed since the resolution.\n</review-history>\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Quality", taskId: "<task 5 ID>"},
+  {agent: "code-reviewer-guidelines", task: "Review this PR for guideline adherence. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read AGENTS.md and check compliance.\n\n<review-history>\nMANDATORY — before reviewing any code, run:\nmyk-pi-tools pr get-review-history {owner} {repo} {pr_number}\nReview the output. Do NOT re-raise any finding marked as resolved_accepted, resolved_fixed, or skipped. These have been evaluated and decided in prior review cycles. Only flag a previously resolved finding if the code at that location has materially changed since the resolution.\n</review-history>\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Guidelines", taskId: "<task 6 ID>"},
+  {agent: "code-reviewer-security", task: "Review this PR for bugs and security. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Trace data flow through changed code.\n\n<review-history>\nMANDATORY — before reviewing any code, run:\nmyk-pi-tools pr get-review-history {owner} {repo} {pr_number}\nReview the output. Do NOT re-raise any finding marked as resolved_accepted, resolved_fixed, or skipped. These have been evaluated and decided in prior review cycles. Only flag a previously resolved finding if the code at that location has materially changed since the resolution.\n</review-history>\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Security", taskId: "<task 7 ID>"},
 ])
 ```
 

--- a/scripts/pidash-server.ts
+++ b/scripts/pidash-server.ts
@@ -101,6 +101,14 @@ function handlePiMessage(ws: any, parsed: any, getPiClient: () => any, setPiClie
 
   const piClient = getPiClient() as PiClient | null;
 
+  // Forward session name changes to all watching browsers
+  if (parsed.type === "session_info_changed" && piClient) {
+    if (parsed.name !== undefined) piClient.session.name = parsed.name;
+    piClient.session.lastActivity = Date.now();
+    sendToWatchers(piClient.session.sessionId, { type: "session_updated", session: piClient.session });
+    return;
+  }
+
   if (parsed.type === "update_info" && piClient) {
     if (parsed.model !== undefined) piClient.session.model = parsed.model;
     if (parsed.branch !== undefined) piClient.session.branch = parsed.branch;

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -457,7 +457,7 @@ function getGitIgnoredDirs(worktreePath: string): Set<string> {
       for (const line of raw.split("\n")) {
         const trimmed = line.replace(/\/$/, "");
         if (trimmed) {
-          const topLevel = trimmed.split(path.sep)[0];
+          const topLevel = trimmed.split("/")[0];
           if (topLevel) dirs.add(topLevel);
         }
       }

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -445,6 +445,45 @@ const activeWatchers = new Map<string, { watcher: any; debounceTimer: ReturnType
 const chokidarRetries = new Map<string, number>();
 const MAX_CHOKIDAR_RETRIES = 10;
 
+/** Get top-level gitignored directories for a worktree path. */
+function getGitIgnoredDirs(worktreePath: string): Set<string> {
+  const dirs = new Set<string>();
+  try {
+    const raw = execFileSync(GIT_BIN, ["ls-files", "-oi", "--directory", "--exclude-standard"], {
+      cwd: worktreePath, encoding: "utf-8", timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"], maxBuffer: 5 * 1024 * 1024,
+    }).trim();
+    if (raw) {
+      for (const line of raw.split("\n")) {
+        const trimmed = line.replace(/\/$/, "");
+        if (trimmed) {
+          const topLevel = trimmed.split(path.sep)[0];
+          if (topLevel) dirs.add(topLevel);
+        }
+      }
+    }
+  } catch (e: any) { log(`getGitIgnoredDirs error for ${worktreePath}: ${e.message}`); }
+  return dirs;
+}
+
+/** Get the global gitignore file path. */
+function getGlobalGitignore(): string | null {
+  try {
+    const result = execFileSync(GIT_BIN, ["config", "--global", "core.excludesfile"], {
+      encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (result) {
+      if (result.startsWith("~")) {
+        const home = process.env.HOME;
+        if (!home) { log("getGlobalGitignore: HOME unset, skipping tilde expansion"); return null; }
+        return path.join(home, result.slice(1));
+      }
+      return result;
+    }
+  } catch { log("getGlobalGitignore: no global core.excludesfile configured"); }
+  return null;
+}
+
 function startWatching(sessionId: string, worktreePath: string) {
   const retryKey = `${sessionId}:${worktreePath}`;
   if (!_chokidar) {
@@ -458,21 +497,27 @@ function startWatching(sessionId: string, worktreePath: string) {
   const key = `${sessionId}:${worktreePath}`;
   if (activeWatchers.has(key)) return;
 
-  log(`starting chokidar watch: ${worktreePath}`);
+  // Load gitignored directories
+  let gitIgnoredDirs = getGitIgnoredDirs(worktreePath);
+  log(`starting chokidar watch: ${worktreePath} (${gitIgnoredDirs.size} gitignored dirs: ${[...gitIgnoredDirs].join(", ")})`);
+
+  // Performance-critical dirs always ignored (avoid recursing into huge dirs)
+  const ALWAYS_IGNORED = new Set([".git", "node_modules"]);
+
   const watcher = _chokidar.watch(worktreePath, {
     ignoreInitial: true,
     persistent: true,
     ignored: (filePath: string) => {
       const rel = path.relative(worktreePath, filePath);
-      if (rel === "") return false; // watch root itself — don't ignore
-      if (rel.startsWith("..")) return true; // outside watch root — ignore
+      if (rel === "") return false;
+      if (rel.startsWith("..")) return true;
       const first = rel.split(path.sep)[0];
-      return first === ".git" || first === "node_modules" || first === ".worktrees" || first === ".venv" || first === "dist" || first === "__pycache__";
+      return ALWAYS_IGNORED.has(first) || gitIgnoredDirs.has(first);
     },
     depth: 20,
   });
 
-  const state = { watcher, debounceTimer: null as ReturnType<typeof setTimeout> | null };
+  const state = { watcher, debounceTimer: null as ReturnType<typeof setTimeout> | null, gitignoreWatcher: null as any };
   activeWatchers.set(key, state);
 
   const onChange = () => {
@@ -488,6 +533,28 @@ function startWatching(sessionId: string, worktreePath: string) {
   watcher.on("unlink", onChange);
   watcher.on("addDir", onChange);
   watcher.on("unlinkDir", onChange);
+
+  // Watch .gitignore files for changes and refresh ignored dirs.
+  // Note: refreshing gitIgnoredDirs only affects event filtering for future changes.
+  // Chokidar won't start watching previously-ignored dirs that become un-ignored,
+  // and won't release watchers for newly-ignored dirs (they just get filtered).
+  // A pidiff restart is needed for full gitignore changes to take effect.
+  const gitignoreFiles = [path.join(worktreePath, ".gitignore")];
+  const globalGitignore = getGlobalGitignore();
+  if (globalGitignore) gitignoreFiles.push(globalGitignore);
+
+  try {
+    const gitignoreWatcher = _chokidar.watch(gitignoreFiles, {
+      ignoreInitial: true,
+      persistent: true,
+    });
+    gitignoreWatcher.on("change", () => {
+      log(`gitignore changed for ${worktreePath}, refreshing ignored dirs`);
+      gitIgnoredDirs = getGitIgnoredDirs(worktreePath);
+      log(`refreshed gitignored dirs: ${[...gitIgnoredDirs].join(", ")}`);
+    });
+    state.gitignoreWatcher = gitignoreWatcher;
+  } catch (e: any) { log(`gitignore watcher setup failed: ${e.message}`); }
 }
 
 function stopWatching(sessionId: string, worktreePath: string) {
@@ -497,6 +564,7 @@ function stopWatching(sessionId: string, worktreePath: string) {
     log(`stopping chokidar watch: ${worktreePath}`);
     if (state.debounceTimer) clearTimeout(state.debounceTimer);
     state.watcher.close();
+    if (state.gitignoreWatcher) state.gitignoreWatcher.close();
     activeWatchers.delete(key);
   }
 }
@@ -506,6 +574,7 @@ function stopAllWatchers(sessionId: string) {
     if (key.startsWith(`${sessionId}:`)) {
       if (state.debounceTimer) clearTimeout(state.debounceTimer);
       state.watcher.close();
+      if (state.gitignoreWatcher) state.gitignoreWatcher.close();
       activeWatchers.delete(key);
     }
   }

--- a/tests/node/orchestrator/version-check.test.ts
+++ b/tests/node/orchestrator/version-check.test.ts
@@ -4,19 +4,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-
-// Replicate compareSemver logic from utils.ts for testing
-function compareSemver(a: string, b: string): number {
-  const pa = a.split("-")[0].split(".").map(Number);
-  const pb = b.split("-")[0].split(".").map(Number);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const na = pa[i] || 0;
-    const nb = pb[i] || 0;
-    if (na < nb) return -1;
-    if (na > nb) return 1;
-  }
-  return 0;
-}
+import { compareSemver } from "../../../extensions/orchestrator/utils.js";
 
 describe("compareSemver", () => {
   it("equal versions return 0", () => {

--- a/tests/node/orchestrator/version-check.test.ts
+++ b/tests/node/orchestrator/version-check.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for pi version check logic.
+ * Run with: npx tsx --test tests/node/orchestrator/version-check.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+// Replicate compareSemver logic from utils.ts for testing
+function compareSemver(a: string, b: string): number {
+  const pa = a.split("-")[0].split(".").map(Number);
+  const pb = b.split("-")[0].split(".").map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+describe("compareSemver", () => {
+  it("equal versions return 0", () => {
+    assert.strictEqual(compareSemver("0.80.3", "0.80.3"), 0);
+  });
+
+  it("a < b returns -1", () => {
+    assert.strictEqual(compareSemver("0.79.0", "0.80.3"), -1);
+    assert.strictEqual(compareSemver("0.80.2", "0.80.3"), -1);
+  });
+
+  it("a > b returns 1", () => {
+    assert.strictEqual(compareSemver("0.81.0", "0.80.3"), 1);
+    assert.strictEqual(compareSemver("1.0.0", "0.80.3"), 1);
+  });
+
+  it("handles prerelease suffix correctly", () => {
+    // 0.80.4-beta should compare as 0.80.4 (greater than 0.80.3)
+    assert.strictEqual(compareSemver("0.80.4-beta", "0.80.3"), 1);
+    // 0.80.3-rc1 should compare as 0.80.3 (equal to 0.80.3)
+    assert.strictEqual(compareSemver("0.80.3-rc1", "0.80.3"), 0);
+  });
+
+  it("handles build metadata", () => {
+    assert.strictEqual(compareSemver("0.80.3-beta.1", "0.80.3"), 0);
+  });
+
+  it("handles different length versions", () => {
+    assert.strictEqual(compareSemver("1.0", "1.0.0"), 0);
+    assert.strictEqual(compareSemver("1.0.1", "1.0"), 1);
+  });
+
+  it("major version difference", () => {
+    assert.strictEqual(compareSemver("2.0.0", "1.99.99"), 1);
+  });
+});

--- a/tests/node/pidiff/gitignore-parse.test.ts
+++ b/tests/node/pidiff/gitignore-parse.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for pidiff gitignore parsing logic.
+ * Validates the output parsing used by getGitIgnoredDirs() in pidiff-server.ts.
+ * Run with: npx tsx --test tests/node/pidiff/gitignore-parse.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+/**
+ * Replicates the parsing logic from getGitIgnoredDirs() in scripts/pidiff-server.ts.
+ * Extracts top-level directory names from `git ls-files -oi --directory --exclude-standard` output.
+ */
+function parseGitIgnoredDirs(raw: string): Set<string> {
+  const dirs = new Set<string>();
+  if (!raw.trim()) return dirs;
+  for (const line of raw.split("\n")) {
+    const trimmed = line.replace(/\/$/, "");
+    if (trimmed) {
+      // Use "/" not path.sep — git always outputs POSIX separators
+      const topLevel = trimmed.split("/")[0];
+      if (topLevel) dirs.add(topLevel);
+    }
+  }
+  return dirs;
+}
+
+describe("parseGitIgnoredDirs", () => {
+  it("extracts top-level dirs from git output", () => {
+    const raw = ".venv/\ndist/\n__pycache__/\n.pi/\n";
+    const dirs = parseGitIgnoredDirs(raw);
+    assert.deepStrictEqual(dirs, new Set([".venv", "dist", "__pycache__", ".pi"]));
+  });
+
+  it("handles nested paths — extracts only top-level", () => {
+    const raw = "build/lib/\nbuild/dist/\n.tox/py313/\ncoverage/html/\n";
+    const dirs = parseGitIgnoredDirs(raw);
+    assert.deepStrictEqual(dirs, new Set(["build", ".tox", "coverage"]));
+  });
+
+  it("handles empty output", () => {
+    const dirs = parseGitIgnoredDirs("");
+    assert.strictEqual(dirs.size, 0);
+  });
+
+  it("handles whitespace-only output", () => {
+    const dirs = parseGitIgnoredDirs("   \n  \n");
+    assert.strictEqual(dirs.size, 0);
+  });
+
+  it("handles paths without trailing slash", () => {
+    const raw = "node_modules\n.venv\n";
+    const dirs = parseGitIgnoredDirs(raw);
+    assert.deepStrictEqual(dirs, new Set(["node_modules", ".venv"]));
+  });
+
+  it("uses POSIX separator — handles Windows-style paths correctly", () => {
+    // git always outputs POSIX separators even on Windows
+    const raw = "dist/build/\n.venv/lib/python3.13/\n";
+    const dirs = parseGitIgnoredDirs(raw);
+    assert.deepStrictEqual(dirs, new Set(["dist", ".venv"]));
+  });
+
+  it("deduplicates same top-level from multiple nested entries", () => {
+    const raw = "dist/\ndist/css/\ndist/js/\ndist/index.html\n";
+    const dirs = parseGitIgnoredDirs(raw);
+    assert.deepStrictEqual(dirs, new Set(["dist"]));
+  });
+});

--- a/tests/python/test_pr_review_store.py
+++ b/tests/python/test_pr_review_store.py
@@ -11,9 +11,11 @@ from click.testing import CliRunner
 
 from myk_pi_tools.pr.commands import pr
 from myk_pi_tools.pr.pr_review_store import (
+    get_review_history,
     get_skipped_comments,
     run_store,
     store_pr_review,
+    update_resolution,
 )
 
 
@@ -299,6 +301,301 @@ def test_cli_get_skipped(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None
     assert len(data) == 1
     assert data[0]["path"] == "x.py"
     assert data[0]["skip_reason"] == "dup"
+
+
+def test_update_resolution_happy_path(db_path: Path) -> None:
+    """Store a posted comment, update its resolution, verify DB reflects the update."""
+    comments = [
+        {"path": "src/main.py", "line": 10, "body": "Fix this", "severity": "warning"},
+    ]
+    store_pr_review("org", "repo", 42, comments, head_sha="abc1234")
+
+    updated = update_resolution(
+        "org",
+        "repo",
+        42,
+        file_path="src/main.py",
+        line=10,
+        resolution_status="resolved_fixed",
+        author_response="Fixed in latest commit",
+        db_path=db_path,
+    )
+    assert updated is True
+
+    stored = _query_all(db_path, "pr_comments")
+    assert len(stored) == 1
+    assert stored[0]["resolution_status"] == "resolved_fixed"
+    assert stored[0]["author_response"] == "Fixed in latest commit"
+
+
+def test_update_resolution_no_match(db_path: Path) -> None:
+    """update_resolution for a non-existent file/line returns False."""
+    comments = [
+        {"path": "src/main.py", "line": 10, "body": "Fix this", "severity": "warning"},
+    ]
+    store_pr_review("org", "repo", 42, comments, head_sha="abc1234")
+
+    updated = update_resolution(
+        "org",
+        "repo",
+        42,
+        file_path="nonexistent.py",
+        line=99,
+        resolution_status="resolved_fixed",
+        db_path=db_path,
+    )
+    assert updated is False
+
+
+def test_update_resolution_invalid_status(db_path: Path) -> None:
+    """update_resolution with an invalid resolution_status raises ValueError."""
+    comments = [
+        {"path": "src/main.py", "line": 10, "body": "Fix this", "severity": "warning"},
+    ]
+    store_pr_review("org", "repo", 42, comments, head_sha="abc1234")
+
+    with pytest.raises(ValueError, match="Invalid resolution_status"):
+        update_resolution(
+            "org",
+            "repo",
+            42,
+            file_path="src/main.py",
+            line=10,
+            resolution_status="invalid_status",
+            db_path=db_path,
+        )
+
+
+def test_update_resolution_line_none(db_path: Path) -> None:
+    """update_resolution with line=None matches by path only."""
+    comments = [
+        {"path": "src/main.py", "line": 10, "body": "Fix this", "severity": "warning"},
+        {"path": "src/main.py", "line": 20, "body": "Fix that", "severity": "error"},
+    ]
+    store_pr_review("org", "repo", 42, comments, head_sha="abc1234")
+
+    updated = update_resolution(
+        "org",
+        "repo",
+        42,
+        file_path="src/main.py",
+        line=None,
+        resolution_status="resolved_accepted",
+        author_response="Accepted",
+        db_path=db_path,
+    )
+    assert updated is True
+
+    # Should update the most recent match (line=20, higher id)
+    stored = _query_all(db_path, "pr_comments")
+    resolved = [r for r in stored if r["resolution_status"] is not None]
+    assert len(resolved) == 1
+    assert resolved[0]["line"] == 20
+    assert resolved[0]["resolution_status"] == "resolved_accepted"
+
+
+def test_get_review_history_mixed(db_path: Path) -> None:
+    """Store comments with different statuses, update one, verify get_review_history returns all."""
+    comments = [
+        {"path": "a.py", "line": 1, "body": "posted1", "severity": "warning", "status": "posted"},
+        {
+            "path": "b.py",
+            "line": 2,
+            "body": "skipped1",
+            "severity": "nitpick",
+            "status": "skipped",
+            "skip_reason": "duplicate",
+        },
+        {"path": "c.py", "line": 3, "body": "posted2", "severity": "error", "status": "posted"},
+    ]
+    store_pr_review("org", "repo", 42, comments, head_sha="abc1234")
+
+    # Update one posted comment with a resolution
+    update_resolution(
+        "org",
+        "repo",
+        42,
+        file_path="a.py",
+        line=1,
+        resolution_status="resolved_fixed",
+        author_response="Fixed it",
+        db_path=db_path,
+    )
+
+    result = get_review_history("org", "repo", 42, db_path=db_path)
+    assert len(result) == 3
+
+    # posted1 — resolved
+    assert result[0]["path"] == "a.py"
+    assert result[0]["status"] == "posted"
+    assert result[0]["resolution_status"] == "resolved_fixed"
+    assert result[0]["author_response"] == "Fixed it"
+    assert result[0]["head_sha"] == "abc1234"
+
+    # skipped1
+    assert result[1]["path"] == "b.py"
+    assert result[1]["status"] == "skipped"
+    assert result[1]["skip_reason"] == "duplicate"
+    assert result[1]["resolution_status"] is None
+    assert result[1]["author_response"] is None
+
+    # posted2 — no resolution
+    assert result[2]["path"] == "c.py"
+    assert result[2]["status"] == "posted"
+    assert result[2]["resolution_status"] is None
+
+
+def test_get_review_history_empty(db_path: Path) -> None:
+    """get_review_history for a PR with no comments returns empty list."""
+    # Store comments for a different PR
+    store_pr_review("org", "repo", 99, [{"body": "test"}], head_sha="sha1")
+
+    result = get_review_history("org", "repo", 42, db_path=db_path)
+    assert result == []
+
+
+def test_get_review_history_no_db(tmp_path: Path) -> None:
+    """get_review_history with a non-existent db_path returns empty list."""
+    nonexistent = tmp_path / "does-not-exist.db"
+    result = get_review_history("org", "repo", 1, db_path=nonexistent)
+    assert result == []
+
+
+def test_schema_migration_adds_resolution_columns(db_path: Path) -> None:
+    """Create DB with old schema (without resolution columns), verify migration adds them."""
+    # Create old-schema DB without resolution_status/author_response columns
+    old_schema = """
+    CREATE TABLE IF NOT EXISTS pr_reviews (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        owner TEXT NOT NULL,
+        repo TEXT NOT NULL,
+        pr_number INTEGER NOT NULL,
+        head_sha TEXT NOT NULL,
+        author TEXT,
+        created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS pr_comments (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        review_id INTEGER NOT NULL REFERENCES pr_reviews(id) ON DELETE CASCADE,
+        thread_id TEXT,
+        comment_id INTEGER,
+        path TEXT,
+        line INTEGER,
+        body TEXT,
+        severity TEXT,
+        posted_at TEXT,
+        status TEXT DEFAULT 'posted',
+        skip_reason TEXT
+    );
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(old_schema)
+    conn.execute(
+        "INSERT INTO pr_reviews (owner, repo, pr_number, head_sha, author, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("org", "repo", 1, "old_sha", None, "2025-01-01T00:00:00"),
+    )
+    conn.execute(
+        "INSERT INTO pr_comments"
+        " (review_id, path, line, body, severity, status, posted_at)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (1, "old.py", 5, "old comment", "warning", "posted", "2025-01-01T00:00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+    # Verify columns don't exist yet
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.execute("PRAGMA table_info(pr_comments)")
+    col_names = {row[1] for row in cursor.fetchall()}
+    conn.close()
+    assert "resolution_status" not in col_names
+    assert "author_response" not in col_names
+
+    # Trigger migration via update_resolution
+    updated = update_resolution(
+        "org",
+        "repo",
+        1,
+        file_path="old.py",
+        line=5,
+        resolution_status="resolved_fixed",
+        author_response="Fixed",
+        db_path=db_path,
+    )
+    assert updated is True
+
+    # Verify columns now exist and data is correct
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    cursor = conn.execute("PRAGMA table_info(pr_comments)")
+    col_names = {row[1] for row in cursor.fetchall()}
+    assert "resolution_status" in col_names
+    assert "author_response" in col_names
+
+    row = conn.execute("SELECT * FROM pr_comments WHERE id = 1").fetchone()
+    assert row["resolution_status"] == "resolved_fixed"
+    assert row["author_response"] == "Fixed"
+    conn.close()
+
+
+def test_cli_update_resolution(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG001
+    """CLI update-resolution updates a comment and exits 0."""
+    comments = [
+        {"path": "src/main.py", "line": 10, "body": "Fix this", "severity": "warning"},
+    ]
+    store_pr_review("org", "repo", 42, comments, head_sha="abc1234")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pr,
+        [
+            "update-resolution",
+            "org",
+            "repo",
+            "42",
+            "--path",
+            "src/main.py",
+            "--line",
+            "10",
+            "--status",
+            "resolved_fixed",
+            "--response",
+            "Fixed in latest commit",
+        ],
+    )
+    assert result.exit_code == 0
+
+    stored = _query_all(db_path, "pr_comments")
+    assert stored[0]["resolution_status"] == "resolved_fixed"
+    assert stored[0]["author_response"] == "Fixed in latest commit"
+
+
+def test_cli_get_review_history(db_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: ARG001
+    """CLI get-review-history returns JSON output with exit code 0."""
+    comments = [
+        {"path": "x.py", "line": 1, "body": "posted", "severity": "warning", "status": "posted"},
+        {
+            "path": "y.py",
+            "line": 2,
+            "body": "skipped",
+            "severity": "nitpick",
+            "status": "skipped",
+            "skip_reason": "dup",
+        },
+    ]
+    store_pr_review("org", "repo", 55, comments, head_sha="bbb2222")
+
+    runner = CliRunner()
+    result = runner.invoke(pr, ["get-review-history", "org", "repo", "55"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert len(data) == 2
+    assert data[0]["path"] == "x.py"
+    assert data[0]["status"] == "posted"
+    assert data[1]["path"] == "y.py"
+    assert data[1]["status"] == "skipped"
+    assert data[1]["skip_reason"] == "dup"
 
 
 def test_run_store_with_author(db_path: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #597
Closes #603

## Changes

### Issue #597 — pidash pi 0.80.3 APIs

- **Forward `session_info_changed` event to browser** — live session name updates in sidebar without full refresh
- **Deterministic `--session-id` for async agents** — enables provider-side prompt caching for repeated agent patterns (`--no-session --session-id` are compatible: in-memory session with stable ID)
- **Display reasoning token usage** — shows 🧠N in the pidash info bar when providers report reasoning tokens
- **Fix pidiff false positive banner** — replaced hardcoded ignore list with git-based ignore rules (`git ls-files -oi --directory --exclude-standard`), watches `.gitignore` + global gitignore for changes

### Issue #603 — PR review history

- **Extended PR DB schema** — added `resolution_status` and `author_response` columns to `pr_comments` with auto-migration
- **New CLI: `pr update-resolution`** — stores LLM evaluation verdicts (our decision, not PR author's) for resolved threads
- **New CLI: `pr get-review-history`** — returns ALL past findings (posted, skipped, resolved) as single source of truth
- **Phase 1c: store verdicts** — resolution decisions now persist to DB instead of being ephemeral
- **Phase 2: MANDATORY DB query** — reviewers must run `get-review-history` before reviewing, cannot re-raise resolved/skipped findings

## Files Changed (14)

| File | Change |
|------|--------|
| `extensions/pidash/pidash.ts` | Forward session_info_changed |
| `extensions/shared/types.ts` | Add name to SessionInfo |
| `pidash-ui/hooks/useMessageHandler.ts` | Handle session_info_changed |
| `pidash-ui/components/SessionSidebar.tsx` | Display session name |
| `pidash-ui/types.ts` | Add reasoning to TokenUsage |
| `pidash-ui/components/InfoBar.tsx` | Display reasoning tokens |
| `extensions/orchestrator/async-agents.ts` | Deterministic --session-id |
| `scripts/pidiff-server.ts` | Git-based ignore rules |
| `myk_pi_tools/pr/pr_review_store.py` | Schema + update_resolution + get_review_history |
| `myk_pi_tools/pr/commands.py` | 2 new CLI commands |
| `prompts/pr-review.md` | Phase 1c + Phase 2 updates |
| `tests/python/test_pr_review_store.py` | 10 new tests (24 total) |
| `dev-docs/async-internals.md` | Document --session-id |
| `dev-docs/memory-architecture.md` | Document resolution tracking |

## Testing

- ✅ pre-commit: all hooks pass
- ✅ pytest: 171/171 passed (10 new tests)
- ✅ node tests: 169/169 passed
- ✅ Deployed and verified CLI commands work