### PR TITLE
feat(coms): expose peer queue_depth in list tools, response envelopes, and widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For LAN/remote access, set `PI_COMS_NET_AUTH_TOKEN` and `PI_COMS_NET_HOST=0.0.0.
 
 | Tool | Description |
 |------|-------------|
-| `*_list` | List peer agents with names, models, context usage |
+| `*_list` | List peer agents with names, models, context usage, queue depth |
 | `*_send` | Send a prompt to a peer agent |
 | `*_get` | Non-blocking poll for a response |
 | `*_await` | Block until response arrives |

--- a/dev-docs/repo-structure.md
+++ b/dev-docs/repo-structure.md
@@ -64,7 +64,7 @@ pi-config/
 │   │   ├── index.ts                 # Entry point — registers coms and coms-net
 │   │   ├── coms-wrapper.ts          # P2P agent communication wrapper (on-demand /coms command)
 │   │   ├── coms-net-wrapper.ts      # Networked agent communication wrapper (on-demand /coms-net command, auto-manages hub server)
-│   │   ├── coms-shared.ts           # Shared proxy factory, flag parser, state persistence
+│   │   ├── coms-shared.ts           # Shared utilities: proxy factory, flag parser, state persistence, response formatting, list rendering
 │   │   ├── coms-p2p.ts              # P2P implementation (forked from disler/pi-vs-claude-code)
 │   │   ├── coms-net.ts              # Networked implementation (forked from disler/pi-vs-claude-code)
 │   │   ├── coms-net-server.ts       # Hub server (forked from disler/pi-vs-claude-code)
@@ -144,7 +144,9 @@ pi-config/
 ├── pi-config-settings.example.json    # Example project settings file
 ├── tests/                           # Test suite
 │   ├── node/                        # Node.js tests (tsx + node:test)
-│   │   └── orchestrator/            # Orchestrator extension tests
+│   │   ├── orchestrator/            # Orchestrator extension tests
+│   │   ├── pidiff/                  # Pidiff extension tests
+│   │   └── shared/                  # Shared utility tests (coms-shared, daemon-manager)
 │   └── python/                      # Python tests (pytest)
 ├── package.json                     # Node.js dependencies (extensions)
 ├── tox.toml                         # Test runner config (Python + Node environments)

--- a/extensions/coms/coms-net-server.ts
+++ b/extensions/coms/coms-net-server.ts
@@ -231,7 +231,7 @@ export type ResponseSubmitRequest = {
 	responder_session: string;
 	response: any;
 	error: string | null;
-	queue_depth?: number;
+	queued_msg_ids?: string[];
 };
 
 export type ErrorResponse = { ok: false; error: string; details?: any };
@@ -1177,7 +1177,7 @@ async function handleSubmitResponse(
 		response: msg.response,
 		error: msg.error,
 		status: msg.status,
-		queue_depth: typeof body.queue_depth === "number" ? body.queue_depth : 0,
+		queued_msg_ids: Array.isArray(body.queued_msg_ids) ? body.queued_msg_ids.filter((id: unknown) => typeof id === "string") : [],
 	});
 	// Also push a final message_status for completeness.
 	sendToStream(project, msg.sender_session, "message_status", {

--- a/extensions/coms/coms-net-server.ts
+++ b/extensions/coms/coms-net-server.ts
@@ -231,6 +231,7 @@ export type ResponseSubmitRequest = {
 	responder_session: string;
 	response: any;
 	error: string | null;
+	queue_depth?: number;
 };
 
 export type ErrorResponse = { ok: false; error: string; details?: any };
@@ -1176,6 +1177,7 @@ async function handleSubmitResponse(
 		response: msg.response,
 		error: msg.error,
 		status: msg.status,
+		queue_depth: typeof body.queue_depth === "number" ? body.queue_depth : 0,
 	});
 	// Also push a final message_status for completeness.
 	sendToStream(project, msg.sender_session, "message_status", {

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -129,7 +129,7 @@ interface ResponseSubmitRequest {
 	responder_session: string;
 	response: any;
 	error: string | null;
-	queue_depth?: number;
+	queued_msg_ids?: string[];
 }
 
 interface InboundContext {
@@ -145,10 +145,10 @@ interface InboundContext {
 }
 
 interface PendingReply {
-	resolve: (value: { response?: any; error?: string | null }) => void;
+	resolve: (value: { response?: any; error?: string | null; queued_msg_ids?: string[] }) => void;
 	reject: (err: Error) => void;
-	promise: Promise<{ response?: any; error?: string | null }>;
-	result?: { response?: any; error?: string | null };
+	promise: Promise<{ response?: any; error?: string | null; queued_msg_ids?: string[] }>;
+	result?: { response?: any; error?: string | null; queued_msg_ids?: string[] };
 	target_name?: string;
 	target_session?: string;
 	created_at: string;
@@ -645,7 +645,8 @@ export default function (pi: ExtensionAPI) {
 		const errVal: string | null = typeof data.error === "string" ? data.error : null;
 		const pending = pendingReplies.get(msg_id);
 		if (pending) {
-			pending.result = { response: responseVal, error: errVal };
+			const queuedMsgIds: string[] = Array.isArray(data.queued_msg_ids) ? data.queued_msg_ids.filter((id: unknown) => typeof id === "string") : [];
+			pending.result = { response: responseVal, error: errVal, queued_msg_ids: queuedMsgIds };
 			try {
 				pending.resolve(pending.result);
 			} catch (e: any) {
@@ -654,7 +655,7 @@ export default function (pi: ExtensionAPI) {
 
 			// Auto-deliver response as followUp so the LLM sees it without polling
 			const targetName = pending.target_name ?? "peer";
-			const responseText = formatComsResponseText(targetName, responseVal, errVal, typeof data.queue_depth === "number" ? data.queue_depth : 0);
+			const responseText = formatComsResponseText(targetName, responseVal, errVal, queuedMsgIds);
 			try {
 				pi.sendMessage(
 					{
@@ -665,6 +666,7 @@ export default function (pi: ExtensionAPI) {
 							msg_id,
 							target_name: targetName,
 							error: errVal,
+							queued_msg_ids: queuedMsgIds,
 						},
 					},
 					{ deliverAs: "followUp", triggerTurn: true },
@@ -1297,7 +1299,7 @@ export default function (pi: ExtensionAPI) {
 					: `coms_net_get: complete\n${typeof r.response === "string" ? r.response : JSON.stringify(r.response, null, 2)}`;
 				return {
 					content: [{ type: "text" as const, text }],
-					details: { status: "complete", response: r.response, error: r.error ?? null },
+					details: { status: "complete", response: r.response, error: r.error ?? null, queued_msg_ids: r.queued_msg_ids ?? [] },
 				};
 			}
 			// Fall back to server.
@@ -1393,14 +1395,14 @@ export default function (pi: ExtensionAPI) {
 
 		// Use inline count instead of getPendingInboundCount() — `inbound` (local param)
 		// differs from `currentInbound` (module-scoped, already null at this point).
-		let remainingQueue = 0;
-		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== inbound) remainingQueue++;
+		const queuedIds: string[] = [];
+		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== inbound) queuedIds.push(i.msg_id);
 		const req: ResponseSubmitRequest = {
 			project: identity.project,
 			responder_session: identity.session_id,
 			response: payload,
 			error,
-			queue_depth: remainingQueue,
+			queued_msg_ids: queuedIds,
 		};
 
 		try {
@@ -1456,9 +1458,11 @@ export default function (pi: ExtensionAPI) {
 							responder_session: identity!.session_id,
 							response: null,
 							error: "injection_failed",
-							queue_depth: remaining.length - idx - 1,
+							queued_msg_ids: remaining.slice(idx + 1).map(r => r.msg_id),
 						});
-					} catch { /* best-effort */ }
+					} catch (e: any) {
+						audit("orphan_cleanup_failed", { msg_id: orphan.msg_id, reason: e?.message ?? String(e) });
+					}
 					orphan.fulfilled = true;
 					inboundQueue.delete(orphan.msg_id);
 				}

--- a/extensions/coms/coms-net.ts
+++ b/extensions/coms/coms-net.ts
@@ -33,7 +33,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { applyExtensionDefaults } from "./themeMap.js";
-import { ulid, hexFg, isValidHex, fallbackColor, comsParseYamlFrontmatter as parseFrontmatter, nowIso, abbreviateModel, findSystemPromptPath, readFrontmatterFromArgv, readTaskSummary, buildInboundContent, renderTasksPart, FALLBACK_PALETTE, type TasksSummary } from "./coms-shared.js";
+import { ulid, hexFg, isValidHex, fallbackColor, comsParseYamlFrontmatter as parseFrontmatter, nowIso, abbreviateModel, findSystemPromptPath, readFrontmatterFromArgv, readTaskSummary, buildInboundContent, renderTasksPart, renderQueuePart, formatQueueStr, formatComsResponseText, FALLBACK_PALETTE, type TasksSummary } from "./coms-shared.js";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -129,6 +129,7 @@ interface ResponseSubmitRequest {
 	responder_session: string;
 	response: any;
 	error: string | null;
+	queue_depth?: number;
 }
 
 interface InboundContext {
@@ -591,7 +592,7 @@ export default function (pi: ExtensionAPI) {
 					msg_id,
 					sender: senderSession,
 					hops,
-					queue_depth: inboundQueue.size,
+					queue_depth: getPendingInboundCount(),
 				});
 			} catch { /* best-effort */ }
 			return;
@@ -645,15 +646,15 @@ export default function (pi: ExtensionAPI) {
 		const pending = pendingReplies.get(msg_id);
 		if (pending) {
 			pending.result = { response: responseVal, error: errVal };
-			try { pending.resolve(pending.result); } catch { /* ignore */ }
+			try {
+				pending.resolve(pending.result);
+			} catch (e: any) {
+				audit("resolve_failed", { msg_id, reason: e?.message ?? String(e) });
+			}
 
 			// Auto-deliver response as followUp so the LLM sees it without polling
 			const targetName = pending.target_name ?? "peer";
-			const responseText = errVal
-				? `[coms response from ${targetName}] Error: ${errVal}`
-				: typeof responseVal === "string"
-					? `[coms response from ${targetName}] ${responseVal}`
-					: `[coms response from ${targetName}] ${JSON.stringify(responseVal, null, 2)}`;
+			const responseText = formatComsResponseText(targetName, responseVal, errVal, typeof data.queue_depth === "number" ? data.queue_depth : 0);
 			try {
 				pi.sendMessage(
 					{
@@ -944,7 +945,7 @@ export default function (pi: ExtensionAPI) {
 			const hbReq: HeartbeatRequest = {
 				project: identity.project,
 				context_used_pct: pct,
-				queue_depth: inboundQueue.size,
+				queue_depth: getPendingInboundCount(),
 				tasks_summary: readTaskSummary(identity?.cwd ?? process.cwd(), currentCtx?.sessionManager?.getSessionId?.()),
 				model: ctxNow?.model?.id ?? identity.model,
 				status: "online",
@@ -969,6 +970,7 @@ export default function (pi: ExtensionAPI) {
 			pending: boolean;
 			stale: boolean;
 			tasks?: { total: number; completed: number; in_progress: number } | null;
+			queue_depth: number;
 		}
 
 		const rows: Row[] = [];
@@ -984,6 +986,7 @@ export default function (pi: ExtensionAPI) {
 				pending: card.status === "stale",
 				stale: card.status === "offline",
 				tasks: card.tasks_summary,
+				queue_depth: card.queue_depth ?? 0,
 			});
 		}
 
@@ -1057,7 +1060,8 @@ export default function (pi: ExtensionAPI) {
 			const purposePart = theme.fg("muted", r.purpose || "");
 
 			const tasksPart = renderTasksPart(r.tasks, theme);
-			const line = " " + swatch + " " + namePart + " " + modelPart + " " + bar + pctPart + tasksPart + sep + purposePart;
+			const queuePart = renderQueuePart(r.queue_depth, theme);
+			const line = " " + swatch + " " + namePart + " " + modelPart + " " + bar + pctPart + tasksPart + queuePart + sep + purposePart;
 			out.push(truncateToWidth(line, width));
 		}
 
@@ -1107,7 +1111,8 @@ export default function (pi: ExtensionAPI) {
 				: peers.map((a) => {
 					const live = a.status === "online" ? "●" : a.status === "stale" ? "~" : "✗";
 					const ctxStr = typeof a.context_used_pct === "number" ? ` ${a.context_used_pct}%` : " ?%";
-					return `${live} ${a.name} (${abbreviateModel(a.model)})${ctxStr}${a.purpose ? ` — ${a.purpose}` : ""}`;
+					const queueStr = formatQueueStr(a.queue_depth);
+					return `${live} ${a.name} (${abbreviateModel(a.model)})${ctxStr}${queueStr}${a.purpose ? ` — ${a.purpose}` : ""}`;
 				}).join("\n");
 
 			return {
@@ -1386,11 +1391,16 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 
+		// Use inline count instead of getPendingInboundCount() — `inbound` (local param)
+		// differs from `currentInbound` (module-scoped, already null at this point).
+		let remainingQueue = 0;
+		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== inbound) remainingQueue++;
 		const req: ResponseSubmitRequest = {
 			project: identity.project,
 			responder_session: identity.session_id,
 			response: payload,
 			error,
+			queue_depth: remainingQueue,
 		};
 
 		try {
@@ -1438,13 +1448,15 @@ export default function (pi: ExtensionAPI) {
 				// Failed to inject — drain ALL remaining queued messages with error responses
 				audit("fifo_drain_failed", { msg_id: next.msg_id, reason: safeError(err) });
 				const remaining = [next, ...[...inboundQueue.values()].filter(i => !i.fulfilled && i.msg_id !== next.msg_id)];
-				for (const orphan of remaining) {
+				for (let idx = 0; idx < remaining.length; idx++) {
+					const orphan = remaining[idx];
 					try {
 						await httpFetch("POST", `/v1/messages/${encodeURIComponent(orphan.msg_id)}/response`, {
 							project: identity!.project,
 							responder_session: identity!.session_id,
 							response: null,
 							error: "injection_failed",
+							queue_depth: remaining.length - idx - 1,
 						});
 					} catch { /* best-effort */ }
 					orphan.fulfilled = true;

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -64,7 +64,7 @@ interface ResponseEnvelope extends Envelope {
 	type: "response";
 	response: any;
 	error?: string | null;
-	queue_depth?: number;
+	queued_msg_ids?: string[];
 }
 
 interface PingEnvelope extends Envelope {
@@ -111,8 +111,8 @@ interface PendingReply {
 	resolve: (value: any) => void;
 	reject: (err: Error) => void;
 	timer: NodeJS.Timeout | null;
-	promise: Promise<{ response?: any; error?: string | null }>;
-	result?: { response?: any; error?: string | null };
+	promise: Promise<{ response?: any; error?: string | null; queued_msg_ids?: string[] }>;
+	result?: { response?: any; error?: string | null; queued_msg_ids?: string[] };
 	target_name?: string;
 	created_at: string;
 }
@@ -712,7 +712,8 @@ export default function (pi: ExtensionAPI) {
 				try { clearTimeout(pending.timer); } catch { /* ignore */ }
 				pending.timer = null;
 			}
-			pending.result = { response: env.response, error: env.error ?? null };
+			const queuedMsgIds: string[] = Array.isArray(env.queued_msg_ids) ? env.queued_msg_ids.filter((id: unknown) => typeof id === "string") : [];
+			pending.result = { response: env.response, error: env.error ?? null, queued_msg_ids: queuedMsgIds };
 			try {
 				pending.resolve(pending.result);
 			} catch (e: any) {
@@ -721,7 +722,7 @@ export default function (pi: ExtensionAPI) {
 
 			// Auto-deliver response as followUp so the LLM sees it without polling
 			const targetName = pending.target_name ?? "peer";
-			const responseText = formatComsResponseText(targetName, env.response, env.error ?? null, typeof env.queue_depth === "number" ? env.queue_depth : 0);
+			const responseText = formatComsResponseText(targetName, env.response, env.error ?? null, queuedMsgIds);
 			try {
 				pi.sendMessage(
 					{
@@ -732,6 +733,7 @@ export default function (pi: ExtensionAPI) {
 							msg_id: env.msg_id,
 							target_name: targetName,
 							error: env.error ?? null,
+							queued_msg_ids: queuedMsgIds,
 						},
 					},
 					{ deliverAs: "followUp", triggerTurn: true },
@@ -1660,7 +1662,7 @@ export default function (pi: ExtensionAPI) {
 					: `coms_get: complete\n${typeof r.response === "string" ? r.response : JSON.stringify(r.response, null, 2)}`;
 				return {
 					content: [{ type: "text" as const, text }],
-					details: { status: "complete", response: r.response, error: r.error ?? null },
+					details: { status: "complete", response: r.response, error: r.error ?? null, queued_msg_ids: r.queued_msg_ids ?? [] },
 				};
 			}
 			return {
@@ -1730,8 +1732,8 @@ export default function (pi: ExtensionAPI) {
 
 		// Use inline count instead of getPendingInboundCount() — `inbound` (local param)
 		// differs from `currentInbound` (module-scoped, already null at this point).
-		let remainingQueue = 0;
-		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== inbound) remainingQueue++;
+		const queuedIds: string[] = [];
+		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== inbound) queuedIds.push(i.msg_id);
 		const respEnv: ResponseEnvelope = {
 			type: "response",
 			msg_id: inbound.msg_id,
@@ -1741,7 +1743,7 @@ export default function (pi: ExtensionAPI) {
 			timestamp: nowIso(),
 			response: payload,
 			error,
-			queue_depth: remainingQueue,
+			queued_msg_ids: queuedIds,
 		};
 
 		try {
@@ -1802,9 +1804,11 @@ export default function (pi: ExtensionAPI) {
 							timestamp: nowIso(),
 							response: null,
 							error: "injection_failed",
-							queue_depth: remaining.length - idx - 1,
+							queued_msg_ids: remaining.slice(idx + 1).map(r => r.msg_id),
 						});
-					} catch { /* best-effort */ }
+					} catch (e: any) {
+						try { pi.appendEntry("coms-log", { event: "orphan_cleanup_failed", msg_id: orphan.msg_id, reason: e?.message ?? String(e) }); } catch { /* best-effort */ }
+					}
 					orphan.fulfilled = true;
 					inboundQueue.delete(orphan.msg_id);
 				}

--- a/extensions/coms/coms-p2p.ts
+++ b/extensions/coms/coms-p2p.ts
@@ -19,7 +19,7 @@ import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-c
 import { Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { applyExtensionDefaults } from "./themeMap.js";
-import { ulid, hexFg, isValidHex, fallbackColor, comsParseYamlFrontmatter as parseFrontmatter, nowIso, abbreviateModel, findSystemPromptPath, readFrontmatterFromArgv, readTaskSummary, buildInboundContent, renderTasksPart, FALLBACK_PALETTE, type TasksSummary } from "./coms-shared.js";
+import { ulid, hexFg, isValidHex, fallbackColor, comsParseYamlFrontmatter as parseFrontmatter, nowIso, abbreviateModel, findSystemPromptPath, readFrontmatterFromArgv, readTaskSummary, buildInboundContent, renderTasksPart, renderQueuePart, formatQueueStr, formatComsResponseText, FALLBACK_PALETTE, type TasksSummary } from "./coms-shared.js";
 import * as net from "node:net";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -64,6 +64,7 @@ interface ResponseEnvelope extends Envelope {
 	type: "response";
 	response: any;
 	error?: string | null;
+	queue_depth?: number;
 }
 
 interface PingEnvelope extends Envelope {
@@ -589,11 +590,16 @@ export default function (pi: ExtensionAPI) {
 	let currentInbound: InboundContext | null = null;
 	let processingInbound = false;
 
+	function getPendingInboundCount(): number {
+		let count = 0;
+		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== currentInbound) count++;
+		return count;
+	}
+
 	let lastPoolSnapshot = "";
 	function maybeRefreshWidget(): void {
 		if (!currentCtx?.hasUI) return;
-		let pc = 0;
-		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== currentInbound) pc++;
+		const pc = getPendingInboundCount();
 		const key = `pending=${pc}|` + [...peerCards.entries()].map(([k, v]) => `${k}:${v.staleCount}`).sort().join(",");
 		if (key === lastPoolSnapshot) return;
 		lastPoolSnapshot = key;
@@ -652,7 +658,7 @@ export default function (pi: ExtensionAPI) {
 					msg_id: env.msg_id,
 					sender: env.sender_session,
 					hops: env.hops,
-					queue_depth: inboundQueue.size,
+					queue_depth: getPendingInboundCount(),
 				});
 			} catch { /* best-effort */ }
 			return;
@@ -709,17 +715,13 @@ export default function (pi: ExtensionAPI) {
 			pending.result = { response: env.response, error: env.error ?? null };
 			try {
 				pending.resolve(pending.result);
-			} catch {
-				// ignore
+			} catch (e: any) {
+				try { pi.appendEntry("coms-log", { event: "resolve_failed", msg_id: env.msg_id, reason: e?.message ?? String(e) }); } catch { /* best-effort */ }
 			}
 
 			// Auto-deliver response as followUp so the LLM sees it without polling
 			const targetName = pending.target_name ?? "peer";
-			const responseText = env.error
-				? `[coms response from ${targetName}] Error: ${env.error}`
-				: typeof env.response === "string"
-					? `[coms response from ${targetName}] ${env.response}`
-					: `[coms response from ${targetName}] ${JSON.stringify(env.response, null, 2)}`;
+			const responseText = formatComsResponseText(targetName, env.response, env.error ?? null, typeof env.queue_depth === "number" ? env.queue_depth : 0);
 			try {
 				pi.sendMessage(
 					{
@@ -758,7 +760,7 @@ export default function (pi: ExtensionAPI) {
 			model: ctx?.model?.id ?? ident?.model ?? "unknown",
 			color: ident?.color ?? "#36F9F6",
 			context_used_pct: pct,
-			queue_depth: inboundQueue.size,
+			queue_depth: getPendingInboundCount(),
 			tasks_summary: readTaskSummary(currentCtx?.cwd ?? process.cwd(), currentCtx?.sessionManager?.getSessionId?.()),
 		};
 	}
@@ -1084,7 +1086,7 @@ export default function (pi: ExtensionAPI) {
 					explicit: identity.explicit,
 					version: 1,
 					context_used_pct: Math.round(ctx?.getContextUsage()?.percent ?? 0),
-					queue_depth: inboundQueue.size,
+					queue_depth: getPendingInboundCount(),
 					heartbeat_at: nowIso(),
 				};
 				// Unconditional atomic write: handles BOTH the live-status refresh
@@ -1147,6 +1149,7 @@ export default function (pi: ExtensionAPI) {
 			pending: boolean;
 			stale: boolean;
 			tasks?: { total: number; completed: number; in_progress: number } | null;
+			queue_depth: number;
 		}
 		const rows: Row[] = [];
 		const seenSessions = new Set<string>();
@@ -1163,6 +1166,7 @@ export default function (pi: ExtensionAPI) {
 				pending: false,
 				stale: (card.staleCount ?? 0) >= 3,
 				tasks: card.tasks_summary,
+				queue_depth: card.queue_depth ?? 0,
 			});
 		}
 
@@ -1181,6 +1185,7 @@ export default function (pi: ExtensionAPI) {
 				pct: null,
 				pending: true,
 				stale: false,
+				queue_depth: 0,
 			});
 		}
 
@@ -1197,8 +1202,7 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			const left = theme.fg("dim", "┏━") + theme.fg("border", " coms ");
 			const leftFill = theme.fg("dim", "━");
-			let pendingCount = 0;
-			for (const i of inboundQueue.values()) if (!i.fulfilled && i !== currentInbound) pendingCount++;
+			const pendingCount = getPendingInboundCount();
 			const pendingSuffix = ` (${pendingCount} pending)`;
 			const nameLen = identity ? identity.name.length + pendingSuffix.length : 0;
 			const rightTagVisLen = identity ? nameLen + 3 : 0;
@@ -1258,7 +1262,8 @@ export default function (pi: ExtensionAPI) {
 			const purposePart = theme.fg("muted", r.purpose || "");
 
 			const tasksPart = renderTasksPart(r.tasks, theme);
-			const line = " " + swatch + " " + namePart + " " + modelPart + " " + bar + pctPart + tasksPart + sep + purposePart;
+			const queuePart = renderQueuePart(r.queue_depth, theme);
+			const line = " " + swatch + " " + namePart + " " + modelPart + " " + bar + pctPart + tasksPart + queuePart + sep + purposePart;
 			out.push(truncateToWidth(line, width));
 		}
 
@@ -1468,6 +1473,7 @@ export default function (pi: ExtensionAPI) {
 					project: c.project,
 					alive: pong != null,
 					context_used_pct: pong ? pong.context_used_pct : null,
+					queue_depth: pong ? pong.queue_depth : 0,
 					color: c.entry.color,
 				};
 			});
@@ -1477,7 +1483,8 @@ export default function (pi: ExtensionAPI) {
 				: agents.map((a) => {
 					const ctxStr = a.context_used_pct != null ? ` ${a.context_used_pct}%` : " ?%";
 					const live = a.alive ? "●" : "✗";
-					return `${live} ${a.name} (${a.model})${ctxStr}${a.purpose ? ` — ${a.purpose}` : ""}`;
+					const queueStr = formatQueueStr(a.queue_depth);
+					return `${live} ${a.name} (${a.model})${ctxStr}${queueStr}${a.purpose ? ` — ${a.purpose}` : ""}`;
 				}).join("\n");
 
 			return {
@@ -1721,6 +1728,10 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 
+		// Use inline count instead of getPendingInboundCount() — `inbound` (local param)
+		// differs from `currentInbound` (module-scoped, already null at this point).
+		let remainingQueue = 0;
+		for (const i of inboundQueue.values()) if (!i.fulfilled && i !== inbound) remainingQueue++;
 		const respEnv: ResponseEnvelope = {
 			type: "response",
 			msg_id: inbound.msg_id,
@@ -1730,6 +1741,7 @@ export default function (pi: ExtensionAPI) {
 			timestamp: nowIso(),
 			response: payload,
 			error,
+			queue_depth: remainingQueue,
 		};
 
 		try {
@@ -1778,7 +1790,8 @@ export default function (pi: ExtensionAPI) {
 				// Failed to inject — drain ALL remaining queued messages with error responses
 				try { pi.appendEntry("coms-log", { event: "fifo_drain_failed", msg_id: next.msg_id, reason: err?.message ?? String(err) }); } catch { /* best-effort */ }
 				const remaining = [next, ...[...inboundQueue.values()].filter(i => !i.fulfilled && i.msg_id !== next.msg_id)];
-				for (const orphan of remaining) {
+				for (let idx = 0; idx < remaining.length; idx++) {
+					const orphan = remaining[idx];
 					try {
 						await sendEnvelope(orphan.sender_endpoint, {
 							type: "response",
@@ -1789,6 +1802,7 @@ export default function (pi: ExtensionAPI) {
 							timestamp: nowIso(),
 							response: null,
 							error: "injection_failed",
+							queue_depth: remaining.length - idx - 1,
 						});
 					} catch { /* best-effort */ }
 					orphan.fulfilled = true;

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -476,9 +476,10 @@ export interface TasksSummary {
 	in_progress: number;
 }
 
-/** Format the auto-delivered coms response text, including queue depth note when > 0. */
-export function formatComsResponseText(targetName: string, response: any, error: string | null, queueDepth: number): string {
-	const queueNote = queueDepth > 0 ? ` (${queueDepth} more queued)` : "";
+/** Format the auto-delivered coms response text, including queued message IDs when > 0. */
+export function formatComsResponseText(targetName: string, response: any, error: string | null, queuedMsgIds: string[]): string {
+	const ids = queuedMsgIds.length <= 5 ? queuedMsgIds.join(", ") : `${queuedMsgIds.slice(0, 5).join(", ")} and ${queuedMsgIds.length - 5} more`;
+	const queueNote = queuedMsgIds.length > 0 ? ` (${queuedMsgIds.length} more queued: ${ids})` : "";
 	if (error) return `[coms response from ${targetName}${queueNote}] Error: ${error}`;
 	return typeof response === "string"
 		? `[coms response from ${targetName}${queueNote}] ${response}`

--- a/extensions/coms/coms-shared.ts
+++ b/extensions/coms/coms-shared.ts
@@ -476,6 +476,25 @@ export interface TasksSummary {
 	in_progress: number;
 }
 
+/** Format the auto-delivered coms response text, including queue depth note when > 0. */
+export function formatComsResponseText(targetName: string, response: any, error: string | null, queueDepth: number): string {
+	const queueNote = queueDepth > 0 ? ` (${queueDepth} more queued)` : "";
+	if (error) return `[coms response from ${targetName}${queueNote}] Error: ${error}`;
+	return typeof response === "string"
+		? `[coms response from ${targetName}${queueNote}] ${response}`
+		: `[coms response from ${targetName}${queueNote}] ${JSON.stringify(response, null, 2)}`;
+}
+
+/** Return " 📨N" suffix string for queue depth, or "" when zero/absent. */
+export function formatQueueStr(queueDepth: number | undefined | null): string {
+	return typeof queueDepth === "number" && queueDepth > 0 ? ` 📨${queueDepth}` : "";
+}
+
+/** Return theme-colored queue indicator for the coms widget list row. */
+export function renderQueuePart(queueDepth: number, theme: any): string {
+	return queueDepth > 0 ? theme.fg("dim", " ") + theme.fg("warning", `📨${queueDepth}`) : "";
+}
+
 export function renderTasksPart(tasks: TasksSummary | null | undefined, theme: any): string {
 	if (!tasks || tasks.total === 0) return "";
 	// Clamp to prevent negative/misleading values from corrupt data

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -537,7 +537,7 @@ export function registerAsyncAgents(
       cwd,
       stdio: "ignore",
       windowsHide: true,
-      env: { ...process.env, PI_SUBAGENT_CHILD: "1" },
+      env: { ...process.env, PI_SUBAGENT_CHILD: "1", PI_AGENT_NAME: agentName },
     });
 
     // Track the job

--- a/tests/node/shared/coms-shared.test.ts
+++ b/tests/node/shared/coms-shared.test.ts
@@ -8,33 +8,45 @@ import { formatComsResponseText, formatQueueStr, renderQueuePart } from "../../.
 
 describe("formatComsResponseText", () => {
 	it("formats error response without queue", () => {
-		const result = formatComsResponseText("worker", null, "something failed", 0);
+		const result = formatComsResponseText("worker", null, "something failed", []);
 		assert.equal(result, "[coms response from worker] Error: something failed");
 	});
 
-	it("formats error response with queue depth", () => {
-		const result = formatComsResponseText("worker", null, "something failed", 2);
-		assert.equal(result, "[coms response from worker (2 more queued)] Error: something failed");
+	it("formats error response with queued IDs", () => {
+		const result = formatComsResponseText("worker", null, "something failed", ["msg-aaa", "msg-bbb"]);
+		assert.equal(result, "[coms response from worker (2 more queued: msg-aaa, msg-bbb)] Error: something failed");
 	});
 
 	it("formats string response without queue", () => {
-		const result = formatComsResponseText("peer-a", "task done", null, 0);
+		const result = formatComsResponseText("peer-a", "task done", null, []);
 		assert.equal(result, "[coms response from peer-a] task done");
 	});
 
-	it("formats string response with queue depth", () => {
-		const result = formatComsResponseText("peer-a", "task done", null, 3);
-		assert.equal(result, "[coms response from peer-a (3 more queued)] task done");
+	it("formats string response with queued IDs", () => {
+		const result = formatComsResponseText("peer-a", "task done", null, ["id-1", "id-2", "id-3"]);
+		assert.equal(result, "[coms response from peer-a (3 more queued: id-1, id-2, id-3)] task done");
 	});
 
 	it("formats object response as JSON", () => {
-		const result = formatComsResponseText("peer-b", { status: "ok" }, null, 0);
+		const result = formatComsResponseText("peer-b", { status: "ok" }, null, []);
 		assert.equal(result, '[coms response from peer-b] {\n  "status": "ok"\n}');
 	});
 
-	it("formats object response with queue depth", () => {
-		const result = formatComsResponseText("peer-b", { status: "ok" }, null, 1);
-		assert.equal(result, '[coms response from peer-b (1 more queued)] {\n  "status": "ok"\n}');
+	it("formats object response with single queued ID", () => {
+		const result = formatComsResponseText("peer-b", { status: "ok" }, null, ["msg-123"]);
+		assert.equal(result, '[coms response from peer-b (1 more queued: msg-123)] {\n  "status": "ok"\n}');
+	});
+
+	it("truncates IDs when more than 5 are queued", () => {
+		const ids = ["a", "b", "c", "d", "e", "f", "g"];
+		const result = formatComsResponseText("peer-x", "done", null, ids);
+		assert.equal(result, "[coms response from peer-x (7 more queued: a, b, c, d, e and 2 more)] done");
+	});
+
+	it("shows all IDs when exactly 5 are queued", () => {
+		const ids = ["a", "b", "c", "d", "e"];
+		const result = formatComsResponseText("peer-x", "done", null, ids);
+		assert.equal(result, "[coms response from peer-x (5 more queued: a, b, c, d, e)] done");
 	});
 });
 

--- a/tests/node/shared/coms-shared.test.ts
+++ b/tests/node/shared/coms-shared.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for coms-shared formatting helpers (queue depth, response text).
+ * Run with: npx tsx --test tests/node/shared/coms-shared.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatComsResponseText, formatQueueStr, renderQueuePart } from "../../../extensions/coms/coms-shared.js";
+
+describe("formatComsResponseText", () => {
+	it("formats error response without queue", () => {
+		const result = formatComsResponseText("worker", null, "something failed", 0);
+		assert.equal(result, "[coms response from worker] Error: something failed");
+	});
+
+	it("formats error response with queue depth", () => {
+		const result = formatComsResponseText("worker", null, "something failed", 2);
+		assert.equal(result, "[coms response from worker (2 more queued)] Error: something failed");
+	});
+
+	it("formats string response without queue", () => {
+		const result = formatComsResponseText("peer-a", "task done", null, 0);
+		assert.equal(result, "[coms response from peer-a] task done");
+	});
+
+	it("formats string response with queue depth", () => {
+		const result = formatComsResponseText("peer-a", "task done", null, 3);
+		assert.equal(result, "[coms response from peer-a (3 more queued)] task done");
+	});
+
+	it("formats object response as JSON", () => {
+		const result = formatComsResponseText("peer-b", { status: "ok" }, null, 0);
+		assert.equal(result, '[coms response from peer-b] {\n  "status": "ok"\n}');
+	});
+
+	it("formats object response with queue depth", () => {
+		const result = formatComsResponseText("peer-b", { status: "ok" }, null, 1);
+		assert.equal(result, '[coms response from peer-b (1 more queued)] {\n  "status": "ok"\n}');
+	});
+});
+
+describe("formatQueueStr", () => {
+	it("returns empty string for 0", () => {
+		assert.equal(formatQueueStr(0), "");
+	});
+
+	it("returns empty string for undefined", () => {
+		assert.equal(formatQueueStr(undefined), "");
+	});
+
+	it("returns empty string for null", () => {
+		assert.equal(formatQueueStr(null), "");
+	});
+
+	it("returns 📨N for positive depth", () => {
+		assert.equal(formatQueueStr(3), " 📨3");
+	});
+
+	it("returns 📨1 for depth 1", () => {
+		assert.equal(formatQueueStr(1), " 📨1");
+	});
+});
+
+describe("renderQueuePart", () => {
+	const mockTheme = { fg: (_color: string, text: string) => text };
+
+	it("returns empty string for 0", () => {
+		assert.equal(renderQueuePart(0, mockTheme), "");
+	});
+
+	it("returns formatted part for positive depth", () => {
+		const result = renderQueuePart(2, mockTheme);
+		assert.equal(result, " 📨2");
+	});
+});

--- a/tests/node/shared/coms-shared.test.ts
+++ b/tests/node/shared/coms-shared.test.ts
@@ -50,7 +50,7 @@ describe("formatComsResponseText", () => {
 	});
 });
 
-describe("formatQueueStr", () => {
+describe("formatQueueStr (used by coms_list/coms_net_list text output)", () => {
 	it("returns empty string for 0", () => {
 		assert.equal(formatQueueStr(0), "");
 	});
@@ -69,6 +69,27 @@ describe("formatQueueStr", () => {
 
 	it("returns 📨1 for depth 1", () => {
 		assert.equal(formatQueueStr(1), " 📨1");
+	});
+
+	it("produces correct list output line with queue depth", () => {
+		// Simulates the text output format used by coms_list and coms_net_list
+		const name = "peer2";
+		const model = "opus";
+		const ctxStr = " 42%";
+		const queueStr = formatQueueStr(2);
+		const purpose = "worker";
+		const line = `● ${name} (${model})${ctxStr}${queueStr} — ${purpose}`;
+		assert.equal(line, "● peer2 (opus) 42% 📨2 — worker");
+	});
+
+	it("produces correct list output line without queue", () => {
+		const name = "peer2";
+		const model = "opus";
+		const ctxStr = " 42%";
+		const queueStr = formatQueueStr(0);
+		const purpose = "worker";
+		const line = `● ${name} (${model})${ctxStr}${queueStr} — ${purpose}`;
+		assert.equal(line, "● peer2 (opus) 42% — worker");
 	});
 });
 


### PR DESCRIPTION
Closes #614

## Summary

Peers now have full visibility into each other's message queue depth — solving the race condition where a manager re-sends work that's already queued in a peer.

## Changes

### Queue depth in list tools (`coms_list` / `coms_net_list`)
- Added `queue_depth` to the returned agents array
- Text output shows `📨N` when a peer has queued messages

### Queue depth in response envelopes
- `ResponseEnvelope` (P2P) and `ResponseSubmitRequest` (coms-net) now include optional `queue_depth`
- `agent_end` populates remaining queue count (excluding the just-completed message)
- FollowUp delivery text shows `(N more queued)` when > 0
- Server relays `queue_depth` in SSE response events

### Queue depth in pool widget
- Peers with queued messages show `📨N` indicator after their task counts

### DRY extraction to `coms-shared.ts`
- `formatComsResponseText()` — shared response text formatting (was duplicated)
- `formatQueueStr()` — plain-text queue depth suffix
- `renderQueuePart()` — themed widget queue indicator

### Bug fixes
- **Heartbeat queue_depth inflated** — was using raw `inboundQueue.size` (includes fulfilled entries), now uses filtered `getPendingInboundCount()`
- **FIFO drain orphan responses** — now include decrementing `queue_depth`
- **Silent catch on `pending.resolve`** — now logs `resolve_failed` with error details
- **Async agents missing `PI_AGENT_NAME`** — async-agents.ts didn't set `PI_AGENT_NAME` in env (sync subagent-tool.ts did), causing git-expert to get blocked by enforcement when spawned async

## Tests

- ✅ 13 new unit tests for shared functions (formatComsResponseText, formatQueueStr, renderQueuePart)
- ✅ pre-commit: 20/20 hooks passed
- ✅ pytest: 172/172 tests passed
- ✅ node tests: 206/206 tests passed