### PR TITLE
fix(enforcement): per-worktree review-state, gitignore bypass fix, worktree-aware review-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Single extension that provides:
 | **Task tracking** | Structured task lists for multi-step workflows — live widget, progress tracking, reminder nudges ([@tintinweb/pi-tasks](https://github.com/tintinweb/pi-tasks)) |
 | **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |
 | **Inter-agent communication** | P2P (`/coms`) and networked (`/coms-net`) agent communication — on-demand activation via slash commands |
-| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/query-db`, `/btw`, `/async-status`, `/status`, `/dream`, `/remember`, `/coms`, `/coms-net` — with autocomplete argument hints |
+| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/review-status`, `/query-db`, `/btw`, `/async-status`, `/status`, `/dream`, `/remember`, `/coms`, `/coms-net` — with autocomplete argument hints |
 | **GitHub autocomplete** | Type `#` in the editor to get issue/PR suggestions from the current repo — lazy-loaded, 5min cache |
 | **Command arg completions** | Tab-complete arguments for slash commands — providers and models for `/external-ai`, branches for `/review-local`, PR numbers for `/pr-review`, and more |
 | **Discord bot** | Control pi sessions from your phone via Discord DMs — send prompts, answer ask_user dialogs, switch sessions |
@@ -216,7 +216,7 @@ After any code change, the orchestrator runs 5 review agents **in parallel**:
 
 Loops until all approve, then runs tests.
 
-Use `/review-status` to inspect the current review loop state.
+Use `/review-status` to inspect the current review loop state. Pass a worktree path to check a specific worktree (e.g., `/review-status .worktrees/issue-42`).
 
 ## Customization
 

--- a/dev-docs/extension-commands.md
+++ b/dev-docs/extension-commands.md
@@ -12,7 +12,7 @@ the extension source files under `extensions/`. Each command uses
 | `/pidash` | `pidash/pidash.ts` | Manage pidash daemon (start/stop/restart/status) |
 | `/pidiff` | `pidiff/pidiff.ts` | Manage pidiff per-project server (start/stop/restart/status) |
 | `/status` | `status.ts` | Unified session status snapshot |
-| `/review-status` | `enforcement.ts` | Show current review loop enforcement state |
+| `/review-status [worktree-path]` | `enforcement.ts` | Show review loop state. Pass a worktree path to check a specific worktree |
 | `/async-status` | `async-agents.ts` | Background agent status |
 | `/dream` | `dreaming.ts` | Memory consolidation |
 | `/dream-auto` | `dreaming.ts` | Toggle automatic dreaming |

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -1,6 +1,8 @@
 /**
  * Enforcement handler — blocks forbidden commands (python/pip, git protection,
  * remote script execution, memory writes, dangerous) + memory-based enforcement rules.
+ * Worktree-aware: resolves file edits to the correct worktree root for per-worktree
+ * review state tracking and gitignore checks.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -8,9 +10,9 @@ import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import { loadEnforcedEntries, matchToolCall, matchBashCommand, executeAction } from "./enforcement-rules.js";
 import { readFileSync, writeFileSync } from "node:fs";
-import { join, resolve } from "node:path";
+import path, { join, resolve, dirname } from "node:path";
 import { getSetting } from "./project-settings.js";
-import { getProjectTmpDir } from "./utils.js";
+import { getProjectTmpDir, resolveWorktreeRoot } from "./utils.js";
 import {
   DANGEROUS,
   getCurrentBranch,
@@ -478,9 +480,11 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     }
 
     // Enforce review loop — block commit unless review state is clean
+    // Use resolveEffectiveCwd to detect the worktree from cd commands (e.g., cd .worktrees/issue-622 && git commit)
     if (process.env.PI_AGENT_NAME === "git-expert" && hasGitSub(command, "commit")) {
-      if (getSetting(ctx.cwd, "review_loop_enforcement") && !isReviewClean(ctx.cwd)) {
-        const state = readReviewState(ctx.cwd);
+      const commitCwd = resolveEffectiveCwd(command, ctx.cwd);
+      if (getSetting(ctx.cwd, "review_loop_enforcement") && !isReviewClean(commitCwd)) {
+        const state = readReviewState(commitCwd);
         return {
           block: true,
           reason: `\u26d4 Review loop incomplete (status: ${state.status}, cycle ${state.cycle}, ${state.findings_count} findings, ${state.reviewers_pending.length} reviewers pending). Fix findings and re-run all reviewers until 0 comments.`,
@@ -639,10 +643,25 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     const isError = (event as any).isError === true;
     if (isError) return;
 
-    // Skip gitignored files (build artifacts, .pi/tmp/, node_modules, etc.)
+    // Resolve the worktree root from the file's location.
+    // This handles files in any worktree (not just .worktrees/) by asking git
+    // which worktree the file belongs to via --show-toplevel.
+    const absPath = resolve(ctx.cwd, filePath);
+    const fileDir = dirname(absPath);
+    let effectiveCwd: string;
     try {
-      const result = spawnSync("git", ["check-ignore", "-q", filePath], {
-        cwd: ctx.cwd,
+      effectiveCwd = resolveWorktreeRoot(fileDir);
+    } catch {
+      effectiveCwd = ctx.cwd; // fallback to session cwd
+    }
+    const relativePath = path.relative(effectiveCwd, absPath);
+
+    // Skip gitignored files (build artifacts, .pi/tmp/, node_modules, etc.)
+    // Run from the worktree root so files in worktrees are checked correctly
+    // (from the main repo, .worktrees/ itself is gitignored — false positive).
+    try {
+      const result = spawnSync("git", ["check-ignore", "-q", relativePath], {
+        cwd: effectiveCwd,
         timeout: 3000,
         stdio: "ignore",
       });
@@ -653,8 +672,9 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
 
     // Retry markNeedsReview on lock failure — missing this would leave state
     // as 'clean' and allow commits to slip through enforcement.
+    // Uses effectiveCwd so each worktree gets its own review-state.json.
     for (let attempt = 0; attempt < 3; attempt++) {
-      try { markNeedsReview(ctx.cwd); break; } catch {
+      try { markNeedsReview(effectiveCwd); break; } catch {
         if (attempt === 2) {
           // Last resort: log but don't crash the extension
           console.error("[enforcement] markNeedsReview failed after 3 attempts — review state may be stale");
@@ -664,14 +684,21 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
   });
 
   // ── /review-status command — read-only access to review state ──────
+  // Usage: /review-status [worktree-path]
+  // Without args: shows main repo state. With path: shows that worktree's state.
+  // Autocomplete for /review-status is provided by extended-autocomplete.ts
+  // via the registerCommand wrapper (lists active worktrees).
   pi.registerCommand("review-status", {
-    description: "Show current review loop enforcement state",
-    handler: async (_args, ctx) => {
+    description: "Show current review loop enforcement state. Pass a worktree path to check its state.",
+    handler: async (args, ctx) => {
       if (!ctx.hasUI) return;
-      const state = readReviewState(ctx.cwd);
+      const worktreePath = args?.trim() || "";
+      const targetCwd = worktreePath ? resolve(ctx.cwd, worktreePath) : ctx.cwd;
+      const state = readReviewState(targetCwd);
       const enabled = getSetting(ctx.cwd, "review_loop_enforcement");
+      const worktreeLabel = worktreePath ? ` (worktree: ${worktreePath})` : "";
       const lines = [
-        `Review Loop Enforcement: ${enabled ? "enabled" : "disabled"}`,
+        `Review Loop Enforcement: ${enabled ? "enabled" : "disabled"}${worktreeLabel}`,
         `Status: ${state.status}`,
         `Cycle: ${state.cycle}`,
         `Findings: ${state.findings_count}`,
@@ -688,13 +715,17 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
   pi.registerTool({
     name: "review_status",
     label: "Review Status",
-    description: "Get current review loop enforcement state. Use to check if review is needed, in progress, clean, or has findings before committing.",
-    parameters: Type.Object({}),
-    async execute(_callId, _params, _signal, _onUpdate, ctx) {
-      const state = readReviewState(ctx.cwd);
+    description: "Get current review loop enforcement state. Use to check if review is needed, in progress, clean, or has findings before committing. Pass worktree_path to check a specific worktree's state.",
+    parameters: Type.Object({
+      worktree_path: Type.Optional(Type.String({ description: "Path to a worktree directory to check its review state instead of the main repo" })),
+    }),
+    async execute(_callId, params, _signal, _onUpdate, ctx) {
+      const targetCwd = params.worktree_path ? resolve(ctx.cwd, params.worktree_path) : ctx.cwd;
+      const state = readReviewState(targetCwd);
       const enabled = getSetting(ctx.cwd, "review_loop_enforcement");
+      const prefix = params.worktree_path ? `worktree: ${params.worktree_path}\n` : "";
       const summary = [
-        `enforcement: ${enabled ? "enabled" : "disabled"}`,
+        `${prefix}enforcement: ${enabled ? "enabled" : "disabled"}`,
         `status: ${state.status}`,
         `cycle: ${state.cycle}`,
         `findings: ${state.findings_count}`,
@@ -705,7 +736,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       ].join("\n");
       return {
         content: [{ type: "text" as const, text: summary }],
-        details: { state, enabled },
+        details: { state, enabled, worktree_path: params.worktree_path || null },
       };
     },
   });

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -14,6 +14,7 @@
  *   /review-local <Tab>          → git branch names
  *   /release <Tab>               → recent git tags + --dry-run, --prerelease, --draft, --target <branch>, --tag-match <pattern>
  *   /review-handler <Tab>        → --autorabbit, --autoqodo
+ *   /review-status <Tab>         → active worktree paths
  *   /create-skill <Tab>          → (free-text name)
  *   /cron <Tab>                  → add, list, list-all, remove
  *   /dream-auto <Tab>            → on, off
@@ -23,6 +24,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AutocompleteItem, AutocompleteProvider, AutocompleteSuggestions } from "@earendil-works/pi-tui";
 import { fuzzyFilter } from "@earendil-works/pi-tui";
 import * as fs from "node:fs";
+import { execFileSync } from "node:child_process";
+import * as path from "node:path";
 import { getCronFilePath } from "./cron.js";
 
 // ── Cache infrastructure ────────────────────────────────────────────
@@ -224,6 +227,31 @@ function registerCompletions(
       ];
       const available = all.filter(item => !selected.has(item.value));
       return filter(available, lastPart);
+    },
+
+    "review-status": (prefix: string) => {
+      // List active worktrees (excluding main repo) as completion options
+      try {
+        const mainRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+          cwd: ctx.lastCwd, encoding: "utf-8", timeout: 3000,
+          stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        const porcelain = execFileSync("git", ["worktree", "list", "--porcelain"], {
+          cwd: ctx.lastCwd, encoding: "utf-8", timeout: 3000,
+          stdio: ["ignore", "pipe", "ignore"],
+        });
+        const worktrees: AutocompleteItem[] = [];
+        for (const line of porcelain.split("\n")) {
+          if (!line.startsWith("worktree ")) continue;
+          const wtPath = line.slice("worktree ".length).trim();
+          if (wtPath === mainRoot) continue; // skip main repo
+          const relative = path.relative(ctx.lastCwd, wtPath);
+          worktrees.push({ value: relative, label: relative, description: `Worktree: ${wtPath}` });
+        }
+        return filter(worktrees, prefix);
+      } catch {
+        return null;
+      }
     },
 
     "dream-auto": (prefix: string) => {

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -232,10 +232,14 @@ function registerCompletions(
     "review-status": (prefix: string) => {
       // List active worktrees (excluding main repo) as completion options
       try {
-        const mainRoot = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+        // Use --git-common-dir to find the shared repo root (not worktree root).
+        // This ensures we correctly identify the main repo even if ctx.lastCwd
+        // happens to be inside a worktree.
+        const gitCommonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
           cwd: ctx.lastCwd, encoding: "utf-8", timeout: 3000,
           stdio: ["ignore", "pipe", "ignore"],
         }).trim();
+        const mainRoot = path.dirname(path.resolve(ctx.lastCwd, gitCommonDir));
         const porcelain = execFileSync("git", ["worktree", "list", "--porcelain"], {
           cwd: ctx.lastCwd, encoding: "utf-8", timeout: 3000,
           stdio: ["ignore", "pipe", "ignore"],

--- a/extensions/orchestrator/review-state.ts
+++ b/extensions/orchestrator/review-state.ts
@@ -1,12 +1,13 @@
 /**
  * Review state machine — tracks code review loop status.
- * State stored in .pi/data/review-state.json.
+ * State stored in <worktree-root>/.pi/data/review-state.json (per-worktree, not shared).
+ * Each worktree gets its own state file via resolveWorktreeRoot (--show-toplevel).
  * Used by enforcement to block git commit until all reviewers approve.
  */
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, renameSync } from "node:fs";
 import { join, dirname } from "node:path";
-import { resolveRepoRoot } from "./utils.js";
+import { resolveWorktreeRoot } from "./utils.js";
 
 const DATA_DIR = ".pi/data";
 
@@ -24,11 +25,11 @@ export interface ReviewState {
 const STATE_FILE = "review-state.json";
 
 export function statePath(cwd: string): string {
-  return join(resolveRepoRoot(cwd), DATA_DIR, STATE_FILE);
+  return join(resolveWorktreeRoot(cwd), DATA_DIR, STATE_FILE);
 }
 
 function ensureDataDir(cwd: string): void {
-  mkdirSync(join(resolveRepoRoot(cwd), DATA_DIR), { recursive: true });
+  mkdirSync(join(resolveWorktreeRoot(cwd), DATA_DIR), { recursive: true });
 }
 
 function defaultState(): ReviewState {

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -68,7 +68,9 @@ export function getPiInvocation(args: string[]): { command: string; args: string
   return { command: "pi", args };
 }
 
-/** Resolve to the main git repo root when cwd is a worktree. */
+/** Resolve to the main git repo root when cwd is a worktree.
+ *  Uses --git-common-dir → always returns the SHARED repo root.
+ *  Use for shared resources: project settings, reviews.db. */
 const repoRootCache = new Map<string, string>();
 
 export function resolveRepoRoot(cwd: string): string {
@@ -84,6 +86,32 @@ export function resolveRepoRoot(cwd: string): string {
     }
   } catch {}
   repoRootCache.set(key, cwd);
+  return cwd;
+}
+
+/** Resolve to the current worktree root (or repo root if not in a worktree).
+ *  Uses --show-toplevel → returns THIS worktree's root, not the shared repo root.
+ *  Use for per-worktree resources: review-state.json.
+ *  For non-worktree repos, returns the same as resolveRepoRoot.
+ *  @param cwd — Directory to resolve from (any path inside the worktree)
+ *  @returns The worktree's top-level directory, or `cwd` as fallback */
+const worktreeRootCache = new Map<string, string>();
+
+export function resolveWorktreeRoot(cwd: string): string {
+  const key = path.resolve(cwd);
+  const cached = worktreeRootCache.get(key);
+  if (cached !== undefined) return cached;
+  try {
+    const toplevel = execFileSync("git", ["rev-parse", "--show-toplevel"], { cwd, encoding: "utf-8", timeout: 3000, stdio: ["ignore", "pipe", "ignore"] }).trim();
+    if (toplevel && !toplevel.startsWith("fatal")) {
+      const root = path.resolve(toplevel);
+      worktreeRootCache.set(key, root);
+      return root;
+    }
+  } catch (e: any) {
+    console.debug("[utils] resolveWorktreeRoot failed:", e?.message);
+  }
+  worktreeRootCache.set(key, cwd);
   return cwd;
 }
 

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -90,8 +90,10 @@ is sufficient — fix what you agree with, skip what you don't. No need to expla
 
 ## Key Rules
 
-Never skip code review — loop until all reviewers approve AND tests pass.
-If there are comments, respond to each (fix or explain) and re-review from step 2; once approved, run tests.
+Never skip code review — all 5 reviewers always run.
+When `review_loop_enforcement` is enabled: loop until all reviewers return 0 findings AND tests pass.
+Respond to each finding (fix or explain) and re-review from step 2; once approved, run tests.
+When disabled: single review pass is sufficient; no mandatory re-review loop or explanations.
 Minor test/config-only fixes skip re-review (go to step 5); substantive code changes require full re-review.
 
 ## Baseline Test Comparison (Step 5)

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -19,7 +19,8 @@ If disabled:
 1. Specialist writes/fixes code
 2. Send to ALL 5 review agents IN PARALLEL (async)
 3. Merge & deduplicate findings
-4. Has comments? ──YES──→ Fix code → go to 2 (if review_loop_enforcement enabled)
+4. Has comments? ──YES──→ For EACH finding: fix code OR explain why not (step 4a)
+                    │     → go to 2 with prior findings + responses (if review_loop_enforcement enabled)
                     NO ↓
 5. Run test-automator
 6. Tests pass? ──NO──→ Minor fix? re-run tests (go to 5)
@@ -50,10 +51,47 @@ Overlapping scope is intentional for comprehensive coverage; step 3's deduplicat
 Same file/line + same issue or root cause = duplicate — keep the most actionable version.
 Conflicts follow priority: security > correctness > performance > style; complementary findings on the same code are kept.
 
+## Step 4a: Respond to Findings (when `review_loop_enforcement` is enabled)
+
+For each finding from step 3, do ONE of:
+
+1. **Fix it** — change the code to address the finding
+2. **Explain why not** — provide a specific technical reason (e.g., "pre-existing pattern,
+   changing it would break X", "intentional for performance", "out of scope for this PR")
+
+**Every finding MUST get a response. No silent ignoring.**
+
+When re-running reviewers (step 2, cycle N+1), pass the prior cycle's findings and
+responses in each reviewer's task prompt using this format:
+
+```text
+<prior-review-cycle>
+The following findings were raised in review cycle {N}. Each has been either fixed or
+explained. Do NOT re-raise findings that were adequately addressed. Only re-raise if:
+- The code fix is incorrect or incomplete
+- The explanation is invalid or factually wrong
+- You disagree with the reasoning (explain why)
+
+Findings with valid explanations that you accept → do not re-raise.
+Findings that were fixed in code → verify the fix, do not re-raise if correct.
+
+{numbered list of findings with their fix/explanation}
+</prior-review-cycle>
+```
+
+**Reviewers MUST respect valid responses:**
+
+- If a finding was fixed → verify the fix is correct, don't re-raise
+- If a finding was explained with a valid technical reason → accept it, don't re-raise
+- If the explanation is wrong or the fix is incomplete → re-raise with specific pushback
+
+**When `review_loop_enforcement` is disabled:** Step 4a is optional. Single review pass
+is sufficient — fix what you agree with, skip what you don't. No need to explain skips.
+
 ## Key Rules
 
 Never skip code review — loop until all reviewers approve AND tests pass.
-If there are comments, fix and re-review from step 2; once approved, run tests.
+If there are comments, respond to each (fix or explain) and re-review from step 2; once approved, run tests.
 Minor test/config-only fixes skip re-review (go to step 5); substantive code changes require full re-review.
 
 ## Baseline Test Comparison (Step 5)

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -389,8 +389,12 @@ describe("worktree state isolation", () => {
     execFileSync("git", ["init"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
     execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
 
-    worktreeA = join(mainRepo, ".worktrees", "wt-a");
-    worktreeB = join(mainRepo, ".worktrees", "wt-b");
+    // Worktrees in separate tmpdir paths — proves isolation works for worktrees ANYWHERE,
+    // not just under .worktrees/ in the repo.
+    worktreeA = join(tmpdir(), `wt-a-${Date.now()}`);
+    worktreeB = join(tmpdir(), `wt-b-${Date.now()}`);
+    rmSync(worktreeA, { recursive: true, force: true });
+    rmSync(worktreeB, { recursive: true, force: true });
     execFileSync("git", ["worktree", "add", worktreeA, "-b", "branch-a"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
     execFileSync("git", ["worktree", "add", worktreeB, "-b", "branch-b"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
   });

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -366,7 +366,16 @@ describe("recordReviewerResult idempotent", () => {
 
 // ── Worktree state isolation ──
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
+
+// Git identity env vars for hermetic tests (CI may not have global git config)
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@test.local",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@test.local",
+};
 
 describe("worktree state isolation", () => {
   let mainRepo: string;
@@ -377,19 +386,19 @@ describe("worktree state isolation", () => {
     // Create a real git repo with two worktrees to exercise the actual
     // git rev-parse --show-toplevel / --git-common-dir code paths.
     mainRepo = mkdtempSync(join(tmpdir(), "wt-main-"));
-    execSync("git init", { cwd: mainRepo, stdio: "ignore" });
-    execSync("git commit --allow-empty -m init", { cwd: mainRepo, stdio: "ignore" });
+    execFileSync("git", ["init"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
+    execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
 
     worktreeA = join(mainRepo, ".worktrees", "wt-a");
     worktreeB = join(mainRepo, ".worktrees", "wt-b");
-    execSync(`git worktree add ${worktreeA} -b branch-a`, { cwd: mainRepo, stdio: "ignore" });
-    execSync(`git worktree add ${worktreeB} -b branch-b`, { cwd: mainRepo, stdio: "ignore" });
+    execFileSync("git", ["worktree", "add", worktreeA, "-b", "branch-a"], { cwd: mainRepo, stdio: "ignore" });
+    execFileSync("git", ["worktree", "add", worktreeB, "-b", "branch-b"], { cwd: mainRepo, stdio: "ignore" });
   });
 
   afterEach(() => {
     // Remove worktrees before deleting the repo
-    try { execSync(`git worktree remove ${worktreeA} --force`, { cwd: mainRepo, stdio: "ignore" }); } catch {}
-    try { execSync(`git worktree remove ${worktreeB} --force`, { cwd: mainRepo, stdio: "ignore" }); } catch {}
+    try { execFileSync("git", ["worktree", "remove", worktreeA, "--force"], { cwd: mainRepo, stdio: "ignore" }); } catch {}
+    try { execFileSync("git", ["worktree", "remove", worktreeB, "--force"], { cwd: mainRepo, stdio: "ignore" }); } catch {}
     rmSync(mainRepo, { recursive: true, force: true });
   });
 

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -391,9 +391,8 @@ describe("worktree state isolation", () => {
 
     // Worktrees in separate tmpdir paths — proves isolation works for worktrees ANYWHERE,
     // not just under .worktrees/ in the repo. Use randomUUID for collision-safe paths.
-    const { randomUUID } = require("node:crypto");
-    worktreeA = join(tmpdir(), `wt-a-${randomUUID()}`);
-    worktreeB = join(tmpdir(), `wt-b-${randomUUID()}`);
+    worktreeA = join(tmpdir(), `wt-a-${crypto.randomUUID()}`);
+    worktreeB = join(tmpdir(), `wt-b-${crypto.randomUUID()}`);
     execFileSync("git", ["worktree", "add", worktreeA, "-b", "branch-a"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
     execFileSync("git", ["worktree", "add", worktreeB, "-b", "branch-b"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
   });

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -366,36 +366,52 @@ describe("recordReviewerResult idempotent", () => {
 
 // ── Worktree state isolation ──
 
+import { execSync } from "node:child_process";
+
 describe("worktree state isolation", () => {
+  let mainRepo: string;
   let worktreeA: string;
   let worktreeB: string;
 
   beforeEach(() => {
-    worktreeA = mkdtempSync(join(tmpdir(), "wt-a-"));
-    worktreeB = mkdtempSync(join(tmpdir(), "wt-b-"));
-    mkdirSync(join(worktreeA, ".git")); // .git dir needed so resolveWorktreeRoot treats these as git roots
-    mkdirSync(join(worktreeB, ".git"));
+    // Create a real git repo with two worktrees to exercise the actual
+    // git rev-parse --show-toplevel / --git-common-dir code paths.
+    mainRepo = mkdtempSync(join(tmpdir(), "wt-main-"));
+    execSync("git init", { cwd: mainRepo, stdio: "ignore" });
+    execSync("git commit --allow-empty -m init", { cwd: mainRepo, stdio: "ignore" });
+
+    worktreeA = join(mainRepo, ".worktrees", "wt-a");
+    worktreeB = join(mainRepo, ".worktrees", "wt-b");
+    execSync(`git worktree add ${worktreeA} -b branch-a`, { cwd: mainRepo, stdio: "ignore" });
+    execSync(`git worktree add ${worktreeB} -b branch-b`, { cwd: mainRepo, stdio: "ignore" });
   });
 
   afterEach(() => {
-    rmSync(worktreeA, { recursive: true, force: true });
-    rmSync(worktreeB, { recursive: true, force: true });
+    // Remove worktrees before deleting the repo
+    try { execSync(`git worktree remove ${worktreeA} --force`, { cwd: mainRepo, stdio: "ignore" }); } catch {}
+    try { execSync(`git worktree remove ${worktreeB} --force`, { cwd: mainRepo, stdio: "ignore" }); } catch {}
+    rmSync(mainRepo, { recursive: true, force: true });
   });
 
-  it("statePath returns different paths for different directories", () => {
+  it("statePath returns different paths for different worktrees sharing same repo", () => {
+    const pathMain = statePath(mainRepo);
     const pathA = statePath(worktreeA);
     const pathB = statePath(worktreeB);
+    // All three must be different
+    assert.notEqual(pathMain, pathA);
+    assert.notEqual(pathMain, pathB);
     assert.notEqual(pathA, pathB);
+    // Each path is under its own worktree root
+    assert.ok(pathMain.startsWith(mainRepo));
     assert.ok(pathA.startsWith(worktreeA));
     assert.ok(pathB.startsWith(worktreeB));
   });
 
-  it("markNeedsReview in worktree A does not affect worktree B", () => {
+  it("markNeedsReview in worktree A does not affect worktree B or main", () => {
     markNeedsReview(worktreeA);
-    const stateA = readReviewState(worktreeA);
-    const stateB = readReviewState(worktreeB);
-    assert.equal(stateA.status, "needs_review");
-    assert.equal(stateB.status, "none");
+    assert.equal(readReviewState(worktreeA).status, "needs_review");
+    assert.equal(readReviewState(worktreeB).status, "none");
+    assert.equal(readReviewState(mainRepo).status, "none");
   });
 
   it("clean state in worktree A does not leak to worktree B", () => {
@@ -412,5 +428,7 @@ describe("worktree state isolation", () => {
     // A's clean state should NOT affect B
     assert.equal(isReviewClean(worktreeA), true);
     assert.equal(isReviewClean(worktreeB), false);
+    // Main repo unaffected
+    assert.equal(readReviewState(mainRepo).status, "none");
   });
 });

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -390,11 +390,10 @@ describe("worktree state isolation", () => {
     execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
 
     // Worktrees in separate tmpdir paths — proves isolation works for worktrees ANYWHERE,
-    // not just under .worktrees/ in the repo.
-    worktreeA = join(tmpdir(), `wt-a-${Date.now()}`);
-    worktreeB = join(tmpdir(), `wt-b-${Date.now()}`);
-    rmSync(worktreeA, { recursive: true, force: true });
-    rmSync(worktreeB, { recursive: true, force: true });
+    // not just under .worktrees/ in the repo. Use randomUUID for collision-safe paths.
+    const { randomUUID } = require("node:crypto");
+    worktreeA = join(tmpdir(), `wt-a-${randomUUID()}`);
+    worktreeB = join(tmpdir(), `wt-b-${randomUUID()}`);
     execFileSync("git", ["worktree", "add", worktreeA, "-b", "branch-a"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
     execFileSync("git", ["worktree", "add", worktreeB, "-b", "branch-b"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
   });

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -391,14 +391,15 @@ describe("worktree state isolation", () => {
 
     worktreeA = join(mainRepo, ".worktrees", "wt-a");
     worktreeB = join(mainRepo, ".worktrees", "wt-b");
-    execFileSync("git", ["worktree", "add", worktreeA, "-b", "branch-a"], { cwd: mainRepo, stdio: "ignore" });
-    execFileSync("git", ["worktree", "add", worktreeB, "-b", "branch-b"], { cwd: mainRepo, stdio: "ignore" });
+    execFileSync("git", ["worktree", "add", worktreeA, "-b", "branch-a"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
+    execFileSync("git", ["worktree", "add", worktreeB, "-b", "branch-b"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV });
   });
 
   afterEach(() => {
-    // Remove worktrees before deleting the repo
-    try { execFileSync("git", ["worktree", "remove", worktreeA, "--force"], { cwd: mainRepo, stdio: "ignore" }); } catch {}
-    try { execFileSync("git", ["worktree", "remove", worktreeB, "--force"], { cwd: mainRepo, stdio: "ignore" }); } catch {}
+    // Remove worktrees before deleting the repo — --force needed because
+    // tests create .pi/data/ files inside worktrees (untracked content).
+    try { execFileSync("git", ["worktree", "remove", worktreeA, "--force"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV }); } catch {}
+    try { execFileSync("git", ["worktree", "remove", worktreeB, "--force"], { cwd: mainRepo, stdio: "ignore", env: GIT_ENV }); } catch {}
     rmSync(mainRepo, { recursive: true, force: true });
   });
 

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -15,13 +15,14 @@ import {
   isReviewClean,
   resetReviewState,
   countFindings,
+  statePath,
 } from "../../../extensions/orchestrator/review-state.js";
 
 let cwd: string;
 
 beforeEach(() => {
   cwd = mkdtempSync(join(tmpdir(), "review-state-test-"));
-  mkdirSync(join(cwd, ".git")); // fake git repo so resolveRepoRoot doesn't shell out
+  mkdirSync(join(cwd, ".git")); // .git dir needed so resolveWorktreeRoot treats this as a git root
 });
 
 afterEach(() => {
@@ -360,5 +361,56 @@ describe("recordReviewerResult idempotent", () => {
     const s = readReviewState(cwd);
     assert.equal(s.findings_count, 3); // not 6
     assert.deepEqual(s.reviewers_pending, ["test"]);
+  });
+});
+
+// ── Worktree state isolation ──
+
+describe("worktree state isolation", () => {
+  let worktreeA: string;
+  let worktreeB: string;
+
+  beforeEach(() => {
+    worktreeA = mkdtempSync(join(tmpdir(), "wt-a-"));
+    worktreeB = mkdtempSync(join(tmpdir(), "wt-b-"));
+    mkdirSync(join(worktreeA, ".git")); // .git dir needed so resolveWorktreeRoot treats these as git roots
+    mkdirSync(join(worktreeB, ".git"));
+  });
+
+  afterEach(() => {
+    rmSync(worktreeA, { recursive: true, force: true });
+    rmSync(worktreeB, { recursive: true, force: true });
+  });
+
+  it("statePath returns different paths for different directories", () => {
+    const pathA = statePath(worktreeA);
+    const pathB = statePath(worktreeB);
+    assert.notEqual(pathA, pathB);
+    assert.ok(pathA.startsWith(worktreeA));
+    assert.ok(pathB.startsWith(worktreeB));
+  });
+
+  it("markNeedsReview in worktree A does not affect worktree B", () => {
+    markNeedsReview(worktreeA);
+    const stateA = readReviewState(worktreeA);
+    const stateB = readReviewState(worktreeB);
+    assert.equal(stateA.status, "needs_review");
+    assert.equal(stateB.status, "none");
+  });
+
+  it("clean state in worktree A does not leak to worktree B", () => {
+    // Make A clean
+    markNeedsReview(worktreeA);
+    addReviewerPending(worktreeA, "lint");
+    recordReviewerResult(worktreeA, "lint", 0);
+    assert.equal(isReviewClean(worktreeA), true);
+
+    // Mark B needs review
+    markNeedsReview(worktreeB);
+    assert.equal(isReviewClean(worktreeB), false);
+
+    // A's clean state should NOT affect B
+    assert.equal(isReviewClean(worktreeA), true);
+    assert.equal(isReviewClean(worktreeB), false);
   });
 });


### PR DESCRIPTION
Closes #625

## Changes

### Bug 1: Gitignore bypass for worktree files
- Enforcement hook now resolves the worktree root from the edited file's path using \`resolveWorktreeRoot(fileDir)\`
- \`git check-ignore\` runs from the worktree root with a relative path, not from the main repo root
- Files in \`.worktrees/\` (or any worktree location) are no longer falsely skipped as gitignored

### Bug 2: Review-state collision across worktrees
- Added \`resolveWorktreeRoot()\` in \`utils.ts\` using \`git rev-parse --show-toplevel\` (separate cache from \`resolveRepoRoot\`)
- \`review-state.ts\` switched from \`resolveRepoRoot\` → \`resolveWorktreeRoot\` — each worktree gets its own \`.pi/data/review-state.json\`
- Commit-time \`isReviewClean()\` check uses \`resolveEffectiveCwd\` for worktree-aware enforcement
- Non-worktree repos unaffected (\`--show-toplevel\` = \`--git-common-dir\` for normal repos)

### UX: Worktree-aware review status
- \`/review-status\` command accepts optional worktree path argument
- \`review_status\` tool accepts \`worktree_path\` parameter for LLM queries
- Tab autocomplete lists active worktrees via \`git worktree list --porcelain\`
- Docs updated: README.md slash commands + usage, dev-docs/extension-commands.md

### Tests
- 3 new worktree isolation tests: \`statePath\` divergence, \`markNeedsReview\` isolation, clean state non-leakage
