### PR TITLE
feat(agents): add code-reviewer-docs — 4th documentation review agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Single extension that provides:
 | **Command arg completions** | Tab-complete arguments for slash commands — providers and models for `/external-ai`, branches for `/review-local`, PR numbers for `/pr-review`, and more |
 | **Discord bot** | Control pi sessions from your phone via Discord DMs — send prompts, answer ask_user dialogs, switch sessions |
 
-### Agents (24)
+### Agents (25)
 
 | Category | Agents |
 |----------|--------|
@@ -45,7 +45,7 @@ Single extension that provides:
 | Infrastructure | docker-expert, kubernetes-expert, jenkins-expert |
 | Dev workflow | git-expert, github-expert, test-runner, test-automator, debugger |
 | Documentation | technical-documentation-writer, api-documenter, docs-fetcher |
-| Code review | code-reviewer-quality, code-reviewer-guidelines, code-reviewer-security |
+| Code review | code-reviewer-quality, code-reviewer-guidelines, code-reviewer-security, code-reviewer-docs |
 | Security | security-auditor |
 | Workflow | scout, planner, worker, reviewer |
 
@@ -55,7 +55,7 @@ Single extension that provides:
 |--------|-------------|
 | `/implement <task>` | scout → planner → worker |
 | `/scout-and-plan <task>` | scout → planner |
-| `/implement-and-review <task>` | worker → 3 reviewers → worker |
+| `/implement-and-review <task>` | worker → 4 reviewers → worker |
 | `/pr-review [number\|url]` | Fetch PR diff, check past review comments, review with guidelines, post and track comments |
 | `/release [flags]` | Create GitHub release with changelog and version bumping |
 | `/review-local [branch]` | Review local uncommitted or branch changes |
@@ -206,11 +206,12 @@ Run scout and planner in a chain to analyze the auth module
 
 ## Code Review Loop
 
-After any code change, the orchestrator runs 3 review agents **in parallel**:
+After any code change, the orchestrator runs 4 review agents **in parallel**:
 
 1. **code-reviewer-quality** — Code quality & maintainability
 2. **code-reviewer-guidelines** — Project guidelines adherence  
 3. **code-reviewer-security** — Bugs, logic errors, security
+4. **code-reviewer-docs** — Documentation quality, completeness, accuracy
 
 Loops until all approve, then runs tests.
 

--- a/agents/code-reviewer-docs.md
+++ b/agents/code-reviewer-docs.md
@@ -1,0 +1,136 @@
+---
+name: code-reviewer-docs
+description: Code review focused on documentation quality, completeness, and accuracy. Reviews for missing docs, stale content, AGENTS.md best practices, and cross-file consistency.
+tools: read, bash
+---
+
+You are a code review specialist focused on **documentation quality, completeness, and accuracy**.
+
+## Base Rules
+
+- Execute first, explain after
+- Do NOT modify files — only review and report findings
+- If a task falls outside your domain, report it and hand off
+
+## Project Guidelines (MANDATORY — read before reviewing)
+
+Before reviewing any code, find and read the project's guidelines files.
+Check these locations in order — use the first `AGENTS.md` found, fall back to `CLAUDE.md` only if no `AGENTS.md` exists anywhere:
+
+**AGENTS.md locations (check in order):**
+
+1. `AGENTS.md` (repository root)
+2. `.agents/AGENTS.md`
+
+**CLAUDE.md fallback (only if no AGENTS.md found):**
+
+1. `CLAUDE.md` (repository root)
+2. `.claude/CLAUDE.md`
+
+If multiple AGENTS.md files exist (e.g., both root and `.agents/`), read and merge ALL of them.
+Use the guidelines to inform your review — flag violations of project-specific
+conventions, patterns, or rules as findings.
+
+Do NOT rely on the calling prompt to provide these files — always read them yourself.
+
+## Learned Review Preferences
+
+After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.
+If it does, read it — these are learned review preferences for this project
+(patterns the reviewer has previously evaluated and dismissed).
+Do NOT raise findings that contradict these guidelines.
+
+## Review History (MANDATORY — check before reviewing)
+
+If reviewing a PR, run:
+
+```bash
+myk-pi-tools pr get-review-history <owner> <repo> <pr_number>
+```
+
+Get owner/repo: `gh repo view --json owner,name --jq '.owner.login + " " + .name'`
+Get PR number: `gh pr view --json number --jq .number`
+If the command returns results, review the output:
+
+- Do NOT re-raise any finding with `resolution_status` of `resolved_accepted`, `resolved_fixed`, or `status` of `skipped`
+- These have been evaluated and decided in prior review cycles
+- Only flag a previously resolved finding if the code at that location has materially changed since the resolution
+- Findings with `resolution_status: null` and `status: posted` are prior findings without a verdict — check if the code was changed before re-raising
+
+## Review Focus
+
+### 1. Missing Documentation
+
+If code was added, changed, or removed — check that relevant docs are updated.
+Use this documentation updates table:
+
+| Change | Check these files |
+|--------|-------------------|
+| New feature/command/tool | `README.md` (feature table, usage examples) |
+| New or modified extension module | `dev-docs/repo-structure.md` (repository structure) |
+| New agent added/removed | `dev-docs/repo-structure.md`, routing rules, bug reporting agent list |
+| New prompt template | `README.md` (prompt templates table) |
+| Docker/container changes | `README.md` (Docker section), `Dockerfile` |
+| New CLI tool or dependency | `README.md` (tools table), `Dockerfile` |
+| Dev workflow changes | `DEVELOPMENT.md` |
+
+Flag missing doc updates as `[CRITICAL]`.
+
+### 2. Incomplete Documentation
+
+- Docs exist but are missing sections, parameters, examples, or edge cases
+- New public APIs/functions without usage examples
+- Changed behavior not reflected in existing docs
+- Missing return values, error cases, or configuration options
+
+### 3. Documentation Quality
+
+- Accuracy — do docs match actual code behavior?
+- Clarity — are instructions unambiguous and actionable?
+- Formatting — consistent markdown, proper headers, working links
+- Stale content — references to removed features, old commands, dead links
+- Contradictory information within the same file
+
+### 4. AGENTS.md / CLAUDE.md Audit
+
+When AGENTS.md or CLAUDE.md files are changed, audit against these best practices:
+
+- [ ] Commands section exists and comes FIRST (before any prose)?
+- [ ] All commands are exact invocations with flags (not just tool names)?
+- [ ] Definition of Done section with specific exit codes?
+- [ ] Escalation rules — what to do when blocked?
+- [ ] Total file under 150 lines? Each section under 50 lines?
+- [ ] Organized by task ("When X") not by topic?
+- [ ] Every "don't" paired with a "do"?
+- [ ] No prose paragraphs without commands?
+- [ ] No ambiguous directives ("be careful", "where possible")?
+- [ ] Detailed content in referenced files, not inline?
+
+Flag audit failures as `[WARNING]` with the specific checklist item that failed.
+
+### 5. Cross-File Consistency
+
+- Do README.md, AGENTS.md, and dev-docs agree on commands, structure, and workflows?
+- Are version numbers, feature lists, and agent counts consistent?
+- Do referenced files actually exist?
+
+### 6. Code-Level Documentation
+
+- Missing or outdated JSDoc/docstrings on public functions/classes
+- Complex logic without inline comments explaining why (not what)
+- Missing type descriptions on exported interfaces/types
+- Outdated parameter descriptions after signature changes
+
+## Output Format
+
+For each finding:
+
+```text
+[SEVERITY] file:line — Description
+  Impact: What breaks or confuses without this fix
+  Suggestion: How to fix
+```
+
+Severity levels: `[CRITICAL]`, `[WARNING]`, `[SUGGESTION]`
+
+If no issues found, explicitly state: "Documentation is complete and accurate. Approved."

--- a/agents/code-reviewer-docs.md
+++ b/agents/code-reviewer-docs.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer-docs
-description: Code review focused on documentation quality, completeness, and accuracy. Reviews for missing docs, stale content, AGENTS.md best practices, and cross-file consistency.
+description: Code review focused on documentation quality, completeness, accuracy, missing docs, stale content, AGENTS.md best practices, and cross-file consistency.
 tools: read, bash
 ---
 

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -15,8 +15,6 @@ You are a code review specialist focused on **project guidelines and style adher
 ## Review Focus
 
 - AGENTS.md / CLAUDE.md compliance
-- **Documentation updates (MANDATORY)** — if code was added/changed/removed, check that AGENTS.md and README.md are updated.
-  Flag missing docs as `[CRITICAL]`. See the Documentation Updates table in AGENTS.md.
 - Project-specific coding standards
 - Naming conventions matching existing codebase
 - File/folder structure consistency
@@ -46,9 +44,8 @@ conventions, patterns, or rules as findings.
 
 Additionally:
 3. Review the changed files against those rules
-4. **Check if AGENTS.md or README.md need updating** based on the changes — missing doc updates are `[CRITICAL]`
-5. Check consistency with existing codebase patterns
-6. Report deviations
+4. Check consistency with existing codebase patterns
+5. Report deviations
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -66,7 +66,6 @@ If the command returns results, review the output:
 - Naming conventions and consistency
 - Error handling patterns
 - Observability and debugging (see below)
-- Documentation quality
 - Dead code and unused imports
 
 ## Test Coverage (MANDATORY)

--- a/dev-docs/repo-structure.md
+++ b/dev-docs/repo-structure.md
@@ -5,6 +5,7 @@ pi-config/
 ├── agents/                          # Specialist agent definitions
 │   ├── api-documenter.md
 │   ├── bash-expert.md
+│   ├── code-reviewer-docs.md
 │   ├── code-reviewer-guidelines.md
 │   ├── code-reviewer-quality.md
 │   ├── code-reviewer-security.md

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -62,6 +62,7 @@ const ASYNC_ONLY_AGENTS = new Set([
   "code-reviewer-quality",
   "code-reviewer-guidelines",
   "code-reviewer-security",
+  "code-reviewer-docs",
 ]);
 // ── Schemas ──────────────────────────────────────────────────────────────
 

--- a/prompts/implement-and-review.md
+++ b/prompts/implement-and-review.md
@@ -1,5 +1,5 @@
 ---
-description: "Implement → 3 parallel reviewers → fix — /implement-and-review <task>"
+description: "Implement → 4 parallel reviewers → fix — /implement-and-review <task>"
 argument-hint: "<task>"
 ---
 
@@ -14,10 +14,11 @@ Use the subagent tool with a chain of agents:
 1. **worker** — Implement the task from the raw arguments above.
    Make all necessary code changes following project conventions.
 
-2. Run 3 review subagents **in parallel**:
+2. Run 4 review subagents **in parallel**:
    - **code-reviewer-quality** — Review {previous} for code quality
    - **code-reviewer-guidelines** — Review {previous} for guideline adherence
    - **code-reviewer-security** — Review {previous} for bugs and security
+   - **code-reviewer-docs** — Review {previous} for documentation quality
 
 3. **worker** — Based on the review feedback from {previous}, fix all issues found.
    Then report what was fixed.

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -66,11 +66,12 @@ using `TaskUpdate` with `addBlockedBy`. The task system enforces execution order
 | 5 | Review — Code Quality | 2 |
 | 6 | Review — Guidelines | 2 |
 | 7 | Review — Security | 2 |
-| 8 | Merge & deduplicate findings | 4, 5, 6, 7 |
-| 9 | User selection | 8 |
-| 10 | Post comments | 9 |
-| 11 | Store comments | 10 |
-| 12 | Summary | 11 |
+| 8 | Review — Docs | 2 |
+| 9 | Merge & deduplicate findings | 4, 5, 6, 7, 8 |
+| 10 | User selection | 9 |
+| 11 | Post comments | 10 |
+| 12 | Store comments | 11 |
+| 13 | Summary | 12 |
 
 ### Dependency Graph
 
@@ -81,21 +82,22 @@ Task 1 (PR Detection)
  │    Task 2 unblocks:                │
  │    ├── Task 5 (Review: Quality)    │
  │    ├── Task 6 (Review: Guidelines) │
- │    └── Task 7 (Review: Security)   │
+ │    ├── Task 7 (Review: Security)   │
+ │    └── Task 8 (Review: Docs)       │
  └── Task 4 (Past comments) ──────────┤  (also needs Task 2)
                                        ▼
-                            Task 8 (Merge findings)
+                            Task 9 (Merge findings)
                                        │
-                            Task 9 (User selection)
+                            Task 10 (User selection)
                                        │
-                            Task 10 (Post comments)
+                            Task 11 (Post comments)
                                        │
-                            Task 11 (Store comments)
+                            Task 12 (Store comments)
                                        │
-                            Task 12 (Summary)
+                            Task 13 (Summary)
 ```
 
-Create all 12 tasks using `TaskCreate` NOW, before starting any work.
+Create all 13 tasks using `TaskCreate` NOW, before starting any work.
 Then IMMEDIATELY set dependencies using `TaskUpdate` with `addBlockedBy` for each task per the table above.
 
 `TaskCreate` does NOT accept `addBlockedBy` — dependencies MUST be set via `TaskUpdate` after creation.
@@ -107,7 +109,8 @@ Example two-step flow:
 TaskCreate(subject="PR Detection", ...)          → Task 1
 TaskCreate(subject="Fetch PR diff", ...)          → Task 2
 TaskCreate(subject="Fetch AGENTS.md", ...)        → Task 3
-...all 12 tasks...
+TaskCreate(subject="Review — Docs", ...)         → Task 8
+...all 13 tasks...
 
 # Step 2: Set dependencies
 TaskUpdate(taskId="2", addBlockedBy=["1"])
@@ -116,17 +119,18 @@ TaskUpdate(taskId="4", addBlockedBy=["1", "2"])
 TaskUpdate(taskId="5", addBlockedBy=["2"])
 TaskUpdate(taskId="6", addBlockedBy=["2"])
 TaskUpdate(taskId="7", addBlockedBy=["2"])
-TaskUpdate(taskId="8", addBlockedBy=["4", "5", "6", "7"])
-TaskUpdate(taskId="9", addBlockedBy=["8"])
+TaskUpdate(taskId="8", addBlockedBy=["2"])
+TaskUpdate(taskId="9", addBlockedBy=["4", "5", "6", "7", "8"])
 TaskUpdate(taskId="10", addBlockedBy=["9"])
 TaskUpdate(taskId="11", addBlockedBy=["10"])
 TaskUpdate(taskId="12", addBlockedBy=["11"])
+TaskUpdate(taskId="13", addBlockedBy=["12"])
 ```
 
 > 🚨 **HARD RULE: NEVER start a task while its `blockedBy` tasks are incomplete.**
 > The task system enforces this via `addBlockedBy` — but even if you could bypass it, **DON'T**.
 > Posting comments from partial reviewer results is a **CRITICAL violation**.
-> ALL 3 reviewers (Tasks 5, 6, 7) MUST complete before merging findings (Task 8).
+> ALL 4 reviewers (Tasks 5, 6, 7, 8) MUST complete before merging findings (Task 9).
 
 ## Workflow
 
@@ -292,9 +296,9 @@ not presented as a separate summary.**
 
 Mark Task 4 as `completed`.
 
-### Phase 2: Code Analysis — Tasks 5, 6, 7
+### Phase 2: Code Analysis — Tasks 5, 6, 7, 8
 
-Mark Tasks 5, 6, 7 as `in_progress`, then spawn ALL 3 review agents as async subagents
+Mark Tasks 5, 6, 7, 8 as `in_progress`, then spawn ALL 4 review agents as async subagents
 with `taskId` linking each to its task:
 
 Use the actual task IDs returned by `TaskCreate` — do NOT hardcode IDs.
@@ -350,6 +354,7 @@ subagent(tasks=[
   {agent: "code-reviewer-quality", task: "Review this PR for code quality. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read any files needed for context.\n\n<review-history>\nMANDATORY — before reviewing any code, run:\nmyk-pi-tools pr get-review-history {owner} {repo} {pr_number}\nReview the output. Do NOT re-raise any finding marked as resolved_accepted, resolved_fixed, or skipped. These have been evaluated and decided in prior review cycles. Only flag a previously resolved finding if the code at that location has materially changed since the resolution.\n</review-history>\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Quality", taskId: "<task 5 ID>"},
   {agent: "code-reviewer-guidelines", task: "Review this PR for guideline adherence. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Read AGENTS.md and check compliance.\n\n<review-history>\nMANDATORY — before reviewing any code, run:\nmyk-pi-tools pr get-review-history {owner} {repo} {pr_number}\nReview the output. Do NOT re-raise any finding marked as resolved_accepted, resolved_fixed, or skipped. These have been evaluated and decided in prior review cycles. Only flag a previously resolved finding if the code at that location has materially changed since the resolution.\n</review-history>\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Guidelines", taskId: "<task 6 ID>"},
   {agent: "code-reviewer-security", task: "Review this PR for bugs and security. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Trace data flow through changed code.\n\n<review-history>\nMANDATORY — before reviewing any code, run:\nmyk-pi-tools pr get-review-history {owner} {repo} {pr_number}\nReview the output. Do NOT re-raise any finding marked as resolved_accepted, resolved_fixed, or skipped. These have been evaluated and decided in prior review cycles. Only flag a previously resolved finding if the code at that location has materially changed since the resolution.\n</review-history>\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Security", taskId: "<task 7 ID>"},
+  {agent: "code-reviewer-docs", task: "Review this PR for documentation quality. Run: git diff origin/<BASE_BRANCH>...HEAD to see changes. Check all docs for completeness and accuracy.\n\n<review-history>\nMANDATORY — before reviewing any code, run:\nmyk-pi-tools pr get-review-history {owner} {repo} {pr_number}\nReview the output. Do NOT re-raise any finding marked as resolved_accepted, resolved_fixed, or skipped. These have been evaluated and decided in prior review cycles. Only flag a previously resolved finding if the code at that location has materially changed since the resolution.\n</review-history>\n\n<existing-unresolved-comments>\nThe following unresolved review comments already exist on this PR from other reviewers. Do NOT raise findings that duplicate these — skip them. If you find the same issue but with additional context or a different angle, note that it references the existing comment.\n\n<EXISTING_COMMENTS>\n</existing-unresolved-comments>\n\n<pr-description-verification>\n<PR_DESCRIPTION_VERIFICATION>\n</pr-description-verification>\n\n<code-suggestions>\n<CODE_SUGGESTIONS>\n</code-suggestions>", cwd: "<REVIEW_DIR>", name: "Review Docs", taskId: "<task 8 ID>"},
 ])
 ```
 
@@ -367,19 +372,19 @@ Each reviewer runs in the cloned repo directory (`REVIEW_DIR`) and has full acce
 Each agent should analyze for security, bugs, error handling, and performance issues
 and return their findings as prose.
 
-**After spawning, verify the response confirms all 3 agents were spawned.**
+**After spawning, verify the response confirms all 4 agents were spawned.**
 If any spawn fails, STOP and report the error — do NOT continue waiting.
 
 **After spawning, your turn is DONE.** Do NOT poll, sleep, call TaskOutput,
 or check status. Results arrive automatically as follow-up messages.
 When each reviewer finishes, its task is auto-completed via `taskId`.
-Task 8 (Merge findings) auto-unblocks when all 3 reviewer tasks complete.
+Task 9 (Merge findings) auto-unblocks when all 4 reviewer tasks complete.
 
-### Phase 3: Merge & Deduplicate Findings — Task 8
+### Phase 3: Merge & Deduplicate Findings — Task 9
 
-Mark Task 8 as `in_progress`.
+Mark Task 9 as `in_progress`.
 
-Merge and deduplicate the findings from all 3 reviewers AND the past review comment analysis from Task 4 into a single combined findings list.
+Merge and deduplicate the findings from all 4 reviewers AND the past review comment analysis from Task 4 into a single combined findings list.
 
 Reviewers were already instructed in Phase 2 to skip findings that duplicate existing
 unresolved PR comments. However, verify that no duplicates slipped through by comparing
@@ -407,11 +412,11 @@ For each `[NEW]` finding, compare against the skipped list using path + body sim
 `"Auto-skipped (previously dismissed): <skip_reason>"`. The user still sees them in the
 Phase 4 table and can override by selecting them explicitly.
 
-Mark Task 8 as `completed`.
+Mark Task 9 as `completed`.
 
-### Phase 4: User Selection — Task 9
+### Phase 4: User Selection — Task 10
 
-Mark Task 9 as `in_progress`.
+Mark Task 10 as `in_progress`.
 
 Present ALL findings to user in one combined list, grouped by severity (CRITICAL, WARNING, SUGGESTION).
 This includes:
@@ -488,14 +493,14 @@ findings minus user-selected findings). If the skipped set is non-empty:
    - Do not flag <finding type> — <refined reason>
    ```
 
-   This file is read by all 3 reviewer agents before reviewing, so the same class of
+   This file is read by all 4 reviewer agents before reviewing, so the same class of
    finding won't be raised again on future PRs in this repo.
 
-Mark Task 9 as `completed`.
+Mark Task 10 as `completed`.
 
-### Phase 5: Post Comments — Task 10
+### Phase 5: Post Comments — Task 11
 
-Mark Task 10 as `in_progress`.
+Mark Task 11 as `in_progress`.
 
 Write JSON to temp file for ALL findings to be posted — this includes both user-selected
 `[NEW]` findings AND auto-posted `[PREV-*]` findings. If only `[PREV-*]` findings exist
@@ -507,11 +512,11 @@ Use the `owner`, `repo`, `pr_number`, and `head_sha` from Phase 0 or Phase 1a me
 myk-pi-tools pr post-comment {owner}/{repo} {pr_number} {head_sha} ${PROJECT_TMP_DIR}/pr-review-comments.json
 ```
 
-Mark Task 10 as `completed`.
+Mark Task 11 as `completed`.
 
-### Phase 5b: Store Posted Comments — Task 11
+### Phase 5b: Store Posted Comments — Task 12
 
-Mark Task 11 as `in_progress`.
+Mark Task 12 as `in_progress`.
 
 After posting comments, store ALL findings (posted AND skipped) in the PR review database
 for future cycle tracking and same-PR dedup of skipped findings.
@@ -561,15 +566,15 @@ myk-pi-tools pr store-pr-review ${PROJECT_TMP_DIR}/pr-review-store.json
 runs to track which comments were posted, verify they were addressed, and auto-skip
 previously dismissed findings.
 
-Mark Task 11 as `completed`.
+Mark Task 12 as `completed`.
 
-### Phase 6: Summary — Task 12
+### Phase 6: Summary — Task 13
 
-Mark Task 12 as `in_progress`.
+Mark Task 13 as `in_progress`.
 
 Display final summary with counts and links.
 
-Mark Task 12 as `completed`.
+Mark Task 13 as `completed`.
 
 ### Cleanup
 

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -38,8 +38,9 @@ using `TaskUpdate` with `addBlockedBy`. The task system enforces execution order
 | 2 | Review — Code Quality | 1 |
 | 3 | Review — Guidelines | 1 |
 | 4 | Review — Security | 1 |
-| 5 | Merge & deduplicate findings | 2, 3, 4 |
-| 6 | Present review | 5 |
+| 5 | Review — Docs | 1 |
+| 6 | Merge & deduplicate findings | 2, 3, 4, 5 |
+| 7 | Present review | 6 |
 
 ### Dependency Graph
 
@@ -47,14 +48,15 @@ using `TaskUpdate` with `addBlockedBy`. The task system enforces execution order
 Task 1 (Get diff)
  ├── Task 2 (Review: Code Quality)  ──┐
  ├── Task 3 (Review: Guidelines)    ──┤
- └── Task 4 (Review: Security)      ──┤
+ ├── Task 4 (Review: Security)      ──┤
+ └── Task 5 (Review: Docs)          ──┤
                                        ▼
-                            Task 5 (Merge findings)
+                            Task 6 (Merge findings)
                                        │
-                            Task 6 (Present review)
+                            Task 7 (Present review)
 ```
 
-Create all 6 tasks using `TaskCreate` NOW, before starting any work.
+Create all 7 tasks using `TaskCreate` NOW, before starting any work.
 Then IMMEDIATELY set dependencies using `TaskUpdate` with `addBlockedBy` for each task per the table above.
 
 `TaskCreate` does NOT accept `addBlockedBy` — dependencies MUST be set via `TaskUpdate` after creation.
@@ -67,21 +69,23 @@ TaskCreate(subject="Get diff", ...)                    → Task 1
 TaskCreate(subject="Review — Code Quality", ...)       → Task 2
 TaskCreate(subject="Review — Guidelines", ...)         → Task 3
 TaskCreate(subject="Review — Security", ...)           → Task 4
-TaskCreate(subject="Merge & deduplicate findings", ...)→ Task 5
-TaskCreate(subject="Present review", ...)              → Task 6
+TaskCreate(subject="Review — Docs", ...)               → Task 5
+TaskCreate(subject="Merge & deduplicate findings", ...)→ Task 6
+TaskCreate(subject="Present review", ...)              → Task 7
 
 # Step 2: Set dependencies
 TaskUpdate(taskId="2", addBlockedBy=["1"])
 TaskUpdate(taskId="3", addBlockedBy=["1"])
 TaskUpdate(taskId="4", addBlockedBy=["1"])
-TaskUpdate(taskId="5", addBlockedBy=["2", "3", "4"])
-TaskUpdate(taskId="6", addBlockedBy=["5"])
+TaskUpdate(taskId="5", addBlockedBy=["1"])
+TaskUpdate(taskId="6", addBlockedBy=["2", "3", "4", "5"])
+TaskUpdate(taskId="7", addBlockedBy=["6"])
 ```
 
 > 🚨 **HARD RULE: NEVER start a task while its `blockedBy` tasks are incomplete.**
 > The task system enforces this via `addBlockedBy` — but even if you could bypass it, **DON'T**.
 > Merging findings from partial reviewer results is a **CRITICAL violation**.
-> ALL 3 reviewers (Tasks 2, 3, 4) MUST complete before merging findings (Task 5).
+> ALL 4 reviewers (Tasks 2, 3, 4, 5) MUST complete before merging findings (Task 6).
 
 ## Workflow
 
@@ -107,9 +111,9 @@ git diff HEAD
 
 Mark Task 1 as `completed`.
 
-### Phase 2: Code Analysis — Tasks 2, 3, 4
+### Phase 2: Code Analysis — Tasks 2, 3, 4, 5
 
-Mark Tasks 2, 3, 4 as `in_progress`, then spawn ALL 3 review agents as async subagents
+Mark Tasks 2, 3, 4, 5 as `in_progress`, then spawn ALL 4 review agents as async subagents
 with `taskId` linking each to its task.
 Use the actual task IDs returned by `TaskCreate` — do NOT hardcode IDs.
 
@@ -118,6 +122,7 @@ subagent(tasks=[
   {agent: "code-reviewer-quality", task: "Review diff for code quality...", cwd: "...", name: "Review Quality", taskId: "<actual task 2 ID>"},
   {agent: "code-reviewer-guidelines", task: "Review diff for guidelines...", cwd: "...", name: "Review Guidelines", taskId: "<actual task 3 ID>"},
   {agent: "code-reviewer-security", task: "Review diff for security...", cwd: "...", name: "Review Security", taskId: "<actual task 4 ID>"},
+  {agent: "code-reviewer-docs", task: "Review diff for documentation quality...", cwd: "...", name: "Review Docs", taskId: "<actual task 5 ID>"},
 ])
 ```
 
@@ -132,25 +137,25 @@ Provide each agent with the diff content from Phase 1 and ask them to analyze fo
 7. Code duplication
 8. Suggestions for improvement
 
-**After spawning, verify the response confirms all 3 agents were spawned.**
+**After spawning, verify the response confirms all 4 agents were spawned.**
 If any spawn fails, STOP and report the error — do NOT continue waiting.
 
 **After spawning, your turn is DONE.** Do NOT poll, sleep, call TaskOutput,
 or check status. Results arrive automatically as follow-up messages.
 When each reviewer finishes, its task is auto-completed via `taskId`.
-Task 5 (Merge findings) auto-unblocks when all 3 reviewer tasks complete.
+Task 6 (Merge findings) auto-unblocks when all 4 reviewer tasks complete.
 
-### Phase 3: Merge & Deduplicate Findings — Task 5
-
-Mark Task 5 as `in_progress`.
-
-Merge and deduplicate the findings from all 3 reviewers into a single combined findings list.
-
-Mark Task 5 as `completed`.
-
-### Phase 4: Present Review — Task 6
+### Phase 3: Merge & Deduplicate Findings — Task 6
 
 Mark Task 6 as `in_progress`.
+
+Merge and deduplicate the findings from all 4 reviewers into a single combined findings list.
+
+Mark Task 6 as `completed`.
+
+### Phase 4: Present Review — Task 7
+
+Mark Task 7 as `in_progress`.
 
 Display findings grouped by severity:
 
@@ -158,4 +163,4 @@ Display findings grouped by severity:
 - **Warnings** (should fix)
 - **Suggestions** (nice to have)
 
-Mark Task 6 as `completed`.
+Mark Task 7 as `completed`.

--- a/rules/10-agent-routing.md
+++ b/rules/10-agent-routing.md
@@ -45,6 +45,13 @@ The orchestrator MUST NEVER fetch external docs directly — always delegate to 
 - Standard library only (no external dependencies)
 - Already fetched docs in current conversation
 
+## Agents Not in Routing Table
+
+Some agents are dispatched internally by rules or prompt templates, not by the routing table:
+
+- `code-reviewer-quality`, `code-reviewer-guidelines`, `code-reviewer-security`, `code-reviewer-docs` — dispatched via `rules/20-code-review-loop.md`
+- `reviewer` — dispatched via prompt templates
+
 ## Fallback
 
 **Fallback:** No specialist? → `worker` agent

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -4,7 +4,7 @@ After ANY code change, follow this loop:
 
 ```text
 1. Specialist writes/fixes code
-2. Send to ALL 3 review agents IN PARALLEL (async)
+2. Send to ALL 4 review agents IN PARALLEL (async)
 3. Merge & deduplicate findings
 4. Has comments? ──YES──→ Fix code → go to 2
                     NO ↓
@@ -17,15 +17,16 @@ After ANY code change, follow this loop:
 
 ## Review Agents
 
-Three agents review code in parallel for comprehensive coverage:
+Four agents review code in parallel for comprehensive coverage:
 
 | Agent | Focus |
 |---|---|
 | `code-reviewer-quality` | General code quality and maintainability |
 | `code-reviewer-guidelines` | Project guidelines and style adherence (AGENTS.md) |
 | `code-reviewer-security` | Bugs, logic errors, and security vulnerabilities |
+| `code-reviewer-docs` | Documentation quality, completeness, and accuracy |
 
-**All 3 MUST be invoked as async subagents (`async: true`) in the same assistant turn.
+**All 4 MUST be invoked as async subagents (`async: true`) in the same assistant turn.
 Do NOT block waiting for reviews — continue working while they run.**
 
 Overlapping scope is intentional for comprehensive coverage; step 3's deduplication handles duplicates.
@@ -82,4 +83,4 @@ For automated review flows (autorabbit, autoqodo), use **two-stage order** inste
    Loop Stage 2 until passed.
 
 Don't polish code that doesn't meet spec — it wastes work.
-Parallel mode (all 3 reviewers at once) remains default for manual reviews.
+Parallel mode (all 4 reviewers at once) remains default for manual reviews.

--- a/rules/50-agent-bug-reporting.md
+++ b/rules/50-agent-bug-reporting.md
@@ -13,8 +13,9 @@ This rule applies ONLY to agents defined in this repository (`agents/` directory
 
 - api-documenter
 - bash-expert
-- code-reviewer-quality
+- code-reviewer-docs
 - code-reviewer-guidelines
+- code-reviewer-quality
 - code-reviewer-security
 - debugger
 - docs-fetcher


### PR DESCRIPTION
Closes #611

## Summary

Adds `code-reviewer-docs` as the 4th code reviewer agent, owning ALL documentation review responsibilities.

## Changes

### New agent: `agents/code-reviewer-docs.md`
Full documentation reviewer covering:
1. **Missing docs** — code changed but docs not updated (Documentation Updates table)
2. **Incomplete docs** — missing sections, parameters, examples, edge cases
3. **Docs quality** — accuracy, clarity, formatting, stale/contradictory info
4. **AGENTS.md / CLAUDE.md audit** — full checklist from `update-agents-md` skill (150-line limit, commands first, task-organized, etc.)
5. **Cross-file consistency** — README vs AGENTS.md vs dev-docs agreement
6. **Code-level docs** — missing/outdated JSDoc, docstrings, inline comments

### Removed docs responsibility from existing reviewers
- `code-reviewer-guidelines` — removed "Documentation updates (MANDATORY)" check and step 4
- `code-reviewer-quality` — removed "Documentation quality" from review focus

### Updated all references 3→4 reviewers
- `rules/20-code-review-loop.md` — flow diagram, table, async note
- `rules/50-agent-bug-reporting.md` — added to agent list (alphabetical)
- `README.md` — agent count 24→25, review section, prompt templates table
- `dev-docs/repo-structure.md` — added to agents listing
- `prompts/review-local.md` — 6→7 tasks, 4th reviewer in spawn block
- `prompts/pr-review.md` — 12→13 tasks, 4th reviewer in spawn block
- `prompts/implement-and-review.md` — 3→4 parallel reviewers

## Tests

- ✅ pre-commit: 20/20 hooks passed
- ✅ pytest: 172/172 tests passed
- ✅ node tests: 193/193 tests passed