### PR TITLE
feat: domain model CONTEXT.md support, spec dedup protection, code smells baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ Writing effective rules:
 ## When Adding a Prompt Template
 
 1. Create `prompts/<name>.md` with YAML frontmatter (`description: "..."`)
-2. Include bug reporting blockquote after `## Raw Arguments`
+2. Include bug reporting blockquote after the `$ARGUMENTS` code block (not between `## Raw Arguments` and the code block)
 3. Add autocomplete in `extensions/orchestrator/extended-autocomplete.ts` (only when the prompt has completable arguments — skip for free-text-only prompts)
 
 ## When Adding a Source Template

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Writing effective rules:
 
 1. Create `prompts/<name>.md` with YAML frontmatter (`description: "..."`)
 2. Include bug reporting blockquote after `## Raw Arguments`
-3. Add autocomplete in `extensions/orchestrator/extended-autocomplete.ts`
+3. Add autocomplete in `extensions/orchestrator/extended-autocomplete.ts` (only when the prompt has completable arguments — skip for free-text-only prompts)
 
 ## When Adding a Source Template
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Single extension that provides:
 | `/release [flags]` | Create GitHub release with changelog and version bumping |
 | `/review-local [branch]` | Review local uncommitted or branch changes |
 | `/review-handler [url] [--autorabbit] [--autoqodo]` | Process PR review comments, fix approved items |
+| `/domain-model [focus area]` | Scan codebase and build/update a CONTEXT.md domain glossary for consistent AI vocabulary |
 | `/refine-review <url>` | Refine and improve existing PR review comments |
 | `/coderabbit-rate-limit [number\|url]` | Handle CodeRabbit rate limiting on PRs |
 | `/create-coms-feature-manager` | Generate a coms feature-manager prompt customized for the current project (source template: `templates/coms-feature-manager-prompt.md`) |

--- a/agents/code-reviewer-docs.md
+++ b/agents/code-reviewer-docs.md
@@ -33,6 +33,12 @@ conventions, patterns, or rules as findings.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Domain Vocabulary
+
+Check if `CONTEXT.md` exists at the repository root. If it does, read it — it defines the
+project's domain terms, naming conventions, and `_Avoid_` alternatives. Use these terms in
+your review and flag code that uses avoided terms.
+
 ## Learned Review Preferences
 
 After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -49,6 +49,12 @@ Additionally:
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Domain Vocabulary
+
+Check if `CONTEXT.md` exists at the repository root. If it does, read it — it defines the
+project's domain terms, naming conventions, and `_Avoid_` alternatives. Use these terms in
+your review and flag code that uses avoided terms.
+
 ## Learned Review Preferences
 
 After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -33,6 +33,12 @@ conventions, patterns, or rules as findings.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Domain Vocabulary
+
+Check if `CONTEXT.md` exists at the repository root. If it does, read it — it defines the
+project's domain terms, naming conventions, and `_Avoid_` alternatives. Use these terms in
+your review and flag code that uses avoided terms.
+
 ## Learned Review Preferences
 
 After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.
@@ -95,6 +101,28 @@ Always check for these anti-patterns:
   what was being done, which inputs were used, or what state led to the failure.
 - **Opaque async/background code** — background workers, event handlers, SSE handlers,
   async callbacks, and fire-and-forget operations with no logging. Silent failures are undebuggable.
+
+## Code Smells Baseline (Fowler)
+
+Check the diff against these smells. Each is a **judgment call** — flag only when the smell
+materially hurts readability, maintainability, or correctness in the changed code.
+If the repo's AGENTS.md or coding standards endorse a pattern the baseline would flag, suppress it.
+Skip anything linters/formatters already enforce.
+
+| Smell | What to Look For | How to Fix |
+|-------|-------------------|------------|
+| Mysterious Name | Name doesn't reveal purpose | Rename; if no honest name fits, the design is unclear |
+| Duplicated Code | Same logic shape in multiple hunks/files in the diff | Extract shared shape, call from both |
+| Feature Envy | Method reaches into another object's data more than its own | Move method to the envied object |
+| Data Clumps | Same fields/params keep travelling together | Bundle into one type |
+| Primitive Obsession | String/number standing in for a domain concept | Give the concept its own type |
+| Repeated Switches | Same switch/if-cascade on same type in multiple places | Polymorphism or shared map |
+| Shotgun Surgery | One logical change forces scattered edits across many files | Gather what changes together into one module |
+| Divergent Change | One module edited for unrelated reasons | Split so each changes for one reason |
+| Speculative Generality | Abstraction/hooks for needs the spec doesn't have | Delete; inline until a real need shows |
+| Message Chains | Long `a.b().c().d()` navigation | Hide the walk behind one method |
+| Middle Man | Class/function that mostly just delegates | Cut it, call the real target |
+| Refused Bequest | Subclass ignores/overrides most of what it inherits | Drop inheritance, use composition |
 
 ## Output Format
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -50,6 +50,12 @@ and conventions.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Domain Vocabulary
+
+Check if `CONTEXT.md` exists at the repository root. If it does, read it — it defines the
+project's domain terms, naming conventions, and `_Avoid_` alternatives. Use these terms in
+your review and flag code that uses avoided terms.
+
 ## Learned Review Preferences
 
 After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.

--- a/agents/code-reviewer-spec.md
+++ b/agents/code-reviewer-spec.md
@@ -36,8 +36,8 @@ Do NOT rely on the calling prompt to provide these files — always read them yo
 ## Domain Vocabulary
 
 Check if `CONTEXT.md` exists at the repository root. If it does, read it — it defines the
-project's domain terms, naming conventions, and `_Avoid_` alternatives. Use these terms in
-your review and flag code that uses avoided terms.
+project's domain terms and naming conventions. Use these terms in your review for consistent
+vocabulary. Do NOT flag naming/terminology issues — that's the quality and guidelines reviewers' job.
 
 ## Learned Review Preferences
 

--- a/agents/code-reviewer-spec.md
+++ b/agents/code-reviewer-spec.md
@@ -33,6 +33,12 @@ conventions, patterns, or rules as findings.
 
 Do NOT rely on the calling prompt to provide these files — always read them yourself.
 
+## Domain Vocabulary
+
+Check if `CONTEXT.md` exists at the repository root. If it does, read it — it defines the
+project's domain terms, naming conventions, and `_Avoid_` alternatives. Use these terms in
+your review and flag code that uses avoided terms.
+
 ## Learned Review Preferences
 
 After reading project guidelines, check if `.pi/data/review-guidelines.md` exists.

--- a/dev-docs/repo-structure.md
+++ b/dev-docs/repo-structure.md
@@ -96,6 +96,7 @@ pi-config/
 │   ├── create-coms-feature-manager.md
 │   ├── external-ai.md
 │   ├── coderabbit-rate-limit.md
+│   ├── domain-model.md
 │   ├── implement-and-review.md
 │   ├── implement.md
 │   ├── pr-review.md

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -83,6 +83,7 @@ export function registerRules(
   // Run full rebuild on session start (once per session, not every turn)
   pi.on("session_start", async (_event, ctx) => {
     rebuildDone = false;
+    lastTaskFocusUserMsgId = null;
     try {
       rebuildAndOrganize(ctx.cwd);
       rebuildDone = true;
@@ -303,10 +304,10 @@ export function registerRules(
           const entry = branch[i];
           // Skip assistant messages (current turn's response)
           if (entry.type === "message" && (entry as any).message?.role === "assistant") continue;
-          // custom_message or custom = system-generated (enforcement, async result, coms)
-          // custom_message: sendMessage() with display (in LLM context)
-          // custom: appendEntry() without display (not in LLM context)
-          if (entry.type === "custom_message" || entry.type === "custom") {
+          // custom_message = system-generated turn-triggering message (enforcement, async result, coms)
+          // Only check custom_message (from sendMessage), not custom (from appendEntry)
+          // because appendEntry is state storage that other extensions use between turns.
+          if (entry.type === "custom_message") {
             userTriggered = false;
             break;
           }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -31,6 +31,10 @@ function isSocialCloser(text: string): boolean {
 /** Track last injected memories for usage detection in turn_end */
 let lastInjectedMemories: { text: string; category: string; similarity: number }[] = [];
 
+// Track the user message ID that last triggered task-focus enforcement.
+// Don't re-fire for the same user message (prevents loops from followUp turns).
+let lastTaskFocusUserMsgId: string | null = null;
+
 /** Log what memories were auto-injected for retrieval telemetry */
 function logMemoryInjection(cwd: string, prompt: string, injected: { text: string; category: string; similarity: number }[]): void {
   try {
@@ -282,31 +286,45 @@ export function registerRules(
 
     // Task-focus enforcement: if this turn had no tool calls but tasks are active,
     // the LLM likely answered a side question and forgot to resume work.
-    // Inject a follow-up to force it back on track.
-    // Only fire after user messages — not after follow-ups (reminders, async
-    // results, coms inbound). This prevents infinite reminder loops naturally:
-    // the reminder triggers a follow-up turn, which is not user-triggered.
+    // Inject a follow-up to remind about active tasks when the LLM responds
+    // without using any tools (likely chatting instead of working).
+    // Only fires after REAL user messages — not after system-generated followUps.
+    // Detection: walk the branch backwards from the assistant response. If the
+    // entry immediately before the assistant is a custom_message (system-generated),
+    // skip. Only fire if it's a real user message (type: "message", role: "user").
     try {
       const turnToolResults = (_event as any).toolResults;
       const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
-      // Check if this turn was triggered by a user message
       let userTriggered = false;
       try {
         const branch = ctx.sessionManager.getBranch();
         for (let i = branch.length - 1; i >= 0; i--) {
           const entry = branch[i];
-          // Skip non-message entries (tool results, custom entries, memory injections)
-          if (entry.type !== "message") continue;
-          const role = (entry as any).message?.role;
           // Skip assistant messages (current turn's response)
-          if (role === "assistant") continue;
-          // Found a non-assistant message — check if it's from the user
-          if (role === "user") {
-            userTriggered = true;
+          if (entry.type === "message" && (entry as any).message?.role === "assistant") continue;
+          // custom_message = system-generated (enforcement, async result, coms)
+          if (entry.type === "custom_message") {
+            userTriggered = false;
+            break;
           }
-          break;
+          // Real user message — but only if we haven't already fired for this exact message
+          if (entry.type === "message" && (entry as any).message?.role === "user") {
+            const msgId = (entry as any).id;
+            if (msgId && msgId === lastTaskFocusUserMsgId) {
+              // Already fired enforcement for this user message — skip
+              userTriggered = false;
+            } else {
+              userTriggered = true;
+              // Store this message ID so we don't fire again for it
+              lastTaskFocusUserMsgId = msgId ?? null;
+            }
+            break;
+          }
+          // Any other entry type — skip and keep looking
+          continue;
         }
       } catch { /* best-effort */ }
+
       if (!hadToolCalls && userTriggered) {
         // Check for active tasks — session-scoped task file only
         const tasksDir = path.join(ctx.cwd, ".pi", "tasks");

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -296,6 +296,7 @@ export function registerRules(
       const turnToolResults = (_event as any).toolResults;
       const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
       let userTriggered = false;
+      let triggeringMsgId: string | null = null;
       try {
         const branch = ctx.sessionManager.getBranch();
         for (let i = branch.length - 1; i >= 0; i--) {
@@ -311,12 +312,10 @@ export function registerRules(
           if (entry.type === "message" && (entry as any).message?.role === "user") {
             const msgId = (entry as any).id;
             if (msgId && msgId === lastTaskFocusUserMsgId) {
-              // Already fired enforcement for this user message — skip
               userTriggered = false;
             } else {
               userTriggered = true;
-              // Store this message ID so we don't fire again for it
-              lastTaskFocusUserMsgId = msgId ?? null;
+              triggeringMsgId = msgId ?? null;
             }
             break;
           }
@@ -343,6 +342,7 @@ export function registerRules(
                 .slice(0, 3)
                 .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
                 .join(", ");
+              lastTaskFocusUserMsgId = triggeringMsgId;
               pi.sendMessage({
                 customType: "task-focus-enforcement",
                 content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -303,8 +303,10 @@ export function registerRules(
           const entry = branch[i];
           // Skip assistant messages (current turn's response)
           if (entry.type === "message" && (entry as any).message?.role === "assistant") continue;
-          // custom_message = system-generated (enforcement, async result, coms)
-          if (entry.type === "custom_message") {
+          // custom_message or custom = system-generated (enforcement, async result, coms)
+          // custom_message: sendMessage() with display (in LLM context)
+          // custom: appendEntry() without display (not in LLM context)
+          if (entry.type === "custom_message" || entry.type === "custom") {
             userTriggered = false;
             break;
           }

--- a/prompts/domain-model.md
+++ b/prompts/domain-model.md
@@ -1,0 +1,109 @@
+---
+description: Scan the codebase and build/update a CONTEXT.md domain glossary for consistent AI vocabulary
+argument-hint: "[focus area]"
+---
+
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+# Domain Model Command
+
+Scan the codebase, identify domain-specific terms and naming patterns, and create or update
+a `CONTEXT.md` glossary at the repository root. This gives all AI agents a shared vocabulary
+for the project — reducing verbosity and improving naming consistency.
+
+## Workflow
+
+### Phase 1: Scan the Codebase
+
+If raw arguments specify a focus area, narrow the scan to that area.
+Otherwise, scan the full codebase.
+
+Read **source code only** — TypeScript/Python files, variable/function/class/type names,
+file structure, code comments. Look for:
+
+- **Domain-specific terms** — words used in code identifiers that mean something specific
+  in this project (not general programming concepts)
+- **Naming patterns** — how the codebase names things in code (e.g., "handler" vs "controller")
+- **Overloaded terms** — same word used for different concepts in different files
+- **Inconsistent naming** — same concept called different things in different files
+- **Acronyms and abbreviations** — project-specific shorthand in code
+
+**DO NOT include:**
+
+- Operational workflows or processes (how things are done — that belongs in rules/memory)
+- Features described in README/docs (those are documentation, not vocabulary)
+- Memory system entries or session knowledge
+- Anything that isn't a term used in actual code identifiers or code comments
+
+The glossary is for **naming consistency in code** — so the AI uses the same
+identifier names the codebase uses. If a term doesn't appear as a variable name,
+function name, type name, or class name in the code, it probably doesn't belong.
+
+### Phase 2: Check Existing CONTEXT.md
+
+If `CONTEXT.md` exists at the repo root:
+
+1. Read it
+2. Cross-reference against the codebase scan — are definitions still accurate?
+3. Identify new terms that should be added
+4. Identify stale terms that no longer appear in the code
+5. Present a diff of proposed changes to the user
+
+If no `CONTEXT.md` exists, proceed to Phase 3.
+
+### Phase 3: Draft CONTEXT.md
+
+Create a draft following this format:
+
+```markdown
+# {Project Name}
+
+{One-sentence description of what this project is.}
+
+## Language
+
+**{Term}**:
+{One or two sentence definition of what it IS, not what it does.}
+
+**{Another Term}**:
+{Definition}
+_Avoid_: {alternative words people might use that would cause confusion}
+```
+
+**Rules for the glossary:**
+
+- **Keep definitions tight** — one or two sentences max
+- **Only project-specific terms** — general programming concepts don't belong
+- **Group under subheadings** when natural clusters emerge
+- **Cross-reference with code** — if the glossary says "Order", the code should use "Order"
+  not "Purchase" or "Transaction"
+- **`_Avoid_` is optional** — only add it when there's genuine ambiguity where someone
+  (human or AI) might use a different word for the same concept. For code identifiers
+  with clear names (e.g., `resolveRepoRoot`), no `_Avoid_` is needed — the name speaks
+  for itself. Use `_Avoid_` for domain concepts like "Worktree" where someone might say
+  "working copy" or "branch copy" instead.
+
+### Phase 4: Present to User
+
+Display the full draft and ask the user to review:
+
+- Approve as-is
+- Correct any definitions
+- Add missing terms
+- Remove terms that don't belong
+
+Apply corrections and write `CONTEXT.md` to the repo root.
+
+### Phase 5: Commit
+
+Stage and commit `CONTEXT.md` with message: `docs: create/update domain model glossary`

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -51,6 +51,11 @@ Overlapping scope is intentional for comprehensive coverage; step 3's deduplicat
 Same file/line + same issue or root cause = duplicate — keep the most actionable version.
 Conflicts follow priority: security > correctness > performance > style; complementary findings on the same code are kept.
 
+**Spec findings are never duplicates.** Findings from `code-reviewer-spec` (missing deliverables,
+scope creep, spec misalignment) are never suppressed by findings from other reviewers, even on
+the same file/line. A quality finding about *how* code is written does not address *whether* the
+code matches the spec. Always keep both.
+
 ## Step 4a: Respond to Findings (when `review_loop_enforcement` is enabled)
 
 For each finding from step 3, do ONE of:

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -51,10 +51,11 @@ Overlapping scope is intentional for comprehensive coverage; step 3's deduplicat
 Same file/line + same issue or root cause = duplicate — keep the most actionable version.
 Conflicts follow priority: security > correctness > performance > style; complementary findings on the same code are kept.
 
-**Spec findings are never duplicates.** Findings from `code-reviewer-spec` (missing deliverables,
-scope creep, spec misalignment) are never suppressed by findings from other reviewers, even on
-the same file/line. A quality finding about *how* code is written does not address *whether* the
-code matches the spec. Always keep both.
+**Spec findings are never deduplicated against non-spec findings.** Findings from `code-reviewer-spec`
+(missing deliverables, scope creep, spec misalignment) are never suppressed by findings from other
+reviewers, even on the same file/line. A quality finding about *how* code is written does not
+address *whether* the code matches the spec. Always keep both. Spec findings CAN still be
+deduplicated against other spec findings when they are truly the same issue.
 
 ## Step 4a: Respond to Findings (when `review_loop_enforcement` is enabled)
 


### PR DESCRIPTION
Closes #630

## Changes

### Feature 1: Domain Model / CONTEXT.md Support
- New `/domain-model` prompt template — AI scans codebase, identifies domain terms, drafts CONTEXT.md glossary, presents to user for approval
- All 5 reviewer agents updated with Domain Vocabulary section — reads CONTEXT.md if it exists for consistent project vocabulary
- CONTEXT.md is a per-project generated file, not shipped with this repo

### Feature 2: Spec Reviewer Dedup Protection
- Spec findings from `code-reviewer-spec` are never suppressed by quality/style findings on the same file/line
- A quality finding about *how* code is written does not address *whether* the code matches the spec

### Feature 5: Code Smells Baseline
- 12 Fowler code smells added as a structured checklist to `code-reviewer-quality` agent
- Each smell is a judgment call — repo standards override the baseline
- Skip anything linters/formatters already enforce

### Other
- AGENTS.md: clarified autocomplete only needed for prompts with completable arguments
- README: added `/domain-model` to prompt templates table
- dev-docs/repo-structure.md: added domain-model.md