### PR TITLE
feat(review-state): integrate test results into review state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ After any code change, the orchestrator runs 6 agents **in parallel** (5 reviewe
 6. **test-automator** — Runs project tests (pytest, node tests, pre-commit)
 
 Loops until all reviewers approve AND tests pass (`tests_passed: true` in `review-state.json`).
-Commit/push is code-enforced — blocked unless both `status: clean` and `tests_passed: true`.
+Commit is code-enforced — blocked unless both `status: clean` and `tests_passed: true`.
 
 Use `/review-status` to inspect the current review loop state. Pass a worktree path to check a specific worktree (e.g., `/review-status .worktrees/issue-42`).
 

--- a/README.md
+++ b/README.md
@@ -207,15 +207,17 @@ Run scout and planner in a chain to analyze the auth module
 
 ## Code Review Loop
 
-After any code change, the orchestrator runs 5 review agents **in parallel**:
+After any code change, the orchestrator runs 6 agents **in parallel** (5 reviewers + test-automator):
 
 1. **code-reviewer-quality** — Code quality & maintainability
-2. **code-reviewer-guidelines** — Project guidelines adherence  
+2. **code-reviewer-guidelines** — Project guidelines adherence
 3. **code-reviewer-security** — Bugs, logic errors, security
 4. **code-reviewer-docs** — Documentation quality, completeness, accuracy
 5. **code-reviewer-spec** — Code/PR/issue spec alignment
+6. **test-automator** — Runs project tests (pytest, node tests, pre-commit)
 
-Loops until all approve, then runs tests.
+Loops until all reviewers approve AND tests pass (`tests_passed: true` in `review-state.json`).
+Commit/push is code-enforced — blocked unless both `status: clean` and `tests_passed: true`.
 
 Use `/review-status` to inspect the current review loop state. Pass a worktree path to check a specific worktree (e.g., `/review-status .worktrees/issue-42`).
 

--- a/agents/code-reviewer-docs.md
+++ b/agents/code-reviewer-docs.md
@@ -11,6 +11,7 @@ You are a code review specialist focused on **documentation quality, completenes
 - Execute first, explain after
 - Do NOT modify files — only review and report findings
 - If a task falls outside your domain, report it and hand off
+- Get the diff with `git diff origin/$PI_REVIEW_BASE_BRANCH...HEAD`
 
 ## Project Guidelines (MANDATORY — read before reviewing)
 
@@ -129,14 +130,14 @@ Flag audit failures as `[WARNING]` with the specific checklist item that failed.
 
 ## Output Format
 
-For each finding:
+Return ONLY a JSON object. No text before or after. No markdown fences.
 
-```text
-[SEVERITY] file:line — Description
-  Impact: What breaks or confuses without this fix
-  Suggestion: How to fix
+```json
+{"findings": [{"severity": "CRITICAL", "file": "path/to/file.ts", "line": 10, "description": "What is wrong", "impact": "What breaks", "suggestion": "How to fix"}]}
 ```
 
-Severity levels: `[CRITICAL]`, `[WARNING]`, `[SUGGESTION]`
+If no issues: `{"findings": []}`
 
-If no issues found, explicitly state: "Documentation is complete and accurate. Approved."
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+After writing your response, validate it is parseable JSON.

--- a/agents/code-reviewer-guidelines.md
+++ b/agents/code-reviewer-guidelines.md
@@ -11,6 +11,7 @@ You are a code review specialist focused on **project guidelines and style adher
 - Execute first, explain after
 - Do NOT modify files — only review and report findings
 - If a task falls outside your domain, report it and hand off
+- Get the diff with `git diff origin/$PI_REVIEW_BASE_BRANCH...HEAD`
 
 ## Review Focus
 
@@ -81,14 +82,14 @@ If the command returns results, review the output:
 
 ## Output Format
 
-For each finding:
+Return ONLY a JSON object. No text before or after. No markdown fences.
 
-```text
-[SEVERITY] file:line — Description
-  Rule: Which guideline is violated
-  Suggestion: How to fix
+```json
+{"findings": [{"severity": "CRITICAL", "file": "path/to/file.ts", "line": 10, "description": "What is wrong", "rule": "Which guideline", "suggestion": "How to fix"}]}
 ```
 
-Severity levels: `[CRITICAL]`, `[WARNING]`, `[SUGGESTION]`
+If no issues: `{"findings": []}`
 
-If no issues found, explicitly state: "Code follows all project guidelines. Approved."
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+After writing your response, validate it is parseable JSON.

--- a/agents/code-reviewer-quality.md
+++ b/agents/code-reviewer-quality.md
@@ -11,6 +11,7 @@ You are a code review specialist focused on **general code quality and maintaina
 - Execute first, explain after
 - Do NOT modify files — only review and report findings
 - If a task falls outside your domain, report it and hand off
+- Get the diff with `git diff origin/$PI_REVIEW_BASE_BRANCH...HEAD`
 
 ## Project Guidelines (MANDATORY — read before reviewing)
 
@@ -126,13 +127,14 @@ Skip anything linters/formatters already enforce.
 
 ## Output Format
 
-For each finding:
+Return ONLY a JSON object. No text before or after. No markdown fences.
 
-```text
-[SEVERITY] file:line — Description
-  Suggestion: What to change and why
+```json
+{"findings": [{"severity": "CRITICAL", "file": "path/to/file.ts", "line": 10, "description": "What is wrong", "suggestion": "How to fix"}]}
 ```
 
-Severity levels: `[CRITICAL]`, `[WARNING]`, `[SUGGESTION]`
+If no issues: `{"findings": []}`
 
-If no issues found, explicitly state: "No quality issues found. Code approved."
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+After writing your response, validate it is parseable JSON.

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -11,6 +11,7 @@ You are a code review specialist focused on **bugs, logic errors, and security v
 - Execute first, explain after
 - Do NOT modify files — only review and report findings
 - If a task falls outside your domain, report it and hand off
+- Get the diff with `git diff origin/$PI_REVIEW_BASE_BRANCH...HEAD`
 
 ## Review Focus
 
@@ -91,14 +92,14 @@ If the command returns results, review the output:
 
 ## Output Format
 
-For each finding:
+Return ONLY a JSON object. No text before or after. No markdown fences.
 
-```text
-[SEVERITY] file:line — Description
-  Risk: What could go wrong
-  Suggestion: How to fix
+```json
+{"findings": [{"severity": "CRITICAL", "file": "path/to/file.ts", "line": 10, "description": "What is wrong", "risk": "What could go wrong", "suggestion": "How to fix"}]}
 ```
 
-Severity levels: `[CRITICAL]`, `[WARNING]`, `[SUGGESTION]`
+If no issues: `{"findings": []}`
 
-If no issues found, explicitly state: "No bugs or security issues found. Code approved."
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+After writing your response, validate it is parseable JSON.

--- a/agents/code-reviewer-spec.md
+++ b/agents/code-reviewer-spec.md
@@ -11,6 +11,8 @@ You are a code review specialist focused on **spec compliance — alignment betw
 - Execute first, explain after
 - Do NOT modify files — only review and report findings
 - If a task falls outside your domain, report it and hand off
+- Get the diff with `git diff origin/$PI_REVIEW_BASE_BRANCH...HEAD`
+- You MUST run `gh pr view` and `gh issue view` commands every time — even if you think you already have the data from a prior turn. Prior turn data is STALE.
 
 ## Project Guidelines (MANDATORY — read before reviewing)
 
@@ -65,36 +67,26 @@ If the command returns results, review the output:
 
 ## Review Flow
 
-### Step 1: Detect PR
+### Step 1: Fetch PR, Issue, and Diff
 
-ALWAYS run this command fresh — never use cached results from a previous session:
+Run ALL of these commands. Data from prior turns is STALE — always re-fetch:
 
 ```bash
-gh pr view --json number,title,body,url 2>/dev/null
+gh pr view --json number,title,body,url
 ```
 
-If no PR exists, state: "No PR found for current branch. Nothing to review." and stop.
+If this fails: "No PR found for current branch. Nothing to review." — stop.
 
-### Step 2: Get Issue References
-
-Parse the PR body for issue references: `Closes #N`, `Fixes #N`, `Resolves #N`, or bare `#N` references.
-For each referenced issue, fetch the body:
+Parse the PR body for issue refs (`Closes #N`, `Fixes #N`, `Resolves #N`, `#N`).
+For each issue:
 
 ```bash
 gh issue view <N> --json body,title --jq '{title: .title, body: .body}'
 ```
 
-If no issue is linked, note it as a `[SUGGESTION]` but continue reviewing.
+If no issue is linked, note as `[SUGGESTION]` but continue.
 
-### Step 3: Get Code Changes
-
-```bash
-git diff origin/<base_branch>...HEAD
-```
-
-Or use `git diff HEAD` for uncommitted changes in local reviews.
-
-### Step 4: Compare
+### Step 2: Compare
 
 #### A. PR Claims vs Diff
 
@@ -132,15 +124,14 @@ For code changes that appear in the diff but are NOT mentioned in either the PR 
 
 ## Output Format
 
-For each finding:
+Return ONLY a JSON object. No text before or after. No markdown fences.
 
-```text
-[SEVERITY] file:line — Description
-  Expected: What the PR/issue claims
-  Actual: What the diff shows (or doesn't show)
-  Suggestion: How to fix the misalignment
+```json
+{"findings": [{"severity": "CRITICAL", "file": "path/to/file.ts", "line": 10, "description": "What is wrong", "expected": "What PR/issue claims", "actual": "What diff shows", "suggestion": "How to fix"}]}
 ```
 
-Severity levels: `[CRITICAL]`, `[WARNING]`, `[SUGGESTION]`
+If no issues: `{"findings": []}`
 
-If no issues found, explicitly state: "Code aligns with PR description and issue spec. Approved."
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+After writing your response, validate it is parseable JSON.

--- a/agents/code-reviewer-spec.md
+++ b/agents/code-reviewer-spec.md
@@ -67,7 +67,7 @@ If the command returns results, review the output:
 
 ### Step 1: Detect PR
 
-Check if a PR exists for the current branch:
+ALWAYS run this command fresh — never use cached results from a previous session:
 
 ```bash
 gh pr view --json number,title,body,url 2>/dev/null

--- a/agents/git-expert.md
+++ b/agents/git-expert.md
@@ -22,8 +22,8 @@ You are a Git Expert responsible for all local git operations and version contro
 
 ## Separation of Concerns
 
-- This agent does NOT run tests. Before pushing, ask the orchestrator if tests have passed.
-- This agent does NOT fix code. If pre-commit/prek hooks fail, report the error.
+- This agent does NOT run tests or fix code.
+- If pre-commit/prek hooks fail, report the error.
 
 ## Commit Message Format
 
@@ -53,8 +53,7 @@ Format rules:
 
 1. `git checkout -b branch-name`
 2. Verify changes committed
-3. Ask orchestrator: "Have all tests passed?"
-4. `git push -u origin branch-name`
+3. `git push -u origin branch-name`
 
 **Create a PR:** → Delegate to `github-expert`
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -33,7 +33,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentConfig } from "./agents.js";
 import { getPiInvocation, getProjectTmpDir, parseProcStartTime, djb2Hash } from "./utils.js";
-import { addReviewerPending, recordReviewerResult, countFindings, readReviewState } from "./review-state.js";
+import { addReviewerPending, recordReviewerResult, countFindings, readReviewState, markTestsPassed, markTestsFailed } from "./review-state.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -394,6 +394,17 @@ export function registerAsyncAgents(
             } catch { /* best-effort */ }
           }
         }
+      }
+
+      // Track test agent completion for review state test tracking
+      if (job.agent === "test-automator" || job.agent === "test-runner") {
+        try {
+          if (data.success) {
+            markTestsPassed(jobCwd(job));
+          } else {
+            markTestsFailed(jobCwd(job));
+          }
+        } catch (e: any) { console.debug(`[async-agents] markTests(Passed|Failed) failed for ${job.agent}: ${e?.message}`); }
       }
 
       // Clean up result file — for grouped jobs, defer to deliverGroupResults

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -2,7 +2,7 @@
  * Async agent infrastructure — background agent spawning, polling, result watching.
  */
 
-import { execFileSync, execSync, spawn } from "node:child_process";
+import { execFileSync, execSync, spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -34,6 +34,7 @@ import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-wo
 import type { AgentConfig } from "./agents.js";
 import { getPiInvocation, getProjectTmpDir, parseProcStartTime, djb2Hash } from "./utils.js";
 import { addReviewerPending, recordReviewerResult, countFindings, readReviewState, markTestsPassed, markTestsFailed } from "./review-state.js";
+import { getMainBranch } from "./git-helpers.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -283,7 +284,9 @@ export function registerAsyncAgents(
       if (!j.agent.startsWith("code-reviewer-") || !lateIngestedIds.has(j.id)) continue;
       try {
         const output = typeof j.output === "string" ? j.output : "";
-        recordReviewerResult(jobCwd(j), j.agent, countFindings(output));
+        const findings = countFindings(output);
+        // -1 means invalid JSON output — treat conservatively as having findings
+        recordReviewerResult(jobCwd(j), j.agent, findings < 0 ? 1 : findings);
       } catch { /* best-effort */ }
     }
 
@@ -367,7 +370,9 @@ export function registerAsyncAgents(
       if (job.agent.startsWith("code-reviewer-")) {
         try {
           const output = typeof data.output === "string" ? data.output : JSON.stringify(data.output ?? "");
-          recordReviewerResult(jobCwd(job), job.agent, countFindings(output));
+          const findings = countFindings(output);
+          // -1 means invalid JSON output — treat conservatively as having findings
+          recordReviewerResult(jobCwd(job), job.agent, findings < 0 ? 1 : findings);
         } catch { /* best-effort */ }
         // Clear reviewer session if context usage > 80% to prevent overflow on next cycle
         // Use model context window from the agent's effective model.
@@ -611,11 +616,31 @@ export function registerAsyncAgents(
       ? [jitiCliPath, runnerPath, configPath]
       : [runnerPath, configPath];
 
+    // Resolve base branch for reviewers so they diff against the correct target
+    const spawnEnv: Record<string, string | undefined> = {
+      ...process.env,
+      PI_SUBAGENT_CHILD: "1",
+      PI_AGENT_NAME: agentName,
+    };
+    if (agentName.startsWith("code-reviewer-") || agentName === "test-automator" || agentName === "test-runner") {
+      try {
+        const prBase = spawnSync("gh", ["pr", "view", "--json", "baseRefName", "--jq", ".baseRefName"], {
+          cwd, timeout: 5000, encoding: "utf-8",
+        });
+        const base = prBase.status === 0 && prBase.stdout?.trim()
+          ? prBase.stdout.trim()
+          : (getMainBranch(cwd) || "main");
+        spawnEnv.PI_REVIEW_BASE_BRANCH = base;
+      } catch {
+        spawnEnv.PI_REVIEW_BASE_BRANCH = getMainBranch(cwd) || "main";
+      }
+    }
+
     const proc = spawn(process.execPath, spawnArgs, {
       cwd,
       stdio: "ignore",
       windowsHide: true,
-      env: { ...process.env, PI_SUBAGENT_CHILD: "1", PI_AGENT_NAME: agentName },
+      env: spawnEnv,
     });
 
     // Track the job

--- a/extensions/orchestrator/async-runner.ts
+++ b/extensions/orchestrator/async-runner.ts
@@ -211,6 +211,78 @@ async function run(config: RunConfig): Promise<void> {
     pidashWs.close();
   }
 
+  // For code reviewers: validate output is JSON, retry if not
+  if (config.agent.startsWith("code-reviewer-") && exitCode === 0) {
+    let validJson = false;
+    let retryOutput = finalOutput || stdoutTail.slice(-2000);
+    let jsonRetryCount = 0;
+    while (!validJson) {
+      jsonRetryCount++;
+      try {
+        let cleaned = retryOutput.trim();
+        if (cleaned.startsWith("```")) {
+          cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "");
+        }
+        const parsed = JSON.parse(cleaned);
+        if (parsed && Array.isArray(parsed.findings)) {
+          validJson = true;
+          finalOutput = cleaned; // Use the cleaned JSON as final output
+        }
+      } catch { /* not valid JSON */ }
+
+      if (!validJson) {
+        // After 3 retries, stop and let the user decide
+        if (jsonRetryCount >= 3) {
+          finalOutput = JSON.stringify({
+            findings: [{
+              severity: "CRITICAL",
+              file: "<reviewer-output>",
+              line: 0,
+              description: `Reviewer ${config.agent} failed to return valid JSON after ${jsonRetryCount} attempts. Raw output included in this result. User action required.`,
+              suggestion: "Re-run the reviewer or check the agent prompt.",
+            }],
+            _jsonRetryExhausted: true,
+            _rawOutput: retryOutput.slice(0, 1000),
+          });
+          break;
+        }
+        // Re-run with same session, asking for JSON
+        const retryArgs = config.piArgs.slice(0, -1); // Remove the last arg (the task)
+        retryArgs.push("Your output is not valid JSON. Return ONLY a raw JSON object: {\"findings\": [...]}. No markdown fences, no text before or after.");
+        const retryCode = await new Promise<number | null>((resolve) => {
+          const retryProc = spawn(config.piCommand, retryArgs, {
+            cwd: config.cwd,
+            stdio: ["ignore", "pipe", "pipe"],
+          });
+          let retryBuf = "";
+          retryProc.stdout.on("data", (chunk: Buffer) => {
+            retryBuf += chunk.toString();
+            outputStream.write(chunk.toString());
+          });
+          retryProc.stderr.on("data", (chunk: Buffer) => {
+            outputStream.write(chunk.toString());
+          });
+          retryProc.on("close", (code) => {
+            // Extract final output from the retry
+            for (const line of retryBuf.split("\n")) {
+              try {
+                const ev = JSON.parse(line.trim());
+                if (ev.type === "message_end" && ev.message?.role === "assistant") {
+                  for (const p of ev.message.content || []) {
+                    if (p.type === "text") retryOutput = p.text;
+                  }
+                }
+              } catch { /* skip */ }
+            }
+            resolve(code);
+          });
+          retryProc.on("error", () => resolve(1));
+        });
+        if (retryCode !== 0) break; // pi itself failed, stop retrying
+      }
+    }
+  }
+
   // Write result for the watcher to pick up
   writeJson(config.resultPath, {
     id: config.id,

--- a/extensions/orchestrator/async-runner.ts
+++ b/extensions/orchestrator/async-runner.ts
@@ -172,12 +172,10 @@ async function run(config: RunConfig): Promise<void> {
     });
 
     proc.on("close", (code) => {
-      outputStream.end();
       resolve(code);
     });
 
     proc.on("error", (err) => {
-      outputStream.end();
       status.error = err.message;
       resolve(1);
     });
@@ -282,6 +280,9 @@ async function run(config: RunConfig): Promise<void> {
       }
     }
   }
+
+  // End the output stream after all retries are done
+  outputStream.end();
 
   // Write result for the watcher to pick up
   writeJson(config.resultPath, {

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -351,3 +351,20 @@ export function stripHeredocBodies(cmd: string): string {
   return cmd.replace(/<<-(\s*)['"]?(\w+)['"]?[^\n]*\n[\s\S]*?\n[ \t]*\2\s*(?=\n|$)/gm, "")
     .replace(/<<(\s*)['"]?(\w+)['"]?[^\n]*\n[\s\S]*?\n\2\s*(?=\n|$)/gm, "");
 }
+
+/**
+ * Detect common test runner commands — require command-start position
+ * (after &&, |, ;, or line start) to avoid false positives from install/grep/cat commands.
+ * NOTE: For compound commands (e.g., pytest && other_cmd), if the non-test part fails,
+ * isError=true marks tests as failed even though pytest passed. This is the conservative/safe
+ * direction — re-run the test command standalone to mark tests_passed.
+ * NOTE: `tox` without `-e` args matches (runs default envs = tests). `tox -e lint` does NOT
+ * match — we exclude tox with explicit -e to avoid marking lint/docs runs as test passes.
+ */
+export function isTestRunnerCommand(command: string): boolean {
+  return /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
+    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s|$)/.test(command) && !/tox\s+-e\b/.test(command)
+    || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
+    || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
+    || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);
+}

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -363,7 +363,7 @@ export function stripHeredocBodies(cmd: string): string {
  */
 export function isTestRunnerCommand(command: string): boolean {
   return /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
-    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s+(?!-e\b)|$)/.test(command)
+    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox\b(?!\s+-e\b)/.test(command)
     || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -363,7 +363,7 @@ export function stripHeredocBodies(cmd: string): string {
  */
 export function isTestRunnerCommand(command: string): boolean {
   return /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
-    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox\b(?!\s+-e\b)/.test(command)
+    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox\b(?!\s*-e)/.test(command)
     || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -30,12 +30,16 @@ export function escapeForSingleQuote(s: string): string {
 
 /** Parse bash command for cd target to resolve the effective working directory (worktree support) */
 export function resolveEffectiveCwd(command: string, sessionCwd: string): string {
-  // Match: cd /path/to/dir && ..., cd /path/to/dir; ...
-  const cdMatch = command.match(/^\s*cd\s+([^\s;&|]+)/);
-  if (cdMatch) {
-    const target = cdMatch[1].replace(/['"]/g, "");
-    if (target.startsWith("/")) return target;
-    return join(sessionCwd, target);
+  // Match cd anywhere in the command (after &&, ;, ||, or at start)
+  // Use the LAST cd match — that's the effective cwd when the test command runs
+  let lastCdTarget: string | null = null;
+  const cdMatches = command.matchAll(/(?:^|[;&|]\s*)cd\s+([^\s;&|]+)/g);
+  for (const m of cdMatches) {
+    lastCdTarget = m[1].replace(/['"]/g, "");
+  }
+  if (lastCdTarget) {
+    if (lastCdTarget.startsWith("/")) return lastCdTarget;
+    return join(sessionCwd, lastCdTarget);
   }
   // Match: git -C /path/to/dir ...
   const gitCMatch = command.match(/\bgit\s+-C\s+([^\s]+)/);

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -363,7 +363,7 @@ export function stripHeredocBodies(cmd: string): string {
  */
 export function isTestRunnerCommand(command: string): boolean {
   return /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
-    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s|$)/.test(command) && !/tox\s+-e\b/.test(command)
+    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s+(?!-e\b)|$)/.test(command)
     || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -363,7 +363,7 @@ export function stripHeredocBodies(cmd: string): string {
  */
 export function isTestRunnerCommand(command: string): boolean {
   return /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
-    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox\b(?!\s*-e)/.test(command)
+    || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox\b(?!\s*-e)(?!\s+--(?:help|version|list))/.test(command)
     || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
     || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);

--- a/extensions/orchestrator/enforcement-helpers.ts
+++ b/extensions/orchestrator/enforcement-helpers.ts
@@ -30,16 +30,15 @@ export function escapeForSingleQuote(s: string): string {
 
 /** Parse bash command for cd target to resolve the effective working directory (worktree support) */
 export function resolveEffectiveCwd(command: string, sessionCwd: string): string {
-  // Match cd anywhere in the command (after &&, ;, ||, or at start)
-  // Use the LAST cd match — that's the effective cwd when the test command runs
-  let lastCdTarget: string | null = null;
-  const cdMatches = command.matchAll(/(?:^|[;&|]\s*)cd\s+([^\s;&|]+)/g);
-  for (const m of cdMatches) {
-    lastCdTarget = m[1].replace(/['"]/g, "");
-  }
-  if (lastCdTarget) {
-    if (lastCdTarget.startsWith("/")) return lastCdTarget;
-    return join(sessionCwd, lastCdTarget);
+  // Match the FIRST cd in the command (at start or after &&, ;, ||)
+  // First cd sets up the working directory before subsequent commands run.
+  // Using LAST cd is unsafe — a trailing cd (e.g., git commit && cd /tmp) would
+  // misattribute the cwd to the wrong directory.
+  const cdMatch = command.match(/(?:^|[;&|]\s*)cd\s+([^\s;&|]+)/);
+  if (cdMatch) {
+    const target = cdMatch[1].replace(/['"]/g, "");
+    if (target.startsWith("/")) return target;
+    return join(sessionCwd, target);
   }
   // Match: git -C /path/to/dir ...
   const gitCMatch = command.match(/\bgit\s+-C\s+([^\s]+)/);

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -39,6 +39,7 @@ import {
   stripHeredocBodies,
   escapeForDoubleQuote,
   escapeForSingleQuote,
+  isTestRunnerCommand,
 } from "./enforcement-helpers.js";
 
 type EnforcementResult = { block: true; reason: string } | undefined;
@@ -703,18 +704,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     const command: string = (event as any).input?.command || "";
     if (!command) return;
 
-    // Detect common test runner commands — require command-start position
-    // (after &&, |, ;, or line start) to avoid false positives from install/grep/cat commands.
-    // NOTE: For compound commands (e.g., pytest && other_cmd), if the non-test part fails,
-    // isError=true marks tests as failed even though pytest passed. This is the conservative/safe
-    // direction — re-run the test command standalone to mark tests_passed.
-    // NOTE: `tox` without `-e` args matches (runs default envs = tests). `tox -e lint` does NOT
-    // match — we exclude tox with explicit -e to avoid marking lint/docs runs as test passes.
-    const isTestCommand = /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
-      || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s|$)/.test(command) && !/tox\s+-e\b/.test(command)
-      || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
-      || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
-      || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);
+    const isTestCommand = isTestRunnerCommand(command);
     if (!isTestCommand) return;
 
     // Resolve the effective cwd BEFORE checking settings — the command may target

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -26,7 +26,7 @@ import {
   runGit,
 } from "./git-helpers.js";
 import { spawnSync } from "node:child_process";
-import { markNeedsReview, isReviewClean, readReviewState, statePath } from "./review-state.js";
+import { markNeedsReview, isReviewClean, readReviewState, statePath, markTestsPassed, markTestsFailed } from "./review-state.js";
 import {
   checkPythonPipBlock,
   checkRemoteExecBlock,
@@ -485,9 +485,11 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       const commitCwd = resolveEffectiveCwd(command, ctx.cwd);
       if (getSetting(ctx.cwd, "review_loop_enforcement") && !isReviewClean(commitCwd)) {
         const state = readReviewState(commitCwd);
+        const testInfo = state.status === "clean" && !state.tests_passed ? " Tests have not passed yet — run tests before committing." : "";
+        const reviewAdvice = state.status !== "clean" ? " Fix findings and re-run all reviewers until 0 comments." : "";
         return {
           block: true,
-          reason: `\u26d4 Review loop incomplete (status: ${state.status}, cycle ${state.cycle}, ${state.findings_count} findings, ${state.reviewers_pending.length} reviewers pending). Fix findings and re-run all reviewers until 0 comments.`,
+          reason: `\u26d4 Review loop incomplete (status: ${state.status}, cycle ${state.cycle}, ${state.findings_count} findings, ${state.reviewers_pending.length} reviewers pending, tests_passed: ${state.tests_passed}).${testInfo}${reviewAdvice}`,
         };
       }
     }
@@ -683,6 +685,59 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
     }
   });
 
+  // ── Test command detection (auto-mark tests_passed in review state) ──
+  // Runs in ALL processes (orchestrator + subagents) to catch test runs from any agent.
+  // When a test command exits successfully, marks tests_passed=true in review-state.json.
+  // When it fails, marks tests_passed=false. Any subsequent file edit resets tests_passed
+  // via markNeedsReview(), so stale results are impossible.
+  // NOTE: Code reviewers are excluded — they may run tests to verify behavior but their
+  // test runs should not mark the project's test state. Only intentional test runs count.
+  pi.on("tool_result", async (event, ctx) => {
+    if (!getSetting(ctx.cwd, "review_loop_enforcement")) return;
+
+    // Skip test detection for code reviewers — their test runs are verification, not validation
+    const agentName = process.env.PI_AGENT_NAME || "";
+    if (agentName.startsWith("code-reviewer-")) return;
+
+    const toolName = (event as any).toolName as string;
+    if (toolName !== "bash") return;
+
+    const command: string = (event as any).input?.command || "";
+    if (!command) return;
+
+    // Detect common test runner commands — require command-start position
+    // (after &&, |, ;, or line start) to avoid false positives from install/grep/cat commands.
+    // NOTE: For compound commands (e.g., pytest && other_cmd), if the non-test part fails,
+    // isError=true marks tests as failed even though pytest passed. This is the conservative/safe
+    // direction — re-run the test command standalone to mark tests_passed.
+    // NOTE: `tox` without `-e` args matches (runs default envs = tests). `tox -e lint` does NOT
+    // match — we exclude tox with explicit -e to avoid marking lint/docs runs as test passes.
+    const isTestCommand = /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
+      || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s|$)/.test(command) && !/tox\s+-e\b/.test(command)
+      || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
+      || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
+      || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);
+    if (!isTestCommand) return;
+
+    const effectiveCwd = resolveEffectiveCwd(command, ctx.cwd);
+    const isError = (event as any).isError === true;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        if (isError) {
+          markTestsFailed(effectiveCwd);
+        } else {
+          markTestsPassed(effectiveCwd);
+        }
+        break;
+      } catch {
+        if (attempt === 2) {
+          console.error("[enforcement] markTests(Passed|Failed) failed after 3 attempts");
+        }
+      }
+    }
+  });
+
   // ── /review-status command — read-only access to review state ──────
   // Usage: /review-status [worktree-path]
   // Without args: shows main repo state. With path: shows that worktree's state.
@@ -704,6 +759,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         `Findings: ${state.findings_count}`,
         `Reviewers pending: ${state.reviewers_pending.length}/${state.reviewers_total}${state.reviewers_pending.length > 0 ? " (" + state.reviewers_pending.join(", ") + ")" : ""}`,
         `Edited during cycle: ${state.edited_during_cycle}`,
+        `Tests passed: ${state.tests_passed}`,
         `Last edit: ${state.last_edit_at || "none"}`,
         `Last clean: ${state.last_clean_at || "none"}`,
       ];
@@ -731,6 +787,7 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
         `findings: ${state.findings_count}`,
         `pending: ${state.reviewers_pending.length}/${state.reviewers_total}${state.reviewers_pending.length > 0 ? " (" + state.reviewers_pending.join(", ") + ")" : ""}`,
         `edited_during_cycle: ${state.edited_during_cycle}`,
+        `tests_passed: ${state.tests_passed}`,
         `last_edit: ${state.last_edit_at || "none"}`,
         `last_clean: ${state.last_clean_at || "none"}`,
       ].join("\n");

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -693,14 +693,12 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
   // NOTE: Code reviewers are excluded — they may run tests to verify behavior but their
   // test runs should not mark the project's test state. Only intentional test runs count.
   pi.on("tool_result", async (event, ctx) => {
-    if (!getSetting(ctx.cwd, "review_loop_enforcement")) return;
+    const toolName = (event as any).toolName as string;
+    if (toolName !== "bash") return;
 
     // Skip test detection for code reviewers — their test runs are verification, not validation
     const agentName = process.env.PI_AGENT_NAME || "";
     if (agentName.startsWith("code-reviewer-")) return;
-
-    const toolName = (event as any).toolName as string;
-    if (toolName !== "bash") return;
 
     const command: string = (event as any).input?.command || "";
     if (!command) return;
@@ -719,7 +717,11 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);
     if (!isTestCommand) return;
 
+    // Resolve the effective cwd BEFORE checking settings — the command may target
+    // a different repo (cd <dir> or git -C <dir>), so we need that repo's settings.
     const effectiveCwd = resolveEffectiveCwd(command, ctx.cwd);
+    if (!getSetting(effectiveCwd, "review_loop_enforcement")) return;
+
     const isError = (event as any).isError === true;
 
     for (let attempt = 0; attempt < 3; attempt++) {

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -364,8 +364,7 @@ function registerMemoryAdd(pi: ExtensionAPI): void {
                   merged = true;
                 }
               }
-              // Remove the just-embedded entry since we're reinforcing instead of adding
-              await removeEmbedding(cwd, text, category);
+              // No removeEmbedding needed — new entry was not embedded before searching
               const enforcementNote = merged ? " (enforcement fields merged)" : "";
               return {
                 content: [{

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -331,9 +331,9 @@ function registerMemoryAdd(pi: ExtensionAPI): void {
           return true;
         });
         await embedMissing(cwd, sameCategoryEntries);
-        // Embed the new entry now so vectorSearch can use the cached embedding
-        // and embedEntry() later is a no-op (already in store)
-        await embedEntry(cwd, text, category);
+        // Do NOT embed the new entry before searching — if the entry already exists
+        // in sameCategoryEntries, it would match itself with similarity 1.000.
+        // embedEntry() is called later after confirming no duplicate.
         const vectorMatches = await vectorSearch(cwd, text, sameCategoryEntries, 20);
         for (const vm of vectorMatches) {
           if (vm.similarity >= NEAR_DUPLICATE_THRESHOLD) {
@@ -485,7 +485,7 @@ function registerMemoryAdd(pi: ExtensionAPI): void {
       scores.entries[hash] = entry;
       saveScores(cwd, scores);
 
-      // Embed the new entry (no-op if already embedded during dedup check above)
+      // Embed the new entry for future similarity searches
       await embedEntry(cwd, text, category);
 
       const pin = isPinned ? " (pinned)" : "";

--- a/extensions/orchestrator/review-state.ts
+++ b/extensions/orchestrator/review-state.ts
@@ -20,6 +20,7 @@ export interface ReviewState {
   last_edit_at: string | null;
   last_clean_at: string | null;
   edited_during_cycle: boolean;
+  tests_passed: boolean;
 }
 
 const STATE_FILE = "review-state.json";
@@ -42,6 +43,7 @@ function defaultState(): ReviewState {
     last_edit_at: null,
     last_clean_at: null,
     edited_during_cycle: false,
+    tests_passed: false,
   };
 }
 
@@ -59,6 +61,7 @@ export function readReviewState(cwd: string): ReviewState {
       last_edit_at: typeof raw.last_edit_at === "string" ? raw.last_edit_at : null,
       last_clean_at: typeof raw.last_clean_at === "string" ? raw.last_clean_at : null,
       edited_during_cycle: raw.edited_during_cycle === true,
+      tests_passed: raw.tests_passed === true,
     };
   } catch (e: any) {
     console.debug("[review-state] failed to parse state:", e?.message);
@@ -154,6 +157,7 @@ export function markNeedsReview(cwd: string): void {
     if (state.status === "in_progress") {
       state.last_edit_at = new Date().toISOString();
       state.edited_during_cycle = true;
+      state.tests_passed = false;
     } else {
       state.status = "needs_review";
       state.last_edit_at = new Date().toISOString();
@@ -162,6 +166,7 @@ export function markNeedsReview(cwd: string): void {
       state.reviewers_pending = [];
       state.reviewers_total = 0;
       state.edited_during_cycle = false;
+      state.tests_passed = false;
     }
     writeState(cwd, state);
   });
@@ -214,7 +219,28 @@ export function isReviewClean(cwd: string): boolean {
   const state = readReviewState(cwd);
   if (state.status === "none") return true; // No tracking active — nothing to enforce
   if (state.status !== "clean") return false;
+  if (!state.tests_passed) return false;
   return true;
+}
+
+/** Mark that tests have passed. Only meaningful when review status is being tracked. */
+export function markTestsPassed(cwd: string): void {
+  withStateLock(cwd, (state) => {
+    if (state.status === "none") return; // No tracking active
+    state.tests_passed = true;
+    writeState(cwd, state);
+  });
+}
+
+/** Mark that tests have failed. No-op when review status is not being tracked.
+ *  Called when a detected test command exits non-zero, or test-automator/test-runner agent fails.
+ *  Resets to false on any file edit via markNeedsReview(). */
+export function markTestsFailed(cwd: string): void {
+  withStateLock(cwd, (state) => {
+    if (state.status === "none") return; // No tracking active
+    state.tests_passed = false;
+    writeState(cwd, state);
+  });
 }
 
 /** Count findings in reviewer output by matching severity markers at line start. */

--- a/extensions/orchestrator/review-state.ts
+++ b/extensions/orchestrator/review-state.ts
@@ -243,12 +243,22 @@ export function markTestsFailed(cwd: string): void {
   });
 }
 
-/** Count findings in reviewer output by matching severity markers at line start. */
+/** Count findings in reviewer output by parsing JSON.
+ *  Returns the number of findings, or -1 if the output is not valid JSON with a findings array. */
 export function countFindings(output: string): number {
-  const criticals = (output.match(/^\[CRITICAL\]/gm) || []).length;
-  const warnings = (output.match(/^\[WARNING\]/gm) || []).length;
-  const suggestions = (output.match(/^\[SUGGESTION\]/gm) || []).length;
-  return criticals + warnings + suggestions;
+  // Try JSON parse — reviewers return {"findings": [...]}
+  try {
+    // Strip markdown code fences if present
+    let cleaned = output.trim();
+    if (cleaned.startsWith("```")) {
+      cleaned = cleaned.replace(/^```(?:json)?\s*\n?/, "").replace(/\n?```\s*$/, "");
+    }
+    const parsed = JSON.parse(cleaned);
+    if (parsed && Array.isArray(parsed.findings)) {
+      return parsed.findings.length;
+    }
+  } catch { /* not valid JSON — return -1 */ }
+  return -1;
 }
 
 /** Reset review state — for testing or manual override. */

--- a/myk_pi_tools/reviews/ask_qodo.py
+++ b/myk_pi_tools/reviews/ask_qodo.py
@@ -1,6 +1,6 @@
 """Ask Qodo a question and wait for reply.
 
-Posts a comment mentioning @qodo-code-review with the question,
+Posts a comment using /qodo command with the question,
 then waits up to 10 minutes for Qodo's reply.
 
 Usage:
@@ -30,13 +30,13 @@ def post_and_wait_for_qodo_reply(
     poll_interval: int = 30,
     label: str = "ask-qodo",
 ) -> str:
-    """Post a comment mentioning @qodo-code-review and wait for reply.
+    """Post a comment using /qodo command and wait for reply.
 
     Args:
         owner: Repository owner.
         repo: Repository name.
         pr_number: PR number.
-        message: Full message body to post (should include @qodo-code-review).
+        message: Full message body to post (should start with /qodo).
         match_lines: Lines to match in Qodo's reply (it quotes our message).
         timeout: Max wait time in seconds (default 600 = 10 min).
         poll_interval: Seconds between checks (default 30).
@@ -63,7 +63,7 @@ def post_and_wait_for_qodo_reply(
             check=True,
             timeout=30,
         )
-        print_stderr(f"[{label}] Posted comment to @qodo-code-review.")
+        print_stderr(f"[{label}] Posted /qodo comment.")
     except subprocess.CalledProcessError as e:
         stderr = e.stderr.strip() if e.stderr else ""
         print_stderr(f"[{label}] Failed to post comment (rc={e.returncode}): {stderr}")
@@ -109,7 +109,7 @@ def post_and_wait_for_qodo_reply(
 
 def ask_qodo(owner: str, repo: str, pr_number: str, question: str) -> str:
     """Post a question to Qodo and wait for reply."""
-    message = f"@qodo-code-review\n\n{question}"
+    message = f"/qodo {question}"
     match_lines = [line.strip() for line in question.strip().splitlines() if line.strip()]
     return post_and_wait_for_qodo_reply(
         owner,

--- a/myk_pi_tools/reviews/commands.py
+++ b/myk_pi_tools/reviews/commands.py
@@ -137,7 +137,7 @@ def reviews_status(pr: int | None, output_dir: str) -> None:
 def reviews_ask_qodo(args: tuple[str, ...]) -> None:
     """Ask Qodo a question about the current PR and wait for reply.
 
-    Posts @qodo-code-review comment with your question, waits up to 10 min for reply.
+    Posts /qodo comment with your question, waits up to 10 min for reply.
 
     Usage:
         reviews ask-qodo "What specific edge cases are missing for finding 11?"

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -245,7 +245,7 @@ def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> str:
 
     Returns Qodo's reply body text, or empty string on timeout/failure.
     """
-    message = f"qodo {_CLEANUP_REQUEST_TEXT}"
+    message = f"/qodo {_CLEANUP_REQUEST_TEXT}"
     match_lines = [line.strip() for line in _CLEANUP_REQUEST_TEXT.strip().splitlines() if line.strip()]
     return post_and_wait_for_qodo_reply(
         owner,

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -355,7 +355,7 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                                 _cleanup_last_requested_at = time.time()
                                 if _cleanup_reply:
                                     _cleanup_response = _cleanup_reply
-                                if _cleanup_response:
+                                if _cleanup_reply:
                                     # Re-fetch to get fresh data
                                     _fresh = fetch_run(review_url, output_dir=output_dir)
                                     if isinstance(_fresh, dict):

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -238,11 +238,14 @@ _CLEANUP_REQUEST_TEXT = (
 
 
 def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> str:
-    """Ask Qodo to re-evaluate sticky findings and wait for reply.
+    """Ask Qodo to re-evaluate sticky findings via /ask command and wait for reply.
+
+    Uses Qodo v2's /ask command instead of @mention — Qodo v2 responds to
+    slash commands, not free-text @mentions.
 
     Returns Qodo's reply body text, or empty string on timeout/failure.
     """
-    message = f"@qodo-code-review\n\n{_CLEANUP_REQUEST_TEXT}"
+    message = f"/ask {_CLEANUP_REQUEST_TEXT}"
     match_lines = [line.strip() for line in _CLEANUP_REQUEST_TEXT.strip().splitlines() if line.strip()]
     return post_and_wait_for_qodo_reply(
         owner,
@@ -264,7 +267,8 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
     """
     owner_repo = f"{owner}/{repo}"
     _qodo_reviewing_since: float | None = None  # Track when Qodo's transient "reviewing" comment first appeared
-    _cleanup_requested = False  # Track if we already asked Qodo to clean up stickies
+    _cleanup_last_requested_at: float = 0  # Timestamp of last cleanup request (0 = never)
+    _CLEANUP_RETRY_COOLDOWN_SECONDS = 300  # 5 min cooldown between cleanup retries
     _cleanup_response = ""  # Qodo's reply to our cleanup request
     cycle = 0
     _result: dict | None = None
@@ -327,7 +331,11 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
             else:
                 _qodo_reviewing_since = None
                 # Check for stale sticky findings and request cleanup
-                if not _cleanup_requested and not has_actionable:
+                _cleanup_cooldown_elapsed = (
+                    _cleanup_last_requested_at == 0
+                    or time.time() - _cleanup_last_requested_at > _CLEANUP_RETRY_COOLDOWN_SECONDS
+                )
+                if _cleanup_cooldown_elapsed and not has_actionable:
                     _review_path = Path(output_dir) / f"pr-{pr_number}-reviews.json"
                     if _review_path.exists():
                         try:
@@ -339,9 +347,12 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                                 for f in _review_data.get("qodo", [])
                             )
                             if _has_stale:
-                                print_stderr("[poll] Stale sticky findings detected — requesting Qodo cleanup.")
+                                _retry_label = "Retrying" if _cleanup_last_requested_at > 0 else "Requesting"
+                                print_stderr(
+                                    f"[poll] Stale sticky findings detected — {_retry_label.lower()} Qodo cleanup."
+                                )
                                 _cleanup_reply = _request_qodo_sticky_cleanup(owner, repo, pr_number)
-                                _cleanup_requested = True
+                                _cleanup_last_requested_at = time.time()
                                 if _cleanup_reply:
                                     _cleanup_response = _cleanup_reply
                                 if _cleanup_response:
@@ -352,6 +363,16 @@ def _run_qodo_poll(review_url: str, owner: str, repo: str, pr_number: str, outpu
                                         _fresh["approved"] = False
                                         _result = _fresh
                                         break
+                                else:
+                                    # Cleanup request timed out — Qodo didn't reply.
+                                    # Force a fresh review via /agentic_review so Qodo
+                                    # re-evaluates the PR and resolves stale stickies.
+                                    print_stderr(
+                                        "[poll] Cleanup timed out — triggering /agentic_review"
+                                        " to force fresh Qodo review."
+                                    )
+                                    _retrigger_qodo_review(owner, repo, pr_number)
+
                         except Exception as e:
                             print_stderr(f"[poll] Cleanup check failed: {e}")
 

--- a/myk_pi_tools/reviews/poll.py
+++ b/myk_pi_tools/reviews/poll.py
@@ -245,7 +245,7 @@ def _request_qodo_sticky_cleanup(owner: str, repo: str, pr_number: str) -> str:
 
     Returns Qodo's reply body text, or empty string on timeout/failure.
     """
-    message = f"/ask {_CLEANUP_REQUEST_TEXT}"
+    message = f"qodo {_CLEANUP_REQUEST_TEXT}"
     match_lines = [line.strip() for line in _CLEANUP_REQUEST_TEXT.strip().splitlines() if line.strip()]
     return post_and_wait_for_qodo_reply(
         owner,

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -468,6 +468,7 @@ def post_body_comment_replies(
     """
     max_len = 55000  # Leave margin below GitHub's ~65KB limit
     header_template = "@{reviewer}\n\nThe following review comments were reviewed and a decision was made:\n\n"
+    _QODO_AUTHORS = {"qodo-code-review[bot]", "qodo-code-review"}
     posted = 0
     posted_updates: list[dict[str, Any]] = []
 
@@ -475,7 +476,11 @@ def post_body_comment_replies(
         if not entries:
             continue
 
-        header = header_template.format(reviewer=reviewer)
+        # Qodo v2 responds to /qodo, not @qodo-code-review[bot]
+        if reviewer in _QODO_AUTHORS:
+            header = "/qodo\n\nThe following review comments were reviewed and a decision was made:\n\n"
+        else:
+            header = header_template.format(reviewer=reviewer)
         part_prefix_budget = 32  # "(Part N/M)\n\n" safety margin
         max_section_len = max_len - len(header) - part_prefix_budget
 

--- a/myk_pi_tools/reviews/post.py
+++ b/myk_pi_tools/reviews/post.py
@@ -427,7 +427,7 @@ def _post_chunk(
         )
         if result.returncode == 0:
             chunk_count = len(chunk)
-            eprint(f"Posted consolidated reply for {chunk_count} body comment(s) mentioning @{reviewer}")
+            eprint(f"Posted consolidated reply for {chunk_count} body comment(s) mentioning {reviewer}")
             ts = get_utc_timestamp()
             for _, entry in chunk:
                 posted_updates.append({
@@ -437,10 +437,10 @@ def _post_chunk(
                     "ts": ts,
                 })
             return True, posted_updates
-        eprint(f"Error posting consolidated reply for @{reviewer}: {result.stderr}")
+        eprint(f"Error posting consolidated reply for {reviewer}: {result.stderr}")
         return False, []
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        eprint(f"Error posting consolidated reply for @{reviewer}: {e}")
+        eprint(f"Error posting consolidated reply for {reviewer}: {e}")
         return False, []
 
 

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -45,6 +45,12 @@ Six agents run in parallel for comprehensive coverage:
 **All 6 MUST be invoked as async subagents (`async: true`) in the same assistant turn.
 Do NOT block waiting for results — continue working while they run.**
 
+Send reviewers "Review the code changes" — never mention `git diff HEAD` in the task prompt.
+Reviewers get `$PI_REVIEW_BASE_BRANCH` env var and use `git diff origin/$PI_REVIEW_BASE_BRANCH...HEAD` themselves.
+
+Reviewers return structured JSON: `{"findings": [{"severity": "...", "file": "...", "line": N, "description": "...", "suggestion": "..."}]}`.
+The async runner validates the output is valid JSON and retries if not (up to 3 times).
+
 Overlapping scope is intentional for comprehensive coverage; step 3's deduplication handles duplicates.
 
 ## Deduplication Criteria
@@ -160,4 +166,4 @@ For automated review flows (autorabbit, autoqodo), use **two-stage order** inste
    Loop Stage 2 until passed.
 
 Don't polish code that doesn't meet spec — it wastes work.
-Parallel mode (all 5 reviewers at once) remains default for manual reviews.
+Parallel mode (all 6 agents at once) remains default for manual reviews.

--- a/rules/20-code-review-loop.md
+++ b/rules/20-code-review-loop.md
@@ -1,6 +1,6 @@
 # Code Review Loop (MANDATORY)
 
-After ANY code change, send to ALL 5 review agents. **Never skip the first review.**
+After ANY code change, send to ALL 6 agents (5 reviewers + test-automator) IN PARALLEL. **Never skip the first review.**
 
 If `review_loop_enforcement` is enabled (default: disabled).
 Resolution: project `.pi/pi-config-settings.json` → global `~/.pi/pi-config-settings.json` → `PI_REVIEW_LOOP_ENFORCEMENT` env var → `false`.
@@ -13,25 +13,25 @@ If disabled:
 - Single review pass is sufficient
 - No commit blocking
 
-**In both cases, all 5 reviewers are always called. The setting only controls whether the loop repeats.**
+**In both cases, all 6 agents are always called. The setting only controls whether the loop repeats.**
 
 ```text
 1. Specialist writes/fixes code
-2. Send to ALL 5 review agents IN PARALLEL (async)
-3. Merge & deduplicate findings
-4. Has comments? ──YES──→ For EACH finding: fix code OR explain why not (step 4a)
-                    │     → go to 2 with prior findings + responses (if review_loop_enforcement enabled)
-                    NO ↓
-5. Run test-automator
-6. Tests pass? ──NO──→ Minor fix? re-run tests (go to 5)
-                        Substantive change? full re-review (go to 2)
-               YES ↓
-✅ DONE
+2. Send ALL 6 agents IN PARALLEL (async): 5 reviewers + test-automator
+3. Wait for all 6 to complete
+4. Merge & deduplicate review findings
+5. Has findings OR tests failed?
+   ── Findings? → For EACH finding: fix code OR explain why not (step 5a)
+   ── Tests failed? → Fix code
+   ── Either? → go to 2 (re-run all 6 with prior findings + responses)
+   ── Neither? ↓
+   status: clean, tests_passed: true
+✅ DONE — commit/push allowed (enforcement checks status: clean AND tests_passed: true)
 ```
 
 ## Review Agents
 
-Five agents review code in parallel for comprehensive coverage:
+Six agents run in parallel for comprehensive coverage:
 
 | Agent | Focus |
 |---|---|
@@ -40,9 +40,10 @@ Five agents review code in parallel for comprehensive coverage:
 | `code-reviewer-security` | Bugs, logic errors, and security vulnerabilities |
 | `code-reviewer-docs` | Documentation quality, completeness, and accuracy |
 | `code-reviewer-spec` | Code/PR/issue spec alignment and compliance |
+| `test-automator` | Run project tests (pytest, node tests, pre-commit) |
 
-**All 5 MUST be invoked as async subagents (`async: true`) in the same assistant turn.
-Do NOT block waiting for reviews — continue working while they run.**
+**All 6 MUST be invoked as async subagents (`async: true`) in the same assistant turn.
+Do NOT block waiting for results — continue working while they run.**
 
 Overlapping scope is intentional for comprehensive coverage; step 3's deduplication handles duplicates.
 
@@ -96,11 +97,27 @@ is sufficient — fix what you agree with, skip what you don't. No need to expla
 
 ## Key Rules
 
-Never skip code review — all 5 reviewers always run.
-When `review_loop_enforcement` is enabled: loop until all reviewers return 0 findings AND tests pass.
-Respond to each finding (fix or explain) and re-review from step 2; once approved, run tests.
-When disabled: single review pass is sufficient; no mandatory re-review loop or explanations.
+Never skip code review — all 6 agents always run (5 reviewers + test-automator).
+When `review_loop_enforcement` is enabled: loop until all reviewers return 0 findings AND `tests_passed: true` in review-state.json.
+Respond to each finding (fix or explain) and re-run all 6 from step 2.
+When disabled: single pass is sufficient; no mandatory re-loop or explanations.
 Minor test/config-only fixes skip re-review (go to step 5); substantive code changes require full re-review.
+
+## Test Tracking
+
+Test results are tracked in `review-state.json` via the `tests_passed` field.
+This is **code-enforced** — commit/push is blocked unless `tests_passed: true` (when `review_loop_enforcement` is enabled).
+
+**How `tests_passed` gets set:**
+
+- **Bash hook detection:** When any agent runs a test command (`pytest`, `npm test`, `npx tsx --test`, `tox`, `go test`, `vitest`, `jest`, `mocha`),
+  the enforcement hook detects it and auto-marks `tests_passed` based on exit code.
+- **Agent completion:** When `test-automator` or `test-runner` agents complete, their result auto-marks `tests_passed`.
+- **Reset on edit:** Any file edit triggers `markNeedsReview()`, which resets `tests_passed: false` —
+  preventing stale results.
+
+**Duplicate test run avoidance:** If a specialist already ran tests before the review loop, `tests_passed` may already be `true`.
+Any file edit resets it, so test-automator in the parallel batch always validates the latest code.
 
 ## Baseline Test Comparison (Step 5)
 

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -95,11 +95,14 @@ The situation report header shows usage: `# Project Memory [72% — 1,224/1,700 
 
 - **One line only** — max ~100 chars, single short sentence
 - **Specific and actionable** — concrete "do X" or "don't do Y", no fluff
+- **Preserve context scope** — if a preference was stated about a specific tool/project/workflow,
+  include that scope in the memory. NEVER generalize a context-specific statement into a universal rule.
 
 | ❌ Bad | ✅ Good |
 |--------|---------|
 | "We had issues with buildah and Docker caching and tried several approaches" | "buildah chown -R breaks cache mounts — use --mount=type=cache with correct uid" |
 | "User prefers a certain approach to handling processes" | "Attach child processes to pi (no detached:true) — kills on exit" |
+| "Never use gemini-2.5-flash model" (said about a specific tool) | "Never use gemini-2.5-flash for X — unreliable for that use case" |
 
 ---
 

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -22,6 +22,7 @@ import {
   checkTempFileEnforcement,
   hasGitAddBulk,
   stripHeredocBodies,
+  isTestRunnerCommand,
 } from "../../../extensions/orchestrator/enforcement-helpers.js";
 
 // ── extractSubshells ──
@@ -631,93 +632,84 @@ describe("stripHeredocBodies", () => {
   });
 });
 
-// ── Test command detection regex ──
-// Tests the regex used by enforcement.ts to detect test runner commands.
-// The regex is duplicated here (not exported) to test the matching logic directly.
+// ── Test command detection (isTestRunnerCommand) ──
+// Tests the exported isTestRunnerCommand from enforcement-helpers.ts.
 
-describe("test command detection regex", () => {
-  // Mirrors the regex from enforcement.ts test detection hook
-  function isTestCommand(command: string): boolean {
-    return /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
-      || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s|$)/.test(command) && !/tox\s+-e\b/.test(command)
-      || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
-      || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
-      || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);
-  }
+describe("isTestRunnerCommand", () => {
 
   it("matches bare pytest", () => {
-    assert.equal(isTestCommand("pytest"), true);
+    assert.equal(isTestRunnerCommand("pytest"), true);
   });
 
   it("matches uv run pytest", () => {
-    assert.equal(isTestCommand("uv run pytest"), true);
+    assert.equal(isTestRunnerCommand("uv run pytest"), true);
   });
 
   it("matches uv run --group tests pytest", () => {
-    assert.equal(isTestCommand("uv run --group tests pytest"), true);
+    assert.equal(isTestRunnerCommand("uv run --group tests pytest"), true);
   });
 
   it("matches uv run --group tests --no-cache pytest", () => {
-    assert.equal(isTestCommand("uv run --group tests --no-cache pytest"), true);
+    assert.equal(isTestRunnerCommand("uv run --group tests --no-cache pytest"), true);
   });
 
   it("matches pytest after && separator", () => {
-    assert.equal(isTestCommand("cd /tmp && pytest"), true);
+    assert.equal(isTestRunnerCommand("cd /tmp && pytest"), true);
   });
 
   it("matches npm test", () => {
-    assert.equal(isTestCommand("npm test"), true);
+    assert.equal(isTestRunnerCommand("npm test"), true);
   });
 
   it("matches npx tsx --test", () => {
-    assert.equal(isTestCommand("npx tsx --test tests/"), true);
+    assert.equal(isTestRunnerCommand("npx tsx --test tests/"), true);
   });
 
   it("matches bare tox", () => {
-    assert.equal(isTestCommand("tox"), true);
+    assert.equal(isTestRunnerCommand("tox"), true);
   });
 
   it("matches go test", () => {
-    assert.equal(isTestCommand("go test ./..."), true);
+    assert.equal(isTestRunnerCommand("go test ./..."), true);
   });
 
   it("matches vitest", () => {
-    assert.equal(isTestCommand("vitest"), true);
+    assert.equal(isTestRunnerCommand("vitest"), true);
   });
 
   it("matches jest", () => {
-    assert.equal(isTestCommand("jest"), true);
+    assert.equal(isTestRunnerCommand("jest"), true);
   });
 
   it("matches mocha", () => {
-    assert.equal(isTestCommand("mocha"), true);
+    assert.equal(isTestRunnerCommand("mocha"), true);
   });
 
   it("does not match pip install pytest", () => {
-    assert.equal(isTestCommand("pip install pytest"), false);
+    assert.equal(isTestRunnerCommand("pip install pytest"), false);
   });
 
   it("does not match grep pytest", () => {
-    assert.equal(isTestCommand("grep pytest requirements.txt"), false);
+    assert.equal(isTestRunnerCommand("grep pytest requirements.txt"), false);
   });
 
   it("does not match echo pytest", () => {
-    assert.equal(isTestCommand("echo pytest"), false);
+    assert.equal(isTestRunnerCommand("echo pytest"), false);
   });
 
   it("does not match cat tox.ini", () => {
-    assert.equal(isTestCommand("cat tox.ini"), false);
+    assert.equal(isTestRunnerCommand("cat tox.ini"), false);
   });
 
   it("does not match tox -e lint", () => {
-    assert.equal(isTestCommand("tox -e lint"), false);
+    assert.equal(isTestRunnerCommand("tox -e lint"), false);
   });
 
   it("does not match tox -e docs", () => {
-    assert.equal(isTestCommand("tox -e docs"), false);
+    assert.equal(isTestRunnerCommand("tox -e docs"), false);
   });
 
   it("does not match npm install jest", () => {
-    assert.equal(isTestCommand("npm install jest"), false);
+    assert.equal(isTestRunnerCommand("npm install jest"), false);
   });
 });

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -709,6 +709,10 @@ describe("isTestRunnerCommand", () => {
     assert.equal(isTestRunnerCommand("tox -e docs"), false);
   });
 
+  it("does not match tox -elint (combined flag)", () => {
+    assert.equal(isTestRunnerCommand("tox -elint"), false);
+  });
+
   it("matches tox after tox -e lint in compound command", () => {
     assert.equal(isTestRunnerCommand("tox -e lint && tox"), true);
   });

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -709,6 +709,10 @@ describe("isTestRunnerCommand", () => {
     assert.equal(isTestRunnerCommand("tox -e docs"), false);
   });
 
+  it("matches tox after tox -e lint in compound command", () => {
+    assert.equal(isTestRunnerCommand("tox -e lint && tox"), true);
+  });
+
   it("does not match npm install jest", () => {
     assert.equal(isTestRunnerCommand("npm install jest"), false);
   });

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -421,6 +421,15 @@ describe("resolveEffectiveCwd", () => {
   it("strips quotes from cd path", () => {
     assert.equal(resolveEffectiveCwd("cd '/foo/bar' && ls", "/home"), "/foo/bar");
   });
+  it("resolves cd after && separator", () => {
+    assert.equal(resolveEffectiveCwd("echo ok && cd /other/repo && pytest", "/home"), "/other/repo");
+  });
+  it("resolves cd after ; separator", () => {
+    assert.equal(resolveEffectiveCwd("echo ok; cd /other/repo; pytest", "/home"), "/other/repo");
+  });
+  it("uses last cd in compound command", () => {
+    assert.equal(resolveEffectiveCwd("cd /first && cd /second && pytest", "/home"), "/second");
+  });
 });
 
 // ── checkPythonPipBlock ──

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -713,6 +713,18 @@ describe("isTestRunnerCommand", () => {
     assert.equal(isTestRunnerCommand("tox -e lint && tox"), true);
   });
 
+  it("matches tox followed by && without space", () => {
+    assert.equal(isTestRunnerCommand("tox&& echo ok"), true);
+  });
+
+  it("matches tox with output redirection", () => {
+    assert.equal(isTestRunnerCommand("tox>out.txt"), true);
+  });
+
+  it("matches tox followed by semicolon without space", () => {
+    assert.equal(isTestRunnerCommand("tox;echo ok"), true);
+  });
+
   it("does not match npm install jest", () => {
     assert.equal(isTestRunnerCommand("npm install jest"), false);
   });

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -630,3 +630,94 @@ describe("stripHeredocBodies", () => {
     assert.ok(stripHeredocBodies(input).includes("rm -rf"));
   });
 });
+
+// ── Test command detection regex ──
+// Tests the regex used by enforcement.ts to detect test runner commands.
+// The regex is duplicated here (not exported) to test the matching logic directly.
+
+describe("test command detection regex", () => {
+  // Mirrors the regex from enforcement.ts test detection hook
+  function isTestCommand(command: string): boolean {
+    return /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?(?:pytest|vitest|jest|mocha)\b/.test(command)
+      || /(?:^|[;&|]\s*)(?:uv\s+run\s+(?:--\S+(?:\s+\S+)?\s+)*)?tox(?:\s|$)/.test(command) && !/tox\s+-e\b/.test(command)
+      || /(?:^|[;&|]\s*)go\s+test\b/.test(command)
+      || /(?:^|[;&|]\s*)npm\s+test\b/.test(command)
+      || /(?:^|[;&|]\s*)npx\s+tsx\s+--test\b/.test(command);
+  }
+
+  it("matches bare pytest", () => {
+    assert.equal(isTestCommand("pytest"), true);
+  });
+
+  it("matches uv run pytest", () => {
+    assert.equal(isTestCommand("uv run pytest"), true);
+  });
+
+  it("matches uv run --group tests pytest", () => {
+    assert.equal(isTestCommand("uv run --group tests pytest"), true);
+  });
+
+  it("matches uv run --group tests --no-cache pytest", () => {
+    assert.equal(isTestCommand("uv run --group tests --no-cache pytest"), true);
+  });
+
+  it("matches pytest after && separator", () => {
+    assert.equal(isTestCommand("cd /tmp && pytest"), true);
+  });
+
+  it("matches npm test", () => {
+    assert.equal(isTestCommand("npm test"), true);
+  });
+
+  it("matches npx tsx --test", () => {
+    assert.equal(isTestCommand("npx tsx --test tests/"), true);
+  });
+
+  it("matches bare tox", () => {
+    assert.equal(isTestCommand("tox"), true);
+  });
+
+  it("matches go test", () => {
+    assert.equal(isTestCommand("go test ./..."), true);
+  });
+
+  it("matches vitest", () => {
+    assert.equal(isTestCommand("vitest"), true);
+  });
+
+  it("matches jest", () => {
+    assert.equal(isTestCommand("jest"), true);
+  });
+
+  it("matches mocha", () => {
+    assert.equal(isTestCommand("mocha"), true);
+  });
+
+  it("does not match pip install pytest", () => {
+    assert.equal(isTestCommand("pip install pytest"), false);
+  });
+
+  it("does not match grep pytest", () => {
+    assert.equal(isTestCommand("grep pytest requirements.txt"), false);
+  });
+
+  it("does not match echo pytest", () => {
+    assert.equal(isTestCommand("echo pytest"), false);
+  });
+
+  it("does not match cat tox.ini", () => {
+    assert.equal(isTestCommand("cat tox.ini"), false);
+  });
+
+  it("does not match tox -e lint", () => {
+    assert.equal(isTestCommand("tox -e lint"), false);
+  });
+
+  it("does not match tox -e docs", () => {
+    assert.equal(isTestCommand("tox -e docs"), false);
+  });
+
+  it("does not match npm install jest", () => {
+    assert.equal(isTestCommand("npm install jest"), false);
+  });
+});

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -713,6 +713,18 @@ describe("isTestRunnerCommand", () => {
     assert.equal(isTestRunnerCommand("tox -elint"), false);
   });
 
+  it("does not match tox --help", () => {
+    assert.equal(isTestRunnerCommand("tox --help"), false);
+  });
+
+  it("does not match tox --version", () => {
+    assert.equal(isTestRunnerCommand("tox --version"), false);
+  });
+
+  it("does not match tox --list", () => {
+    assert.equal(isTestRunnerCommand("tox --list"), false);
+  });
+
   it("matches tox after tox -e lint in compound command", () => {
     assert.equal(isTestRunnerCommand("tox -e lint && tox"), true);
   });

--- a/tests/node/orchestrator/enforcement.test.ts
+++ b/tests/node/orchestrator/enforcement.test.ts
@@ -427,8 +427,11 @@ describe("resolveEffectiveCwd", () => {
   it("resolves cd after ; separator", () => {
     assert.equal(resolveEffectiveCwd("echo ok; cd /other/repo; pytest", "/home"), "/other/repo");
   });
-  it("uses last cd in compound command", () => {
-    assert.equal(resolveEffectiveCwd("cd /first && cd /second && pytest", "/home"), "/second");
+  it("uses first cd in compound command", () => {
+    assert.equal(resolveEffectiveCwd("cd /first && cd /second && pytest", "/home"), "/first");
+  });
+  it("ignores trailing cd after git command", () => {
+    assert.equal(resolveEffectiveCwd("cd /repo && git commit && cd /tmp", "/home"), "/repo");
   });
 });
 

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -281,36 +281,39 @@ describe("Full cycle — one reviewer has findings", () => {
 });
 
 describe("countFindings", () => {
-  it("returns 0 for empty string", () => {
-    assert.equal(countFindings(""), 0);
+  it("returns -1 for empty string", () => {
+    assert.equal(countFindings(""), -1);
   });
 
-  it("returns 0 for approved output", () => {
-    assert.equal(countFindings("No quality issues found. Code approved."), 0);
+  it("returns -1 for non-JSON text", () => {
+    assert.equal(countFindings("No quality issues found. Code approved."), -1);
   });
 
-  it("counts single CRITICAL", () => {
-    assert.equal(countFindings("[CRITICAL] file.ts:10 — Missing null check"), 1);
+  it("returns 0 for empty findings array", () => {
+    assert.equal(countFindings('{"findings": []}'), 0);
   });
 
-  it("counts mixed severities", () => {
-    const output = `[CRITICAL] a.ts:1 — Bug\n[WARNING] b.ts:2 — Style\n[SUGGESTION] c.ts:3 — Improvement`;
+  it("counts single finding", () => {
+    const output = '{"findings": [{"severity": "CRITICAL", "file": "a.ts", "line": 10, "description": "bug"}]}';
+    assert.equal(countFindings(output), 1);
+  });
+
+  it("counts multiple findings", () => {
+    const output = '{"findings": [{"severity": "CRITICAL", "file": "a.ts", "line": 1, "description": "bug"}, {"severity": "WARNING", "file": "b.ts", "line": 2, "description": "style"}, {"severity": "SUGGESTION", "file": "c.ts", "line": 3, "description": "improve"}]}';
     assert.equal(countFindings(output), 3);
   });
 
-  it("counts multiple of same severity", () => {
-    const output = `[WARNING] a.ts:1\n[WARNING] b.ts:2\n[WARNING] c.ts:3`;
-    assert.equal(countFindings(output), 3);
+  it("strips markdown code fences", () => {
+    const output = '```json\n{"findings": [{"severity": "WARNING", "file": "a.ts", "line": 1, "description": "x"}]}\n```';
+    assert.equal(countFindings(output), 1);
   });
 
-  it("does not count markers in prose (not at line start)", () => {
-    const output = "The reviewer should not raise [CRITICAL] for this pattern.";
-    assert.equal(countFindings(output), 0);
+  it("returns -1 for invalid JSON", () => {
+    assert.equal(countFindings('{"findings": [}'), -1);
   });
 
-  it("counts markers at line start but not mid-line", () => {
-    const output = "[CRITICAL] real finding\nDo not raise [WARNING] here\n[SUGGESTION] another real one";
-    assert.equal(countFindings(output), 2);
+  it("returns -1 for JSON without findings array", () => {
+    assert.equal(countFindings('{"result": "ok"}'), -1);
   });
 });
 

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -161,10 +161,15 @@ describe("recordReviewerResult with findings", () => {
 // ── 9. isReviewClean ──
 
 describe("isReviewClean", () => {
-  it("returns true when status is clean and tests passed", () => {
+  it("returns false when status is clean but tests not passed", () => {
     addReviewerPending(cwd, "lint");
     recordReviewerResult(cwd, "lint", 0);
-    assert.equal(isReviewClean(cwd), false); // clean but tests not passed yet
+    assert.equal(isReviewClean(cwd), false);
+  });
+
+  it("returns true when status is clean with tests passed", () => {
+    addReviewerPending(cwd, "lint");
+    recordReviewerResult(cwd, "lint", 0);
     markTestsPassed(cwd);
     assert.equal(isReviewClean(cwd), true);
   });

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -16,6 +16,8 @@ import {
   resetReviewState,
   countFindings,
   statePath,
+  markTestsPassed,
+  markTestsFailed,
 } from "../../../extensions/orchestrator/review-state.js";
 
 let cwd: string;
@@ -159,9 +161,11 @@ describe("recordReviewerResult with findings", () => {
 // ── 9. isReviewClean ──
 
 describe("isReviewClean", () => {
-  it("returns true when status is clean", () => {
+  it("returns true when status is clean and tests passed", () => {
     addReviewerPending(cwd, "lint");
     recordReviewerResult(cwd, "lint", 0);
+    assert.equal(isReviewClean(cwd), false); // clean but tests not passed yet
+    markTestsPassed(cwd);
     assert.equal(isReviewClean(cwd), true);
   });
 
@@ -180,6 +184,7 @@ describe("isReviewClean after edit", () => {
   it("returns false when edit happened after clean", () => {
     addReviewerPending(cwd, "lint");
     recordReviewerResult(cwd, "lint", 0);
+    markTestsPassed(cwd);
     assert.equal(isReviewClean(cwd), true);
 
     // Simulate an edit after clean by writing state with last_edit_at > last_clean_at
@@ -237,6 +242,8 @@ describe("Full cycle — all reviewers clean", () => {
     done = recordReviewerResult(cwd, "security", 0);
     assert.equal(done, true);
 
+    assert.equal(isReviewClean(cwd), false); // clean but tests not passed yet
+    markTestsPassed(cwd);
     assert.equal(isReviewClean(cwd), true);
     const s = readReviewState(cwd);
     assert.equal(s.status, "clean");
@@ -364,6 +371,70 @@ describe("recordReviewerResult idempotent", () => {
   });
 });
 
+// ── tests_passed field ──
+
+describe("tests_passed", () => {
+  it("defaults to false", () => {
+    const s = readReviewState(cwd);
+    assert.equal(s.tests_passed, false);
+  });
+
+  it("markTestsPassed sets tests_passed to true", () => {
+    markNeedsReview(cwd); // activate tracking
+    markTestsPassed(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, true);
+  });
+
+  it("markTestsFailed sets tests_passed to false", () => {
+    markNeedsReview(cwd);
+    markTestsPassed(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, true);
+    markTestsFailed(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, false);
+  });
+
+  it("markNeedsReview resets tests_passed to false", () => {
+    markNeedsReview(cwd);
+    addReviewerPending(cwd, "lint");
+    recordReviewerResult(cwd, "lint", 0);
+    markTestsPassed(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, true);
+
+    // Edit resets everything
+    markNeedsReview(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, false);
+  });
+
+  it("markNeedsReview during in_progress also resets tests_passed", () => {
+    addReviewerPending(cwd, "lint");
+    markTestsPassed(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, true);
+
+    // Edit during review resets tests_passed
+    markNeedsReview(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, false);
+    assert.equal(readReviewState(cwd).status, "in_progress"); // reviewers still pending
+  });
+
+  it("markTestsPassed is no-op when status is none", () => {
+    markTestsPassed(cwd);
+    assert.equal(readReviewState(cwd).tests_passed, false); // still default
+    assert.equal(readReviewState(cwd).status, "none");
+  });
+
+  it("isReviewClean requires both clean status and tests_passed", () => {
+    markNeedsReview(cwd);
+    addReviewerPending(cwd, "lint");
+    recordReviewerResult(cwd, "lint", 0);
+    // status is clean but tests haven't passed
+    assert.equal(readReviewState(cwd).status, "clean");
+    assert.equal(isReviewClean(cwd), false);
+
+    markTestsPassed(cwd);
+    assert.equal(isReviewClean(cwd), true);
+  });
+});
+
 // ── Worktree state isolation ──
 
 import { execFileSync } from "node:child_process";
@@ -431,13 +502,14 @@ describe("worktree state isolation", () => {
     markNeedsReview(worktreeA);
     addReviewerPending(worktreeA, "lint");
     recordReviewerResult(worktreeA, "lint", 0);
+    markTestsPassed(worktreeA);
     assert.equal(isReviewClean(worktreeA), true);
 
     // Mark B needs review
     markNeedsReview(worktreeB);
     assert.equal(isReviewClean(worktreeB), false);
 
-    // A's clean state should NOT affect B
+    // A's clean state should NOT affect B (tests_passed is per-worktree too)
     assert.equal(isReviewClean(worktreeA), true);
     assert.equal(isReviewClean(worktreeB), false);
     // Main repo unaffected


### PR DESCRIPTION
## Summary

Adds `tests_passed: boolean` to the review state JSON, making test results part of the code-enforced review loop. Commit/push is blocked unless **both** `status: clean` AND `tests_passed: true`.

Closes #634

## Changes

- **`review-state.ts`** — Added `tests_passed` to `ReviewState`, `markTestsPassed()`, `markTestsFailed()`, reset in `markNeedsReview()`, check in `isReviewClean()`
- **`enforcement.ts`** — Bash hook detects test commands (pytest, npm test, tox, etc.) and auto-marks `tests_passed`. Updated commit-blocking message. Updated `/review-status` and `review_status` tool output. Code reviewers excluded from test detection.
- **`async-agents.ts`** — test-automator/test-runner completion auto-marks `tests_passed`
- **`git-expert.md`** — Removed "ask orchestrator if tests passed" (now code-enforced)
- **`rules/20-code-review-loop.md`** — Updated flow: 6 agents in parallel (5 reviewers + test-automator), documented test tracking
- **`review-state.test.ts`** — 7 new tests for `tests_passed`, updated existing tests

## Key behaviors

- **6 agents in parallel**: 5 reviewers + test-automator run together, not sequentially
- **Bash hook detection**: `pytest`, `npm test`, `npx tsx --test`, `tox`, `go test`, `vitest`, `jest`, `mocha` auto-detected at command position
- **Edit resets everything**: any file edit → `tests_passed: false` + `status: needs_review`
- **Code reviewers excluded**: reviewer test runs don't mark `tests_passed`
- **Backward compatible**: `status: none` (no tracking) allows commit as before

## Additional fixes (discovered during review loop)

- **Qodo v2 migration** (`ask_qodo.py`, `commands.py`, `poll.py`, `post.py`): Changed `@qodo-code-review[bot]` mentions to `/qodo` command — Qodo v2 ignores `@` mentions entirely. Added cleanup retry with 5-min cooldown (was one-shot). Added `/agentic_review` fallback on cleanup timeout. Fixed stale `@` in log messages.
- **Memory dedup self-match bug** (`memory-tools.ts`): Fixed `embedEntry` being called before search, causing new entries to match themselves with similarity 1.000.
- **Memory scope rule** (`rules/35-memory.md`): Added "preserve context scope" quality rule — never generalize context-specific preferences into universal rules.
- **Spec reviewer prompt** (`code-reviewer-spec.md`): Consolidated Steps 1-3 into single step. Added "data from prior turns is STALE" instruction.
- **Reviewer base branch resolution** (`async-agents.ts`): Set `PI_REVIEW_BASE_BRANCH` env var for all reviewers/test agents. All 5 reviewer agents updated to use `git diff origin/$PI_REVIEW_BASE_BRANCH...HEAD`.
- **Review loop rule** (`rules/20-code-review-loop.md`): Added instruction to send "Review the code changes" task prompt (not `git diff HEAD`). Updated stale "5 reviewers" count to "6 agents".
- **Structured JSON reviewer output** (`review-state.ts`, `async-runner.ts`, all 5 reviewer agents): Reviewers now return `{"findings": [...]}` JSON instead of free text. `countFindings()` parses JSON (returns -1 for invalid). `async-runner.ts` validates reviewer output is JSON and retries with same session (up to 3 times) if not.
- **Log message cleanup** (`post.py`): Removed stale `@` prefix from reviewer name in error log messages.

## Testing

10/10 manual tests passed — see test plan in `.dev/test-plans/`
