### PR TITLE
refactor(pidiff): per-project server with lockfile-based port discovery (#608)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ Writing effective rules:
 
 ## When Modifying Extensions
 
+- **pidiff** runs as a per-project server (one per cwd, not shared).
+  Random free port, tracked via `.pi/tmp/pidiff.port` and `.pi/tmp/pidiff.pid`.
 - Extension commands: see `dev-docs/extension-commands.md`
 - Async agents, async-only list, temp dirs: see `dev-docs/async-internals.md`
 - Memory system: see `dev-docs/memory-architecture.md`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Single extension that provides:
 | **Desktop notifications** | Notifies via `notify-send` on task completion, waiting for input, and action required |
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching, live session name updates, reasoning token display |
-| **Pidiff viewer** | Standalone diff viewer with review comments — branch diffs, file tree, inline comments, git-based ignore rules |
+| **Pidiff viewer** | Per-project diff viewer with review comments — branch diffs, file tree, inline comments, git-based ignore rules |
 | **Dreaming** | Background memory consolidation — extracts memories from sessions, deduplicates, maintains topic-based memory |
 | **Memory enforcement** | Code-enforced memory entries — triggers on bash/tool/file events, actions: block, run_after, warn. LLM cannot ignore enforced rules. Dreaming-safe via *(enforced)* marker |
 | **Upgrade changelog** | Shows release notes on session start after pi-config version upgrade |
@@ -72,7 +72,7 @@ Single extension that provides:
 | `/cron add\|list\|remove` | Schedule recurring tasks within the pi session (e.g., `/cron add every 2h check for new issues`, `/cron add at 12:00 /review-handler`). Tasks run while pi is active, survive `/reload`, and stop on exit |
 | `/status` | Unified session snapshot — async agents, cron tasks, git branch, context usage |
 | `/nvim-changed-files` | Send git changed files to nvim's quickfix list (only inside nvim) |
-| `/pidiff start\|stop\|restart\|status` | Manage the pidiff diff viewer daemon |
+| `/pidiff start\|stop\|restart\|status` | Manage the pidiff diff viewer server (per-project) |
 | `/coms start\|stop\|status` | P2P local agent communication (Unix socket) |
 | `/coms-net start\|connect\|disconnect\|stop\|status` | Networked agent communication (HTTP/SSE hub) |
 
@@ -422,7 +422,7 @@ Pidash is a web-based dashboard that runs alongside the TUI, accessible from any
 - Model and thinking level switching from browser
 - Extension commands (`/release`, `/dream`, `/remember`, etc.) work from browser
 - Info bar: model, tokens, context %, git status, diff viewer toggle
-- Standalone diff viewer (pidiff) — opens in browser via link in info bar, powered by `@pierre/diffs` + `@pierre/trees`, with review comments
+- Per-project diff viewer (pidiff) — opens in browser via link in info bar, powered by `@pierre/diffs` + `@pierre/trees`, with review comments
 - Collapsible thinking and tool blocks with copy buttons
 - ask_user tool bridging (answer from browser or TUI)
 - Mobile responsive
@@ -466,14 +466,16 @@ npm install && npm run build
 
 > **Note:** Session switching (`/resume`) and new sessions (`/new`) from the browser are not yet supported due to a pi API limitation. Use the TUI for these operations.
 
-### Pidiff — standalone diff viewer
+### Pidiff — per-project diff viewer
 
-Pidiff is a standalone diff viewer that opens in your browser, providing rich branch diffs with inline review comments.
+Pidiff is a per-project diff viewer that opens in your browser, providing rich branch diffs with inline review comments.
 
 **How it works:**
 
-- A daemon (`pidiff-server.ts`) runs on port `19290` and aggregates diff sessions from all pi instances
-- Each pi session's extension (`pidiff.ts`) connects to the daemon and registers its repo
+- Each pi session spawns its own server (`pidiff-server.ts`) on a random free port
+- Container and native sessions get separate servers automatically
+- Lockfiles in `.pi/tmp/` track port and PID for each server
+- The extension (`pidiff.ts`) connects to its session's server and registers its repo
 - The React UI uses `@pierre/diffs` and `@pierre/trees` for a full-featured diff experience
 
 **Features:**
@@ -482,17 +484,14 @@ Pidiff is a standalone diff viewer that opens in your browser, providing rich br
 - File tree with search and filtering
 - Inline review comments on specific lines
 - Publish review comments back to the pi session
-- Multi-session support — each repo gets its own diff view
+- Per-project isolation — no port conflicts between sessions
 - Accessible via link in pidash info bar
 
 **Access:**
 
 ```bash
-# Open in browser:
-http://localhost:19290
-
-# Custom port:
-PI_PIDIFF_PORT=9999 pi
+# Open in browser (port shown in pidash info bar):
+http://localhost:<port>
 
 # Disable pidiff entirely:
 PI_PIDIFF_ENABLE=false pi
@@ -502,9 +501,9 @@ PI_PIDIFF_ENABLE=false pi
 
 ```bash
 /pidiff status    # Check server status
-/pidiff stop      # Stop the daemon
-/pidiff start     # Start the daemon
-/pidiff restart   # Restart the daemon
+/pidiff stop      # Stop the server
+/pidiff start     # Start the server
+/pidiff restart   # Restart the server
 ```
 
 ### Optional mounts

--- a/dev-docs/extension-commands.md
+++ b/dev-docs/extension-commands.md
@@ -10,7 +10,7 @@ the extension source files under `extensions/`. Each command uses
 |---------|--------|-------------|
 | `/btw` | `btw.ts` | Quick side questions |
 | `/pidash` | `pidash/pidash.ts` | Manage pidash daemon (start/stop/restart/status) |
-| `/pidiff` | `pidiff/pidiff.ts` | Manage pidiff daemon (start/stop/restart/status) |
+| `/pidiff` | `pidiff/pidiff.ts` | Manage pidiff per-project server (start/stop/restart/status) |
 | `/status` | `status.ts` | Unified session status snapshot |
 | `/async-status` | `async-agents.ts` | Background agent status |
 | `/dream` | `dreaming.ts` | Memory consolidation |

--- a/dev-docs/repo-structure.md
+++ b/dev-docs/repo-structure.md
@@ -76,10 +76,10 @@ pi-config/
 │   │       └── dist/               # Built output (generated, gitignored)
 │   ├── pidiff/                      # Diff viewer extension (standalone)
 │   │   ├── index.ts                 # Entry point
-│   │   ├── pidiff.ts                # Diff viewer logic (spawns/connects to pidiff daemon)
+│   │   ├── pidiff.ts                # Diff viewer logic (spawns/connects to per-project pidiff server via .pi/tmp/ lockfiles)
 │   │   └── pidiff-ui/               # React diff viewer UI (@pierre/diffs + @pierre/trees)
 │   ├── shared/                      # Shared extension utilities
-│   │   ├── daemon-manager.ts        # Daemon infrastructure (spawn, health check, WebSocket) — shared by pidash and pidiff
+│   │   ├── daemon-manager.ts        # Server infrastructure (spawn, health check, WebSocket) — shared by pidash and pidiff
 │   │   ├── ws-client.ts             # WebSocket heartbeat + reconnect helpers (used by pidash, pidiff)
 │   │   └── ui/                      # Shared shadcn/ui components (used by pidash-ui and pidiff-ui via @ui alias)
 │   ├── acpx-provider/              # ACPX provider extension (acpx/runtime library API)
@@ -132,7 +132,7 @@ pi-config/
 │   ├── docker-safe                  # Restricted Docker/Podman CLI wrapper (container only)
 │   ├── httpd.py                     # HTTP file server for file preview (used by rules/45-file-preview.md)
 │   ├── pidash-server.ts             # Pidash daemon (WebSocket hub for all pi sessions + Discord bot)
-│   ├── pidiff-server.ts             # Pidiff daemon (multi-session diff hub with review comments)
+│   ├── pidiff-server.ts             # Pidiff per-project server (diff hub with review comments, one per project cwd)
 │   ├── serve-ui.ts                  # Shared static UI serving + auto-build for daemon servers
 │   └── install.py                   # Interactive TUI installer for native deployment (questionary)
 ├── .coderabbit.yaml                 # CodeRabbit CLI config (assertive profile, linter selection)

--- a/extensions/pidiff/pidiff-ui/src/App.tsx
+++ b/extensions/pidiff/pidiff-ui/src/App.tsx
@@ -401,22 +401,12 @@ export function App() {
       <header className="flex-shrink-0 border-b border-border">
         <div className="flex items-center justify-between px-4 h-11 bg-card">
           <div className="flex items-center gap-3 h-full">
-            {/* Session selector — always show dropdown */}
-            <select
-              value={activeSession?.sessionId || ""}
-              onChange={e => {
-                const s = sessions.find(s => s.sessionId === e.target.value);
-                if (s) switchSession(s);
-              }}
-              className="bg-card border border-border rounded-md px-2 py-1 text-xs text-foreground outline-none focus:ring-1 focus:ring-ring max-w-[220px]"
-            >
-              {sessions.length === 0 && <option value="">No sessions</option>}
-              {sessions.map(s => (
-                <option key={s.sessionId} value={s.sessionId}>
-                  {s.repo}
-                </option>
-              ))}
-            </select>
+            {activeSession && (
+              <span className="text-xs font-medium text-foreground">{activeSession.repo}</span>
+            )}
+            {!activeSession && (
+              <span className="text-xs text-muted-foreground">Waiting for session...</span>
+            )}
             {activeSession && (
               <div className="flex items-center gap-1.5">
                 <GitBranch className="h-3.5 w-3.5 text-muted-foreground" />

--- a/extensions/pidiff/pidiff.ts
+++ b/extensions/pidiff/pidiff.ts
@@ -1,8 +1,9 @@
 /**
- * pidiff — diff viewer extension (single server, like pidash).
+ * pidiff — diff viewer extension (per-project server mode).
  *
  * Uses daemon-manager for spawn/connect/reconnect.
- * Connects to pidiff-server on fixed port, registers this session's cwd.
+ * Each project gets its own server on a dynamically allocated port,
+ * tracked via lockfiles in <cwd>/.pi/tmp/.
  * Receives published review comments and injects into pi session.
  */
 
@@ -16,13 +17,15 @@ import {
   checkHealth,
   ensureUiBuilt,
   spawnDaemon,
-  killDaemon,
+  killDaemonByPid,
   waitForDaemon,
+  findFreePort,
+  writeLockfile,
+  readLockfile,
+  removeLockfile,
 } from "../shared/daemon-manager.js";
 import { setupHeartbeat, setupReconnectPoller } from "../shared/ws-client.js";
 
-const DEFAULT_PORT = 19290;
-const PIDIFF_PORT = parseInt(process.env.PI_PIDIFF_PORT || "", 10) || DEFAULT_PORT;
 const RECONNECT_INTERVAL_MS = 5000;
 const ICON_DIFF = "";
 
@@ -73,16 +76,18 @@ export function registerPidiff(pi: ExtensionAPI): void {
   let spawning = false;
   let lastCtx: any = null;
   let cleanupHeartbeat: (() => void) | null = null;
+  let lockDir = ""; // Set on session_start from ctx.cwd
+  let activePort = 0;
 
   function setStatus(ctx: any): void {
     try {
-      if (ctx?.hasUI) {
-        ctx.ui.setStatus("8-diff", ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${PIDIFF_PORT}`));
+      if (ctx?.hasUI && activePort) {
+        ctx.ui.setStatus("8-diff", ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${activePort}`));
       }
     } catch {
       // ctx may be stale if session was replaced during WebSocket connect
     }
-    pi.events?.emit("diff-viewer:port", PIDIFF_PORT);
+    if (activePort) pi.events?.emit("diff-viewer:port", activePort);
   }
 
   function findGitBin(): string {
@@ -91,14 +96,14 @@ export function registerPidiff(pi: ExtensionAPI): void {
     } catch { return "git"; }
   }
 
-  function doSpawn(): void {
+  function doSpawn(port: number, cwd: string): void {
     ensureUiBuilt(import.meta.url, "pidiff-ui", log);
     const gitBin = findGitBin();
     log(`resolved git for daemon: ${gitBin}`);
     spawnDaemon({
       serverScript: "pidiff-server.ts",
       logFile: path.join(process.env.HOME || "/tmp", ".pi", "pidiff-server.log"),
-      env: { PI_PIDIFF_PORT: String(PIDIFF_PORT), PI_GIT_BIN: gitBin },
+      env: { PI_PIDIFF_PORT: String(port), PI_PIDIFF_CWD: cwd, PI_GIT_BIN: gitBin },
       log,
     });
   }
@@ -109,24 +114,41 @@ export function registerPidiff(pi: ExtensionAPI): void {
     connecting = true;
     lastCtx = ctx;
 
-    const running = await checkHealth(PIDIFF_PORT);
-    log(`daemon running: ${running}`);
+    // Try to discover port from lockfile
+    let port = activePort;
+    if (!port) {
+      const lock = readLockfile(lockDir);
+      if (lock) port = lock.port;
+    }
+
+    // Check if existing port is healthy
+    let running = false;
+    if (port) {
+      running = await checkHealth(port);
+      log(`lockfile port=${port}, healthy=${running}`);
+    }
+
     if (!running) {
       if (!spawning) {
         spawning = true;
         log("spawning daemon...");
-        doSpawn();
+        port = await findFreePort();
+        log(`allocated free port: ${port}`);
+        doSpawn(port, ctx.cwd);
+        writeLockfile(lockDir, port, null, log);
       }
-      const ready = await waitForDaemon(PIDIFF_PORT, 60, log);
+      const ready = await waitForDaemon(port, 60, log);
       spawning = false;
       if (!ready) { connecting = false; return; }
     }
 
+    activePort = port;
+
     try {
       const _require = createRequire(import.meta.url);
       const WebSocket = _require("ws");
-      log("connecting WebSocket...");
-      const wsClient = new WebSocket(`ws://127.0.0.1:${PIDIFF_PORT}/ws/pi`);
+      log(`connecting WebSocket to port ${activePort}...`);
+      const wsClient = new WebSocket(`ws://127.0.0.1:${activePort}/ws/pi`);
 
       wsClient.on("open", () => {
         log("WebSocket connected");
@@ -223,22 +245,30 @@ export function registerPidiff(pi: ExtensionAPI): void {
       if (cmd === "stop") {
         if (ws) { try { ws.close(); } catch {} ws = null; }
         connected = false;
-        killDaemon("pidiff-server", log);
+        const pidFile = path.join(lockDir, "pidiff.pid");
+        killDaemonByPid(pidFile, log);
+        removeLockfile(lockDir, log);
+        activePort = 0;
         if (ctx.hasUI) { ctx.ui.setStatus("8-diff", undefined); ctx.ui.notify("pidiff server stopped", "info"); }
         return;
       }
 
       if (cmd === "start") {
-        if (await checkHealth(PIDIFF_PORT)) {
-          if (ctx.hasUI) ctx.ui.notify(`pidiff already running at http://localhost:${PIDIFF_PORT}`, "info");
+        const lock = readLockfile(lockDir);
+        if (lock && await checkHealth(lock.port)) {
+          activePort = lock.port;
+          if (ctx.hasUI) ctx.ui.notify(`pidiff already running at http://localhost:${activePort}`, "info");
           if (!connected) connect(ctx);
           return;
         }
-        doSpawn();
+        const port = await findFreePort();
+        doSpawn(port, ctx.cwd);
+        writeLockfile(lockDir, port, null, log);
         if (ctx.hasUI) ctx.ui.notify("Starting pidiff server...", "info");
-        if (await waitForDaemon(PIDIFF_PORT, 60, log)) {
+        if (await waitForDaemon(port, 60, log)) {
+          activePort = port;
           connect(ctx);
-          if (ctx.hasUI) ctx.ui.notify(`pidiff started at http://localhost:${PIDIFF_PORT}`, "info");
+          if (ctx.hasUI) ctx.ui.notify(`pidiff started at http://localhost:${activePort}`, "info");
         } else {
           if (ctx.hasUI) ctx.ui.notify("pidiff failed to start", "warning");
         }
@@ -248,22 +278,30 @@ export function registerPidiff(pi: ExtensionAPI): void {
       if (cmd === "restart") {
         if (ws) { try { ws.close(); } catch {} ws = null; }
         connected = false;
-        killDaemon("pidiff-server", log);
+        const pidFile = path.join(lockDir, "pidiff.pid");
+        killDaemonByPid(pidFile, log);
+        removeLockfile(lockDir, log);
         await new Promise(r => setTimeout(r, 1000));
-        doSpawn();
+        const port = await findFreePort();
+        doSpawn(port, ctx.cwd);
+        writeLockfile(lockDir, port, null, log);
         if (ctx.hasUI) ctx.ui.notify("Restarting pidiff server...", "info");
-        if (await waitForDaemon(PIDIFF_PORT, 60, log)) {
+        if (await waitForDaemon(port, 60, log)) {
+          activePort = port;
           connect(ctx);
-          if (ctx.hasUI) ctx.ui.notify(`pidiff restarted at http://localhost:${PIDIFF_PORT}`, "info");
+          if (ctx.hasUI) ctx.ui.notify(`pidiff restarted at http://localhost:${activePort}`, "info");
         } else {
           if (ctx.hasUI) ctx.ui.notify("pidiff failed to restart", "warning");
         }
         return;
       }
 
-      const running = await checkHealth(PIDIFF_PORT);
-      let msg = `Server: ${running ? "running" : "stopped"}\nPort: ${PIDIFF_PORT}\n`;
-      msg += `Extension: ${connected ? "connected" : "disconnected"}\nURL: http://localhost:${PIDIFF_PORT}`;
+      const lock = readLockfile(lockDir);
+      const statusPort = activePort || lock?.port || 0;
+      const running = statusPort ? await checkHealth(statusPort) : false;
+      let msg = `Server: ${running ? "running" : "stopped"}\nPort: ${statusPort || "(none)"}\n`;
+      msg += `Extension: ${connected ? "connected" : "disconnected"}`;
+      if (statusPort) msg += `\nURL: http://localhost:${statusPort}`;
       if (ctx.hasUI) ctx.ui.notify(msg, "info");
     },
   });
@@ -271,6 +309,7 @@ export function registerPidiff(pi: ExtensionAPI): void {
   // Session lifecycle
   pi.on("session_start", async (_event, ctx) => {
     lastCtx = ctx;
+    lockDir = path.join(ctx.cwd, ".pi", "tmp");
     if (!isGitRepo(ctx.cwd)) return;
     if (!connected && ctx.mode === "tui") connect(ctx);
   });

--- a/extensions/pidiff/pidiff.ts
+++ b/extensions/pidiff/pidiff.ts
@@ -90,20 +90,12 @@ export function registerPidiff(pi: ExtensionAPI): void {
     if (activePort) pi.events?.emit("diff-viewer:port", activePort);
   }
 
-  function findGitBin(): string {
-    try {
-      return execFileSync("which", ["git"], { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim() || "git";
-    } catch { return "git"; }
-  }
-
   function doSpawn(port: number, cwd: string): void {
     ensureUiBuilt(import.meta.url, "pidiff-ui", log);
-    const gitBin = findGitBin();
-    log(`resolved git for daemon: ${gitBin}`);
     spawnDaemon({
       serverScript: "pidiff-server.ts",
       logFile: path.join(process.env.HOME || "/tmp", ".pi", "pidiff-server.log"),
-      env: { PI_PIDIFF_PORT: String(port), PI_PIDIFF_CWD: cwd, PI_GIT_BIN: gitBin },
+      env: { PI_PIDIFF_PORT: String(port), PI_PIDIFF_CWD: cwd },
       log,
     });
   }
@@ -135,6 +127,24 @@ export function registerPidiff(pi: ExtensionAPI): void {
         connecting = false;
         return;
       }
+
+      // Atomic spawn guard — prevent two sessions from racing to spawn
+      const spawnLock = path.join(lockDir, "pidiff.spawning");
+      try {
+        fs.writeFileSync(spawnLock, String(process.pid), { flag: "wx" });
+      } catch {
+        // Another session is already spawning — wait for it
+        log("another session is spawning pidiff, waiting...");
+        const ready = await waitForDaemon(port || 19290, 30, log);
+        if (ready) {
+          const lock = readLockfile(lockDir);
+          if (lock) { port = lock.port; activePort = port; }
+        }
+        connecting = false;
+        if (ready && port) setTimeout(() => connect(ctx), 1000);
+        return;
+      }
+
       spawning = true;
       log("spawning daemon...");
       port = await findFreePort();
@@ -143,6 +153,7 @@ export function registerPidiff(pi: ExtensionAPI): void {
       writeLockfile(lockDir, port, null, log);
       const ready = await waitForDaemon(port, 60, log);
       spawning = false;
+      try { fs.unlinkSync(spawnLock); } catch {}
       if (!ready) { connecting = false; return; }
     }
 

--- a/extensions/pidiff/pidiff.ts
+++ b/extensions/pidiff/pidiff.ts
@@ -133,28 +133,35 @@ export function registerPidiff(pi: ExtensionAPI): void {
       try {
         fs.writeFileSync(spawnLock, String(process.pid), { flag: "wx" });
       } catch {
-        // Another session is already spawning — wait for it
-        log("another session is spawning pidiff, waiting...");
-        const ready = await waitForDaemon(port || 19290, 30, log);
-        if (ready) {
+        // Another session is already spawning — wait for lockfile to appear
+        log("another session is spawning pidiff, waiting for lockfile...");
+        for (let i = 0; i < 30; i++) {
+          await new Promise(r => setTimeout(r, 1000));
           const lock = readLockfile(lockDir);
-          if (lock) { port = lock.port; activePort = port; }
+          if (lock && await checkHealth(lock.port)) {
+            port = lock.port;
+            activePort = port;
+            break;
+          }
         }
         connecting = false;
-        if (ready && port) setTimeout(() => connect(ctx), 1000);
+        if (port) setTimeout(() => connect(ctx), 1000);
         return;
       }
 
       spawning = true;
-      log("spawning daemon...");
-      port = await findFreePort();
-      log(`allocated free port: ${port}`);
-      doSpawn(port, ctx.cwd);
-      writeLockfile(lockDir, port, null, log);
-      const ready = await waitForDaemon(port, 60, log);
-      spawning = false;
-      try { fs.unlinkSync(spawnLock); } catch {}
-      if (!ready) { connecting = false; return; }
+      try {
+        log("spawning daemon...");
+        port = await findFreePort();
+        log(`allocated free port: ${port}`);
+        doSpawn(port, ctx.cwd);
+        writeLockfile(lockDir, port, null, log);
+        const ready = await waitForDaemon(port, 60, log);
+        if (!ready) { connecting = false; return; }
+      } finally {
+        spawning = false;
+        try { fs.unlinkSync(spawnLock); } catch {}
+      }
     }
 
     activePort = port;

--- a/extensions/pidiff/pidiff.ts
+++ b/extensions/pidiff/pidiff.ts
@@ -113,6 +113,7 @@ export function registerPidiff(pi: ExtensionAPI): void {
     if (connected || connecting || shuttingDown) return;
     connecting = true;
     lastCtx = ctx;
+    if (!lockDir) { log("connect: lockDir not set (session_start not fired yet)"); connecting = false; return; }
 
     // Try to discover port from lockfile
     let port = activePort;
@@ -129,14 +130,17 @@ export function registerPidiff(pi: ExtensionAPI): void {
     }
 
     if (!running) {
-      if (!spawning) {
-        spawning = true;
-        log("spawning daemon...");
-        port = await findFreePort();
-        log(`allocated free port: ${port}`);
-        doSpawn(port, ctx.cwd);
-        writeLockfile(lockDir, port, null, log);
+      if (spawning) {
+        log("daemon already spawning, waiting...");
+        connecting = false;
+        return;
       }
+      spawning = true;
+      log("spawning daemon...");
+      port = await findFreePort();
+      log(`allocated free port: ${port}`);
+      doSpawn(port, ctx.cwd);
+      writeLockfile(lockDir, port, null, log);
       const ready = await waitForDaemon(port, 60, log);
       spawning = false;
       if (!ready) { connecting = false; return; }
@@ -331,6 +335,8 @@ export function registerPidiff(pi: ExtensionAPI): void {
   });
 
   pi.on("session_shutdown", () => {
+    // Server auto-exits when last pi session disconnects (onPiClose in pidiff-server.ts).
+    // No need to kill here — just disconnect and let the server decide.
     shuttingDown = true;
     cleanupReconnect();
     if (cleanupHeartbeat) { cleanupHeartbeat(); cleanupHeartbeat = null; }

--- a/extensions/shared/daemon-manager.ts
+++ b/extensions/shared/daemon-manager.ts
@@ -140,6 +140,83 @@ export function killDaemon(pattern: string, log: (msg: string) => void): void {
   } catch {}
 }
 
+// ── Kill daemon by PID ──────────────────────────────────────────────
+
+/** Kill a daemon by its stored PID. Returns true if killed. */
+export function killDaemonByPid(pidFile: string, log: (msg: string) => void): boolean {
+  try {
+    if (!fs.existsSync(pidFile)) return false;
+    const pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
+    if (isNaN(pid)) { log(`invalid PID in ${pidFile}`); return false; }
+    try { process.kill(pid, 0); } catch { log(`PID ${pid} not running`); fs.unlinkSync(pidFile); return false; }
+    process.kill(pid, "SIGTERM");
+    log(`killed daemon PID ${pid}`);
+    // Wait briefly for process to exit
+    for (let i = 0; i < 10; i++) {
+      try { process.kill(pid, 0); } catch { break; }
+      execSync("sleep 0.1", { stdio: "ignore" });
+    }
+    // Force kill if still alive
+    try { process.kill(pid, "SIGKILL"); } catch {}
+    try { fs.unlinkSync(pidFile); } catch {}
+    return true;
+  } catch (e: any) { log(`killDaemonByPid error: ${e.message}`); return false; }
+}
+
+// ── Find free port ──────────────────────────────────────────────────
+
+/** Find a free TCP port by binding to port 0. */
+export function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = require("node:net").createServer();
+    srv.listen(0, "127.0.0.1", () => {
+      const port = srv.address().port;
+      srv.close(() => resolve(port));
+    });
+    srv.on("error", reject);
+  });
+}
+
+// ── Lockfile management ─────────────────────────────────────────────
+
+/** Write a lockfile with port and PID. */
+export function writeLockfile(lockDir: string, port: number, pid: number | null, log: (msg: string) => void): void {
+  try {
+    if (!fs.existsSync(lockDir)) fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(path.join(lockDir, "pidiff.port"), String(port), { mode: 0o600 });
+    if (pid !== null) fs.writeFileSync(path.join(lockDir, "pidiff.pid"), String(pid), { mode: 0o600 });
+    log(`lockfile written: port=${port} pid=${pid}`);
+  } catch (e: any) { log(`writeLockfile error: ${e.message}`); }
+}
+
+/** Read port from lockfile. Returns port number or null. */
+export function readLockfile(lockDir: string): { port: number; pid: number | null } | null {
+  try {
+    const portFile = path.join(lockDir, "pidiff.port");
+    if (!fs.existsSync(portFile)) return null;
+    const port = parseInt(fs.readFileSync(portFile, "utf-8").trim(), 10);
+    if (isNaN(port)) return null;
+    let pid: number | null = null;
+    const pidFile = path.join(lockDir, "pidiff.pid");
+    if (fs.existsSync(pidFile)) {
+      pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
+      if (isNaN(pid)) pid = null;
+    }
+    return { port, pid };
+  } catch { return null; }
+}
+
+/** Clean up lockfiles. */
+export function removeLockfile(lockDir: string, log: (msg: string) => void): void {
+  try {
+    const portFile = path.join(lockDir, "pidiff.port");
+    const pidFile = path.join(lockDir, "pidiff.pid");
+    if (fs.existsSync(portFile)) fs.unlinkSync(portFile);
+    if (fs.existsSync(pidFile)) fs.unlinkSync(pidFile);
+    log("lockfiles removed");
+  } catch (e: any) { log(`removeLockfile error: ${e.message}`); }
+}
+
 // ── Wait for daemon ─────────────────────────────────────────────────
 
 export async function waitForDaemon(

--- a/extensions/shared/daemon-manager.ts
+++ b/extensions/shared/daemon-manager.ts
@@ -7,6 +7,7 @@
 
 import * as fs from "node:fs";
 import * as http from "node:http";
+import * as net from "node:net";
 import * as path from "node:path";
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -149,12 +150,23 @@ export function killDaemonByPid(pidFile: string, log: (msg: string) => void): bo
     const pid = parseInt(fs.readFileSync(pidFile, "utf-8").trim(), 10);
     if (isNaN(pid)) { log(`invalid PID in ${pidFile}`); return false; }
     try { process.kill(pid, 0); } catch { log(`PID ${pid} not running`); fs.unlinkSync(pidFile); return false; }
+    // Verify PID belongs to a pidiff-server to avoid killing unrelated processes
+    try {
+      const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, "utf-8");
+      if (!cmdline.includes("pidiff-server")) {
+        log(`PID ${pid} is not a pidiff-server process — skipping kill`);
+        fs.unlinkSync(pidFile);
+        return false;
+      }
+    } catch { /* /proc not available (non-Linux) — proceed with kill */ }
     process.kill(pid, "SIGTERM");
     log(`killed daemon PID ${pid}`);
     // Wait briefly for process to exit
+    // Sync sleep without spawning shell processes
+    const waitBuf = new Int32Array(new SharedArrayBuffer(4));
     for (let i = 0; i < 10; i++) {
       try { process.kill(pid, 0); } catch { break; }
-      execSync("sleep 0.1", { stdio: "ignore" });
+      Atomics.wait(waitBuf, 0, 0, 100);
     }
     // Force kill if still alive
     try { process.kill(pid, "SIGKILL"); } catch {}
@@ -168,7 +180,7 @@ export function killDaemonByPid(pidFile: string, log: (msg: string) => void): bo
 /** Find a free TCP port by binding to port 0. */
 export function findFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
-    const srv = require("node:net").createServer();
+    const srv = net.createServer();
     srv.listen(0, "127.0.0.1", () => {
       const port = srv.address().port;
       srv.close(() => resolve(port));
@@ -203,7 +215,7 @@ export function readLockfile(lockDir: string): { port: number; pid: number | nul
       if (isNaN(pid)) pid = null;
     }
     return { port, pid };
-  } catch { return null; }
+  } catch (e: any) { console.debug(`[daemon-manager] readLockfile error: ${e?.message}`); return null; }
 }
 
 /** Clean up lockfiles. */

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -366,10 +366,25 @@ const { piClients, browserClients, browserWatchMap, broadcastToBrowsers, start }
     piClients.delete(piClient.session.sessionId);
     log(`session disconnected: ${piClient.session.sessionId}`);
     broadcastToBrowsers({ type: "session_removed", sessionId: piClient.session.sessionId });
-    // Exit when last pi session disconnects — no sessions = no reason to keep running
-    if (piClients.size === 0) {
-      log("last session disconnected — shutting down");
-      process.exit(0);
+    // Start idle shutdown timer when last pi session disconnects
+    if (piClients.size === 0 && browserClients.size === 0) {
+      log("last session and browser disconnected — shutting down in 5s");
+      const shutdownTimer = setTimeout(() => {
+        if (piClients.size === 0) {
+          log("idle shutdown — no sessions reconnected");
+          process.exit(0);
+        }
+      }, 5000);
+      if (shutdownTimer.unref) shutdownTimer.unref();
+    } else if (piClients.size === 0) {
+      log("last pi session disconnected — browsers still connected, waiting 30s");
+      const shutdownTimer = setTimeout(() => {
+        if (piClients.size === 0) {
+          log("idle shutdown — no sessions reconnected after 30s");
+          process.exit(0);
+        }
+      }, 30000);
+      if (shutdownTimer.unref) shutdownTimer.unref();
     }
   },
 

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -366,22 +366,10 @@ const { piClients, browserClients, browserWatchMap, broadcastToBrowsers, start }
     piClients.delete(piClient.session.sessionId);
     log(`session disconnected: ${piClient.session.sessionId}`);
     broadcastToBrowsers({ type: "session_removed", sessionId: piClient.session.sessionId });
-    // Start idle shutdown timer when last pi session disconnects
+    // Last session gone — server exits
     if (piClients.size === 0) {
-      const delay = browserClients.size === 0 ? 5000 : 30000;
-      log(`last pi session disconnected — shutting down in ${delay / 1000}s (${browserClients.size} browsers)`);
-      const shutdownTimer = setTimeout(() => {
-        if (piClients.size === 0 && browserClients.size === 0) {
-          log("idle shutdown — no sessions or browsers");
-          process.exit(0);
-        } else if (piClients.size === 0) {
-          log("idle shutdown — no sessions reconnected, closing remaining browsers");
-          process.exit(0);
-        } else {
-          log("shutdown cancelled — session reconnected");
-        }
-      }, delay);
-      if (shutdownTimer.unref) shutdownTimer.unref();
+      log("last session disconnected — shutting down");
+      process.exit(0);
     }
   },
 

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -17,6 +17,11 @@ import { createDaemonServer } from "./daemon-shared.ts";
 const DEFAULT_PORT = 19290;
 const port = parseInt(process.env.PI_PIDIFF_PORT || "", 10) || DEFAULT_PORT;
 
+const PROJECT_CWD = process.env.PI_PIDIFF_CWD || "";
+if (!PROJECT_CWD) {
+  console.log(`${new Date().toISOString()} [pidiff] WARNING: PI_PIDIFF_CWD not set — server will only work when sessions register`);
+}
+
 function log(msg: string) {
   console.log(`${new Date().toISOString()} [pidiff] ${msg}`);
 }
@@ -311,6 +316,17 @@ const { piClients, browserClients, browserWatchMap, broadcastToBrowsers, start }
       piClients.set(sessionId, piClient);
       log(`session registered: ${sessionId} (${session.repo})`);
       broadcastToBrowsers({ type: "session_added", session });
+      // Auto-watch for browsers without a session (per-project mode)
+      for (const browser of browserClients) {
+        const watchInfo = browserWatchMap.get(browser);
+        if (!watchInfo?.sessionId) {
+          browserWatchMap.set(browser, { sessionId, worktreePath: null });
+          const payload = buildDiffPayload(cwd, "branch");
+          try { browser.send(JSON.stringify(payload)); } catch {}
+          const commits = getLog(cwd, 30);
+          try { browser.send(JSON.stringify({ type: "commits-list", commits })); } catch {}
+        }
+      }
       for (const wt of session.worktrees) startWatching(sessionId, wt.path);
       if (session.worktrees.length === 0) startWatching(sessionId, session.cwd);
       return;
@@ -350,6 +366,15 @@ const { piClients, browserClients, browserWatchMap, broadcastToBrowsers, start }
     browserWatchMap.set(ws, { sessionId: null, worktreePath: null });
     const sessions = Array.from(piClients.values()).map((c: any) => c.session);
     try { ws.send(JSON.stringify({ type: "sessions-list", sessions })); } catch {}
+    // In per-project mode, auto-watch the first registered session
+    if (PROJECT_CWD && sessions.length > 0) {
+      const firstSession = sessions[0];
+      browserWatchMap.set(ws, { sessionId: firstSession.sessionId, worktreePath: null });
+      const payload = buildDiffPayload(firstSession.cwd, "branch");
+      try { ws.send(JSON.stringify(payload)); } catch {}
+      const commits = getLog(firstSession.cwd, 30);
+      try { ws.send(JSON.stringify({ type: "commits-list", commits })); } catch {}
+    }
   },
 
   onBrowserMessage: (ws, parsed) => {
@@ -608,3 +633,13 @@ if (worktreeRefreshInterval.unref) worktreeRefreshInterval.unref();
 // ── Start ───────────────────────────────────────────────────────────
 
 start();
+
+// Write PID file for lockfile-based management
+if (PROJECT_CWD) {
+  const pidDir = path.join(PROJECT_CWD, ".pi", "tmp");
+  try {
+    if (!fs.existsSync(pidDir)) fs.mkdirSync(pidDir, { recursive: true });
+    fs.writeFileSync(path.join(pidDir, "pidiff.pid"), String(process.pid), { mode: 0o600 });
+    log(`PID file written: ${pidDir}/pidiff.pid (PID ${process.pid})`);
+  } catch (e: any) { log(`PID file write error: ${e.message}`); }
+}

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -350,6 +350,11 @@ const { piClients, browserClients, browserWatchMap, broadcastToBrowsers, start }
     piClients.delete(piClient.session.sessionId);
     log(`session disconnected: ${piClient.session.sessionId}`);
     broadcastToBrowsers({ type: "session_removed", sessionId: piClient.session.sessionId });
+    // Exit when last pi session disconnects — no sessions = no reason to keep running
+    if (piClients.size === 0) {
+      log("last session disconnected — shutting down");
+      process.exit(0);
+    }
   },
 
   onBrowserWatch: (ws, watchId, client) => {
@@ -632,9 +637,7 @@ if (worktreeRefreshInterval.unref) worktreeRefreshInterval.unref();
 
 // ── Start ───────────────────────────────────────────────────────────
 
-start();
-
-// Write PID file for lockfile-based management
+// Write PID file for lockfile-based management (before start so /pidiff stop works during startup)
 if (PROJECT_CWD) {
   const pidDir = path.join(PROJECT_CWD, ".pi", "tmp");
   try {
@@ -643,3 +646,12 @@ if (PROJECT_CWD) {
     log(`PID file written: ${pidDir}/pidiff.pid (PID ${process.pid})`);
   } catch (e: any) { log(`PID file write error: ${e.message}`); }
 }
+
+// Clean PID file on exit to prevent stale PID issues
+process.on("exit", () => {
+  if (PROJECT_CWD) {
+    try { fs.unlinkSync(path.join(PROJECT_CWD, ".pi", "tmp", "pidiff.pid")); } catch {}
+  }
+});
+
+start();

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -30,18 +30,29 @@ function log(msg: string) {
 
 const GIT_OPTS = { encoding: "utf-8" as const, timeout: 3000, stdio: ["ignore", "pipe", "ignore"] as const, maxBuffer: 10 * 1024 * 1024 };
 
-// Resolve git binary — prefer PI_GIT_BIN env var (set by the spawning extension which has the correct PATH)
-let GIT_BIN = process.env.PI_GIT_BIN || "git";
+// Resolve git binary — search common paths, no PI_GIT_BIN dependency
+let GIT_BIN = "git";
 let gitBinResolved = false;
 
+const GIT_SEARCH_PATHS = [
+  "git",                                    // PATH lookup
+  "/usr/bin/git",                            // standard Linux/container
+  "/usr/local/bin/git",                      // macOS / manual install
+  "/home/linuxbrew/.linuxbrew/bin/git",      // Homebrew on Linux
+  "/opt/homebrew/bin/git",                   // Homebrew on macOS ARM
+];
+
 function resolveGitBin(): string {
-  // 1. PI_GIT_BIN from env (set by extension with correct PATH)
-  if (process.env.PI_GIT_BIN) {
-    try { execFileSync(process.env.PI_GIT_BIN, ["--version"], { stdio: "ignore" }); GIT_BIN = process.env.PI_GIT_BIN; gitBinResolved = true; return GIT_BIN; } catch {}
+  for (const candidate of GIT_SEARCH_PATHS) {
+    try {
+      execFileSync(candidate, ["--version"], { stdio: "ignore", timeout: 3000 });
+      GIT_BIN = candidate;
+      gitBinResolved = true;
+      if (candidate !== "git") log(`resolved git binary: ${candidate}`);
+      return GIT_BIN;
+    } catch {}
   }
-  // 2. Try "git" on PATH
-  try { execFileSync("git", ["--version"], { stdio: "ignore" }); GIT_BIN = "git"; gitBinResolved = true; return GIT_BIN; } catch {}
-  log("WARNING: git binary not found — set PI_GIT_BIN or ensure git is in PATH");
+  log("WARNING: git binary not found in any known location");
   gitBinResolved = false;
   return GIT_BIN;
 }
@@ -309,6 +320,11 @@ const { piClients, browserClients, browserWatchMap, broadcastToBrowsers, start }
       const sessionId = parsed.sessionId || `${parsed.pid}:${parsed.cwd}`;
       const cwd = parsed.cwd || "";
       if (!cwd) { log(`register rejected: empty cwd from ${sessionId}`); return; }
+      // In per-project mode, validate that the registering session's cwd matches
+      if (PROJECT_CWD && cwd !== PROJECT_CWD) {
+        log(`register rejected: cwd ${cwd} does not match PROJECT_CWD ${PROJECT_CWD}`);
+        return;
+      }
       const worktrees = getWorktrees(cwd);
       const session: SessionInfo = { sessionId, cwd, branch: parsed.branch || "", repo: cwd.split("/").pop() || "", worktrees };
       const piClient = { ws, session };

--- a/scripts/pidiff-server.ts
+++ b/scripts/pidiff-server.ts
@@ -367,23 +367,20 @@ const { piClients, browserClients, browserWatchMap, broadcastToBrowsers, start }
     log(`session disconnected: ${piClient.session.sessionId}`);
     broadcastToBrowsers({ type: "session_removed", sessionId: piClient.session.sessionId });
     // Start idle shutdown timer when last pi session disconnects
-    if (piClients.size === 0 && browserClients.size === 0) {
-      log("last session and browser disconnected — shutting down in 5s");
+    if (piClients.size === 0) {
+      const delay = browserClients.size === 0 ? 5000 : 30000;
+      log(`last pi session disconnected — shutting down in ${delay / 1000}s (${browserClients.size} browsers)`);
       const shutdownTimer = setTimeout(() => {
-        if (piClients.size === 0) {
-          log("idle shutdown — no sessions reconnected");
+        if (piClients.size === 0 && browserClients.size === 0) {
+          log("idle shutdown — no sessions or browsers");
           process.exit(0);
-        }
-      }, 5000);
-      if (shutdownTimer.unref) shutdownTimer.unref();
-    } else if (piClients.size === 0) {
-      log("last pi session disconnected — browsers still connected, waiting 30s");
-      const shutdownTimer = setTimeout(() => {
-        if (piClients.size === 0) {
-          log("idle shutdown — no sessions reconnected after 30s");
+        } else if (piClients.size === 0) {
+          log("idle shutdown — no sessions reconnected, closing remaining browsers");
           process.exit(0);
+        } else {
+          log("shutdown cancelled — session reconnected");
         }
-      }, 30000);
+      }, delay);
       if (shutdownTimer.unref) shutdownTimer.unref();
     }
   },

--- a/tests/node/shared/daemon-manager.test.ts
+++ b/tests/node/shared/daemon-manager.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for daemon-manager lockfile and port helpers.
+ * Run with: npx tsx --test tests/node/shared/daemon-manager.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeLockfile, readLockfile, removeLockfile, findFreePort } from "../../../extensions/shared/daemon-manager.js";
+
+describe("writeLockfile + readLockfile", () => {
+  it("writes and reads port + pid", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
+    try {
+      const log = () => {};
+      writeLockfile(dir, 12345, 99999, log);
+      const result = readLockfile(dir);
+      assert.ok(result);
+      assert.strictEqual(result!.port, 12345);
+      assert.strictEqual(result!.pid, 99999);
+    } finally { rmSync(dir, { recursive: true }); }
+  });
+
+  it("reads port without pid", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
+    try {
+      const log = () => {};
+      writeLockfile(dir, 8080, null, log);
+      const result = readLockfile(dir);
+      assert.ok(result);
+      assert.strictEqual(result!.port, 8080);
+      assert.strictEqual(result!.pid, null);
+    } finally { rmSync(dir, { recursive: true }); }
+  });
+
+  it("returns null for non-existent dir", () => {
+    const result = readLockfile("/tmp/nonexistent-dm-test-" + Date.now());
+    assert.strictEqual(result, null);
+  });
+});
+
+describe("removeLockfile", () => {
+  it("removes port and pid files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
+    try {
+      const log = () => {};
+      writeLockfile(dir, 12345, 99999, log);
+      assert.ok(existsSync(join(dir, "pidiff.port")));
+      assert.ok(existsSync(join(dir, "pidiff.pid")));
+      removeLockfile(dir, log);
+      assert.ok(!existsSync(join(dir, "pidiff.port")));
+      assert.ok(!existsSync(join(dir, "pidiff.pid")));
+    } finally { rmSync(dir, { recursive: true }); }
+  });
+
+  it("handles missing files gracefully", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
+    try {
+      const log = () => {};
+      removeLockfile(dir, log); // should not throw
+    } finally { rmSync(dir, { recursive: true }); }
+  });
+});
+
+describe("findFreePort", () => {
+  it("returns a valid port number", async () => {
+    const port = await findFreePort();
+    assert.ok(typeof port === "number");
+    assert.ok(port > 0);
+    assert.ok(port < 65536);
+  });
+
+  it("returns different ports on successive calls", async () => {
+    const port1 = await findFreePort();
+    const port2 = await findFreePort();
+    // Not guaranteed but very likely
+    assert.ok(typeof port1 === "number");
+    assert.ok(typeof port2 === "number");
+  });
+});

--- a/tests/node/shared/daemon-manager.test.ts
+++ b/tests/node/shared/daemon-manager.test.ts
@@ -7,10 +7,10 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { writeLockfile, readLockfile, removeLockfile, findFreePort } from "../../../extensions/shared/daemon-manager.js";
+import { writeLockfile, readLockfile, removeLockfile, findFreePort, killDaemonByPid } from "../../../extensions/shared/daemon-manager.js";
 
-describe("writeLockfile + readLockfile", () => {
-  it("writes and reads port + pid", () => {
+describe("lockfile operations", () => {
+  it("stores port and pid via writeLockfile, retrieves via readLockfile", () => {
     const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
     try {
       const log = () => {};
@@ -22,7 +22,7 @@ describe("writeLockfile + readLockfile", () => {
     } finally { rmSync(dir, { recursive: true }); }
   });
 
-  it("reads port without pid", () => {
+  it("handles null pid in lockfile", () => {
     const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
     try {
       const log = () => {};
@@ -41,7 +41,7 @@ describe("writeLockfile + readLockfile", () => {
 });
 
 describe("removeLockfile", () => {
-  it("removes port and pid files", () => {
+  it("cleans up both lockfile entries", () => {
     const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
     try {
       const log = () => {};
@@ -60,6 +60,38 @@ describe("removeLockfile", () => {
       const log = () => {};
       removeLockfile(dir, log); // should not throw
     } finally { rmSync(dir, { recursive: true }); }
+  });
+});
+
+describe("killDaemonByPid", () => {
+  it("returns false for non-existent pid file", () => {
+    const log = () => {};
+    const result = killDaemonByPid("/tmp/nonexistent-pid-" + Date.now(), log);
+    assert.strictEqual(result, false);
+  });
+
+  it("returns false for invalid pid in file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
+    const pidFile = join(dir, "test.pid");
+    try {
+      writeFileSync(pidFile, "not-a-number");
+      const log = () => {};
+      const result = killDaemonByPid(pidFile, log);
+      assert.strictEqual(result, false);
+    } finally { rmSync(dir, { recursive: true }); }
+  });
+
+  it("returns false for dead pid and cleans up file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "dm-test-"));
+    const pidFile = join(dir, "test.pid");
+    try {
+      // Use a PID that's almost certainly not running
+      writeFileSync(pidFile, "999999999");
+      const log = () => {};
+      const result = killDaemonByPid(pidFile, log);
+      assert.strictEqual(result, false);
+      assert.ok(!existsSync(pidFile));
+    } finally { rmSync(dir, { recursive: true, force: true }); }
   });
 });
 


### PR DESCRIPTION
Closes #608

## Changes

### Extension (`extensions/pidiff/pidiff.ts`)
- Lockfile-based port discovery (`.pi/tmp/pidiff.port` + `.pi/tmp/pidiff.pid`)
- Free port finding via `findFreePort()`
- PID-based kill instead of `pkill -f` (only kills our project's server)
- Pass `PI_PIDIFF_CWD` to server for single-project mode
- `/pidiff stop|start|restart|status` operates on current project only

### Server (`scripts/pidiff-server.ts`)
- Takes `PI_PIDIFF_CWD` env var — serves only that project root
- Writes PID file on startup for lockfile management
- Auto-watches on browser connect (no session selection needed)
- Auto-watches on session register for browsers without a session

### UI (`extensions/pidiff/pidiff-ui/src/App.tsx`)
- Removed session picker dropdown — replaced with static repo name display
- Server auto-sends diffs on connect, no manual selection needed
- Kept all worktree tabs, diff display, review comments, commit view

### Daemon Manager (`extensions/shared/daemon-manager.ts`)
- `killDaemonByPid()` — kill by stored PID instead of pattern match
- `findFreePort()` — bind to port 0 to get a free port
- `writeLockfile()` / `readLockfile()` / `removeLockfile()` — lockfile helpers

## Container/Native Isolation
- Container `.pi/tmp/` is separate from native (different filesystem)
- Each environment gets its own lockfile → own port → own server
- Same-environment sessions share via lockfile

## Testing
- 183 node tests passed
- 172 pytest passed
- pre-commit clean
- Live verified: native server on random port, container server separate