### PR TITLE
fix(pr-review): skip auto-repost of unresolved findings when no new commits exist

### DIFF
--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -147,22 +147,25 @@ Mark Task 1 as `in_progress`.
 
 If the raw arguments are empty:
 
-1. If the raw arguments do NOT contain a PR number or URL, detect from current branch:
+1. Detect from current branch and fetch PR metadata:
 
    ```bash
    myk-pi-tools pr info $(gh pr view --json number --jq '.number')
    ```
 
-2. Fetch PR metadata using the CLI:
-
-   ```bash
-   myk-pi-tools pr info <cleaned_arguments>
-   ```
-
    This returns JSON with all needed fields: `owner`, `repo`, `pr_number`, `author`,
    `head_sha`, `base_ref`, `title`, `state`, `labels`, `assignees`, `is_fork`, `head_repo`, `body`.
 
-3. Extract and store all fields from the JSON output — these are used by Phase 1c and Phase 5.
+2. Extract and store all fields from the JSON output — these are used by Phase 1c and Phase 5.
+
+3. Fetch the latest commit timestamp from `head_sha` (needed by Phase 1c to compare
+   against comment timestamps):
+
+   ```bash
+   gh api /repos/{owner}/{repo}/commits/{head_sha} --jq '.commit.committer.date'
+   ```
+
+   Store this as `LATEST_COMMIT_DATE` (ISO 8601 timestamp).
 
 If the raw arguments contain a PR number or URL:
 
@@ -176,6 +179,15 @@ If the raw arguments contain a PR number or URL:
    `head_sha`, `base_ref`, `title`, `state`, `labels`, `assignees`, `is_fork`, `head_repo`, `body`.
 
 2. Extract and store all fields from the JSON output — these are used by Phase 1c and Phase 5.
+
+3. Fetch the latest commit timestamp from `head_sha` (needed by Phase 1c to compare
+   against comment timestamps):
+
+   ```bash
+   gh api /repos/{owner}/{repo}/commits/{head_sha} --jq '.commit.committer.date'
+   ```
+
+   Store this as `LATEST_COMMIT_DATE` (ISO 8601 timestamp).
 
 Mark Task 1 as `completed`.
 
@@ -258,9 +270,17 @@ For the `human` list, categorize each thread:
       "✅ Fixed but not resolved by author — resolved by us". Store verdict to DB as `resolved_fixed`.
     - Fix looks wrong/incomplete → include in findings as "❌ Code changed but fix is incorrect".
       Store verdict to DB as `resolved_bad_fix`.
-  - **Code NOT changed:** The finding is genuinely unaddressed.
-    - Include in the findings presented to the user in Phase 4.
-    - Mark as "⚠️ UNRESOLVED from previous review"
+  - **Code NOT changed:** The finding may be genuinely unaddressed — but only re-raise
+    if the PR author has pushed new commits since the comment was posted.
+    - Compare the comment's `created_at` timestamp against `LATEST_COMMIT_DATE` from Phase 0.
+    - **New commits exist after comment** (`LATEST_COMMIT_DATE` > comment `created_at`):
+      The author pushed changes but didn't address this finding.
+      Include in the findings presented to the user in Phase 4.
+      Mark as "⚠️ UNRESOLVED from previous review"
+    - **No new commits after comment** (`LATEST_COMMIT_DATE` ≤ comment `created_at`):
+      The comment is already visible on the PR and the author hasn't pushed any changes yet.
+      Silently skip — do NOT include in findings or auto-post.
+      This avoids replying to our own still-visible unresolved thread with no new information.
 
 **Resolved threads:**
 
@@ -485,6 +505,9 @@ Each finding shows its source:
 findings are **automatically included** in the post list — they are the user's own prior
 comments that remain unaddressed and MUST be re-raised. Do NOT ask the user to select these.
 Show them in the list marked as "(auto-post)" so the user knows they'll be re-raised.
+
+> **Note:** `[PREV-UNRESOLVED]` findings where no new commits exist after the comment
+> (silently skipped in Phase 1c) do NOT appear here — they were already filtered out.
 
 **Author questions require user approval:** `[AUTHOR-QUESTION]` findings are NOT auto-posted.
 They require user review because the AI-generated answer may need editing or the user may

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -165,6 +165,9 @@ If the raw arguments are empty:
    gh api /repos/{owner}/{repo}/commits/{head_sha} --jq '.commit.committer.date'
    ```
 
+   Always use the base repo (`{owner}/{repo}`) — GitHub resolves fork PR commits
+   from the base repo via `refs/pull/*/head`, so this works for both fork and non-fork PRs.
+
    Store this as `LATEST_COMMIT_DATE` (ISO 8601 timestamp).
 
 If the raw arguments contain a PR number or URL:
@@ -186,6 +189,9 @@ If the raw arguments contain a PR number or URL:
    ```bash
    gh api /repos/{owner}/{repo}/commits/{head_sha} --jq '.commit.committer.date'
    ```
+
+   Always use the base repo (`{owner}/{repo}`) — GitHub resolves fork PR commits
+   from the base repo via `refs/pull/*/head`, so this works for both fork and non-fork PRs.
 
    Store this as `LATEST_COMMIT_DATE` (ISO 8601 timestamp).
 


### PR DESCRIPTION
## Summary

Fixes #632

The `/pr-review` prompt template (Phase 1c + Phase 4) was auto-reposting `[PREV-UNRESOLVED]` findings by replying to the reviewer's own unresolved thread — even when the PR author hadn't pushed any new commits since the original comment. This added noise without value.

## Changes

### Phase 0: Fetch latest commit timestamp
- Added a new step in **both** Phase 0 branches (empty args and explicit PR args) to fetch `LATEST_COMMIT_DATE` from `head_sha` via `gh api /repos/{owner}/{repo}/commits/{head_sha}`
- Uses `.commit.committer.date` (not author date) — committer date updates on rebase/amend

### Phase 1c: Timestamp-gated unresolved thread classification
- When code has NOT changed at the finding's location, compare the comment's `created_at` against `LATEST_COMMIT_DATE`
- **New commits exist** (`LATEST_COMMIT_DATE` > `created_at`): re-raise as `[PREV-UNRESOLVED]` (author pushed but didn't address)
- **No new commits** (`LATEST_COMMIT_DATE` ≤ `created_at`): silently skip — comment is already visible on the PR

### Phase 4: Clarifying note
- Added blockquote noting that silently-skipped findings don't appear in the auto-post list

### Bonus fix: Pre-existing contradictory condition
- Fixed the empty-args branch of Phase 0 which had a redundant nested condition and a dangling `<cleaned_arguments>` reference

## Testing

- 3 review cycles, all 5 reviewers approved with 0 findings
- All pre-commit hooks passed