### PR TITLE
feat(extensions): leverage pi 0.80.x features (#637)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ Resolution order: project file → global `~/.pi/pi-config-settings.json` → en
 
 Global env vars: `PI_COMMIT_TRAILER`, `PI_ALLOW_PUSH_TO_PROTECTED_BRANCHES`, `PI_USE_WORKTREES`, `PI_DREAM_INTERVAL_HOURS`, `PI_REVIEW_LOOP_ENFORCEMENT`
 
+#### Per-Project Resource Management
+
+Use `pi config -l` to manage which resources (reviewers, skills, prompt templates) are enabled per-project:
+
+```bash
+pi config -l          # Open project-local resource config
+```
+
+Press **Tab** to switch between global and project-local views. This lets you disable specific reviewers or skills for a project without editing JSON files.
+
 ### Override agents
 
 Place a `.md` file with the same `name` frontmatter in `~/.pi/agent/agents/` (user) or `.pi/agents/` (project) to override a bundled agent.
@@ -309,6 +319,16 @@ The `generate_image` tool creates images from structured descriptions via Gemini
 **Usage:** Ask naturally — "generate an image of a sunset" — or use structured params: `subject`, `action`, `scene`, `composition`, `lighting`, `style`, `text`, `aspect_ratio`.
 
 In containers, images are auto-served via HTTP for browser preview.
+
+### Cache Miss Notices
+
+Enable `showCacheMissNotices` in pi settings to see transcript notices on significant prompt-cache misses — useful for investigating unexpected token costs:
+
+```bash
+pi config              # Toggle showCacheMissNotices in settings UI
+```
+
+Defaults to `false`. Enable when debugging cost spikes from cache invalidation.
 
 ## Docker (Sandboxed Execution)
 

--- a/dev-docs/repo-structure.md
+++ b/dev-docs/repo-structure.md
@@ -47,6 +47,7 @@ pi-config/
 │   │   ├── git-helpers.ts           # Git utility functions
 │   │   ├── icons.ts                 # Shared Nerd Font icon constants
 │   │   ├── review-state.ts          # Review state machine (review loop enforcement)
+│   │   ├── review-ui.ts             # Review loop TUI — status bar indicator + transcript status cards
 │   │   ├── rules.ts                 # Rule + memory injection (before_agent_start)
 │   │   ├── session-search.ts            # Keyword search over past conversation summaries
 │   │   ├── session-validation.ts    # Session start tool checks + upgrade changelog notification

--- a/extensions/orchestrator/icons.ts
+++ b/extensions/orchestrator/icons.ts
@@ -9,3 +9,9 @@ export const ICON_GIT_CLEAN = "";
 export const ICON_GIT_DIRTY = "";
 export const ICON_DIFF = "";
 export const ICON_DREAM = "󰖔";
+
+// Review loop status
+export const ICON_REVIEW_CLEAN = "✓";
+export const ICON_REVIEW_NEEDED = "";
+export const ICON_REVIEW_PROGRESS = "";
+export const ICON_REVIEW_FINDINGS = "";

--- a/extensions/orchestrator/index.ts
+++ b/extensions/orchestrator/index.ts
@@ -31,6 +31,7 @@ import { registerStatus } from "./status.js";
 import { registerNvim } from "./nvim.js";
 import { registerPreferenceExtractor } from "./preference-extractor.js";
 import { registerMemoryTools } from "./memory-tools.js";
+import { registerReviewUI } from "./review-ui.js";
 import { registerSessionSearch } from "./session-search.js";
 import { ensureGitSshTimeout, isRunningInContainer, terminalNotify } from "./utils.js";
 
@@ -82,6 +83,7 @@ export default function (pi: ExtensionAPI) {
   registerSubagentTool(pi, spawnAsyncAgent, killAsyncAgent);
   registerProjectSettings(pi);
   registerEnforcement(pi, IN_CONTAINER);
+  registerReviewUI(pi);
   registerRules(pi, getAsyncJobs);
 
   registerStatusLine(pi, IN_CONTAINER, terminalNotify);

--- a/extensions/orchestrator/review-state.ts
+++ b/extensions/orchestrator/review-state.ts
@@ -170,6 +170,8 @@ function withStateLock<T>(cwd: string, fn: (state: ReviewState) => T): T {
  *  are tracked via last_edit_at but don't wipe the pending reviewer list. */
 export function markNeedsReview(cwd: string): void {
   withStateLock(cwd, (state) => {
+    const prevStatus = state.status;
+    const prevTestsPassed = state.tests_passed;
     if (state.status === "in_progress") {
       state.last_edit_at = new Date().toISOString();
       state.edited_during_cycle = true;
@@ -185,7 +187,10 @@ export function markNeedsReview(cwd: string): void {
       state.tests_passed = false;
     }
     writeState(cwd, state);
-    notifyTransition(state);
+    // Skip notification if nothing meaningful changed (e.g., repeated edits while already needs_review)
+    if (state.status !== prevStatus || state.tests_passed !== prevTestsPassed) {
+      notifyTransition(state);
+    }
   });
 }
 

--- a/extensions/orchestrator/review-state.ts
+++ b/extensions/orchestrator/review-state.ts
@@ -9,6 +9,22 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, renameS
 import { join, dirname } from "node:path";
 import { resolveWorktreeRoot } from "./utils.js";
 
+type StateTransitionCallback = (state: ReviewState) => void;
+let onTransitionCb: StateTransitionCallback | null = null;
+
+/** Register a callback to be notified on review state transitions.
+ *  Only one callback is supported — subsequent calls replace the previous one. */
+export function onStateTransition(cb: StateTransitionCallback): void {
+  onTransitionCb = cb;
+}
+
+/** Fire-and-forget state transition notification. Never throws. */
+function notifyTransition(state: ReviewState): void {
+  if (!onTransitionCb) return;
+  try { onTransitionCb({ ...state, reviewers_pending: [...state.reviewers_pending] }); }
+  catch (e: any) { console.debug("[review-state] transition callback failed:", e?.message); }
+}
+
 const DATA_DIR = ".pi/data";
 
 export interface ReviewState {
@@ -169,6 +185,7 @@ export function markNeedsReview(cwd: string): void {
       state.tests_passed = false;
     }
     writeState(cwd, state);
+    notifyTransition(state);
   });
 }
 
@@ -186,6 +203,7 @@ export function addReviewerPending(cwd: string, reviewerName: string): void {
       state.edited_during_cycle = false;
     }
     writeState(cwd, state);
+    notifyTransition(state);
   });
 }
 
@@ -210,6 +228,7 @@ export function recordReviewerResult(cwd: string, reviewerName: string, findings
       }
     }
     writeState(cwd, state);
+    notifyTransition(state);
     return state.reviewers_pending.length === 0;
   });
 }
@@ -229,6 +248,7 @@ export function markTestsPassed(cwd: string): void {
     if (state.status === "none") return; // No tracking active
     state.tests_passed = true;
     writeState(cwd, state);
+    notifyTransition(state);
   });
 }
 
@@ -240,6 +260,7 @@ export function markTestsFailed(cwd: string): void {
     if (state.status === "none") return; // No tracking active
     state.tests_passed = false;
     writeState(cwd, state);
+    notifyTransition(state);
   });
 }
 
@@ -265,5 +286,6 @@ export function countFindings(output: string): number {
 export function resetReviewState(cwd: string): void {
   withStateLock(cwd, () => {
     writeState(cwd, defaultState());
+    notifyTransition(defaultState());
   });
 }

--- a/extensions/orchestrator/review-ui.ts
+++ b/extensions/orchestrator/review-ui.ts
@@ -1,0 +1,170 @@
+/**
+ * Review loop status — status bar indicator + transcript cards.
+ *
+ * Status bar: persistent "5-review" key (last in bar, after git).
+ * Cards: durable entry renderers via pi.appendEntry (persist across reload,
+ * no LLM context cost).
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Box, Text } from "@earendil-works/pi-tui";
+import { onStateTransition, readReviewState, type ReviewState } from "./review-state.js";
+import { ICON_REVIEW_CLEAN, ICON_REVIEW_NEEDED, ICON_REVIEW_PROGRESS, ICON_REVIEW_FINDINGS } from "./icons.js";
+
+interface ReviewStatusData {
+  status: ReviewState["status"];
+  cycle: number;
+  findings_count: number;
+  tests_passed: boolean;
+  reviewers_pending: string[];
+  reviewers_total: number;
+  timestamp: number;
+}
+
+// Deduplication — skip append if status+cycle hasn't changed
+let lastAppendedKey = "";
+
+/** Dedup key shared by status bar and transcript cards. */
+function stateKey(s: { status: string; cycle: number; findings_count: number; tests_passed: boolean; reviewers_pending: { length: number } }): string {
+  return `${s.status}:${s.cycle}:${s.findings_count}:${s.tests_passed}:${s.reviewers_pending.length}`;
+}
+
+export function registerReviewUI(pi: ExtensionAPI): void {
+  // Register the entry renderer for "review-status" custom type
+  pi.registerEntryRenderer<ReviewStatusData>("review-status", (entry, { expanded }, theme) => {
+    const data = entry.data ?? {
+      status: "none" as const,
+      cycle: 0,
+      findings_count: 0,
+      tests_passed: false,
+      reviewers_pending: [],
+      reviewers_total: 0,
+      timestamp: Date.now(),
+    };
+
+    if (data.status === "none") {
+      return new Box(0, 0, (text) => text);
+    }
+
+    const box = new Box(1, 1, (text) => theme.bg("customMessageBg", text));
+
+    let line: string;
+    switch (data.status) {
+      case "in_progress": {
+        const testsIcon = data.tests_passed ? "✅" : "⏳";
+        const waiting = data.reviewers_pending.length > 0
+          ? ` — waiting: ${data.reviewers_pending.join(", ")}`
+          : "";
+        line = `🔄 Review cycle ${data.cycle} — ${data.findings_count} findings — tests ${testsIcon}${waiting}`;
+        break;
+      }
+      case "clean": {
+        const testsLabel = data.tests_passed ? "tests passed" : "tests pending";
+        line = `✅ Review clean — cycle ${data.cycle} — ${testsLabel} — ${data.tests_passed ? "ready to commit" : "awaiting tests"}`;
+        break;
+      }
+      case "needs_review":
+        line = `⚠️ Code changed — review needed`;
+        break;
+      case "has_findings":
+        line = `🔍 Review cycle ${data.cycle} — ${data.findings_count} finding${data.findings_count !== 1 ? "s" : ""} — needs fixes`;
+        break;
+      default:
+        line = `📋 Review: ${data.status}`;
+    }
+
+    const colorMap: Record<string, string> = {
+      in_progress: "accent",
+      clean: "success",
+      needs_review: "warning",
+      has_findings: "error",
+    };
+    const color = colorMap[data.status] || "dim";
+    box.addChild(new Text(theme.fg(color, line), 0, 0));
+
+    if (expanded && data.timestamp) {
+      box.addChild(new Text(theme.fg("dim", new Date(data.timestamp).toLocaleString()), 0, 0));
+    }
+
+    return box;
+  });
+
+  // ── Status bar indicator ─────────────────────────────────────────────
+
+  let lastCtx: ExtensionContext | null = null;
+  let lastBarKey = "";
+
+  function updateStatusBar(state: ReviewState): void {
+    if (!lastCtx?.hasUI) return;
+    const ctx = lastCtx;
+
+    let label: string;
+    let color: string;
+    switch (state.status) {
+      case "none":
+        ctx.ui.setStatus("5-review", undefined);
+        lastBarKey = "";
+        return;
+      case "needs_review":
+        label = `${ICON_REVIEW_NEEDED} review needed`;
+        color = "warning";
+        break;
+      case "in_progress": {
+        const pending = state.reviewers_pending.length;
+        const total = state.reviewers_total;
+        label = `${ICON_REVIEW_PROGRESS} review ${total - pending}/${total}`;
+        color = "accent";
+        break;
+      }
+      case "has_findings":
+        label = `${ICON_REVIEW_FINDINGS} ${state.findings_count} finding${state.findings_count !== 1 ? "s" : ""}`;
+        color = "error";
+        break;
+      case "clean":
+        label = state.tests_passed ? `${ICON_REVIEW_CLEAN} ready` : `${ICON_REVIEW_CLEAN} review clean`;
+        color = "success";
+        break;
+      default:
+        label = `${ICON_REVIEW_PROGRESS} ${state.status}`;
+        color = "dim";
+    }
+
+    const barKey = stateKey(state);
+    if (barKey === lastBarKey) return;
+    lastBarKey = barKey;
+    ctx.ui.setStatus("5-review", ctx.ui.theme.fg(color, label));
+  }
+
+  // Capture ctx and show current state on load
+  pi.on("session_start", (_event, ctx) => {
+    lastCtx = ctx;
+    updateStatusBar(readReviewState(ctx.cwd));
+  });
+  pi.on("agent_end", (_event, ctx) => { lastCtx = ctx; });
+
+  // ── Hook into review state transitions ───────────────────────────────
+
+  onStateTransition((state: ReviewState) => {
+    // Always update status bar (even for "none" — clears it)
+    updateStatusBar(state);
+
+    if (state.status === "none") return;
+
+    const data: ReviewStatusData = {
+      status: state.status,
+      cycle: state.cycle,
+      findings_count: state.findings_count,
+      tests_passed: state.tests_passed,
+      reviewers_pending: [...state.reviewers_pending],
+      reviewers_total: state.reviewers_total,
+      timestamp: Date.now(),
+    };
+
+    // Deduplicate transcript cards — skip if nothing meaningful changed
+    const key = stateKey(data);
+    if (key === lastAppendedKey) return;
+    lastAppendedKey = key;
+
+    pi.appendEntry<ReviewStatusData>("review-status", data);
+  });
+}

--- a/extensions/orchestrator/review-ui.ts
+++ b/extensions/orchestrator/review-ui.ts
@@ -143,6 +143,7 @@ export function registerReviewUI(pi: ExtensionAPI): void {
       updateStatusBar(readReviewState(ctx.cwd));
     } else if (ctx.hasUI) {
       ctx.ui.setStatus("5-review", undefined);
+      lastBarKey = "";
     }
   });
   pi.on("agent_end", (_event, ctx) => { lastCtx = ctx; });

--- a/extensions/orchestrator/review-ui.ts
+++ b/extensions/orchestrator/review-ui.ts
@@ -141,7 +141,7 @@ export function registerReviewUI(pi: ExtensionAPI): void {
     lastCtx = ctx;
     if (getSetting(ctx.cwd, "review_loop_enforcement")) {
       updateStatusBar(readReviewState(ctx.cwd));
-    } else {
+    } else if (ctx.hasUI) {
       ctx.ui.setStatus("5-review", undefined);
     }
   });
@@ -154,7 +154,7 @@ export function registerReviewUI(pi: ExtensionAPI): void {
     try { void lastCtx.ui.theme; } catch { lastCtx = null; return; }
     try {
       if (!getSetting(lastCtx.cwd, "review_loop_enforcement")) {
-        lastCtx.ui.setStatus("5-review", undefined);
+        if (lastCtx.hasUI) lastCtx.ui.setStatus("5-review", undefined);
         lastBarKey = "";
         return;
       }

--- a/extensions/orchestrator/review-ui.ts
+++ b/extensions/orchestrator/review-ui.ts
@@ -10,6 +10,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { Box, Text } from "@earendil-works/pi-tui";
 import { onStateTransition, readReviewState, type ReviewState } from "./review-state.js";
 import { ICON_REVIEW_CLEAN, ICON_REVIEW_NEEDED, ICON_REVIEW_PROGRESS, ICON_REVIEW_FINDINGS } from "./icons.js";
+import { getSetting } from "./project-settings.js";
 
 interface ReviewStatusData {
   status: ReviewState["status"];
@@ -83,7 +84,7 @@ export function registerReviewUI(pi: ExtensionAPI): void {
     box.addChild(new Text(theme.fg(color, line), 0, 0));
 
     if (expanded && data.timestamp) {
-      box.addChild(new Text(theme.fg("dim", new Date(data.timestamp).toLocaleString()), 0, 0));
+      box.addChild(new Text(theme.fg("dim", new Date(data.timestamp).toLocaleString()), 0, 1));
     }
 
     return box;
@@ -138,15 +139,44 @@ export function registerReviewUI(pi: ExtensionAPI): void {
   // Capture ctx and show current state on load
   pi.on("session_start", (_event, ctx) => {
     lastCtx = ctx;
-    updateStatusBar(readReviewState(ctx.cwd));
+    if (getSetting(ctx.cwd, "review_loop_enforcement")) {
+      updateStatusBar(readReviewState(ctx.cwd));
+    } else {
+      ctx.ui.setStatus("5-review", undefined);
+    }
   });
   pi.on("agent_end", (_event, ctx) => { lastCtx = ctx; });
+
+  // Poll review-state.json for cross-process updates (subagents write state too)
+  const reviewPoller = setInterval(() => {
+    if (!lastCtx) return;
+    // Access a ctx property to detect stale/disposed context (throws if invalidated)
+    try { void lastCtx.ui.theme; } catch { lastCtx = null; return; }
+    try {
+      if (!getSetting(lastCtx.cwd, "review_loop_enforcement")) {
+        lastCtx.ui.setStatus("5-review", undefined);
+        lastBarKey = "";
+        return;
+      }
+      updateStatusBar(readReviewState(lastCtx.cwd));
+    } catch (e: any) {
+      console.debug("[review-ui] poller error:", e?.message);
+    }
+  }, 5000);
+  if (reviewPoller.unref) reviewPoller.unref();
+
+  pi.on("session_shutdown", () => {
+    clearInterval(reviewPoller);
+  });
 
   // ── Hook into review state transitions ───────────────────────────────
 
   onStateTransition((state: ReviewState) => {
     // Always update status bar (even for "none" — clears it)
-    updateStatusBar(state);
+    // Only show if enforcement is enabled
+    if (lastCtx && getSetting(lastCtx.cwd, "review_loop_enforcement")) {
+      updateStatusBar(state);
+    }
 
     if (state.status === "none") return;
 

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -146,9 +146,9 @@ export function registerStatusLine(
     clearInterval(timePoller);
   });
 
-  // ── Desktop notifications — notify when user attention is needed ─────
+  // ── Desktop notifications — notify when pi is truly idle ─────────────
 
-  pi.on("agent_end", async () => {
+  pi.on("agent_settled", async () => {
     terminalNotify("pi", "Task completed");
   });
 

--- a/extensions/pidash/pidash-ui/src/hooks/useMessageHandler.ts
+++ b/extensions/pidash/pidash-ui/src/hooks/useMessageHandler.ts
@@ -85,12 +85,14 @@ export function useMessageHandler(
           setQueuedCount(0);
           break;
         case "agent_end":
-          setStreaming(false);
           setQueuedCount(0);
           setStreamingBehavior(null);
           thinkRef.current = { id: "", text: "", startTs: 0 };
           assistRef.current = { id: "", text: "" };
           lastUserRef.current = "";
+          break;
+        case "agent_settled":
+          setStreaming(false);
           break;
 
         case "message_start": {

--- a/extensions/pidash/pidash.ts
+++ b/extensions/pidash/pidash.ts
@@ -679,10 +679,11 @@ export function registerPidash(
   function setupEventForwarding(): void {
     forward("agent_start");
     forward("agent_end");
+    forward("agent_settled");
 
     // Track streaming state for prompt-queued feedback
     pi.on("agent_start", () => { isStreaming = true; });
-    pi.on("agent_end", () => { isStreaming = false; });
+    pi.on("agent_settled", () => { isStreaming = false; });
     forward("turn_start");
     forward("turn_end");
     forward("message_start");

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -18,6 +18,7 @@ import {
   statePath,
   markTestsPassed,
   markTestsFailed,
+  onStateTransition,
 } from "../../../extensions/orchestrator/review-state.js";
 
 let cwd: string;
@@ -522,5 +523,84 @@ describe("worktree state isolation", () => {
     assert.equal(isReviewClean(worktreeB), false);
     // Main repo unaffected
     assert.equal(readReviewState(mainRepo).status, "none");
+  });
+});
+
+// ── onStateTransition callback ──
+
+describe("onStateTransition", () => {
+  afterEach(() => {
+    // Clear callback to avoid leaking into other tests
+    onStateTransition(() => {});
+  });
+
+  it("fires callback on markNeedsReview", () => {
+    const states: Array<{ status: string }> = [];
+    onStateTransition((s) => states.push({ status: s.status }));
+    markNeedsReview(cwd);
+    assert.equal(states.length, 1);
+    assert.equal(states[0].status, "needs_review");
+  });
+
+  it("fires callback on addReviewerPending and recordReviewerResult", () => {
+    const states: Array<{ status: string; reviewers_pending: string[] }> = [];
+    onStateTransition((s) => states.push({ status: s.status, reviewers_pending: [...s.reviewers_pending] }));
+    markNeedsReview(cwd);
+    addReviewerPending(cwd, "reviewer-a");
+    recordReviewerResult(cwd, "reviewer-a", 0);
+    assert.equal(states.length, 3);
+    assert.equal(states[1].status, "in_progress");
+    assert.deepEqual(states[1].reviewers_pending, ["reviewer-a"]);
+    assert.equal(states[2].status, "clean");
+  });
+
+  it("fires callback on markTestsPassed and markTestsFailed", () => {
+    const states: Array<{ tests_passed: boolean }> = [];
+    markNeedsReview(cwd); // activate tracking
+    onStateTransition((s) => states.push({ tests_passed: s.tests_passed }));
+    markTestsPassed(cwd);
+    markTestsFailed(cwd);
+    assert.equal(states.length, 2);
+    assert.equal(states[0].tests_passed, true);
+    assert.equal(states[1].tests_passed, false);
+  });
+
+  it("fires callback on resetReviewState", () => {
+    const states: Array<{ status: string }> = [];
+    markNeedsReview(cwd);
+    onStateTransition((s) => states.push({ status: s.status }));
+    resetReviewState(cwd);
+    assert.equal(states.length, 1);
+    assert.equal(states[0].status, "none");
+  });
+
+  it("deep-copies reviewers_pending (no shared reference)", () => {
+    let captured: string[] = [];
+    onStateTransition((s) => { captured = s.reviewers_pending; });
+    addReviewerPending(cwd, "r1");
+    addReviewerPending(cwd, "r2");
+    // captured should be the snapshot from the last call, not mutated
+    assert.deepEqual(captured, ["r1", "r2"]);
+    // Mutating captured should not affect internal state
+    captured.push("r3");
+    const state = readReviewState(cwd);
+    assert.ok(!state.reviewers_pending.includes("r3"));
+  });
+
+  it("is fire-and-forget — callback errors do not propagate", () => {
+    onStateTransition(() => { throw new Error("boom"); });
+    // Should not throw
+    assert.doesNotThrow(() => markNeedsReview(cwd));
+  });
+
+  it("subsequent calls replace the previous callback", () => {
+    const calls1: string[] = [];
+    const calls2: string[] = [];
+    onStateTransition(() => calls1.push("a"));
+    markNeedsReview(cwd);
+    onStateTransition(() => calls2.push("b"));
+    resetReviewState(cwd);
+    assert.equal(calls1.length, 1); // Only fired before replacement
+    assert.equal(calls2.length, 1); // Fires after replacement
   });
 });

--- a/tests/node/orchestrator/review-state.test.ts
+++ b/tests/node/orchestrator/review-state.test.ts
@@ -542,27 +542,42 @@ describe("onStateTransition", () => {
     assert.equal(states[0].status, "needs_review");
   });
 
-  it("fires callback on addReviewerPending and recordReviewerResult", () => {
+  it("fires callback on addReviewerPending", () => {
     const states: Array<{ status: string; reviewers_pending: string[] }> = [];
     onStateTransition((s) => states.push({ status: s.status, reviewers_pending: [...s.reviewers_pending] }));
     markNeedsReview(cwd);
     addReviewerPending(cwd, "reviewer-a");
-    recordReviewerResult(cwd, "reviewer-a", 0);
-    assert.equal(states.length, 3);
+    assert.equal(states.length, 2);
     assert.equal(states[1].status, "in_progress");
     assert.deepEqual(states[1].reviewers_pending, ["reviewer-a"]);
-    assert.equal(states[2].status, "clean");
   });
 
-  it("fires callback on markTestsPassed and markTestsFailed", () => {
+  it("fires callback on recordReviewerResult", () => {
+    const states: Array<{ status: string }> = [];
+    markNeedsReview(cwd);
+    addReviewerPending(cwd, "reviewer-a");
+    onStateTransition((s) => states.push({ status: s.status }));
+    recordReviewerResult(cwd, "reviewer-a", 0);
+    assert.equal(states.length, 1);
+    assert.equal(states[0].status, "clean");
+  });
+
+  it("fires callback on markTestsPassed", () => {
     const states: Array<{ tests_passed: boolean }> = [];
     markNeedsReview(cwd); // activate tracking
     onStateTransition((s) => states.push({ tests_passed: s.tests_passed }));
     markTestsPassed(cwd);
-    markTestsFailed(cwd);
-    assert.equal(states.length, 2);
+    assert.equal(states.length, 1);
     assert.equal(states[0].tests_passed, true);
-    assert.equal(states[1].tests_passed, false);
+  });
+
+  it("fires callback on markTestsFailed", () => {
+    const states: Array<{ tests_passed: boolean }> = [];
+    markNeedsReview(cwd); // activate tracking
+    onStateTransition((s) => states.push({ tests_passed: s.tests_passed }));
+    markTestsFailed(cwd);
+    assert.equal(states.length, 1);
+    assert.equal(states[0].tests_passed, false);
   });
 
   it("fires callback on resetReviewState", () => {
@@ -591,6 +606,15 @@ describe("onStateTransition", () => {
     onStateTransition(() => { throw new Error("boom"); });
     // Should not throw
     assert.doesNotThrow(() => markNeedsReview(cwd));
+  });
+
+  it("does not fire duplicate notifications for repeated edits while needs_review", () => {
+    const states: Array<{ status: string }> = [];
+    onStateTransition((s) => states.push({ status: s.status }));
+    markNeedsReview(cwd);
+    markNeedsReview(cwd); // second edit — already needs_review
+    markNeedsReview(cwd); // third edit
+    assert.equal(states.length, 1); // Only the first transition fires
   });
 
   it("subsequent calls replace the previous callback", () => {


### PR DESCRIPTION
Closes #637

## Changes

### 1. Review Loop Status UI (entry renderers + status bar)
- New `review-ui.ts` — registers entry renderer for `"review-status"` transcript cards + persistent status bar indicator (`5-review` key)
- Status bar shows current review state with Nerd Font icons: `✓ ready`, ` review needed`, ` review 3/5`, ` findings`
- Transcript cards render on state transitions (durable, no LLM context cost)
- Added `onStateTransition` callback + `notifyTransition` helper in `review-state.ts` (fire-and-forget, deep-copies state)
- New review icons added to `icons.ts`

### 2. `agent_settled` for notifications + pidash
- Desktop notification moved from `agent_end` → `agent_settled` in `status-line.ts` — no more premature "Task completed" during compaction/retry
- Pidash forwards `agent_settled` event; uses it for `isStreaming = false` instead of `agent_end`
- Browser UI (`useMessageHandler.ts`) handles `agent_settled` for streaming state

### 3. Documentation
- `README.md`: Added `pi config -l` per-project resource management section
- `README.md`: Added `showCacheMissNotices` opt-in cache debugging section
- `dev-docs/repo-structure.md`: Added `review-ui.ts` entry

## Files Changed
| File | Change |
|------|--------|
| `extensions/orchestrator/review-ui.ts` | **NEW** — entry renderer + status bar |
| `extensions/orchestrator/review-state.ts` | `onStateTransition` callback + `notifyTransition` |
| `extensions/orchestrator/icons.ts` | Review status Nerd Font icons |
| `extensions/orchestrator/index.ts` | Wire `registerReviewUI` |
| `extensions/orchestrator/status-line.ts` | `agent_end` → `agent_settled` |
| `extensions/pidash/pidash.ts` | Forward `agent_settled`, streaming state |
| `extensions/pidash/pidash-ui/src/hooks/useMessageHandler.ts` | `agent_settled` case |
| `README.md` | `pi config -l` + `showCacheMissNotices` docs |
| `dev-docs/repo-structure.md` | `review-ui.ts` entry |