### PR TITLE
feat(memory): graduate high-evidence memories into structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ Writing effective rules:
 - Extension commands: see `dev-docs/extension-commands.md`
 - Async agents, async-only list, temp dirs: see `dev-docs/async-internals.md`
 - Memory system: see `dev-docs/memory-architecture.md`
+- Enforcement honesty (code vs injected): see `dev-docs/enforcement-honesty-map.md`
+- Memory inventory CLI: `uv run myk-pi-tools memory status`
 - Project settings: see `dev-docs/project-settings.md`
 - When adding slash command arguments: update autocomplete in `extended-autocomplete.ts`
 - Memory `*(enforced)*` marker: entries with this marker are hash-keyed — never change their text, only add/remove whole entries

--- a/dev-docs/enforcement-honesty-map.md
+++ b/dev-docs/enforcement-honesty-map.md
@@ -1,0 +1,50 @@
+# Enforcement Honesty Map
+
+Declares what is actually code-enforced versus prompt-only. A tier is about
+**checkability**, not importance — prose rules can still be load-bearing.
+
+| Tier | Meaning | Mechanism |
+|------|---------|-----------|
+| `code` | Runtime hooks act without relying on LLM compliance | `enforcement-rules.ts`, remote-exec helpers in `enforcement-helpers.ts` |
+| `injected` | Present in situation report / rules markdown; LLM compliance only | Topic memories, package/user/project `rules/*.md` |
+| `aspirational` | Documented guidance with no injection or hook guarantee | Rare edge docs, stale comments |
+
+## Code tier (mechanical)
+
+- Memory entries with `trigger` + `action` (and optional `verifier`) in `.pi/memory/memory-scores.json`
+- Topic marker `*(enforced)*` (display only; scores hold the binding)
+- Trigger types: `bash_contains`, `bash_regex`, `tool_name`, `file_modified`
+- Actions: `block`, `warn`, `run_after <cmd>`
+- Verifiers: `tool_called <tool> before <command>` at `turn_end`
+- Remote script exec blocks: `curl \| bash`, nested `$(bash -c "$(curl)")`, etc. (`checkRemoteExecBlock`)
+
+Inventory a project’s code-tier memories:
+
+```bash
+# Human-readable inventory (code-tier + injected counts + open promotions)
+uv run myk-pi-tools memory status
+
+# Or raw scores:
+jq -r '.entries | to_entries[] | select(.value.trigger and .value.action or .value.verifier) | .key' .pi/memory/memory-scores.json
+```
+
+## Injected tier (LLM)
+
+- Situation report sections (preferences, lessons, mistakes, …)
+- Vector / session-history auto-injection
+- Package rules `rules/00-69`, user `~/.pi/agent/rules/70-89`, project `.pi/rules/90-99`
+- Promotion candidates section (open items in `.pi/memory/promotions.md`)
+
+## Aspirational / propose-only
+
+- `project_rule` promotions — never auto-written into `rules/` or `.pi/rules/`
+- Dream skill suggestions that were not written under `.pi/skills/`
+- Docs that describe desired behavior without a matching hook
+
+## Promotion path into code tier
+
+1. Live agent adds enforcement via `memory_add(trigger=…, action=…)` when mechanical
+2. Or evidence accumulates → `memory-promotion.ts` auto-applies high-confidence `block`/`warn`
+3. Ambiguous mechanical lessons stay `proposed` in `promotions.md` until filled in
+
+See also: `dev-docs/memory-architecture.md` Layer 5–6, `rules/35-memory.md`.

--- a/dev-docs/memory-architecture.md
+++ b/dev-docs/memory-architecture.md
@@ -106,3 +106,34 @@ Research proves tail position gets highest LLM attention (U-shaped attention cur
 ## Preference Auto-Extraction
 
 `preference-extractor.ts`: Detects "I prefer…"/"always use…"/"never…" patterns, auto-adds to memory, reinforces on repetition.
+
+## Layer 6 — Promotion Queue (correction → structure)
+
+`promotion-queue.ts` + `memory-promotion.ts`: High-evidence memories graduate into
+skills, enforcement, or proposed project rules.
+
+- Queue: `.pi/memory/promotions.md` (`proposed` → `applied` | `rejected`)
+- Destinations: `memory` | `skill` | `enforcement` | `project_rule` | `discard`
+- Thresholds: enforcement/skill at evidenceCount ≥ 3; project_rule ≥ 5
+- Safe auto-apply: high-confidence `block`/`warn` enforcement only — never writes `rules/`
+- Hooks: dream `onComplete`, `memory_reinforce` threshold crossings, dream/`memory_consolidate` prompt writers
+- Situation report includes a short `## Promotion Candidates` section
+
+## Provenance
+
+Optional `ScoredEntry` fields: `sourceSession`, `derivedFrom`, `informs`.
+Set via `memory_add` / `memory_edit`, preference extractor (`sourceSession` when
+session id is available), or dream sidecar `.pi/memory/provenance-pending.json`
+merged by `mergeProvenancePending` on dream `onComplete`.
+Preserved across `rebuild()`. Not injected into situation reports; surfaced in
+`memory_search` / `memory_reflect`.
+
+## Query-class injection
+
+`memory-query-class.ts`: heuristic classifier (`pr_review` | `git_release` | `debug` | `general`)
+on `before_agent_start`. Adjusts situation-report section priority/budgets and vector `topK`.
+Logged in `.pi/data/memory-telemetry.jsonl` as `queryClass`.
+
+## Enforcement honesty map
+
+See `dev-docs/enforcement-honesty-map.md` — declares code vs injected vs aspirational enforcement.

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -19,6 +19,8 @@ import { getSetting } from "./project-settings.js";
 import { discoverAgents } from "./agents.js";
 import { ICON_DREAM } from "./icons.js";
 import { rebuildAndOrganize } from "./situation-report.js";
+import { runPromotionPass } from "./memory-promotion.js";
+import { mergeProvenancePending } from "./memory-provenance.js";
 import { getProjectTmpDir } from "./utils.js";
 
 // Default: 3 hours. Override with PI_DREAM_INTERVAL_HOURS env var (0.5–24).
@@ -110,7 +112,26 @@ export function registerDreaming(
       `   ---\n` +
       `   Only create skills for workflows with 3+ steps that are likely to recur.\n` +
       `8. Write the current timestamp to ${topicsDir}/../.dream-watermark to track progress.\n` +
-      `9. Memory rules: one line per entry, max ~100 chars, specific and actionable, no fluff.`,
+      `9. Memory rules: one line per entry, max ~100 chars, specific and actionable, no fluff.\n` +
+      `10. Promotion destinations: append candidates to ${topicsDir}/../promotions.md using this block format:\n` +
+      `   ### <12-char-id>\n` +
+      `   - destination: memory|skill|enforcement|project_rule|discard\n` +
+      `   - status: proposed\n` +
+      `   - category: <category>\n` +
+      `   - text: <exact topic entry text>\n` +
+      `   - reason: <why this should graduate>\n` +
+      `   - created: <ISO timestamp>\n` +
+      `   Optional fields: evidence_count, trigger, action, verifier, skill_name, skill_created.\n` +
+      `   Rules:\n` +
+      `   - skill: create .pi/skills/ when confident; set skill_created: true\n` +
+      `   - enforcement: propose trigger/action when mechanical (never/always + command); do NOT invent run_after\n` +
+      `   - project_rule: propose only — NEVER write rules/ or .pi/rules/\n` +
+      `   - discard: stale or superseded noise\n` +
+      `   - Do not reopen entries already marked applied or rejected in promotions.md\n` +
+      `11. Provenance sidecar (optional): for newly extracted entries, write\n` +
+      `   ${topicsDir}/../provenance-pending.json as JSON:\n` +
+      `   {"entries":[{"category":"lesson","text":"<exact topic text>","sourceSession":"<session basename>","derivedFrom":"<optional>","informs":["optional"]}]}\n` +
+      `   Do NOT edit memory-scores.json yourself — onComplete merges the sidecar.`,
       cwd,
       agents,
       {
@@ -120,6 +141,11 @@ export function registerDreaming(
           dreamInFlight = false;
           updateDreamStatus();
           try { rebuildAndOrganize(cwd); } catch (e: any) { console.debug("[dreaming] rebuildAndOrganize failed:", e?.message || e); }
+          try {
+            const n = mergeProvenancePending(cwd);
+            if (n > 0) console.debug(`[dreaming] merged provenance for ${n} entries`);
+          } catch (e: any) { console.debug("[dreaming] provenance merge failed:", e?.message || e); }
+          try { runPromotionPass(cwd); } catch (e: any) { console.debug("[dreaming] promotion pass failed:", e?.message || e); }
         },
       },
     );

--- a/extensions/orchestrator/memory-promotion.ts
+++ b/extensions/orchestrator/memory-promotion.ts
@@ -20,11 +20,13 @@ import {
 import { CATEGORY_TO_TOPIC, readAllTopicEntries } from "./memory-tree.js";
 import {
   type PromotionCandidate,
+  type PromotionCandidatePatch,
   appendPromotions,
   formatPromotionsForReport,
   loadPromotions,
   promotionId,
   updatePromotionCandidates,
+  updatePromotionStatus,
 } from "./promotion-queue.js";
 
 export const EVIDENCE_ENFORCEMENT = 3;
@@ -354,7 +356,7 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
   const existing = loadPromotions(cwd);
   const byId = new Map(existing.map((x) => [x.id, x]));
   const toAppend: PromotionCandidate[] = [];
-  const patches: { id: string; patch: Partial<PromotionCandidate> }[] = [];
+  const patches: { id: string; patch: PromotionCandidatePatch }[] = [];
 
   for (const c of toQueue) {
     const prev = byId.get(c.id);
@@ -366,14 +368,27 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
     // Don't reopen applied/rejected as proposed
     if (prev.status !== "proposed" && c.status === "proposed") continue;
     if (c.status === "applied" && prev.status === "proposed") {
-      // Merge enforcement metadata for auditability; keep human reason if present
+      // Merge enforcement metadata for auditability; keep human reason + createdAt
       const merged: PromotionCandidate = {
         ...prev,
         ...c,
         status: "applied",
         reason: prev.reason || c.reason,
+        createdAt: prev.createdAt,
       };
-      patches.push({ id: c.id, patch: merged });
+      patches.push({
+        id: c.id,
+        patch: {
+          status: "applied",
+          reason: merged.reason,
+          evidenceCount: c.evidenceCount,
+          trigger: c.trigger,
+          action: c.action,
+          verifier: c.verifier,
+          skillName: c.skillName,
+          skillCreated: c.skillCreated,
+        },
+      });
       byId.set(c.id, merged);
     }
   }

--- a/extensions/orchestrator/memory-promotion.ts
+++ b/extensions/orchestrator/memory-promotion.ts
@@ -375,18 +375,29 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
         status: "applied",
         reason: prev.reason || c.reason,
         createdAt: prev.createdAt,
+        // Prefer new scan values when present; otherwise keep queued metadata
+        evidenceCount: c.evidenceCount ?? prev.evidenceCount,
+        trigger: c.trigger ?? prev.trigger,
+        action: c.action ?? prev.action,
+        verifier: c.verifier ?? prev.verifier,
+        skillName: c.skillName ?? prev.skillName,
+        skillCreated: c.skillCreated ?? prev.skillCreated,
       };
       patches.push({
         id: c.id,
         patch: {
           status: "applied",
           reason: merged.reason,
-          evidenceCount: c.evidenceCount,
-          trigger: c.trigger,
-          action: c.action,
-          verifier: c.verifier,
-          skillName: c.skillName,
-          skillCreated: c.skillCreated,
+          ...(c.evidenceCount !== undefined
+            ? { evidenceCount: c.evidenceCount }
+            : {}),
+          ...(c.trigger !== undefined ? { trigger: c.trigger } : {}),
+          ...(c.action !== undefined ? { action: c.action } : {}),
+          ...(c.verifier !== undefined ? { verifier: c.verifier } : {}),
+          ...(c.skillName !== undefined ? { skillName: c.skillName } : {}),
+          ...(c.skillCreated !== undefined
+            ? { skillCreated: c.skillCreated }
+            : {}),
         },
       });
       byId.set(c.id, merged);

--- a/extensions/orchestrator/memory-promotion.ts
+++ b/extensions/orchestrator/memory-promotion.ts
@@ -1,0 +1,398 @@
+/**
+ * Memory promotion — graduate high-evidence memories into structure.
+ *
+ * Safe auto-apply: enforcement metadata on existing memories.
+ * Propose-only: project_rule (never writes rules files).
+ * Skill: queue + dream may auto-create under .pi/skills/.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  type EnforcementAction,
+  type EnforcementTrigger,
+  type MemoryCategory,
+  type ScoredEntry,
+  entryHash,
+  loadScores,
+  saveScores,
+} from "./memory-scoring.js";
+import { CATEGORY_TO_TOPIC, readAllTopicEntries } from "./memory-tree.js";
+import {
+  type PromotionCandidate,
+  appendPromotions,
+  formatPromotionsForReport,
+  loadPromotions,
+  promotionId,
+  updatePromotionStatus,
+  writePromotions,
+} from "./promotion-queue.js";
+
+export const EVIDENCE_ENFORCEMENT = 3;
+export const EVIDENCE_SKILL = 3;
+export const EVIDENCE_PROJECT_RULE = 5;
+
+export interface InferredEnforcement {
+  trigger: EnforcementTrigger;
+  action: EnforcementAction;
+  actionCommand?: string;
+  verifier?: string;
+  confidence: "high" | "low";
+}
+
+/** Detect unambiguous mechanical enforcement from memory text. */
+export function inferMechanicalEnforcement(text: string): InferredEnforcement | null {
+  const t = text.trim();
+
+  // never/don't use|run `cmd` or "cmd"
+  const neverCmd = t.match(
+    /\b(?:never|don'?t|do not)\s+(?:use|run|execute)\s+[`"']([^`"']+)[`"']/i,
+  );
+  if (neverCmd?.[1]) {
+    return {
+      trigger: `bash_contains ${neverCmd[1].trim()}` as EnforcementTrigger,
+      action: "block",
+      confidence: "high",
+    };
+  }
+
+  // never/don't git add .
+  const neverGitAdd = t.match(/\b(?:never|don'?t|do not)\s+.*\bgit\s+add\s+\./i);
+  if (neverGitAdd) {
+    return {
+      trigger: "bash_contains git add ." as EnforcementTrigger,
+      action: "block",
+      confidence: "high",
+    };
+  }
+
+  // never use tool X / never call X
+  const neverTool = t.match(
+    /\b(?:never|don'?t|do not)\s+(?:use|call|invoke)\s+(?:the\s+)?([a-z_][a-z0-9_-]{1,40})\b/i,
+  );
+  if (neverTool?.[1]) {
+    const tool = neverTool[1].toLowerCase();
+    // Avoid matching generic words
+    if (!["this", "that", "the", "a", "an", "any", "our"].includes(tool)) {
+      return {
+        trigger: `tool_name ${tool}` as EnforcementTrigger,
+        action: "block",
+        confidence: "high",
+      };
+    }
+  }
+
+  // always ask_user before <command>
+  const askBefore = t.match(
+    /\balways\s+(?:call\s+)?ask_user\s+before\s+(.+)$/i,
+  );
+  if (askBefore?.[1]) {
+    const cmd = askBefore[1].replace(/[.!]+$/, "").trim();
+    if (cmd.length > 2 && cmd.length < 80) {
+      return {
+        trigger: "tool_name bash" as EnforcementTrigger,
+        action: "warn",
+        verifier: `tool_called ask_user before ${cmd}`,
+        confidence: "high",
+      };
+    }
+  }
+
+  // warn when modifying <pattern>
+  const warnFile = t.match(
+    /\bwarn\s+when\s+modifying\s+([^\s,]+)/i,
+  );
+  if (warnFile?.[1]) {
+    return {
+      trigger: `file_modified ${warnFile[1].trim()}` as EnforcementTrigger,
+      action: "warn",
+      confidence: "high",
+    };
+  }
+
+  // Soft mechanical cue without extractable trigger
+  if (
+    /\b(?:never|always|don'?t|do not)\b/i.test(t) &&
+    /\b(?:git|bash|npm|uv|docker|kubectl|gh|curl)\b/i.test(t)
+  ) {
+    return null; // mechanical-looking but ambiguous — caller may queue low-confidence
+  }
+
+  return null;
+}
+
+function looksProcedural(text: string): boolean {
+  return (
+    /\b(step\s*\d|then\s+|after that|workflow|pipeline)\b/i.test(text) ||
+    (text.includes(" → ") || text.includes("->"))
+  );
+}
+
+function looksProjectConvention(text: string): boolean {
+  return /\b(always|never|must|convention|in this (repo|project)|project-wide)\b/i.test(
+    text,
+  );
+}
+
+function hasEnforcement(entry: ScoredEntry): boolean {
+  return !!((entry.trigger && entry.action) || entry.verifier);
+}
+
+/** Mark *(enforced)* on the topic line for an entry. */
+export function markTopicEntryEnforced(
+  cwd: string,
+  category: MemoryCategory,
+  text: string,
+): boolean {
+  const topicName = CATEGORY_TO_TOPIC[category];
+  if (!topicName) return false;
+  const topicPath = join(cwd, ".pi", "memory", "topics", `${topicName}.md`);
+  if (!existsSync(topicPath)) return false;
+
+  let content = readFileSync(topicPath, "utf-8");
+  const escaped = text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const lineRe = new RegExp(
+    `^(- \\[${category}\\] ${escaped})((?: \\*\\(pinned\\)\\*)?)((?: \\*\\(enforced\\)\\*)?)(\\s*)$`,
+    "m",
+  );
+  const m = content.match(lineRe);
+  if (!m) return false;
+  if (m[3]) return true; // already enforced
+
+  content = content.replace(lineRe, `$1$2 *(enforced)*$4`);
+  writeFileSync(topicPath, content, "utf-8");
+  return true;
+}
+
+export interface TopicScored {
+  text: string;
+  category: MemoryCategory;
+  pinned: boolean;
+  hash: string;
+  scored: ScoredEntry;
+}
+
+function loadTopicScored(cwd: string): TopicScored[] {
+  const scores = loadScores(cwd);
+  const out: TopicScored[] = [];
+  for (const te of readAllTopicEntries(cwd)) {
+    const hash = entryHash(`- [${te.category}] ${te.text}`);
+    const scored = scores.entries[hash];
+    if (!scored) continue;
+    out.push({
+      text: te.text,
+      category: te.category,
+      pinned: te.pinned,
+      hash,
+      scored,
+    });
+  }
+  return out;
+}
+
+/**
+ * Scan memories for promotion candidates (does not write).
+ */
+export function scanPromotionCandidates(cwd: string): PromotionCandidate[] {
+  const now = new Date().toISOString();
+  const candidates: PromotionCandidate[] = [];
+  const entries = loadTopicScored(cwd);
+
+  for (const e of entries) {
+    const evidence = e.scored.evidenceCount;
+    const inferred = inferMechanicalEnforcement(e.text);
+
+    // Enforcement path
+    if (
+      evidence >= EVIDENCE_ENFORCEMENT &&
+      !hasEnforcement(e.scored) &&
+      (e.category === "lesson" ||
+        e.category === "mistake" ||
+        e.category === "preference")
+    ) {
+      if (inferred && inferred.confidence === "high") {
+        candidates.push({
+          id: promotionId("enforcement", e.category, e.text),
+          destination: "enforcement",
+          text: e.text,
+          category: e.category,
+          reason: `evidenceCount=${evidence} with extractable mechanical trigger`,
+          evidenceCount: evidence,
+          status: "proposed",
+          trigger: inferred.trigger,
+          action: inferred.actionCommand
+            ? `run_after ${inferred.actionCommand}`
+            : inferred.action,
+          verifier: inferred.verifier,
+          createdAt: now,
+        });
+      } else if (
+        /\b(?:never|always|don'?t|do not)\b/i.test(e.text) &&
+        !inferred
+      ) {
+        candidates.push({
+          id: promotionId("enforcement", e.category, e.text),
+          destination: "enforcement",
+          text: e.text,
+          category: e.category,
+          reason: `evidenceCount=${evidence}; mechanical language but trigger needs human/LLM fill-in`,
+          evidenceCount: evidence,
+          status: "proposed",
+          createdAt: now,
+        });
+      }
+    }
+
+    // Skill path
+    if (
+      evidence >= EVIDENCE_SKILL &&
+      looksProcedural(e.text) &&
+      (e.category === "pattern" || e.category === "lesson" || e.category === "done")
+    ) {
+      const skillName = e.text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-|-$/g, "")
+        .slice(0, 40) || "workflow";
+      candidates.push({
+        id: promotionId("skill", e.category, e.text),
+        destination: "skill",
+        text: e.text,
+        category: e.category,
+        reason: `evidenceCount=${evidence}; looks like a multi-step workflow`,
+        evidenceCount: evidence,
+        status: "proposed",
+        skillName,
+        skillCreated: false,
+        createdAt: now,
+      });
+    }
+
+    // Project rule path (propose only)
+    if (
+      evidence >= EVIDENCE_PROJECT_RULE &&
+      looksProjectConvention(e.text) &&
+      !hasEnforcement(e.scored) &&
+      !inferred
+    ) {
+      candidates.push({
+        id: promotionId("project_rule", e.category, e.text),
+        destination: "project_rule",
+        text: e.text,
+        category: e.category,
+        reason: `evidenceCount=${evidence}; project-wide convention — propose only, never auto-write rules/`,
+        evidenceCount: evidence,
+        status: "proposed",
+        createdAt: now,
+      });
+    }
+  }
+
+  return candidates;
+}
+
+export interface ApplySafeResult {
+  applied: number;
+  queued: number;
+  details: string[];
+}
+
+/**
+ * Apply high-confidence enforcement promotions; queue the rest.
+ * Never writes rules files.
+ */
+export function applySafePromotions(cwd: string): ApplySafeResult {
+  const details: string[] = [];
+  let applied = 0;
+
+  const scanned = scanPromotionCandidates(cwd);
+  const toQueue: PromotionCandidate[] = [];
+  const scores = loadScores(cwd);
+
+  for (const c of scanned) {
+    if (c.destination !== "enforcement" || !c.trigger || !c.action) {
+      toQueue.push(c);
+      continue;
+    }
+
+    // Only auto-apply when action is block/warn (not run_after — safer)
+    if (c.action !== "block" && c.action !== "warn") {
+      toQueue.push(c);
+      continue;
+    }
+
+    const hash = entryHash(`- [${c.category}] ${c.text}`);
+    const entry = scores.entries[hash];
+    if (!entry || hasEnforcement(entry)) {
+      toQueue.push({ ...c, status: "proposed" });
+      continue;
+    }
+
+    entry.trigger = c.trigger as EnforcementTrigger;
+    entry.action = c.action as EnforcementAction;
+    if (c.verifier) entry.verifier = c.verifier;
+    entry.lifecycle = "active";
+    markTopicEntryEnforced(cwd, c.category as MemoryCategory, c.text);
+
+    const appliedCandidate: PromotionCandidate = { ...c, status: "applied" };
+    toQueue.push(appliedCandidate);
+    applied += 1;
+    details.push(`enforced: [${c.category}] ${c.text}`);
+  }
+
+  saveScores(cwd, scores);
+
+  // Merge with existing queue: upsert by id (don't reopen applied/rejected)
+  const all = loadPromotions(cwd);
+  const byId = new Map(all.map((x) => [x.id, x]));
+
+  for (const c of toQueue) {
+    const prev = byId.get(c.id);
+    if (prev && prev.status !== "proposed" && c.status === "proposed") {
+      continue;
+    }
+    byId.set(c.id, c);
+  }
+  writePromotions(cwd, [...byId.values()]);
+
+  const queued = [...byId.values()].filter((c) => c.status === "proposed").length;
+  return { applied, queued, details };
+}
+
+/**
+ * Full promotion pass: scan, apply safe enforcement, refresh queue.
+ * Call after reinforce threshold crossings and after dream completes.
+ */
+export function runPromotionPass(cwd: string): ApplySafeResult {
+  try {
+    return applySafePromotions(cwd);
+  } catch (e: any) {
+    console.debug("[memory-promotion] pass failed:", e?.message || e);
+    return { applied: 0, queued: 0, details: [] };
+  }
+}
+
+/**
+ * After reinforce: if evidence crossed a threshold, run promotion pass.
+ */
+export function maybePromoteAfterReinforce(
+  cwd: string,
+  entryLine: string,
+): ApplySafeResult | null {
+  const scores = loadScores(cwd);
+  const hash = entryHash(entryLine);
+  const entry = scores.entries[hash];
+  if (!entry) return null;
+
+  const crossed =
+    entry.evidenceCount === EVIDENCE_ENFORCEMENT ||
+    entry.evidenceCount === EVIDENCE_SKILL ||
+    entry.evidenceCount === EVIDENCE_PROJECT_RULE ||
+    (entry.evidenceCount > EVIDENCE_ENFORCEMENT &&
+      entry.evidenceCount % 3 === 0);
+
+  if (!crossed) return null;
+  return runPromotionPass(cwd);
+}
+
+export { formatPromotionsForReport, updatePromotionStatus, appendPromotions };

--- a/extensions/orchestrator/memory-promotion.ts
+++ b/extensions/orchestrator/memory-promotion.ts
@@ -24,7 +24,7 @@ import {
   formatPromotionsForReport,
   loadPromotions,
   promotionId,
-  updatePromotionStatuses,
+  updatePromotionCandidates,
 } from "./promotion-queue.js";
 
 export const EVIDENCE_ENFORCEMENT = 3;
@@ -354,7 +354,7 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
   const existing = loadPromotions(cwd);
   const byId = new Map(existing.map((x) => [x.id, x]));
   const toAppend: PromotionCandidate[] = [];
-  const statusUpdates: { id: string; status: "applied" }[] = [];
+  const patches: { id: string; patch: Partial<PromotionCandidate> }[] = [];
 
   for (const c of toQueue) {
     const prev = byId.get(c.id);
@@ -366,11 +366,18 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
     // Don't reopen applied/rejected as proposed
     if (prev.status !== "proposed" && c.status === "proposed") continue;
     if (c.status === "applied" && prev.status === "proposed") {
-      statusUpdates.push({ id: c.id, status: "applied" });
-      byId.set(c.id, { ...prev, status: "applied" });
+      // Merge enforcement metadata for auditability; keep human reason if present
+      const merged: PromotionCandidate = {
+        ...prev,
+        ...c,
+        status: "applied",
+        reason: prev.reason || c.reason,
+      };
+      patches.push({ id: c.id, patch: merged });
+      byId.set(c.id, merged);
     }
   }
-  if (statusUpdates.length > 0) updatePromotionStatuses(cwd, statusUpdates);
+  if (patches.length > 0) updatePromotionCandidates(cwd, patches);
   if (toAppend.length > 0) appendPromotions(cwd, toAppend);
 
   const queued = [...byId.values()].filter((c) => c.status === "proposed").length;

--- a/extensions/orchestrator/memory-promotion.ts
+++ b/extensions/orchestrator/memory-promotion.ts
@@ -24,7 +24,7 @@ import {
   formatPromotionsForReport,
   loadPromotions,
   promotionId,
-  updatePromotionStatus,
+  updatePromotionStatuses,
 } from "./promotion-queue.js";
 
 export const EVIDENCE_ENFORCEMENT = 3;
@@ -350,11 +350,11 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
 
   saveScores(cwd, scores);
 
-  // Append-only / status-update — never full-rewrite promotions.md (lossy parser
-  // would drop human notes and malformed blocks).
+  // Append-only / batched status updates — avoid lossy full rewrite and per-item I/O.
   const existing = loadPromotions(cwd);
   const byId = new Map(existing.map((x) => [x.id, x]));
   const toAppend: PromotionCandidate[] = [];
+  const statusUpdates: { id: string; status: "applied" }[] = [];
 
   for (const c of toQueue) {
     const prev = byId.get(c.id);
@@ -366,10 +366,11 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
     // Don't reopen applied/rejected as proposed
     if (prev.status !== "proposed" && c.status === "proposed") continue;
     if (c.status === "applied" && prev.status === "proposed") {
-      updatePromotionStatus(cwd, c.id, "applied");
+      statusUpdates.push({ id: c.id, status: "applied" });
       byId.set(c.id, { ...prev, status: "applied" });
     }
   }
+  if (statusUpdates.length > 0) updatePromotionStatuses(cwd, statusUpdates);
   if (toAppend.length > 0) appendPromotions(cwd, toAppend);
 
   const queued = [...byId.values()].filter((c) => c.status === "proposed").length;

--- a/extensions/orchestrator/memory-promotion.ts
+++ b/extensions/orchestrator/memory-promotion.ts
@@ -25,7 +25,6 @@ import {
   loadPromotions,
   promotionId,
   updatePromotionStatus,
-  writePromotions,
 } from "./promotion-queue.js";
 
 export const EVIDENCE_ENFORCEMENT = 3;
@@ -99,15 +98,24 @@ export function inferMechanicalEnforcement(text: string): InferredEnforcement | 
   }
 
   // warn when modifying <pattern>
+  // Only high-confidence when the pattern is matchable by enforcement runtime:
+  // `*.ext` suffix or a plain path fragment (no glob metacharacters).
   const warnFile = t.match(
     /\bwarn\s+when\s+modifying\s+([^\s,]+)/i,
   );
   if (warnFile?.[1]) {
-    return {
-      trigger: `file_modified ${warnFile[1].trim()}` as EnforcementTrigger,
-      action: "warn",
-      confidence: "high",
-    };
+    const pattern = warnFile[1].trim();
+    const isExtGlob = /^\*\.[A-Za-z0-9]+$/.test(pattern);
+    const hasGlobMeta = /[*?[\]{}]|\*\*/.test(pattern);
+    if (isExtGlob || !hasGlobMeta) {
+      return {
+        trigger: `file_modified ${pattern}` as EnforcementTrigger,
+        action: "warn",
+        confidence: "high",
+      };
+    }
+    // Glob-like patterns (e.g. src/**/*.py) are not matchable — leave for propose-only
+    return null;
   }
 
   // Soft mechanical cue without extractable trigger
@@ -342,18 +350,27 @@ export function applySafePromotions(cwd: string): ApplySafeResult {
 
   saveScores(cwd, scores);
 
-  // Merge with existing queue: upsert by id (don't reopen applied/rejected)
-  const all = loadPromotions(cwd);
-  const byId = new Map(all.map((x) => [x.id, x]));
+  // Append-only / status-update — never full-rewrite promotions.md (lossy parser
+  // would drop human notes and malformed blocks).
+  const existing = loadPromotions(cwd);
+  const byId = new Map(existing.map((x) => [x.id, x]));
+  const toAppend: PromotionCandidate[] = [];
 
   for (const c of toQueue) {
     const prev = byId.get(c.id);
-    if (prev && prev.status !== "proposed" && c.status === "proposed") {
+    if (!prev) {
+      toAppend.push(c);
+      byId.set(c.id, c);
       continue;
     }
-    byId.set(c.id, c);
+    // Don't reopen applied/rejected as proposed
+    if (prev.status !== "proposed" && c.status === "proposed") continue;
+    if (c.status === "applied" && prev.status === "proposed") {
+      updatePromotionStatus(cwd, c.id, "applied");
+      byId.set(c.id, { ...prev, status: "applied" });
+    }
   }
-  writePromotions(cwd, [...byId.values()]);
+  if (toAppend.length > 0) appendPromotions(cwd, toAppend);
 
   const queued = [...byId.values()].filter((c) => c.status === "proposed").length;
   return { applied, queued, details };

--- a/extensions/orchestrator/memory-provenance.ts
+++ b/extensions/orchestrator/memory-provenance.ts
@@ -1,0 +1,80 @@
+/**
+ * Provenance pending merge — dream writes a sidecar JSON; onComplete merges
+ * into memory-scores.json without asking the LLM to edit scores JSON.
+ *
+ * Sidecar: `.pi/memory/provenance-pending.json`
+ * Shape: { entries: [{ category, text, sourceSession?, derivedFrom?, informs? }] }
+ */
+
+import { existsSync, readFileSync, unlinkSync, writeFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { entryHash, loadScores, saveScores, type MemoryCategory } from "./memory-scoring.js";
+
+export interface ProvenancePendingItem {
+  category: MemoryCategory | string;
+  text: string;
+  sourceSession?: string;
+  derivedFrom?: string;
+  informs?: string[];
+}
+
+export interface ProvenancePendingFile {
+  entries: ProvenancePendingItem[];
+}
+
+export function getProvenancePendingPath(cwd: string): string {
+  return join(cwd, ".pi", "memory", "provenance-pending.json");
+}
+
+export function writeProvenancePending(
+  cwd: string,
+  entries: ProvenancePendingItem[],
+): void {
+  const path = getProvenancePendingPath(cwd);
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const payload: ProvenancePendingFile = { entries };
+  writeFileSync(path, JSON.stringify(payload, null, 2) + "\n", "utf-8");
+}
+
+/**
+ * Merge provenance-pending.json into scores, then delete the sidecar.
+ * Returns number of entries updated.
+ */
+export function mergeProvenancePending(cwd: string): number {
+  const path = getProvenancePendingPath(cwd);
+  if (!existsSync(path)) return 0;
+
+  let pending: ProvenancePendingFile;
+  try {
+    pending = JSON.parse(readFileSync(path, "utf-8")) as ProvenancePendingFile;
+  } catch (e: any) {
+    console.debug("[memory-provenance] parse failed:", e?.message || e);
+    return 0;
+  }
+
+  if (!pending?.entries?.length) {
+    try { unlinkSync(path); } catch { /* ignore */ }
+    return 0;
+  }
+
+  const scores = loadScores(cwd);
+  let updated = 0;
+
+  for (const item of pending.entries) {
+    if (!item?.category || !item?.text) continue;
+    const hash = entryHash(`- [${item.category}] ${item.text}`);
+    const entry = scores.entries[hash];
+    if (!entry) continue;
+
+    if (item.sourceSession) entry.sourceSession = item.sourceSession;
+    if (item.derivedFrom) entry.derivedFrom = item.derivedFrom;
+    if (item.informs?.length) entry.informs = item.informs;
+    updated += 1;
+  }
+
+  if (updated > 0) saveScores(cwd, scores);
+
+  try { unlinkSync(path); } catch { /* ignore */ }
+  return updated;
+}

--- a/extensions/orchestrator/memory-query-class.ts
+++ b/extensions/orchestrator/memory-query-class.ts
@@ -1,0 +1,90 @@
+/**
+ * Query-class classifier for memory injection routing.
+ * Cheap heuristics only — no LLM call.
+ */
+
+export type QueryClass = "pr_review" | "git_release" | "debug" | "general";
+
+export interface QueryClassBias {
+  /** Categories to boost (higher section budget / earlier priority) */
+  boostCategories: string[];
+  /** Vector topK override */
+  vectorTopK: number;
+  /** Extra note injected into situation report when relevant */
+  hint?: string;
+}
+
+const CLASS_BIAS: Record<QueryClass, QueryClassBias> = {
+  pr_review: {
+    boostCategories: ["mistake", "pattern", "lesson"],
+    vectorTopK: 7,
+    hint: "PR review context — prefer mistakes/patterns; check `.pi/data/review-guidelines.md` when reviewing.",
+  },
+  git_release: {
+    boostCategories: ["lesson", "decision", "preference"],
+    vectorTopK: 6,
+    hint: "Git/release context — prefer enforced lessons and decisions.",
+  },
+  debug: {
+    boostCategories: ["mistake", "lesson"],
+    vectorTopK: 7,
+    hint: "Debug context — prefer mistakes and lessons.",
+  },
+  general: {
+    boostCategories: [],
+    vectorTopK: 5,
+  },
+};
+
+const PR_REVIEW_RE =
+  /\b(pr review|code review|review (this |the )?(pr|pull request)|gh pr\b|pull request)\b/i;
+const GIT_RELEASE_RE =
+  /\b(git (commit|push|tag|rebase|merge)|release|changelog|semver|deploy(ment)?)\b/i;
+const DEBUG_RE =
+  /\b(error|stack( ?trace)?|traceback|fail(ed|ing|ure)?|exception|bug|debug|segfault|panic)\b/i;
+
+/**
+ * Classify the user prompt into a query class for injection bias.
+ */
+export function classifyQueryClass(prompt: string): QueryClass {
+  const text = (prompt || "").trim();
+  if (!text) return "general";
+
+  if (PR_REVIEW_RE.test(text)) return "pr_review";
+  if (GIT_RELEASE_RE.test(text)) return "git_release";
+  if (DEBUG_RE.test(text)) return "debug";
+  return "general";
+}
+
+export function getQueryClassBias(queryClass: QueryClass): QueryClassBias {
+  return CLASS_BIAS[queryClass];
+}
+
+/**
+ * Reorder section priority: boosted categories get a modest priority lift
+ * (lower number = earlier). Non-boosted keep base order.
+ */
+export function sectionPriorityBoost(
+  sectionName: string,
+  basePriority: number,
+  queryClass: QueryClass,
+): number {
+  const bias = getQueryClassBias(queryClass);
+  if (bias.boostCategories.length === 0) return basePriority;
+
+  const topicMap: Record<string, string> = {
+    "Active Preferences": "preference",
+    "Active Lessons": "lesson",
+    "Vetoes & Mistakes": "mistake",
+    Patterns: "pattern",
+    "Recent Decisions": "decision",
+    "Recent Completions": "done",
+  };
+  const cat = topicMap[sectionName];
+  if (cat && bias.boostCategories.includes(cat)) {
+    // Lower number sorts earlier; allow 0/negative so boosted sections
+    // beat unboosted priority-1 sections (e.g. preferences).
+    return basePriority - 3;
+  }
+  return basePriority;
+}

--- a/extensions/orchestrator/memory-scoring.ts
+++ b/extensions/orchestrator/memory-scoring.ts
@@ -59,6 +59,14 @@ export interface ScoredEntry {
   actionCommand?: string;
   /** Semantic verifier — condition to check (e.g., 'tool_called ask_user before gh pr merge') */
   verifier?: string;
+
+  // ── Provenance fields (optional; not injected into situation report) ──
+  /** Session id or path basename this memory came from */
+  sourceSession?: string;
+  /** Short note or prior entry hash this was derived from */
+  derivedFrom?: string;
+  /** Free-text targets this memory informs (e.g. pr-review, git, skill name) */
+  informs?: string[];
 }
 
 export interface ScoresFile {

--- a/extensions/orchestrator/memory-tools.ts
+++ b/extensions/orchestrator/memory-tools.ts
@@ -27,6 +27,7 @@ import {
 } from "./memory-scoring.js";
 import { listTopics, readAllTopicEntries, CATEGORY_TO_TOPIC, MAX_TOPIC_CHARS, type TopicInfo } from "./memory-tree.js";
 import { embedEntry, removeEmbedding, vectorSearch, embedMissing } from "./memory-embeddings.js";
+import { maybePromoteAfterReinforce } from "./memory-promotion.js";
 
 const NEAR_DUPLICATE_THRESHOLD = 0.90;
 
@@ -149,7 +150,13 @@ function registerMemorySearch(pi: ExtensionAPI, state: { embeddingsMigrated: boo
       const lines = results.map((r) => {
         const pin = r.pinned ? " (pinned)" : "";
         const sim = r.similarity !== undefined ? `, similarity: ${r.similarity.toFixed(3)}` : "";
-        return `- [${r.category}] ${r.text}${pin} — score: ${typeof r.score === "number" ? r.score.toFixed(2) : r.score}, evidence: ${r.evidenceCount}${sim}`;
+        const scored = scores.entries[entryHash(`- [${r.category}] ${r.text}`)];
+        const provParts: string[] = [];
+        if (scored?.sourceSession) provParts.push(`session: ${scored.sourceSession}`);
+        if (scored?.derivedFrom) provParts.push(`from: ${scored.derivedFrom}`);
+        if (scored?.informs?.length) provParts.push(`informs: ${scored.informs.join(", ")}`);
+        const prov = provParts.length ? ` [${provParts.join("; ")}]` : "";
+        return `- [${r.category}] ${r.text}${pin} — score: ${typeof r.score === "number" ? r.score.toFixed(2) : r.score}, evidence: ${r.evidenceCount}${sim}${prov}`;
       });
 
       const text = `Found ${results.length} memories matching "${params.query}":\n\n${lines.join("\n")}`;
@@ -184,10 +191,20 @@ function registerMemoryReinforce(pi: ExtensionAPI): void {
         const scores = loadScores(ctx.cwd);
         const hash = entryHash(entryLine);
         const entry = scores.entries[hash];
+        let promoNote = "";
+        try {
+          const promo = maybePromoteAfterReinforce(ctx.cwd, entryLine);
+          if (promo && (promo.applied > 0 || promo.queued > 0)) {
+            promoNote = `\nPromotion pass: applied=${promo.applied}, proposed=${promo.queued}` +
+              (promo.details.length ? ` (${promo.details.join("; ")})` : "");
+          }
+        } catch (e: any) {
+          console.debug("[memory] promote-after-reinforce failed:", e?.message || e);
+        }
         return {
           content: [{
             type: "text",
-            text: `Reinforced: [${params.category}] ${params.entryText}\nNew evidence count: ${entry?.evidenceCount ?? "?"}, score: ${entry?.score?.toFixed(2) ?? "?"}`,
+            text: `Reinforced: [${params.category}] ${params.entryText}\nNew evidence count: ${entry?.evidenceCount ?? "?"}, score: ${entry?.score?.toFixed(2) ?? "?"}${promoNote}`,
           }],
         };
       }
@@ -262,6 +279,21 @@ function registerMemoryAdd(pi: ExtensionAPI): void {
       verifier: Type.Optional(
         Type.String({
           description: "Semantic verifier condition (e.g., 'tool_called ask_user before gh pr merge'). Checked at turn_end.",
+        }),
+      ),
+      sourceSession: Type.Optional(
+        Type.String({
+          description: "Optional provenance: session id or basename this memory came from",
+        }),
+      ),
+      derivedFrom: Type.Optional(
+        Type.String({
+          description: "Optional provenance: short note or prior entry this was derived from",
+        }),
+      ),
+      informs: Type.Optional(
+        Type.Array(Type.String(), {
+          description: "Optional provenance: what this memory informs (e.g. pr-review, git, skill name)",
         }),
       ),
     }),
@@ -480,6 +512,9 @@ function registerMemoryAdd(pi: ExtensionAPI): void {
       if (params.verifier) {
         entry.verifier = params.verifier;
       }
+      if (params.sourceSession) entry.sourceSession = params.sourceSession;
+      if (params.derivedFrom) entry.derivedFrom = params.derivedFrom;
+      if (params.informs && params.informs.length > 0) entry.informs = params.informs;
 
       scores.entries[hash] = entry;
       saveScores(cwd, scores);
@@ -617,12 +652,19 @@ function registerMemoryReflect(pi: ExtensionAPI): void {
         return { content: [{ type: "text", text: `No relevant memories found for: "${params.query}"` }] };
       }
 
-      // Format as structured context for the AI to synthesize
+      // Format as structured context for the AI to synthesize (include provenance when present)
+      const scores = loadScores(cwd);
       const memoryContext = relevant
         .slice(0, 15)
         .map(r => {
           const sim = r.similarity !== undefined ? ` (${r.similarity.toFixed(3)})` : "";
-          return `- [${r.category}] ${r.text}${sim}`;
+          const scored = scores.entries[entryHash(`- [${r.category}] ${r.text}`)];
+          const provParts: string[] = [];
+          if (scored?.sourceSession) provParts.push(`session: ${scored.sourceSession}`);
+          if (scored?.derivedFrom) provParts.push(`from: ${scored.derivedFrom}`);
+          if (scored?.informs?.length) provParts.push(`informs: ${scored.informs.join(", ")}`);
+          const prov = provParts.length ? ` [${provParts.join("; ")}]` : "";
+          return `- [${r.category}] ${r.text}${sim}${prov}`;
         })
         .join("\n");
 
@@ -652,6 +694,9 @@ function registerMemoryEdit(pi: ExtensionAPI): void {
       category: Type.String({ description: "Category: preference, lesson, pattern, decision, done, mistake" }),
       newText: Type.Optional(Type.String({ description: "New text content (for update)" })),
       supersededBy: Type.Optional(Type.String({ description: "Text of the replacement entry (for invalidate)" })),
+      sourceSession: Type.Optional(Type.String({ description: "Optional provenance: session id" })),
+      derivedFrom: Type.Optional(Type.String({ description: "Optional provenance: derived-from note" })),
+      informs: Type.Optional(Type.Array(Type.String(), { description: "Optional provenance: informs targets" })),
     }),
     async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
       const cwd = ctx.cwd;
@@ -718,8 +763,14 @@ function registerMemoryEdit(pi: ExtensionAPI): void {
         if (scores.entries[oldHash]) {
           scores.entries[newHash] = { ...scores.entries[oldHash] };
           delete scores.entries[oldHash];
-          saveScores(cwd, scores);
         }
+        const target = scores.entries[newHash];
+        if (target) {
+          if (params.sourceSession !== undefined) target.sourceSession = params.sourceSession;
+          if (params.derivedFrom !== undefined) target.derivedFrom = params.derivedFrom;
+          if (params.informs !== undefined) target.informs = params.informs;
+        }
+        saveScores(cwd, scores);
 
         // Update embeddings
         removeEmbedding(cwd, text, category);
@@ -798,11 +849,15 @@ function registerMemoryConsolidate(pi: ExtensionAPI): void {
       report += `Review the above memories and take ALL of these actions:\n`;
       report += `1. **Identify contradictions** — if two entries conflict, keep the newer/more specific one. Use memory_edit to invalidate the stale one.\n`;
       report += `2. **Merge duplicates** — if entries say the same thing differently, keep the best version. Use memory_edit to update.\n`;
-      report += `3. **Identify skill candidates** — if you see a multi-step workflow (3+ steps) that recurs across entries,\n`;
-      report += `   report it and suggest using /create-skill <name> to capture it.\n`;
+      report += `3. **Promotion destinations** — append candidates to \`.pi/memory/promotions.md\` with destination:\n`;
+      report += `   \`memory\` | \`skill\` | \`enforcement\` | \`project_rule\` | \`discard\`.\n`;
+      report += `   - skill: suggest /create-skill or note existing .pi/skills/; set skill_created if you write one\n`;
+      report += `   - enforcement: propose trigger/action when mechanical; do not invent run_after\n`;
+      report += `   - project_rule: propose only — NEVER write rules/ or .pi/rules/\n`;
+      report += `   Block format: ### <id> then fields destination, status: proposed, category, text, reason, created\n`;
       report += `4. **Remove stale** — if entries reference things that no longer exist or apply, use memory_remove.\n`;
       report += `5. **NEVER touch pinned entries** — they are user-explicit and permanent.\n\n`;
-      report += `*Take actions using memory_edit and memory_remove. Report skill candidates for user to create.*`;
+      report += `*Take actions using memory_edit and memory_remove. Write promotions.md for graduation candidates.*`;
 
       return { content: [{ type: "text", text: report }] };
     },

--- a/extensions/orchestrator/preference-extractor.ts
+++ b/extensions/orchestrator/preference-extractor.ts
@@ -53,6 +53,8 @@ export function registerPreferenceExtractor(pi: ExtensionAPI): void {
 
     const scores = loadScores(ctx.cwd);
     let added = 0;
+    const sourceSession =
+      (ctx as any).sessionManager?.getSessionId?.() || undefined;
 
     for (const pref of preferences) {
       const entryLine = `- [preference] ${pref}`;
@@ -68,6 +70,9 @@ export function registerPreferenceExtractor(pi: ExtensionAPI): void {
         if (scores.entries[hash]) {
           scores.entries[hash]!.evidenceCount += 1;
           scores.entries[hash]!.lastReinforced = new Date().toISOString();
+          if (sourceSession && !scores.entries[hash]!.sourceSession) {
+            scores.entries[hash]!.sourceSession = sourceSession;
+          }
         }
         recentExtractions.set(hash, Date.now());
         continue;
@@ -86,6 +91,7 @@ export function registerPreferenceExtractor(pi: ExtensionAPI): void {
         lastReinforced: new Date().toISOString(),
         userState: "auto",
         lifecycle: "active",
+        ...(sourceSession ? { sourceSession } : {}),
       } as ScoredEntry;
 
       recentExtractions.set(hash, Date.now());

--- a/extensions/orchestrator/promotion-queue.ts
+++ b/extensions/orchestrator/promotion-queue.ts
@@ -216,6 +216,39 @@ const IMMUTABLE_PROMOTION_KEYS = new Set([
   "createdAt",
 ]);
 
+const STRING_PATCH_KEYS = new Set([
+  "reason",
+  "trigger",
+  "action",
+  "verifier",
+  "skillName",
+]);
+
+/** Normalize one patch entry; returns undefined to leave the stored field unchanged. */
+function normalizePatchValue(
+  key: string,
+  value: unknown,
+): unknown | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (key === "status") {
+    return typeof value === "string" && STATUSES.includes(value as PromotionStatus)
+      ? value
+      : undefined;
+  }
+  if (key === "evidenceCount") {
+    return typeof value === "number" && Number.isFinite(value)
+      ? value
+      : undefined;
+  }
+  if (key === "skillCreated") {
+    return typeof value === "boolean" ? value : undefined;
+  }
+  if (STRING_PATCH_KEYS.has(key)) {
+    return typeof value === "string" ? value : undefined;
+  }
+  return undefined;
+}
+
 /** Batch patch promotion candidates — one load/write. Returns how many ids were updated. */
 export function updatePromotionCandidates(
   cwd: string,
@@ -231,9 +264,11 @@ export function updatePromotionCandidates(
     const safePatch: PromotionCandidatePatch = {};
     for (const [key, value] of Object.entries(u.patch)) {
       if (IMMUTABLE_PROMOTION_KEYS.has(key)) continue;
-      if (value === undefined) continue;
-      (safePatch as Record<string, unknown>)[key] = value;
+      const normalized = normalizePatchValue(key, value);
+      if (normalized === undefined) continue;
+      (safePatch as Record<string, unknown>)[key] = normalized;
     }
+    if (Object.keys(safePatch).length === 0) continue;
     Object.assign(entry, safePatch);
     entry.id = u.id;
     n += 1;

--- a/extensions/orchestrator/promotion-queue.ts
+++ b/extensions/orchestrator/promotion-queue.ts
@@ -203,10 +203,23 @@ export function updatePromotionStatuses(
   );
 }
 
+/** Mutable fields only — identity keys cannot be patched. */
+export type PromotionCandidatePatch = Partial<
+  Omit<PromotionCandidate, "id" | "destination" | "text" | "category" | "createdAt">
+>;
+
+const IMMUTABLE_PROMOTION_KEYS = new Set([
+  "id",
+  "destination",
+  "text",
+  "category",
+  "createdAt",
+]);
+
 /** Batch patch promotion candidates — one load/write. Returns how many ids were updated. */
 export function updatePromotionCandidates(
   cwd: string,
-  updates: { id: string; patch: Partial<PromotionCandidate> }[],
+  updates: { id: string; patch: PromotionCandidatePatch }[],
 ): number {
   if (updates.length === 0) return 0;
   const existing = loadPromotions(cwd);
@@ -215,7 +228,13 @@ export function updatePromotionCandidates(
   for (const u of updates) {
     const entry = byId.get(u.id);
     if (!entry) continue;
-    Object.assign(entry, u.patch);
+    const safePatch: PromotionCandidatePatch = {};
+    for (const [key, value] of Object.entries(u.patch)) {
+      if (IMMUTABLE_PROMOTION_KEYS.has(key)) continue;
+      (safePatch as Record<string, unknown>)[key] = value;
+    }
+    Object.assign(entry, safePatch);
+    entry.id = u.id;
     n += 1;
   }
   if (n > 0) writePromotions(cwd, [...byId.values()]);

--- a/extensions/orchestrator/promotion-queue.ts
+++ b/extensions/orchestrator/promotion-queue.ts
@@ -189,12 +189,26 @@ export function updatePromotionStatus(
   id: string,
   status: PromotionStatus,
 ): boolean {
+  return updatePromotionStatuses(cwd, [{ id, status }]) === 1;
+}
+
+/** Batch status updates — one load/write cycle. Returns how many ids were updated. */
+export function updatePromotionStatuses(
+  cwd: string,
+  updates: { id: string; status: PromotionStatus }[],
+): number {
+  if (updates.length === 0) return 0;
   const existing = loadPromotions(cwd);
-  const idx = existing.findIndex((c) => c.id === id);
-  if (idx < 0) return false;
-  existing[idx]!.status = status;
-  writePromotions(cwd, existing);
-  return true;
+  const byId = new Map(existing.map((c) => [c.id, c]));
+  let n = 0;
+  for (const u of updates) {
+    const entry = byId.get(u.id);
+    if (!entry) continue;
+    entry.status = u.status;
+    n += 1;
+  }
+  if (n > 0) writePromotions(cwd, [...byId.values()]);
+  return n;
 }
 
 export function listProposedPromotions(cwd: string): PromotionCandidate[] {

--- a/extensions/orchestrator/promotion-queue.ts
+++ b/extensions/orchestrator/promotion-queue.ts
@@ -231,6 +231,7 @@ export function updatePromotionCandidates(
     const safePatch: PromotionCandidatePatch = {};
     for (const [key, value] of Object.entries(u.patch)) {
       if (IMMUTABLE_PROMOTION_KEYS.has(key)) continue;
+      if (value === undefined) continue;
       (safePatch as Record<string, unknown>)[key] = value;
     }
     Object.assign(entry, safePatch);

--- a/extensions/orchestrator/promotion-queue.ts
+++ b/extensions/orchestrator/promotion-queue.ts
@@ -197,6 +197,17 @@ export function updatePromotionStatuses(
   cwd: string,
   updates: { id: string; status: PromotionStatus }[],
 ): number {
+  return updatePromotionCandidates(
+    cwd,
+    updates.map((u) => ({ id: u.id, patch: { status: u.status } })),
+  );
+}
+
+/** Batch patch promotion candidates — one load/write. Returns how many ids were updated. */
+export function updatePromotionCandidates(
+  cwd: string,
+  updates: { id: string; patch: Partial<PromotionCandidate> }[],
+): number {
   if (updates.length === 0) return 0;
   const existing = loadPromotions(cwd);
   const byId = new Map(existing.map((c) => [c.id, c]));
@@ -204,7 +215,7 @@ export function updatePromotionStatuses(
   for (const u of updates) {
     const entry = byId.get(u.id);
     if (!entry) continue;
-    entry.status = u.status;
+    Object.assign(entry, u.patch);
     n += 1;
   }
   if (n > 0) writePromotions(cwd, [...byId.values()]);

--- a/extensions/orchestrator/promotion-queue.ts
+++ b/extensions/orchestrator/promotion-queue.ts
@@ -1,0 +1,231 @@
+/**
+ * Promotion queue — structured candidates for graduating memories into
+ * skills, enforcement, or project rules.
+ *
+ * Storage: `.pi/memory/promotions.md` (human + agent readable).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { createHash } from "node:crypto";
+
+export type PromotionDestination =
+  | "memory"
+  | "skill"
+  | "enforcement"
+  | "project_rule"
+  | "discard";
+
+export type PromotionStatus = "proposed" | "applied" | "rejected";
+
+export interface PromotionCandidate {
+  id: string;
+  destination: PromotionDestination;
+  text: string;
+  category: string;
+  reason: string;
+  evidenceCount?: number;
+  status: PromotionStatus;
+  trigger?: string;
+  action?: string;
+  verifier?: string;
+  skillName?: string;
+  skillCreated?: boolean;
+  createdAt: string;
+}
+
+const DESTINATIONS: PromotionDestination[] = [
+  "memory",
+  "skill",
+  "enforcement",
+  "project_rule",
+  "discard",
+];
+
+const STATUSES: PromotionStatus[] = ["proposed", "applied", "rejected"];
+
+export function getPromotionsPath(cwd: string): string {
+  return join(cwd, ".pi", "memory", "promotions.md");
+}
+
+/** Stable id from destination + category + text (dedup key). */
+export function promotionId(
+  destination: PromotionDestination,
+  category: string,
+  text: string,
+): string {
+  return createHash("sha256")
+    .update(`${destination}|${category}|${text}`)
+    .digest("hex")
+    .slice(0, 12);
+}
+
+export function formatPromotionBlock(c: PromotionCandidate): string {
+  const lines = [
+    `### ${c.id}`,
+    `- destination: ${c.destination}`,
+    `- status: ${c.status}`,
+    `- category: ${c.category}`,
+    `- text: ${c.text}`,
+    `- reason: ${c.reason}`,
+    `- created: ${c.createdAt}`,
+  ];
+  if (c.evidenceCount !== undefined) {
+    lines.push(`- evidence_count: ${c.evidenceCount}`);
+  }
+  if (c.trigger) lines.push(`- trigger: ${c.trigger}`);
+  if (c.action) lines.push(`- action: ${c.action}`);
+  if (c.verifier) lines.push(`- verifier: ${c.verifier}`);
+  if (c.skillName) lines.push(`- skill_name: ${c.skillName}`);
+  if (c.skillCreated !== undefined) {
+    lines.push(`- skill_created: ${c.skillCreated ? "true" : "false"}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+function parseField(block: string, key: string): string | undefined {
+  const re = new RegExp(`^- ${key}: (.+)$`, "m");
+  const m = block.match(re);
+  return m?.[1]?.trim();
+}
+
+export function parsePromotionsMarkdown(content: string): PromotionCandidate[] {
+  if (!content.trim()) return [];
+
+  const chunks = content.split(/^### /m).filter((c) => c.trim());
+  const results: PromotionCandidate[] = [];
+
+  for (const chunk of chunks) {
+    const lines = chunk.trim().split("\n");
+    const id = lines[0]?.trim();
+    if (!id) continue;
+
+    const body = chunk;
+    const destination = parseField(body, "destination") as PromotionDestination | undefined;
+    const status = parseField(body, "status") as PromotionStatus | undefined;
+    const category = parseField(body, "category");
+    const text = parseField(body, "text");
+    const reason = parseField(body, "reason");
+    const createdAt = parseField(body, "created");
+
+    if (!destination || !DESTINATIONS.includes(destination)) continue;
+    if (!status || !STATUSES.includes(status)) continue;
+    if (!category || !text || !reason || !createdAt) continue;
+
+    const evidenceRaw = parseField(body, "evidence_count");
+    const skillCreatedRaw = parseField(body, "skill_created");
+
+    results.push({
+      id,
+      destination,
+      status,
+      category,
+      text,
+      reason,
+      createdAt,
+      evidenceCount: evidenceRaw !== undefined ? Number(evidenceRaw) : undefined,
+      trigger: parseField(body, "trigger"),
+      action: parseField(body, "action"),
+      verifier: parseField(body, "verifier"),
+      skillName: parseField(body, "skill_name"),
+      skillCreated:
+        skillCreatedRaw === undefined
+          ? undefined
+          : skillCreatedRaw === "true",
+    });
+  }
+
+  return results;
+}
+
+export function loadPromotions(cwd: string): PromotionCandidate[] {
+  const path = getPromotionsPath(cwd);
+  if (!existsSync(path)) return [];
+  try {
+    return parsePromotionsMarkdown(readFileSync(path, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+export function writePromotions(cwd: string, candidates: PromotionCandidate[]): void {
+  const path = getPromotionsPath(cwd);
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+  const header =
+    "# Memory Promotion Queue\n\n" +
+    "Candidates for graduating memories into skills, enforcement, or project rules.\n" +
+    "Statuses: `proposed` → `applied` | `rejected`.\n" +
+    "Never auto-write package or project rules — `project_rule` stays proposed until a human applies it.\n\n";
+
+  const body = candidates.map(formatPromotionBlock).join("\n");
+  writeFileSync(path, header + body, "utf-8");
+}
+
+/**
+ * Append new candidates, skipping ids that already exist.
+ * Returns how many were newly added.
+ */
+export function appendPromotions(
+  cwd: string,
+  incoming: PromotionCandidate[],
+): number {
+  const existing = loadPromotions(cwd);
+  const seen = new Set(existing.map((c) => c.id));
+  let added = 0;
+  for (const c of incoming) {
+    if (seen.has(c.id)) continue;
+    existing.push(c);
+    seen.add(c.id);
+    added += 1;
+  }
+  if (added > 0) writePromotions(cwd, existing);
+  return added;
+}
+
+export function updatePromotionStatus(
+  cwd: string,
+  id: string,
+  status: PromotionStatus,
+): boolean {
+  const existing = loadPromotions(cwd);
+  const idx = existing.findIndex((c) => c.id === id);
+  if (idx < 0) return false;
+  existing[idx]!.status = status;
+  writePromotions(cwd, existing);
+  return true;
+}
+
+export function listProposedPromotions(cwd: string): PromotionCandidate[] {
+  return loadPromotions(cwd).filter((c) => c.status === "proposed");
+}
+
+/** Compact section for situation-report injection (~150 tokens). */
+export function formatPromotionsForReport(
+  cwd: string,
+  maxItems: number = 5,
+): string {
+  const proposed = listProposedPromotions(cwd).slice(0, maxItems);
+  if (proposed.length === 0) return "";
+
+  const lines = proposed.map((c) => {
+    const dest =
+      c.destination === "project_rule"
+        ? "project_rule (propose only)"
+        : c.destination;
+    return `- [${dest}] ${c.text}`;
+  });
+
+  const omitted = listProposedPromotions(cwd).length - proposed.length;
+  if (omitted > 0) {
+    lines.push(`- ... ${omitted} more proposed`);
+  }
+
+  return (
+    `## Promotion Candidates\n` +
+    `Open promotions in \`.pi/memory/promotions.md\` — apply safe ones; never auto-write package rules.\n` +
+    lines.join("\n") +
+    "\n"
+  );
+}

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -12,6 +12,7 @@ import * as path from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { formatDuration } from "./async-agents.js";
 import { buildSituationReport, estimateMemoryBudget, rebuildAndOrganize } from "./situation-report.js";
+import { classifyQueryClass, getQueryClassBias } from "./memory-query-class.js";
 
 /** Social closer gate — skip expensive vector search for trivial messages */
 const SOCIAL_CLOSERS = new Set([
@@ -36,7 +37,12 @@ let lastInjectedMemories: { text: string; category: string; similarity: number }
 let lastTaskFocusUserMsgId: string | null = null;
 
 /** Log what memories were auto-injected for retrieval telemetry */
-function logMemoryInjection(cwd: string, prompt: string, injected: { text: string; category: string; similarity: number }[]): void {
+function logMemoryInjection(
+  cwd: string,
+  prompt: string,
+  injected: { text: string; category: string; similarity: number }[],
+  queryClass?: string,
+): void {
   try {
     const telemetryPath = path.join(cwd, ".pi", "data", "memory-telemetry.jsonl");
     const dir = path.dirname(telemetryPath);
@@ -44,6 +50,7 @@ function logMemoryInjection(cwd: string, prompt: string, injected: { text: strin
     const entry = JSON.stringify({
       ts: new Date().toISOString(),
       prompt: prompt.slice(0, 200),
+      queryClass: queryClass ?? "general",
       injected: injected.map(m => ({ text: m.text.slice(0, 100), category: m.category, similarity: m.similarity })),
     });
     fs.appendFileSync(telemetryPath, entry + "\n", "utf-8");
@@ -193,7 +200,11 @@ export function registerRules(
     // Project memories — situation report (scored, token-budgeted) injected BEFORE rules
     // systemPrompt.length is chars; estimateMemoryBudget converts internally
     const budget = estimateMemoryBudget(event.systemPrompt?.length ?? 0);
-    const memories = loadMemoriesWithScoring(ctx.cwd, isSubagent, budget);
+    const queryClass =
+      !isSubagent && event.prompt && !isSocialCloser(event.prompt)
+        ? classifyQueryClass(event.prompt)
+        : "general";
+    const memories = loadMemoriesWithScoring(ctx.cwd, isSubagent, budget, queryClass);
 
     // Auto-inject contextually relevant memories via vector search (~2.5ms, in-process)
     const shouldSearch = !isSubagent && !!event.prompt && !isSocialCloser(event.prompt);
@@ -204,7 +215,17 @@ export function registerRules(
         const { readAllTopicEntries } = await import("./memory-tree.js");
         const entries = readAllTopicEntries(ctx.cwd);
         if (entries.length > 0) {
-          const results = await vectorSearch(ctx.cwd, event.prompt, entries, 5);
+          const topK = getQueryClassBias(queryClass).vectorTopK;
+          const boostCats = new Set(getQueryClassBias(queryClass).boostCategories);
+          // Prefer boosted categories when present; fall back to full set
+          const searchPool =
+            boostCats.size > 0 && entries.some((e) => boostCats.has(e.category))
+              ? [
+                  ...entries.filter((e) => boostCats.has(e.category)),
+                  ...entries.filter((e) => !boostCats.has(e.category)),
+                ]
+              : entries;
+          const results = await vectorSearch(ctx.cwd, event.prompt, searchPool, topK);
           const relevant = results.filter(r => r.similarity > 0.65);
           if (relevant.length > 0) {
             contextMemories = "\n# Contextually Relevant Memories\n\n" +
@@ -212,7 +233,7 @@ export function registerRules(
               relevant.map(r => `- [${r.category}] ${r.text} (similarity: ${r.similarity.toFixed(3)})`).join("\n") +
               "\n\n";
             // Retrieval telemetry — track what was injected
-            logMemoryInjection(ctx.cwd, event.prompt, relevant);
+            logMemoryInjection(ctx.cwd, event.prompt, relevant, queryClass);
             lastInjectedMemories = relevant;
           }
         }
@@ -429,9 +450,14 @@ export function registerRules(
 }
 
 // Loads memories using situation report (scored, token-budgeted) from topic files
-function loadMemoriesWithScoring(cwd: string, isSubagent: boolean, tokenBudget?: number): string {
+function loadMemoriesWithScoring(
+  cwd: string,
+  isSubagent: boolean,
+  tokenBudget?: number,
+  queryClass: import("./memory-query-class.js").QueryClass = "general",
+): string {
   try {
-    const report = buildSituationReport(cwd, tokenBudget);
+    const report = buildSituationReport(cwd, tokenBudget, { queryClass });
     if (report) {
       let result = "\n" + report + "\n";
       if (isSubagent) {

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -456,6 +456,7 @@ function loadMemoriesWithScoring(
   tokenBudget?: number,
   queryClass: import("./memory-query-class.js").QueryClass = "general",
 ): string {
+  if (!tokenBudget || tokenBudget <= 0) return "";
   try {
     const report = buildSituationReport(cwd, tokenBudget, { queryClass });
     if (report) {

--- a/extensions/orchestrator/situation-report.ts
+++ b/extensions/orchestrator/situation-report.ts
@@ -132,6 +132,9 @@ export function buildSituationReport(
   tokenBudget: number = DEFAULT_TOKEN_BUDGET,
   options: SituationReportOptions = {},
 ): string {
+  // Exhausted memory budget — do not inject (avoids divide-by-zero / NaN usage %)
+  if (tokenBudget <= 0) return "";
+
   const topicsDir = join(cwd, ".pi", "memory", "topics");
   const queryClass: QueryClass = options.queryClass ?? "general";
   const bias = getQueryClassBias(queryClass);
@@ -169,12 +172,12 @@ export function buildSituationReport(
   }
 
   // Build body sections first, then compute actual capacity from emitted content
-  let charBudget = tokenBudget * CHARS_PER_TOKEN;
+  let charBudget = Math.max(0, tokenBudget * CHARS_PER_TOKEN);
   const bodySections: string[] = [];
 
   // Reserve budget for header + possible warning + ground truth instruction
   const headerReserve = 330;
-  charBudget -= headerReserve;
+  charBudget = Math.max(0, charBudget - headerReserve);
 
   // Promotion candidates (low budget) — show even when topics empty
   const promoSection = formatPromotionsForReport(cwd, 5);

--- a/extensions/orchestrator/situation-report.ts
+++ b/extensions/orchestrator/situation-report.ts
@@ -18,7 +18,13 @@ import {
   entryHash,
   rebuild,
 } from "./memory-scoring.js";
-import { listTopics, readAllTopicEntries, type TopicInfo } from "./memory-tree.js";
+import { listTopics, readAllTopicEntries } from "./memory-tree.js";
+import { formatPromotionsForReport } from "./promotion-queue.js";
+import {
+  type QueryClass,
+  getQueryClassBias,
+  sectionPriorityBoost,
+} from "./memory-query-class.js";
 
 // ── Constants ──────────────────────────────────────────────────────────────
 
@@ -110,6 +116,11 @@ export function rebuildAndOrganize(cwd: string): void {
   }
 }
 
+export interface SituationReportOptions {
+  /** Query class for section budget / priority bias */
+  queryClass?: QueryClass;
+}
+
 /**
  * Build a situation report from scored memory entries.
  *
@@ -119,16 +130,20 @@ export function rebuildAndOrganize(cwd: string): void {
 export function buildSituationReport(
   cwd: string,
   tokenBudget: number = DEFAULT_TOKEN_BUDGET,
+  options: SituationReportOptions = {},
 ): string {
   const topicsDir = join(cwd, ".pi", "memory", "topics");
-  if (!existsSync(topicsDir)) return "";
+  const queryClass: QueryClass = options.queryClass ?? "general";
+  const bias = getQueryClassBias(queryClass);
+
+  const hasTopics = existsSync(topicsDir);
 
   // Read scores (rebuilt on session start + dreaming, not every turn)
-  const scores = loadScores(cwd);
+  const scores = hasTopics ? loadScores(cwd) : { entries: {}, lastRebuild: "" };
 
   // Read from topic files (source of truth) with hotness ordering
-  const topics = listTopics(cwd);
-  const topicEntries = readAllTopicEntries(cwd);
+  const topics = hasTopics ? listTopics(cwd) : [];
+  const topicEntries = hasTopics ? readAllTopicEntries(cwd) : [];
 
   // Build topic hotness map for section ordering
   const topicHotness = new Map<string, number>();
@@ -153,11 +168,6 @@ export function buildSituationReport(
     });
   }
 
-  if (entries.length === 0) return "";
-
-  // Sort entries by score descending within each category
-  entries.sort((a, b) => b.scored.score - a.scored.score);
-
   // Build body sections first, then compute actual capacity from emitted content
   let charBudget = tokenBudget * CHARS_PER_TOKEN;
   const bodySections: string[] = [];
@@ -165,6 +175,29 @@ export function buildSituationReport(
   // Reserve budget for header + possible warning + ground truth instruction
   const headerReserve = 330;
   charBudget -= headerReserve;
+
+  // Promotion candidates (low budget) — show even when topics empty
+  const promoSection = formatPromotionsForReport(cwd, 5);
+  if (promoSection) {
+    const promoBudget = Math.min(150 * CHARS_PER_TOKEN, charBudget);
+    const truncated =
+      promoSection.length > promoBudget
+        ? promoSection.slice(0, promoBudget) + "\n"
+        : promoSection;
+    bodySections.push(truncated);
+    charBudget -= truncated.length;
+  }
+
+  if (bias.hint && queryClass !== "general") {
+    const hintLine = `> Query class: \`${queryClass}\` — ${bias.hint}\n`;
+    bodySections.push(hintLine);
+    charBudget -= hintLine.length;
+  }
+
+  if (entries.length === 0 && bodySections.length === 0) return "";
+
+  // Sort entries by score descending within each category
+  entries.sort((a, b) => b.scored.score - a.scored.score);
 
   // Pinned entries always come first (no budget limit)
   const pinned = entries.filter((e) => e.isPinned);
@@ -174,7 +207,7 @@ export function buildSituationReport(
     charBudget -= pinnedSection.length;
   }
 
-  // Build each scored section in priority order, boosted by topic hotness
+  // Build each scored section in priority order, boosted by topic hotness + query class
   const nonPinned = entries.filter((e) => !e.isPinned);
 
   // Sort sections: use base priority but boost sections whose topic is hotter
@@ -188,10 +221,12 @@ export function buildSituationReport(
       "Recent Decisions": "decisions",
       "Recent Completions": "completions",
     };
+    const aPriority = sectionPriorityBoost(a.name, a.priority, queryClass);
+    const bPriority = sectionPriorityBoost(b.name, b.priority, queryClass);
     const aHot = topicHotness.get(topicMap[a.name] || "") || 0;
     const bHot = topicHotness.get(topicMap[b.name] || "") || 0;
     // Primary: priority (lower = higher). Secondary: hotness (higher = first)
-    if (a.priority !== b.priority) return a.priority - b.priority;
+    if (aPriority !== bPriority) return aPriority - bPriority;
     return bHot - aHot;
   });
 
@@ -204,8 +239,23 @@ export function buildSituationReport(
 
     if (sectionEntries.length === 0) continue;
 
+    // Boost token budget for query-class-relevant sections
+    const sectionCatMap: Record<string, MemoryCategory> = {
+      "Active Preferences": "preference",
+      "Active Lessons": "lesson",
+      "Vetoes & Mistakes": "mistake",
+      Patterns: "pattern",
+      "Recent Decisions": "decision",
+      "Recent Completions": "done",
+    };
+    const sectionCat = sectionCatMap[sectionDef.name];
+    const boosted = !!(sectionCat && bias.boostCategories.includes(sectionCat));
+    const sectionTokenBudget = boosted
+      ? Math.floor(sectionDef.tokenBudget * 1.25)
+      : sectionDef.tokenBudget;
+
     const sectionCharBudget = Math.min(
-      sectionDef.tokenBudget * CHARS_PER_TOKEN,
+      sectionTokenBudget * CHARS_PER_TOKEN,
       charBudget,
     );
 

--- a/myk_pi_tools/memory/commands.py
+++ b/myk_pi_tools/memory/commands.py
@@ -1,5 +1,8 @@
 """Memory CLI commands."""
 
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 import click
@@ -123,3 +126,93 @@ def memory_path(ctx: click.Context) -> None:
     """
     mem = ctx.obj["mem"]
     click.echo(str(mem.file_path))
+
+
+def _count_topic_entries(topics_dir: Path) -> int:
+    """Count markdown bullet entries across topic files."""
+    if not topics_dir.is_dir():
+        return 0
+    total = 0
+    for path in topics_dir.glob("*.md"):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            if line.startswith("- ["):
+                total += 1
+    return total
+
+
+def _load_scores(topics_dir: Path) -> dict:
+    scores_path = topics_dir.parent / "memory-scores.json"
+    if not scores_path.is_file():
+        return {}
+    try:
+        data = json.loads(scores_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    entries = data.get("entries")
+    return entries if isinstance(entries, dict) else {}
+
+
+@memory.command("status")
+@click.pass_context
+def memory_status(ctx: click.Context) -> None:
+    """Show enforcement honesty inventory for project memory.
+
+    Reports code-tier (trigger/action/verifier), injected topic counts,
+    and open promotion candidates. See dev-docs/enforcement-honesty-map.md.
+
+    Examples:
+
+        myk-pi-tools memory status
+    """
+    mem: MemoryFile = ctx.obj["mem"]
+    topics_dir: Path = mem.file_path
+    entries = _load_scores(topics_dir)
+
+    code_tier: list[str] = []
+    for _hash, entry in entries.items():
+        if not isinstance(entry, dict):
+            continue
+        trigger = entry.get("trigger")
+        action = entry.get("action")
+        verifier = entry.get("verifier")
+        if (trigger and action) or verifier:
+            cls = entry.get("class", "?")
+            bits = [f"[{cls}]"]
+            if trigger:
+                bits.append(str(trigger))
+            if action:
+                bits.append(str(action))
+            if verifier:
+                bits.append(f"verifier={verifier}")
+            code_tier.append(" ".join(bits))
+
+    injected = _count_topic_entries(topics_dir)
+    promotions_path = topics_dir.parent / "promotions.md"
+    proposed = 0
+    if promotions_path.is_file():
+        try:
+            promo = promotions_path.read_text(encoding="utf-8")
+            proposed = promo.count("- status: proposed")
+        except OSError:
+            proposed = 0
+
+    click.echo("# Memory status (enforcement honesty)\n")
+    click.echo(f"topics: {topics_dir}")
+    click.echo(f"injected (topic lines): {injected}")
+    click.echo(f"code-tier (enforced scores): {len(code_tier)}")
+    click.echo(f"promotion candidates (proposed): {proposed}")
+    click.echo("")
+    if code_tier:
+        click.echo("## Code-tier entries")
+        for line in code_tier:
+            click.echo(f"- {line}")
+    else:
+        click.echo("## Code-tier entries")
+        click.echo("- (none)")
+    click.echo("")
+    click.echo("Tiers: code = hooked; injected = situation report / rules; ")
+    click.echo("aspirational = docs only. See dev-docs/enforcement-honesty-map.md")

--- a/rules/35-memory.md
+++ b/rules/35-memory.md
@@ -175,10 +175,12 @@ Only memorize **outcomes** (what happened), not **intentions** (what was discuss
 ## CLI
 
 ```bash
-uv run myk-pi-tools memory <command>   # Commands: add, forget, show, migrate, path
+uv run myk-pi-tools memory <command>   # Commands: add, forget, show, migrate, path, status
 ```
 
 **Categories:** `lesson`, `decision`, `mistake`, `pattern`, `done`, `preference`
+
+`memory status` — enforcement honesty inventory (code-tier vs injected topic counts + open promotions).
 
 ---
 
@@ -200,3 +202,39 @@ Memory stores facts; **skills store procedures.**
 When you complete a multi-step workflow (3+ steps, or doing the same multi-step task for the second time,
 trial-and-error, or non-obvious commands), save it as a skill via `/create-skill <name>`.
 Don't create skills for simple one-step tasks or standard workflows already covered by existing skills.
+
+---
+
+## Promotion Destinations (Correction → Structure)
+
+Memories are a staging area. High-evidence or recurring lessons should graduate:
+
+| Destination | When | Auto? |
+|-------------|------|-------|
+| `memory` | Stay as a scored topic line | default |
+| `skill` | Multi-step recurring workflow | dream may write `.pi/skills/` |
+| `enforcement` | Mechanical never/always + command/tool | safe auto-apply (`block`/`warn` + clear trigger) |
+| `project_rule` | Project-wide convention, not mechanical | **propose only** — never auto-write `rules/` or `.pi/rules/` |
+| `discard` | Stale / superseded | mark in queue |
+
+Queue file: `.pi/memory/promotions.md`. Situation report shows open `proposed` items.
+Thresholds (evidenceCount): enforcement/skill ≥ 3; project_rule ≥ 5.
+On reinforce crossing a threshold, a promotion pass runs automatically.
+`memory_consolidate` and dreaming must write promotion candidates to that queue.
+
+---
+
+## Provenance (optional)
+
+`memory_add` / `memory_edit` accept optional `sourceSession`, `derivedFrom`, `informs`.
+Preference extractor sets `sourceSession` when the session id is available.
+Dream may write `.pi/memory/provenance-pending.json`; merge happens on dream complete.
+Stored in `memory-scores.json` only — not injected into the situation report.
+Shown in `memory_search` / `memory_reflect` when present.
+
+---
+
+## Query-class injection (automatic)
+
+Injection biases section budgets from the user prompt (no tool call needed):
+`pr_review`, `git_release`, `debug`, or `general`.

--- a/scripts/live-memory-all5-check.ts
+++ b/scripts/live-memory-all5-check.ts
@@ -1,0 +1,144 @@
+/**
+ * Full live smoke for all 5 memory-promotion plan phases.
+ * Usage: LIVE_CWD=/tmp/proj npx tsx scripts/live-memory-all5-check.ts
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  entryHash,
+  loadScores,
+  saveScores,
+  reinforce,
+} from "../extensions/orchestrator/memory-scoring.ts";
+import { runPromotionPass } from "../extensions/orchestrator/memory-promotion.ts";
+import {
+  loadEnforcedEntries,
+  matchBashCommand,
+} from "../extensions/orchestrator/enforcement-rules.ts";
+import { buildSituationReport } from "../extensions/orchestrator/situation-report.ts";
+import { loadPromotions } from "../extensions/orchestrator/promotion-queue.ts";
+import {
+  writeProvenancePending,
+  mergeProvenancePending,
+} from "../extensions/orchestrator/memory-provenance.ts";
+import { classifyQueryClass } from "../extensions/orchestrator/memory-query-class.ts";
+
+const cwd = process.env.LIVE_CWD;
+if (!cwd) {
+  console.error("LIVE_CWD required");
+  process.exit(2);
+}
+
+function ensureScore(
+  category: "lesson" | "preference" | "pattern",
+  text: string,
+): void {
+  const line = `- [${category}] ${text}`;
+  const scores = loadScores(cwd);
+  const hash = entryHash(line);
+  if (!scores.entries[hash]) {
+    scores.entries[hash] = {
+      class: category,
+      score: 1,
+      evidenceCount: 1,
+      cue: "explicit",
+      firstSeen: new Date().toISOString(),
+      lastReinforced: new Date().toISOString(),
+      userState: "auto",
+      lifecycle: "active",
+    };
+    saveScores(cwd, scores);
+  }
+}
+
+const lesson = "Never use `git add .`";
+const pref = "Always follow the project release convention in this repo";
+const pattern = "Deploy workflow: build → test → tag → push";
+
+// Topics may already exist from CLI; ensure score rows
+ensureScore("lesson", lesson);
+ensureScore("preference", pref);
+
+const topicsDir = path.join(cwd, ".pi", "memory", "topics");
+fs.mkdirSync(topicsDir, { recursive: true });
+const patternPath = path.join(topicsDir, "patterns.md");
+if (!fs.existsSync(patternPath) || !fs.readFileSync(patternPath, "utf-8").includes(pattern)) {
+  const header = fs.existsSync(patternPath)
+    ? fs.readFileSync(patternPath, "utf-8")
+    : "# Patterns\n";
+  fs.writeFileSync(patternPath, header.trimEnd() + `\n- [pattern] ${pattern}\n`);
+}
+ensureScore("pattern", pattern);
+
+const lessonLine = `- [lesson] ${lesson}`;
+reinforce(cwd, lessonLine);
+reinforce(cwd, lessonLine);
+
+const prefLine = `- [preference] ${pref}`;
+for (let i = 0; i < 4; i++) reinforce(cwd, prefLine);
+
+const patternLine = `- [pattern] ${pattern}`;
+for (let i = 0; i < 3; i++) reinforce(cwd, patternLine);
+
+// Phase 3 provenance sidecar
+writeProvenancePending(cwd, [
+  {
+    category: "lesson",
+    text: lesson,
+    sourceSession: "live-all5",
+    derivedFrom: "cli-smoke",
+    informs: ["git"],
+  },
+]);
+const provMerged = mergeProvenancePending(cwd);
+if (provMerged !== 1) {
+  throw new Error(`provenance merge expected 1, got ${provMerged}`);
+}
+
+// Phase 1–2 promotion
+const pass = runPromotionPass(cwd);
+console.log("[all5] promotion", pass);
+
+const enforced = loadEnforcedEntries(cwd);
+const hits = matchBashCommand(enforced, "git add . && true");
+const miss = matchBashCommand(enforced, "git add src/foo.ts");
+console.log("[all5] enforce hits", hits.length, "miss", miss.length);
+if (hits.length !== 1 || hits[0]!.rule.action !== "block") {
+  throw new Error("expected block on git add .");
+}
+if (miss.length !== 0) {
+  throw new Error("path-scoped git add should not match");
+}
+
+const entry = loadScores(cwd).entries[entryHash(lessonLine)];
+if (!entry?.trigger || entry.sourceSession !== "live-all5") {
+  throw new Error(`lesson entry incomplete: ${JSON.stringify(entry)}`);
+}
+
+const queue = loadPromotions(cwd);
+if (!queue.some((c) => c.destination === "project_rule" && c.status === "proposed")) {
+  throw new Error("expected proposed project_rule");
+}
+if (!queue.some((c) => c.destination === "skill" && c.status === "proposed")) {
+  throw new Error("expected proposed skill");
+}
+if (fs.existsSync(path.join(cwd, "rules")) || fs.existsSync(path.join(cwd, ".pi", "rules"))) {
+  throw new Error("rules were auto-written");
+}
+
+// Phase 4 query-class
+if (classifyQueryClass("review this PR") !== "pr_review") {
+  throw new Error("pr_review classify failed");
+}
+const report = buildSituationReport(cwd, 1700, { queryClass: "git_release" });
+if (!report.includes("Promotion Candidates") || !report.includes("Query class: `git_release`")) {
+  throw new Error("situation report missing query-class content\n" + report);
+}
+
+const lessons = fs.readFileSync(path.join(topicsDir, "lessons.md"), "utf-8");
+if (!lessons.includes("*(enforced)*")) {
+  throw new Error("lessons.md missing enforced marker");
+}
+
+console.log("[all5] phases 1-4 LIVE PASS");
+console.log("[all5] report head:\n" + report.split("\n").slice(0, 18).join("\n"));

--- a/scripts/live-memory-promotion-check.ts
+++ b/scripts/live-memory-promotion-check.ts
@@ -1,0 +1,85 @@
+/**
+ * Live smoke check: CLI-written topics → reinforce → promote → enforce → inject.
+ * Usage: LIVE_CWD=/tmp/proj npx tsx scripts/live-memory-promotion-check.ts
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { entryHash, loadScores, saveScores, reinforce } from "../extensions/orchestrator/memory-scoring.ts";
+import { runPromotionPass } from "../extensions/orchestrator/memory-promotion.ts";
+import { loadEnforcedEntries, matchBashCommand } from "../extensions/orchestrator/enforcement-rules.ts";
+import { buildSituationReport } from "../extensions/orchestrator/situation-report.ts";
+import { loadPromotions } from "../extensions/orchestrator/promotion-queue.ts";
+
+const cwd = process.env.LIVE_CWD;
+if (!cwd) {
+  console.error("LIVE_CWD required");
+  process.exit(2);
+}
+
+function ensureScore(category: "lesson" | "preference", text: string): void {
+  const line = `- [${category}] ${text}`;
+  const scores = loadScores(cwd);
+  const hash = entryHash(line);
+  if (!scores.entries[hash]) {
+    scores.entries[hash] = {
+      class: category,
+      score: 1,
+      evidenceCount: 1,
+      cue: "explicit",
+      firstSeen: new Date().toISOString(),
+      lastReinforced: new Date().toISOString(),
+      userState: "auto",
+      lifecycle: "active",
+    };
+    saveScores(cwd, scores);
+  }
+}
+
+const lesson = "Never use `git add .`";
+const pref = "Always follow the project release convention in this repo";
+
+ensureScore("lesson", lesson);
+ensureScore("preference", pref);
+
+const lessonLine = `- [lesson] ${lesson}`;
+reinforce(cwd, lessonLine);
+reinforce(cwd, lessonLine);
+
+const prefLine = `- [preference] ${pref}`;
+for (let i = 0; i < 4; i++) reinforce(cwd, prefLine);
+
+const pass = runPromotionPass(cwd);
+console.log("[live-cli] promotion", pass);
+
+const enforced = loadEnforcedEntries(cwd);
+const hits = matchBashCommand(enforced, "git add . && true");
+console.log(
+  "[live-cli] enforced",
+  enforced.length,
+  "hits",
+  hits.length,
+  hits[0]?.matched,
+  hits[0]?.rule.action,
+);
+if (hits.length !== 1 || hits[0]!.rule.action !== "block") {
+  throw new Error("LIVE FAIL: expected block on git add .");
+}
+
+const queue = loadPromotions(cwd);
+console.log(
+  "[live-cli] promotions",
+  queue.map((c) => ({ dest: c.destination, status: c.status, text: c.text.slice(0, 50) })),
+);
+if (!queue.some((c) => c.destination === "project_rule" && c.status === "proposed")) {
+  throw new Error("LIVE FAIL: expected proposed project_rule");
+}
+if (fs.existsSync(path.join(cwd, "rules")) || fs.existsSync(path.join(cwd, ".pi", "rules"))) {
+  throw new Error("LIVE FAIL: rules were written");
+}
+
+const report = buildSituationReport(cwd, 1700, { queryClass: "git_release" });
+if (!report.includes("Promotion Candidates") || !report.includes("git add")) {
+  throw new Error("LIVE FAIL: situation report missing expected content\n" + report);
+}
+console.log("[live-cli] report excerpt:\n" + report.split("\n").slice(0, 22).join("\n"));
+console.log("[live-cli] PASS");

--- a/tests/node/orchestrator/memory-promotion.live.test.ts
+++ b/tests/node/orchestrator/memory-promotion.live.test.ts
@@ -1,0 +1,192 @@
+/**
+ * LIVE end-to-end test — real filesystem, real scores, real enforcement loaders.
+ *
+ * Simulates a project that accumulates evidence, crosses promotion thresholds,
+ * gets auto-enforced, and injects promotion candidates into the situation report.
+ *
+ * Run: npx tsx --test tests/node/orchestrator/memory-promotion.live.test.ts
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { entryHash, loadScores, reinforce, saveScores, type ScoredEntry } from "../../../extensions/orchestrator/memory-scoring.js";
+import { runPromotionPass, maybePromoteAfterReinforce } from "../../../extensions/orchestrator/memory-promotion.js";
+import { loadPromotions } from "../../../extensions/orchestrator/promotion-queue.js";
+import { buildSituationReport } from "../../../extensions/orchestrator/situation-report.js";
+import { classifyQueryClass } from "../../../extensions/orchestrator/memory-query-class.js";
+import {
+  loadEnforcedEntries,
+  matchBashCommand,
+  executeAction,
+} from "../../../extensions/orchestrator/enforcement-rules.js";
+
+const LESSON = "Never use `git add .`";
+const CONVENTION = "Always follow the project release convention in this repo";
+const PATTERN = "Deploy workflow: build → test → tag → push";
+
+let cwd = "";
+
+function writeTopic(category: string, topicFile: string, text: string): void {
+  const topicsDir = path.join(cwd, ".pi", "memory", "topics");
+  fs.mkdirSync(topicsDir, { recursive: true });
+  const p = path.join(topicsDir, topicFile);
+  const header = `# ${topicFile.replace(/\.md$/, "")}\n\n`;
+  const prev = fs.existsSync(p) ? fs.readFileSync(p, "utf-8") : header;
+  if (!prev.includes(text)) {
+    fs.writeFileSync(p, prev.trimEnd() + `\n- [${category}] ${text}\n`, "utf-8");
+  }
+}
+
+function seedEntry(
+  category: ScoredEntry["class"],
+  text: string,
+  evidenceCount: number,
+): void {
+  const scores = loadScores(cwd);
+  const hash = entryHash(`- [${category}] ${text}`);
+  scores.entries[hash] = {
+    class: category,
+    score: 1.0,
+    evidenceCount,
+    cue: "explicit",
+    firstSeen: new Date().toISOString(),
+    lastReinforced: new Date().toISOString(),
+    userState: "auto",
+    lifecycle: "active",
+    sourceSession: "live-test-session-1",
+    informs: ["git", "live-test"],
+  };
+  saveScores(cwd, scores);
+}
+
+describe("LIVE memory promotion e2e", () => {
+  before(() => {
+    cwd = fs.mkdtempSync(path.join(os.tmpdir(), "pi-memory-live-"));
+    writeTopic("lesson", "lessons.md", LESSON);
+    writeTopic("preference", "preferences.md", CONVENTION);
+    writeTopic("pattern", "patterns.md", PATTERN);
+    seedEntry("lesson", LESSON, 1);
+    seedEntry("preference", CONVENTION, 1);
+    seedEntry("pattern", PATTERN, 1);
+    console.log(`[live] project root: ${cwd}`);
+  });
+
+  after(() => {
+    if (cwd && fs.existsSync(cwd)) {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("step 1: reinforce lesson until evidence crosses enforcement threshold", () => {
+    const line = `- [lesson] ${LESSON}`;
+    // evidence starts at 1; reinforce twice → 3
+    assert.equal(reinforce(cwd, line), true);
+    assert.equal(reinforce(cwd, line), true);
+    const entry = loadScores(cwd).entries[entryHash(line)];
+    assert.ok(entry);
+    assert.equal(entry!.evidenceCount, 3);
+    console.log(`[live] lesson evidenceCount=${entry!.evidenceCount}`);
+  });
+
+  it("step 2: maybePromoteAfterReinforce auto-applies enforcement on disk", () => {
+    const line = `- [lesson] ${LESSON}`;
+    // evidence is already 3 from step 1 — threshold crossing should fire
+    const result = maybePromoteAfterReinforce(cwd, line);
+    assert.ok(result, "expected promotion pass to run at evidenceCount=3");
+    console.log(`[live] promote result: applied=${result!.applied} queued=${result!.queued}`, result!.details);
+
+    const scores = loadScores(cwd);
+    const entry = scores.entries[entryHash(line)];
+    assert.ok(entry?.trigger, "trigger should be written to memory-scores.json");
+    assert.equal(entry!.trigger, "bash_contains git add .");
+    assert.equal(entry!.action, "block");
+
+    const lessonsPath = path.join(cwd, ".pi", "memory", "topics", "lessons.md");
+    const lessons = fs.readFileSync(lessonsPath, "utf-8");
+    assert.match(lessons, /\*\(enforced\)\*/);
+    console.log(`[live] lessons.md:\n${lessons}`);
+    console.log(`[live] scores entry:`, JSON.stringify(entry, null, 2));
+  });
+
+  it("step 3: loadEnforcedEntries + matchBashCommand blocks git add . live", () => {
+    const enforced = loadEnforcedEntries(cwd);
+    assert.ok(enforced.length >= 1, `expected enforced entries, got ${enforced.length}`);
+    console.log(
+      `[live] enforced rules:`,
+      enforced.map((e) => ({ text: e.text, trigger: e.trigger, action: e.action })),
+    );
+
+    const hits = matchBashCommand(enforced, "git add . && git commit -m x");
+    assert.equal(hits.length, 1);
+    assert.equal(hits[0]!.rule.action, "block");
+    assert.equal(hits[0]!.matched, "git add .");
+
+    const miss = matchBashCommand(enforced, "git add src/foo.ts");
+    assert.equal(miss.length, 0, "should not match path-scoped git add");
+    console.log(`[live] bash match OK; non-match OK`);
+  });
+
+  it("step 4: reinforce convention to project_rule propose-only (no rules/ write)", () => {
+    const line = `- [preference] ${CONVENTION}`;
+    for (let i = 0; i < 4; i++) assert.equal(reinforce(cwd, line), true);
+    const pass = runPromotionPass(cwd);
+    console.log(`[live] convention pass: applied=${pass.applied} queued=${pass.queued}`);
+
+    const queuePath = path.join(cwd, ".pi", "memory", "promotions.md");
+    assert.ok(fs.existsSync(queuePath), "promotions.md must exist on disk");
+    const queueMd = fs.readFileSync(queuePath, "utf-8");
+    console.log(`[live] promotions.md:\n${queueMd}`);
+
+    const queue = loadPromotions(cwd);
+    const rule = queue.find((c) => c.destination === "project_rule");
+    assert.ok(rule, "expected project_rule candidate");
+    assert.equal(rule!.status, "proposed");
+
+    assert.equal(fs.existsSync(path.join(cwd, "rules")), false);
+    assert.equal(fs.existsSync(path.join(cwd, ".pi", "rules")), false);
+  });
+
+  it("step 5: reinforce procedural pattern → skill candidate in queue", () => {
+    const line = `- [pattern] ${PATTERN}`;
+    for (let i = 0; i < 3; i++) assert.equal(reinforce(cwd, line), true);
+    runPromotionPass(cwd);
+    const skill = loadPromotions(cwd).find((c) => c.destination === "skill");
+    assert.ok(skill, "expected skill candidate");
+    assert.equal(skill!.status, "proposed");
+    console.log(`[live] skill candidate:`, skill);
+  });
+
+  it("step 6: situation report injects promotion candidates + query-class bias", () => {
+    const report = buildSituationReport(cwd, 1700, { queryClass: "git_release" });
+    assert.ok(report.length > 0, "report should not be empty");
+    assert.match(report, /Promotion Candidates/);
+    assert.match(report, /Query class: `git_release`/);
+    assert.match(report, /git add/);
+    console.log(`[live] situation report:\n${report}`);
+
+    assert.equal(classifyQueryClass("please review this PR"), "pr_review");
+    assert.equal(classifyQueryClass("git push and tag release"), "git_release");
+  });
+
+  it("step 7: provenance survives on disk after promotion", () => {
+    const entry = loadScores(cwd).entries[entryHash(`- [lesson] ${LESSON}`)];
+    assert.equal(entry?.sourceSession, "live-test-session-1");
+    assert.deepEqual(entry?.informs, ["git", "live-test"]);
+  });
+
+  it("step 8: executeAction still respects allowlist (sanity of enforcement runtime)", () => {
+    process.env.PI_ENFORCEMENT_ALLOWED_COMMANDS = "echo live-ok";
+    try {
+      const ok = executeAction("echo live-ok", cwd);
+      assert.equal(ok.success, true);
+      assert.match(ok.output, /live-ok/);
+      const blocked = executeAction("rm -rf /", cwd);
+      assert.equal(blocked.success, false);
+      console.log(`[live] executeAction allowlist OK`);
+    } finally {
+      delete process.env.PI_ENFORCEMENT_ALLOWED_COMMANDS;
+    }
+  });
+});

--- a/tests/node/orchestrator/memory-promotion.test.ts
+++ b/tests/node/orchestrator/memory-promotion.test.ts
@@ -86,10 +86,24 @@ describe("inferMechanicalEnforcement", () => {
       null,
     );
   });
+
+  it("treats plain file_modified patterns as high confidence", () => {
+    const inf = inferMechanicalEnforcement("warn when modifying Dockerfile");
+    assert.ok(inf);
+    assert.equal(inf!.trigger, "file_modified Dockerfile");
+    assert.equal(inf!.confidence, "high");
+  });
+
+  it("rejects glob file_modified patterns as non-inferable", () => {
+    assert.equal(
+      inferMechanicalEnforcement("warn when modifying src/**/*.py"),
+      null,
+    );
+  });
 });
 
 describe("scanPromotionCandidates + applySafePromotions", () => {
-  it("auto-applies high-confidence enforcement and never writes rules/", () => {
+  it("auto-applies high-confidence enforcement without writing rules/", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-m-"));
     try {
       seedMemory(cwd, 'Never use `git add .`', "lesson", EVIDENCE_ENFORCEMENT);

--- a/tests/node/orchestrator/memory-promotion.test.ts
+++ b/tests/node/orchestrator/memory-promotion.test.ts
@@ -299,4 +299,30 @@ describe("scanPromotionCandidates + applySafePromotions", () => {
       fs.rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  it("keeps existing verifier when upgrade patch omits it", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-verifier-"));
+    try {
+      const lesson = "Never use `git add .`";
+      seedMemory(cwd, lesson, "lesson", EVIDENCE_ENFORCEMENT);
+      appendPromotions(cwd, [
+        {
+          id: promotionId("enforcement", "lesson", lesson),
+          destination: "enforcement",
+          status: "proposed",
+          category: "lesson",
+          text: lesson,
+          reason: "needs apply",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          verifier: "git status --porcelain",
+        },
+      ]);
+      applySafePromotions(cwd);
+      const entry = loadPromotions(cwd).find((c) => c.text === lesson);
+      assert.equal(entry?.status, "applied");
+      assert.equal(entry?.verifier, "git status --porcelain");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/node/orchestrator/memory-promotion.test.ts
+++ b/tests/node/orchestrator/memory-promotion.test.ts
@@ -274,4 +274,29 @@ describe("scanPromotionCandidates + applySafePromotions", () => {
       fs.rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  it("preserves original createdAt when upgrading proposed to applied", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-created-"));
+    try {
+      const lesson = "Never use `git add .`";
+      seedMemory(cwd, lesson, "lesson", EVIDENCE_ENFORCEMENT);
+      appendPromotions(cwd, [
+        {
+          id: promotionId("enforcement", "lesson", lesson),
+          destination: "enforcement",
+          status: "proposed",
+          category: "lesson",
+          text: lesson,
+          reason: "needs apply",
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+      ]);
+      applySafePromotions(cwd);
+      const entry = loadPromotions(cwd).find((c) => c.text === lesson);
+      assert.equal(entry?.status, "applied");
+      assert.equal(entry?.createdAt, "2026-07-01T00:00:00.000Z");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/node/orchestrator/memory-promotion.test.ts
+++ b/tests/node/orchestrator/memory-promotion.test.ts
@@ -20,7 +20,11 @@ import {
   saveScores,
   type ScoredEntry,
 } from "../../../extensions/orchestrator/memory-scoring.js";
-import { loadPromotions } from "../../../extensions/orchestrator/promotion-queue.js";
+import {
+  appendPromotions,
+  loadPromotions,
+  promotionId,
+} from "../../../extensions/orchestrator/promotion-queue.js";
 
 function seedMemory(
   cwd: string,
@@ -156,6 +160,67 @@ describe("scanPromotionCandidates + applySafePromotions", () => {
         "utf-8",
       );
       assert.equal((content.match(/\*\(enforced\)\*/g) || []).length, 1);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves applied or rejected queue entries across promotion passes", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-merge-"));
+    try {
+      const rejectedText = "Always follow the project release convention";
+      seedMemory(cwd, 'Never use `git add .`', "lesson", EVIDENCE_ENFORCEMENT);
+      seedMemory(cwd, rejectedText, "preference", 5);
+
+      appendPromotions(cwd, [
+        {
+          id: promotionId("project_rule", "preference", rejectedText),
+          destination: "project_rule",
+          status: "rejected",
+          category: "preference",
+          text: rejectedText,
+          reason: "user rejected",
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+        {
+          id: promotionId("enforcement", "lesson", 'Never use `git add .`'),
+          destination: "enforcement",
+          status: "applied",
+          category: "lesson",
+          text: 'Never use `git add .`',
+          reason: "already applied",
+          createdAt: "2026-07-01T00:00:00.000Z",
+          trigger: "bash_contains git add .",
+          action: "block",
+        },
+      ]);
+
+      // Pre-seed enforcement on lesson so apply path skips re-applying scores
+      const scores = loadScores(cwd);
+      const hash = entryHash("- [lesson] Never use `git add .`");
+      scores.entries[hash]!.trigger = "bash_contains git add ." as any;
+      scores.entries[hash]!.action = "block";
+      saveScores(cwd, scores);
+
+      applySafePromotions(cwd);
+      const queue = loadPromotions(cwd);
+
+      const rejected = queue.find((c) => c.text === rejectedText && c.destination === "project_rule");
+      assert.equal(rejected?.status, "rejected");
+
+      const applied = queue.find((c) => c.text.includes("git add") && c.destination === "enforcement");
+      assert.equal(applied?.status, "applied");
+
+      // Must not reopen rejected project_rule as proposed
+      assert.equal(
+        queue.filter(
+          (c) =>
+            c.text === rejectedText &&
+            c.destination === "project_rule" &&
+            c.status === "proposed",
+        ).length,
+        0,
+      );
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/node/orchestrator/memory-promotion.test.ts
+++ b/tests/node/orchestrator/memory-promotion.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for memory promotion scan + safe apply.
+ * Run with: npx tsx --test tests/node/orchestrator/memory-promotion.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  applySafePromotions,
+  inferMechanicalEnforcement,
+  markTopicEntryEnforced,
+  scanPromotionCandidates,
+  EVIDENCE_ENFORCEMENT,
+} from "../../../extensions/orchestrator/memory-promotion.js";
+import {
+  entryHash,
+  loadScores,
+  saveScores,
+  type ScoredEntry,
+} from "../../../extensions/orchestrator/memory-scoring.js";
+import { loadPromotions } from "../../../extensions/orchestrator/promotion-queue.js";
+
+function seedMemory(
+  cwd: string,
+  text: string,
+  category: "lesson" | "mistake" | "preference" | "pattern" = "lesson",
+  evidenceCount: number,
+): void {
+  const topicsDir = path.join(cwd, ".pi", "memory", "topics");
+  fs.mkdirSync(topicsDir, { recursive: true });
+  const topic =
+    category === "lesson"
+      ? "lessons"
+      : category === "mistake"
+        ? "mistakes"
+        : category === "preference"
+          ? "preferences"
+          : "patterns";
+  const topicPath = path.join(topicsDir, `${topic}.md`);
+  const header = `# ${topic}\n\n`;
+  const prev = fs.existsSync(topicPath) ? fs.readFileSync(topicPath, "utf-8") : header;
+  fs.writeFileSync(topicPath, prev.trimEnd() + `\n- [${category}] ${text}\n`, "utf-8");
+
+  const scores = loadScores(cwd);
+  const hash = entryHash(`- [${category}] ${text}`);
+  const entry: ScoredEntry = {
+    class: category,
+    score: 2.0,
+    evidenceCount,
+    cue: "explicit",
+    firstSeen: new Date().toISOString(),
+    lastReinforced: new Date().toISOString(),
+    userState: "auto",
+    lifecycle: "active",
+  };
+  scores.entries[hash] = entry;
+  saveScores(cwd, scores);
+}
+
+describe("inferMechanicalEnforcement", () => {
+  it("extracts bash_contains for never use `git add .`", () => {
+    const inf = inferMechanicalEnforcement('Never use `git add .`');
+    assert.ok(inf);
+    assert.equal(inf!.trigger, "bash_contains git add .");
+    assert.equal(inf!.action, "block");
+    assert.equal(inf!.confidence, "high");
+  });
+
+  it("extracts git add . without backticks", () => {
+    const inf = inferMechanicalEnforcement("Never run git add . in this repo");
+    assert.ok(inf);
+    assert.equal(inf!.trigger, "bash_contains git add .");
+  });
+
+  it("extracts ask_user verifier", () => {
+    const inf = inferMechanicalEnforcement("Always ask_user before gh pr merge");
+    assert.ok(inf);
+    assert.equal(inf!.verifier, "tool_called ask_user before gh pr merge");
+  });
+
+  it("returns null for non-mechanical knowledge", () => {
+    assert.equal(
+      inferMechanicalEnforcement("buildah chown breaks cache mounts"),
+      null,
+    );
+  });
+});
+
+describe("scanPromotionCandidates + applySafePromotions", () => {
+  it("auto-applies high-confidence enforcement and never writes rules/", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-m-"));
+    try {
+      seedMemory(cwd, 'Never use `git add .`', "lesson", EVIDENCE_ENFORCEMENT);
+      seedMemory(
+        cwd,
+        "Always follow the project release convention",
+        "preference",
+        5,
+      );
+
+      const scanned = scanPromotionCandidates(cwd);
+      assert.ok(scanned.some((c) => c.destination === "enforcement"));
+      assert.ok(scanned.some((c) => c.destination === "project_rule"));
+
+      const result = applySafePromotions(cwd);
+      assert.ok(result.applied >= 1);
+
+      const scores = loadScores(cwd);
+      const hash = entryHash("- [lesson] Never use `git add .`");
+      assert.equal(scores.entries[hash]?.trigger, "bash_contains git add .");
+      assert.equal(scores.entries[hash]?.action, "block");
+
+      const lessons = fs.readFileSync(
+        path.join(cwd, ".pi", "memory", "topics", "lessons.md"),
+        "utf-8",
+      );
+      assert.match(lessons, /\*\(enforced\)\*/);
+
+      assert.equal(fs.existsSync(path.join(cwd, "rules")), false);
+      assert.equal(fs.existsSync(path.join(cwd, ".pi", "rules")), false);
+
+      const queue = loadPromotions(cwd);
+      const enforced = queue.find((c) => c.text.includes("git add"));
+      assert.equal(enforced?.status, "applied");
+      const rule = queue.find((c) => c.destination === "project_rule");
+      assert.equal(rule?.status, "proposed");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("markTopicEntryEnforced is idempotent", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-mark-"));
+    try {
+      seedMemory(cwd, "Never use `npm publish`", "lesson", 1);
+      assert.equal(markTopicEntryEnforced(cwd, "lesson", "Never use `npm publish`"), true);
+      assert.equal(markTopicEntryEnforced(cwd, "lesson", "Never use `npm publish`"), true);
+      const content = fs.readFileSync(
+        path.join(cwd, ".pi", "memory", "topics", "lessons.md"),
+        "utf-8",
+      );
+      assert.equal((content.match(/\*\(enforced\)\*/g) || []).length, 1);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/node/orchestrator/memory-promotion.test.ts
+++ b/tests/node/orchestrator/memory-promotion.test.ts
@@ -165,55 +165,78 @@ describe("scanPromotionCandidates + applySafePromotions", () => {
     }
   });
 
-  it("preserves applied or rejected queue entries across promotion passes", () => {
-    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-merge-"));
+  function seedMergeFixture(cwd: string): { rejectedText: string; lesson: string } {
+    const rejectedText = "Always follow the project release convention";
+    const lesson = "Never use `git add .`";
+    seedMemory(cwd, lesson, "lesson", EVIDENCE_ENFORCEMENT);
+    seedMemory(cwd, rejectedText, "preference", 5);
+
+    appendPromotions(cwd, [
+      {
+        id: promotionId("project_rule", "preference", rejectedText),
+        destination: "project_rule",
+        status: "rejected",
+        category: "preference",
+        text: rejectedText,
+        reason: "user rejected",
+        createdAt: "2026-07-01T00:00:00.000Z",
+      },
+      {
+        id: promotionId("enforcement", "lesson", lesson),
+        destination: "enforcement",
+        status: "applied",
+        category: "lesson",
+        text: lesson,
+        reason: "already applied",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        trigger: "bash_contains git add .",
+        action: "block",
+      },
+    ]);
+
+    const scores = loadScores(cwd);
+    const hash = entryHash(`- [lesson] ${lesson}`);
+    scores.entries[hash]!.trigger = "bash_contains git add ." as any;
+    scores.entries[hash]!.action = "block";
+    saveScores(cwd, scores);
+    return { rejectedText, lesson };
+  }
+
+  it("keeps rejected project_rule status after promotion pass", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-rej-"));
     try {
-      const rejectedText = "Always follow the project release convention";
-      seedMemory(cwd, 'Never use `git add .`', "lesson", EVIDENCE_ENFORCEMENT);
-      seedMemory(cwd, rejectedText, "preference", 5);
-
-      appendPromotions(cwd, [
-        {
-          id: promotionId("project_rule", "preference", rejectedText),
-          destination: "project_rule",
-          status: "rejected",
-          category: "preference",
-          text: rejectedText,
-          reason: "user rejected",
-          createdAt: "2026-07-01T00:00:00.000Z",
-        },
-        {
-          id: promotionId("enforcement", "lesson", 'Never use `git add .`'),
-          destination: "enforcement",
-          status: "applied",
-          category: "lesson",
-          text: 'Never use `git add .`',
-          reason: "already applied",
-          createdAt: "2026-07-01T00:00:00.000Z",
-          trigger: "bash_contains git add .",
-          action: "block",
-        },
-      ]);
-
-      // Pre-seed enforcement on lesson so apply path skips re-applying scores
-      const scores = loadScores(cwd);
-      const hash = entryHash("- [lesson] Never use `git add .`");
-      scores.entries[hash]!.trigger = "bash_contains git add ." as any;
-      scores.entries[hash]!.action = "block";
-      saveScores(cwd, scores);
-
+      const { rejectedText } = seedMergeFixture(cwd);
       applySafePromotions(cwd);
-      const queue = loadPromotions(cwd);
-
-      const rejected = queue.find((c) => c.text === rejectedText && c.destination === "project_rule");
+      const rejected = loadPromotions(cwd).find(
+        (c) => c.text === rejectedText && c.destination === "project_rule",
+      );
       assert.equal(rejected?.status, "rejected");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 
-      const applied = queue.find((c) => c.text.includes("git add") && c.destination === "enforcement");
+  it("keeps applied enforcement status after promotion pass", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-app-"));
+    try {
+      seedMergeFixture(cwd);
+      applySafePromotions(cwd);
+      const applied = loadPromotions(cwd).find(
+        (c) => c.text.includes("git add") && c.destination === "enforcement",
+      );
       assert.equal(applied?.status, "applied");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 
-      // Must not reopen rejected project_rule as proposed
+  it("does not reopen rejected project_rule as proposed", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-noreopen-"));
+    try {
+      const { rejectedText } = seedMergeFixture(cwd);
+      applySafePromotions(cwd);
       assert.equal(
-        queue.filter(
+        loadPromotions(cwd).filter(
           (c) =>
             c.text === rejectedText &&
             c.destination === "project_rule" &&
@@ -221,6 +244,32 @@ describe("scanPromotionCandidates + applySafePromotions", () => {
         ).length,
         0,
       );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("merges trigger metadata when upgrading proposed to applied", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-meta-"));
+    try {
+      const lesson = "Never use `git add .`";
+      seedMemory(cwd, lesson, "lesson", EVIDENCE_ENFORCEMENT);
+      appendPromotions(cwd, [
+        {
+          id: promotionId("enforcement", "lesson", lesson),
+          destination: "enforcement",
+          status: "proposed",
+          category: "lesson",
+          text: lesson,
+          reason: "needs apply",
+          createdAt: "2026-07-01T00:00:00.000Z",
+        },
+      ]);
+      applySafePromotions(cwd);
+      const entry = loadPromotions(cwd).find((c) => c.text === lesson);
+      assert.equal(entry?.status, "applied");
+      assert.equal(entry?.trigger, "bash_contains git add .");
+      assert.equal(entry?.action, "block");
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/node/orchestrator/memory-provenance-merge.test.ts
+++ b/tests/node/orchestrator/memory-provenance-merge.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Live provenance sidecar merge tests.
+ * Run: npx tsx --test tests/node/orchestrator/memory-provenance-merge.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  mergeProvenancePending,
+  writeProvenancePending,
+  getProvenancePendingPath,
+} from "../../../extensions/orchestrator/memory-provenance.js";
+import {
+  entryHash,
+  loadScores,
+  saveScores,
+  type ScoredEntry,
+} from "../../../extensions/orchestrator/memory-scoring.js";
+
+describe("mergeProvenancePending", () => {
+  it("merges sidecar into scores and deletes pending file", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "prov-merge-"));
+    try {
+      const topicsDir = path.join(cwd, ".pi", "memory", "topics");
+      fs.mkdirSync(topicsDir, { recursive: true });
+      const text = "Never use `git add .`";
+      fs.writeFileSync(
+        path.join(topicsDir, "lessons.md"),
+        `# Lessons\n\n- [lesson] ${text}\n`,
+      );
+
+      const hash = entryHash(`- [lesson] ${text}`);
+      const entry: ScoredEntry = {
+        class: "lesson",
+        score: 1,
+        evidenceCount: 1,
+        cue: "explicit",
+        firstSeen: new Date().toISOString(),
+        lastReinforced: new Date().toISOString(),
+        userState: "auto",
+        lifecycle: "active",
+      };
+      saveScores(cwd, { entries: { [hash]: entry }, lastRebuild: new Date().toISOString() });
+
+      writeProvenancePending(cwd, [
+        {
+          category: "lesson",
+          text,
+          sourceSession: "dream-session-9",
+          derivedFrom: "weekly review",
+          informs: ["git"],
+        },
+      ]);
+      assert.ok(fs.existsSync(getProvenancePendingPath(cwd)));
+
+      const updated = mergeProvenancePending(cwd);
+      assert.equal(updated, 1);
+      assert.equal(fs.existsSync(getProvenancePendingPath(cwd)), false);
+
+      const after = loadScores(cwd).entries[hash]!;
+      assert.equal(after.sourceSession, "dream-session-9");
+      assert.equal(after.derivedFrom, "weekly review");
+      assert.deepEqual(after.informs, ["git"]);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when sidecar missing", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "prov-empty-"));
+    try {
+      assert.equal(mergeProvenancePending(cwd), 0);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/node/orchestrator/memory-provenance-merge.test.ts
+++ b/tests/node/orchestrator/memory-provenance-merge.test.ts
@@ -20,7 +20,7 @@ import {
 } from "../../../extensions/orchestrator/memory-scoring.js";
 
 describe("mergeProvenancePending", () => {
-  it("merges sidecar into scores and deletes pending file", () => {
+  it("merges sidecar into scores then deletes pending file", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "prov-merge-"));
     try {
       const topicsDir = path.join(cwd, ".pi", "memory", "topics");

--- a/tests/node/orchestrator/memory-provenance.test.ts
+++ b/tests/node/orchestrator/memory-provenance.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for provenance fields on ScoredEntry surviving rebuild.
+ * Run with: npx tsx --test tests/node/orchestrator/memory-provenance.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  entryHash,
+  loadScores,
+  rebuild,
+  saveScores,
+  type ScoredEntry,
+} from "../../../extensions/orchestrator/memory-scoring.js";
+
+describe("provenance fields", () => {
+  it("rebuild preserves sourceSession/derivedFrom/informs", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "mem-prov-"));
+    try {
+      const topicsDir = path.join(cwd, ".pi", "memory", "topics");
+      fs.mkdirSync(topicsDir, { recursive: true });
+      const text = "Prefer uv run for Python";
+      fs.writeFileSync(
+        path.join(topicsDir, "preferences.md"),
+        `# Preferences\n\n- [preference] ${text}\n`,
+        "utf-8",
+      );
+
+      const hash = entryHash(`- [preference] ${text}`);
+      const entry: ScoredEntry = {
+        class: "preference",
+        score: 2,
+        evidenceCount: 2,
+        cue: "explicit",
+        firstSeen: new Date().toISOString(),
+        lastReinforced: new Date().toISOString(),
+        userState: "auto",
+        lifecycle: "active",
+        sourceSession: "2026-07-17-abc",
+        derivedFrom: "user said prefer uv",
+        informs: ["python", "tooling"],
+      };
+      saveScores(cwd, { entries: { [hash]: entry }, lastRebuild: new Date().toISOString() });
+
+      rebuild(cwd, [{ category: "preference", text, pinned: false }]);
+
+      const after = loadScores(cwd).entries[hash];
+      assert.ok(after);
+      assert.equal(after!.sourceSession, "2026-07-17-abc");
+      assert.equal(after!.derivedFrom, "user said prefer uv");
+      assert.deepEqual(after!.informs, ["python", "tooling"]);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/node/orchestrator/memory-query-class.test.ts
+++ b/tests/node/orchestrator/memory-query-class.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for query-class classification.
+ * Run with: npx tsx --test tests/node/orchestrator/memory-query-class.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyQueryClass,
+  getQueryClassBias,
+  sectionPriorityBoost,
+} from "../../../extensions/orchestrator/memory-query-class.js";
+
+describe("classifyQueryClass", () => {
+  it("detects pr_review", () => {
+    assert.equal(classifyQueryClass("Please review this PR"), "pr_review");
+    assert.equal(classifyQueryClass("gh pr create"), "pr_review");
+  });
+
+  it("detects git_release", () => {
+    assert.equal(classifyQueryClass("git commit and push"), "git_release");
+    assert.equal(classifyQueryClass("prepare the release"), "git_release");
+  });
+
+  it("detects debug", () => {
+    assert.equal(classifyQueryClass("fix this stack trace error"), "debug");
+    assert.equal(classifyQueryClass("the build failed"), "debug");
+  });
+
+  it("defaults to general", () => {
+    assert.equal(classifyQueryClass("add a button to the form"), "general");
+    assert.equal(classifyQueryClass(""), "general");
+  });
+});
+
+describe("sectionPriorityBoost", () => {
+  it("boosts mistakes for debug class below unboosted preferences", () => {
+    const mistakes = sectionPriorityBoost("Vetoes & Mistakes", 3, "debug");
+    const prefs = sectionPriorityBoost("Active Preferences", 1, "debug");
+    assert.ok(mistakes < prefs);
+  });
+
+  it("leaves general unchanged", () => {
+    assert.equal(
+      sectionPriorityBoost("Active Lessons", 2, "general"),
+      2,
+    );
+  });
+});
+
+describe("getQueryClassBias", () => {
+  it("raises vectorTopK for pr_review", () => {
+    assert.ok(getQueryClassBias("pr_review").vectorTopK > getQueryClassBias("general").vectorTopK);
+  });
+});

--- a/tests/node/orchestrator/promotion-queue.test.ts
+++ b/tests/node/orchestrator/promotion-queue.test.ts
@@ -139,4 +139,30 @@ describe("updatePromotionCandidates", () => {
       fs.rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  it("ignores undefined patch values so existing fields stay", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-undef-"));
+    try {
+      const a = makeCandidate({
+        verifier: "keep-me",
+        trigger: "bash_contains git add .",
+      });
+      appendPromotions(cwd, [a]);
+      updatePromotionCandidates(cwd, [
+        {
+          id: a.id,
+          patch: {
+            status: "applied",
+            verifier: undefined,
+          },
+        },
+      ]);
+      const loaded = loadPromotions(cwd).find((x) => x.id === a.id);
+      assert.equal(loaded?.status, "applied");
+      assert.equal(loaded?.verifier, "keep-me");
+      assert.equal(loaded?.trigger, "bash_contains git add .");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/node/orchestrator/promotion-queue.test.ts
+++ b/tests/node/orchestrator/promotion-queue.test.ts
@@ -14,6 +14,7 @@ import {
   loadPromotions,
   parsePromotionsMarkdown,
   promotionId,
+  updatePromotionCandidates,
   updatePromotionStatus,
   type PromotionCandidate,
 } from "../../../extensions/orchestrator/promotion-queue.js";
@@ -97,6 +98,43 @@ describe("appendPromotions with updatePromotionStatus", () => {
       assert.match(report, /Promotion Candidates/);
       assert.match(report, /Always ask_user/);
       assert.doesNotMatch(report, /Never use git add/);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("updatePromotionCandidates", () => {
+  it("ignores immutable identity fields in patches", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-patch-"));
+    try {
+      const a = makeCandidate({
+        createdAt: "2026-07-01T00:00:00.000Z",
+        reason: "original",
+      });
+      appendPromotions(cwd, [a]);
+      updatePromotionCandidates(cwd, [
+        {
+          id: a.id,
+          patch: {
+            status: "applied",
+            reason: "updated",
+            // @ts-expect-error identity fields must be ignored at runtime
+            id: "mutated-id",
+            // @ts-expect-error
+            createdAt: "2099-01-01T00:00:00.000Z",
+            // @ts-expect-error
+            destination: "discard",
+          },
+        },
+      ]);
+      const loaded = loadPromotions(cwd);
+      assert.equal(loaded.length, 1);
+      assert.equal(loaded[0]!.id, a.id);
+      assert.equal(loaded[0]!.status, "applied");
+      assert.equal(loaded[0]!.reason, "updated");
+      assert.equal(loaded[0]!.createdAt, "2026-07-01T00:00:00.000Z");
+      assert.equal(loaded[0]!.destination, "enforcement");
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/node/orchestrator/promotion-queue.test.ts
+++ b/tests/node/orchestrator/promotion-queue.test.ts
@@ -165,4 +165,30 @@ describe("updatePromotionCandidates", () => {
       fs.rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  it("rejects invalid status so the candidate still reloads", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-invalid-"));
+    try {
+      const a = makeCandidate({ status: "proposed", reason: "keep" });
+      appendPromotions(cwd, [a]);
+      const updated = updatePromotionCandidates(cwd, [
+        {
+          id: a.id,
+          patch: {
+            // @ts-expect-error invalid runtime status must be ignored
+            status: null,
+            reason: "still-valid",
+          },
+        },
+      ]);
+      assert.equal(updated, 1);
+      const loaded = loadPromotions(cwd);
+      assert.equal(loaded.length, 1);
+      assert.equal(loaded[0]!.id, a.id);
+      assert.equal(loaded[0]!.status, "proposed");
+      assert.equal(loaded[0]!.reason, "still-valid");
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/node/orchestrator/promotion-queue.test.ts
+++ b/tests/node/orchestrator/promotion-queue.test.ts
@@ -78,8 +78,8 @@ describe("format/parse round-trip", () => {
   });
 });
 
-describe("appendPromotions / updatePromotionStatus", () => {
-  it("dedups by id and updates status", () => {
+describe("appendPromotions with updatePromotionStatus", () => {
+  it("dedups by id then updates status", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-q-"));
     try {
       const a = makeCandidate();

--- a/tests/node/orchestrator/promotion-queue.test.ts
+++ b/tests/node/orchestrator/promotion-queue.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests for promotion-queue parser/formatter.
+ * Run with: npx tsx --test tests/node/orchestrator/promotion-queue.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  appendPromotions,
+  formatPromotionBlock,
+  formatPromotionsForReport,
+  loadPromotions,
+  parsePromotionsMarkdown,
+  promotionId,
+  updatePromotionStatus,
+  type PromotionCandidate,
+} from "../../../extensions/orchestrator/promotion-queue.js";
+
+function makeCandidate(
+  overrides: Partial<PromotionCandidate> = {},
+): PromotionCandidate {
+  const text = overrides.text ?? "Never use git add .";
+  const category = overrides.category ?? "lesson";
+  const destination = overrides.destination ?? "enforcement";
+  return {
+    id: overrides.id ?? promotionId(destination, category, text),
+    destination,
+    status: overrides.status ?? "proposed",
+    category,
+    text,
+    reason: overrides.reason ?? "test reason",
+    createdAt: overrides.createdAt ?? "2026-07-17T00:00:00.000Z",
+    evidenceCount: overrides.evidenceCount,
+    trigger: overrides.trigger,
+    action: overrides.action,
+    verifier: overrides.verifier,
+    skillName: overrides.skillName,
+    skillCreated: overrides.skillCreated,
+  };
+}
+
+describe("promotionId", () => {
+  it("is stable for the same inputs", () => {
+    assert.equal(
+      promotionId("enforcement", "lesson", "Never use git add ."),
+      promotionId("enforcement", "lesson", "Never use git add ."),
+    );
+  });
+
+  it("differs across destinations", () => {
+    assert.notEqual(
+      promotionId("enforcement", "lesson", "x"),
+      promotionId("skill", "lesson", "x"),
+    );
+  });
+});
+
+describe("format/parse round-trip", () => {
+  it("round-trips a full candidate block", () => {
+    const c = makeCandidate({
+      trigger: "bash_contains git add .",
+      action: "block",
+      evidenceCount: 3,
+      skillName: "unused",
+      skillCreated: false,
+    });
+    const md = "# Memory Promotion Queue\n\n" + formatPromotionBlock(c);
+    const parsed = parsePromotionsMarkdown(md);
+    assert.equal(parsed.length, 1);
+    assert.deepEqual(parsed[0], c);
+  });
+
+  it("skips malformed blocks", () => {
+    const md = "### abc\n- destination: nope\n- status: proposed\n";
+    assert.equal(parsePromotionsMarkdown(md).length, 0);
+  });
+});
+
+describe("appendPromotions / updatePromotionStatus", () => {
+  it("dedups by id and updates status", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "promo-q-"));
+    try {
+      const a = makeCandidate();
+      const b = makeCandidate({ text: "Always ask_user before gh pr merge" });
+      assert.equal(appendPromotions(cwd, [a, a, b]), 2);
+      assert.equal(loadPromotions(cwd).length, 2);
+      assert.equal(appendPromotions(cwd, [a]), 0);
+
+      assert.equal(updatePromotionStatus(cwd, a.id, "applied"), true);
+      const loaded = loadPromotions(cwd);
+      assert.equal(loaded.find((x) => x.id === a.id)?.status, "applied");
+      assert.equal(updatePromotionStatus(cwd, "missing", "rejected"), false);
+
+      const report = formatPromotionsForReport(cwd, 5);
+      assert.match(report, /Promotion Candidates/);
+      assert.match(report, /Always ask_user/);
+      assert.doesNotMatch(report, /Never use git add/);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/node/orchestrator/situation-report-query-class.test.ts
+++ b/tests/node/orchestrator/situation-report-query-class.test.ts
@@ -61,7 +61,7 @@ function seed(cwd: string): void {
 }
 
 describe("buildSituationReport queryClass", () => {
-  it("includes promotion candidates and query-class hint for git_release", () => {
+  it("includes promotion candidates with query-class hint for git_release", () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "sitrep-qc-"));
     try {
       seed(cwd);
@@ -107,6 +107,16 @@ describe("buildSituationReport queryClass", () => {
       const report = buildSituationReport(cwd, 1700, { queryClass: "pr_review" });
       assert.match(report, /review-guidelines/);
       assert.match(report, /Query class: `pr_review`/);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty string when tokenBudget is zero", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "sitrep-zero-"));
+    try {
+      seed(cwd);
+      assert.equal(buildSituationReport(cwd, 0, { queryClass: "git_release" }), "");
     } finally {
       fs.rmSync(cwd, { recursive: true, force: true });
     }

--- a/tests/node/orchestrator/situation-report-query-class.test.ts
+++ b/tests/node/orchestrator/situation-report-query-class.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Situation report query-class budget / ordering shifts.
+ * Run: npx tsx --test tests/node/orchestrator/situation-report-query-class.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildSituationReport } from "../../../extensions/orchestrator/situation-report.js";
+import {
+  entryHash,
+  saveScores,
+  type ScoredEntry,
+} from "../../../extensions/orchestrator/memory-scoring.js";
+import { writePromotions, promotionId } from "../../../extensions/orchestrator/promotion-queue.js";
+
+function seed(cwd: string): void {
+  const topicsDir = path.join(cwd, ".pi", "memory", "topics");
+  fs.mkdirSync(topicsDir, { recursive: true });
+
+  const rows: { cat: ScoredEntry["class"]; file: string; text: string }[] = [
+    { cat: "preference", file: "preferences.md", text: "Prefer uv run for Python" },
+    { cat: "lesson", file: "lessons.md", text: "Always ask before force push" },
+    { cat: "mistake", file: "mistakes.md", text: "Do not swallow stack traces" },
+    { cat: "pattern", file: "patterns.md", text: "Review PRs with checklist" },
+    { cat: "decision", file: "decisions.md", text: "Use tox for full verify" },
+  ];
+
+  const scores: Record<string, ScoredEntry> = {};
+  for (const r of rows) {
+    fs.writeFileSync(
+      path.join(topicsDir, r.file),
+      `# ${r.file}\n\n- [${r.cat}] ${r.text}\n`,
+    );
+    const hash = entryHash(`- [${r.cat}] ${r.text}`);
+    scores[hash] = {
+      class: r.cat,
+      score: 3,
+      evidenceCount: 3,
+      cue: "explicit",
+      firstSeen: new Date().toISOString(),
+      lastReinforced: new Date().toISOString(),
+      userState: "auto",
+      lifecycle: "active",
+    };
+  }
+  saveScores(cwd, { entries: scores, lastRebuild: new Date().toISOString() });
+
+  writePromotions(cwd, [
+    {
+      id: promotionId("project_rule", "lesson", "Always ask before force push"),
+      destination: "project_rule",
+      status: "proposed",
+      category: "lesson",
+      text: "Always ask before force push",
+      reason: "test",
+      createdAt: new Date().toISOString(),
+    },
+  ]);
+}
+
+describe("buildSituationReport queryClass", () => {
+  it("includes promotion candidates and query-class hint for git_release", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "sitrep-qc-"));
+    try {
+      seed(cwd);
+      const report = buildSituationReport(cwd, 1700, { queryClass: "git_release" });
+      assert.match(report, /Promotion Candidates/);
+      assert.match(report, /Query class: `git_release`/);
+      // Lessons should appear (boosted for git_release)
+      assert.match(report, /Always ask before force push/);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("boosts mistakes earlier for debug vs general", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "sitrep-dbg-"));
+    try {
+      seed(cwd);
+      const debug = buildSituationReport(cwd, 1700, { queryClass: "debug" });
+      const general = buildSituationReport(cwd, 1700, { queryClass: "general" });
+
+      assert.match(debug, /Do not swallow stack traces/);
+      assert.match(debug, /Query class: `debug`/);
+      assert.doesNotMatch(general, /Query class:/);
+
+      const debugMistakeIdx = debug.indexOf("Vetoes & Mistakes");
+      const debugPrefIdx = debug.indexOf("Active Preferences");
+      // With boost, mistakes can appear before preferences in debug class
+      assert.ok(debugMistakeIdx >= 0);
+      assert.ok(debugPrefIdx >= 0);
+      assert.ok(
+        debugMistakeIdx < debugPrefIdx,
+        `expected mistakes before preferences in debug report\n${debug}`,
+      );
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("pr_review hint points at review-guidelines", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "sitrep-pr-"));
+    try {
+      seed(cwd);
+      const report = buildSituationReport(cwd, 1700, { queryClass: "pr_review" });
+      assert.match(report, /review-guidelines/);
+      assert.match(report, /Query class: `pr_review`/);
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/python/test_memory.py
+++ b/tests/python/test_memory.py
@@ -276,7 +276,7 @@ class TestMigration:
 
 
 class TestMemoryStatus:
-    def test_status_reports_code_tier_and_injected(self, tmp_path: Path) -> None:
+    def test_status_reports_code_tier_counts(self, tmp_path: Path) -> None:
         topics_dir = tmp_path / "memory" / "topics"
         topics_dir.mkdir(parents=True)
         (topics_dir / "lessons.md").write_text(

--- a/tests/python/test_memory.py
+++ b/tests/python/test_memory.py
@@ -5,7 +5,9 @@ import sqlite3
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from myk_pi_tools.memory.commands import memory
 from myk_pi_tools.memory.store import CATEGORY_TO_TOPIC, MemoryFile, _entry_hash, _topic_template
 
 
@@ -271,3 +273,47 @@ class TestMigration:
         # Second call — no DB, returns 0
         count = mem.migrate_from_db()
         assert count == 0
+
+
+class TestMemoryStatus:
+    def test_status_reports_code_tier_and_injected(self, tmp_path: Path) -> None:
+        topics_dir = tmp_path / "memory" / "topics"
+        topics_dir.mkdir(parents=True)
+        (topics_dir / "lessons.md").write_text(
+            "# Lessons\n\n- [lesson] Never use `git add .`\n",
+            encoding="utf-8",
+        )
+        hash_key = _entry_hash("- [lesson] Never use `git add .`")
+        scores = {
+            "entries": {
+                hash_key: {
+                    "class": "lesson",
+                    "score": 2,
+                    "evidenceCount": 3,
+                    "cue": "explicit",
+                    "firstSeen": "2026-07-17T00:00:00Z",
+                    "lastReinforced": "2026-07-17T00:00:00Z",
+                    "userState": "auto",
+                    "lifecycle": "active",
+                    "trigger": "bash_contains git add .",
+                    "action": "block",
+                }
+            },
+            "lastRebuild": "2026-07-17T00:00:00Z",
+        }
+        (tmp_path / "memory" / "memory-scores.json").write_text(
+            json.dumps(scores),
+            encoding="utf-8",
+        )
+        (tmp_path / "memory" / "promotions.md").write_text(
+            "### abc\n- status: proposed\n",
+            encoding="utf-8",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(memory, ["--file-path", str(topics_dir), "status"])
+        assert result.exit_code == 0, result.output
+        assert "injected (topic lines): 1" in result.output
+        assert "code-tier (enforced scores): 1" in result.output
+        assert "promotion candidates (proposed): 1" in result.output
+        assert "bash_contains git add ." in result.output


### PR DESCRIPTION
## Summary
- Add a promotion queue (`.pi/memory/promotions.md`) so memories can graduate to `skill` / `enforcement` / `project_rule` (rules stay propose-only)
- Auto-apply high-confidence mechanical enforcement on evidence thresholds; dream + reinforce run promotion passes
- Add provenance fields, query-class injection bias (`pr_review` / `git_release` / `debug`), and `myk-pi-tools memory status` honesty inventory

## Test plan
- [x] `npx tsx --test tests/node/orchestrator/memory-promotion*.test.ts tests/node/orchestrator/promotion-queue.test.ts tests/node/orchestrator/memory-query-class.test.ts tests/node/orchestrator/memory-provenance*.test.ts tests/node/orchestrator/situation-report-query-class.test.ts`
- [x] Live e2e: CLI add → reinforce → promote → `matchBashCommand` blocks `git add .` → situation report + `memory status`
- [x] `npx tsx --test tests/node/**/*.test.ts`
- [x] `uv run --group tests pytest` / `uvx tox`
- [x] `prek run --all-files`
- [ ] Manual: start pi session, reinforce a mechanical lesson to evidence ≥ 3, confirm `*(enforced)*` + promotions queue


Made with [Cursor](https://cursor.com)