### PR TITLE
feat(status-line): clickable pi-diff/pi-dash labels and PR number

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Single extension that provides:
 | **Remote script exec block** | Blocks `curl \| bash`, `eval $(curl)`, etc. Allows safe `VAR=$(curl ...)` variable assignments |
 | **Dangerous command gate** | Confirms `rm -rf`, `sudo`, `mkfs`, etc. |
 | **Rule injection** | Injects orchestrator routing rules into system prompt |
-| **Git status** | Live git status in status line with colored icons — updates after every tool call. Last-activity clock `⏱ HH:MM (Xm/Xh ago)` shows time since last response |
+| **Git status** | Live git status in status line with colored icons — updates after every tool call. Shows clickable `#N` when the branch has an open PR. Last-activity clock `⏱ HH:MM (Xm/Xh ago)` shows time since last response |
 | **Desktop notifications** | Notifies via `notify-send` on task completion, waiting for input, and action required |
 | **File preview** | Serves generated HTML/frontend files via HTTP for browser preview from container |
 | **Pidash dashboard** | Live web dashboard — multi-session monitoring, browser messaging, model switching, live session name updates, reasoning token display |
@@ -466,8 +466,8 @@ Pidash is a web-based dashboard that runs alongside the TUI, accessible from any
 - Send messages from browser to pi
 - Model and thinking level switching from browser
 - Extension commands (`/release`, `/dream`, `/remember`, etc.) work from browser
-- Info bar: model, tokens, context %, git status, diff viewer toggle
-- Per-project diff viewer (pidiff) — opens in browser via link in info bar, powered by `@pierre/diffs` + `@pierre/trees`, with review comments
+- Info bar: model, tokens, context %, git status (with PR `#N` when present), clickable `pi-diff` / `pi-dash` labels
+- Per-project diff viewer (pidiff) — opens in browser via clickable `pi-diff` status-line link, powered by `@pierre/diffs` + `@pierre/trees`, with review comments
 - Collapsible thinking and tool blocks with copy buttons
 - ask_user tool bridging (answer from browser or TUI)
 - Mobile responsive
@@ -530,12 +530,12 @@ Pidiff is a per-project diff viewer that opens in your browser, providing rich b
 - Inline review comments on specific lines
 - Publish review comments back to the pi session
 - Per-project isolation — no port conflicts between sessions
-- Accessible via link in pidash info bar
+- Accessible via clickable `pi-diff` label in the status line (and from pidash)
 
 **Access:**
 
 ```bash
-# Open in browser (port shown in pidash info bar):
+# Open in browser (click `pi-diff` in the status line, or use the port):
 http://localhost:<port>
 
 # Disable pidiff (or set pidiff_enable: false in pi-config-settings.json):

--- a/README.md
+++ b/README.md
@@ -466,7 +466,8 @@ Pidash is a web-based dashboard that runs alongside the TUI, accessible from any
 - Send messages from browser to pi
 - Model and thinking level switching from browser
 - Extension commands (`/release`, `/dream`, `/remember`, etc.) work from browser
-- Info bar: model, tokens, context %, git status (with PR `#N` when present), clickable `pi-diff` / `pi-dash` labels
+- Info bar: model, tokens, context %, git status (with PR `#N` when present)
+- TUI status line: clickable `pi-diff` / `pi-dash` labels and open-PR `#N` hyperlink
 - Per-project diff viewer (pidiff) — opens in browser via clickable `pi-diff` status-line link, powered by `@pierre/diffs` + `@pierre/trees`, with review comments
 - Collapsible thinking and tool blocks with copy buttons
 - ask_user tool bridging (answer from browser or TUI)

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -104,6 +104,8 @@ const SAFE_PR_URL = /^https:\/\/[^\x00-\x1f]+$/;
 type OpenPrCacheEntry = { at: number; pr: OpenPr | null };
 const openPrCache = new Map<string, OpenPrCacheEntry>();
 const openPrInFlight = new Map<string, Promise<OpenPr | null>>();
+/** Keys with an active scheduleOpenPrStatusRefresh .then subscription. */
+const openPrSchedulePending = new Set<string>();
 
 type GhPrViewRunner = (cwd?: string) => Promise<string>;
 
@@ -151,6 +153,7 @@ export function parseOpenPrJson(out: string): OpenPr | null {
 export function clearOpenPrCache(): void {
   openPrCache.clear();
   openPrInFlight.clear();
+  openPrSchedulePending.clear();
 }
 
 /** Seed cache entry (tests) — use past `at` to exercise TTL / SWR. */
@@ -298,35 +301,44 @@ export function scheduleOpenPrStatusRefresh(opts: {
   refresh?: typeof refreshOpenPr;
 }): void {
   const refreshKey = `${opts.cwd || ""}:${opts.branch}`;
+  // One .then per in-flight key — refreshOpenPr coalesces Promises but
+  // repeated schedule calls would otherwise all fire onRerender.
+  if (openPrSchedulePending.has(refreshKey)) return;
+  openPrSchedulePending.add(refreshKey);
+
   const shownKey = opts.shownPr
     ? `${opts.shownPr.number}\0${opts.shownPr.url}`
     : "";
   const refresh = opts.refresh ?? refreshOpenPr;
   void refresh(opts.cwd, opts.branch, {
     assumeGithub: opts.assumeGithub,
-  }).then((fresh) => {
-    const { lastCtx, lastBranch } = opts.getState();
-    if (
-      decideOpenPrRefreshRerender({
-        lastCtx,
-        lastBranch,
-        refreshKey,
-        shownKey,
-        fresh,
-      }) !== "rerender"
-    ) {
-      return;
-    }
-    if (!lastCtx) return;
-    try {
-      opts.onRerender(lastCtx);
-    } catch (e: any) {
-      console.debug(
-        "[status-line] open-PR refresh update failed:",
-        e?.message || e,
-      );
-    }
-  });
+  })
+    .then((fresh) => {
+      const { lastCtx, lastBranch } = opts.getState();
+      if (
+        decideOpenPrRefreshRerender({
+          lastCtx,
+          lastBranch,
+          refreshKey,
+          shownKey,
+          fresh,
+        }) !== "rerender"
+      ) {
+        return;
+      }
+      if (!lastCtx) return;
+      try {
+        opts.onRerender(lastCtx);
+      } catch (e: any) {
+        console.debug(
+          "[status-line] open-PR refresh update failed:",
+          e?.message || e,
+        );
+      }
+    })
+    .finally(() => {
+      openPrSchedulePending.delete(refreshKey);
+    });
 }
 
 // Cache protected branches per repo (fetched once per session)

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -340,7 +340,12 @@ export function scheduleOpenPrStatusRefresh(opts: {
       .finally(() => {
         openPrSchedulePending.delete(refreshKey);
       })
-      .catch(() => {});
+      .catch((e: any) => {
+        console.debug(
+          "[status-line] open-PR refresh failed:",
+          e?.message || e,
+        );
+      });
   } catch {
     openPrSchedulePending.delete(refreshKey);
   }

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -2,7 +2,7 @@
  * Git utility functions for enforcement and status line.
  */
 
-import { execSync } from "node:child_process";
+import { execFile, execSync } from "node:child_process";
 
 export function runGit(
   args: string[],
@@ -98,17 +98,46 @@ export function getPrMergeStatus(
 export type OpenPr = { number: number; url: string };
 
 const OPEN_PR_TTL_MS = 30_000;
-const openPrCache = new Map<string, { at: number; pr: OpenPr | null }>();
+const OPEN_PR_CACHE_MAX = 50;
+const SAFE_PR_URL = /^https:\/\/[^\x00-\x1f]+$/;
 
-/** Parse `gh pr view --json number,url` output. */
+type OpenPrCacheEntry = { at: number; pr: OpenPr | null };
+const openPrCache = new Map<string, OpenPrCacheEntry>();
+const openPrInFlight = new Map<string, Promise<OpenPr | null>>();
+
+type GhPrViewRunner = (cwd?: string) => Promise<string>;
+
+const defaultGhPrView: GhPrViewRunner = (cwd) =>
+  new Promise((resolve, reject) => {
+    execFile(
+      "gh",
+      ["pr", "view", "--json", "number,url,state"],
+      { cwd, timeout: 5000, encoding: "utf-8", maxBuffer: 1024 * 1024 },
+      (err, stdout) => {
+        if (err) reject(err);
+        else resolve(typeof stdout === "string" ? stdout : String(stdout));
+      },
+    );
+  });
+
+let ghPrViewRunner: GhPrViewRunner = defaultGhPrView;
+
+/** Override `gh pr view` runner (tests). Pass null to restore default. */
+export function setGhPrViewRunner(runner: GhPrViewRunner | null): void {
+  ghPrViewRunner = runner ?? defaultGhPrView;
+}
+
+/** Parse `gh pr view --json number,url,state` output (OPEN only). */
 export function parseOpenPrJson(out: string): OpenPr | null {
   try {
     const data = JSON.parse(out);
     if (
       data &&
-      typeof data.number === "number" &&
+      Number.isInteger(data.number) &&
+      data.number > 0 &&
       typeof data.url === "string" &&
-      data.url.length > 0
+      SAFE_PR_URL.test(data.url) &&
+      data.state === "OPEN"
     ) {
       return { number: data.number, url: data.url };
     }
@@ -118,37 +147,97 @@ export function parseOpenPrJson(out: string): OpenPr | null {
   return null;
 }
 
-/** Clear open-PR cache (tests). */
+/** Clear open-PR cache and in-flight lookups (tests). */
 export function clearOpenPrCache(): void {
   openPrCache.clear();
+  openPrInFlight.clear();
+}
+
+/** Seed cache entry (tests) — use past `at` to exercise TTL / SWR. */
+export function seedOpenPrCacheForTests(
+  cwd: string,
+  branch: string,
+  entry: { at: number; pr: OpenPr | null },
+): void {
+  openPrCache.set(openPrCacheKey(cwd, branch), entry);
+}
+
+/** Evict oldest keys when over max size (LRU via touch-on-hit). */
+function enforceOpenPrCacheMax(): void {
+  while (openPrCache.size > OPEN_PR_CACHE_MAX) {
+    const oldest = openPrCache.keys().next().value;
+    if (oldest === undefined) break;
+    openPrCache.delete(oldest);
+  }
+}
+
+function openPrCacheKey(cwd: string | undefined, branch: string): string {
+  return `${cwd || process.cwd()}:${branch}`;
+}
+
+function touchOpenPrCache(key: string, entry: OpenPrCacheEntry): void {
+  openPrCache.delete(key);
+  openPrCache.set(key, entry);
+  enforceOpenPrCacheMax();
 }
 
 /**
- * Open PR for the current (or given) branch via `gh pr view`.
- * Cached per cwd+branch for 30s so the status-line poller does not spam gh.
+ * Cached open PR only — never calls `gh`.
+ * Returns stale entries past TTL (stale-while-revalidate); kick
+ * {@link refreshOpenPr} to refresh asynchronously.
  */
 export function getOpenPr(cwd?: string, branch?: string | null): OpenPr | null {
   const b = branch ?? getCurrentBranch(cwd);
   if (!b || !isGithubRepo(cwd)) return null;
 
-  const key = `${cwd || process.cwd()}:${b}`;
+  const key = openPrCacheKey(cwd, b);
   const cached = openPrCache.get(key);
-  if (cached && Date.now() - cached.at < OPEN_PR_TTL_MS) return cached.pr;
+  if (!cached) return null;
+  // Touch for LRU even on stale hits so hot keys survive eviction.
+  touchOpenPrCache(key, cached);
+  return cached.pr;
+}
 
-  let pr: OpenPr | null = null;
-  try {
-    const out = execSync("gh pr view --json number,url", {
-      cwd,
-      timeout: 5000,
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    pr = parseOpenPrJson(out.trim());
-  } catch {
-    pr = null;
+/**
+ * Async `gh pr view` for the current (or given) branch.
+ * Coalesces in-flight lookups per cwd+branch; caches result for 30s.
+ * Status-line callers must use {@link getOpenPr} synchronously and only
+ * await this to refresh — never block the update path on `gh`.
+ */
+export function refreshOpenPr(
+  cwd?: string,
+  branch?: string | null,
+): Promise<OpenPr | null> {
+  const b = branch ?? getCurrentBranch(cwd);
+  if (!b || !isGithubRepo(cwd)) return Promise.resolve(null);
+
+  const now = Date.now();
+  const key = openPrCacheKey(cwd, b);
+  const cached = openPrCache.get(key);
+  if (cached && now - cached.at < OPEN_PR_TTL_MS) {
+    touchOpenPrCache(key, cached);
+    return Promise.resolve(cached.pr);
   }
-  openPrCache.set(key, { at: Date.now(), pr });
-  return pr;
+
+  const inflight = openPrInFlight.get(key);
+  if (inflight) return inflight;
+
+  const pending = (async (): Promise<OpenPr | null> => {
+    let pr: OpenPr | null = null;
+    try {
+      const out = await ghPrViewRunner(cwd);
+      pr = parseOpenPrJson(out.trim());
+    } catch {
+      pr = null;
+    }
+    touchOpenPrCache(key, { at: Date.now(), pr });
+    return pr;
+  })().finally(() => {
+    openPrInFlight.delete(key);
+  });
+
+  openPrInFlight.set(key, pending);
+  return pending;
 }
 
 // Cache protected branches per repo (fetched once per session)

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -310,35 +310,40 @@ export function scheduleOpenPrStatusRefresh(opts: {
     ? `${opts.shownPr.number}\0${opts.shownPr.url}`
     : "";
   const refresh = opts.refresh ?? refreshOpenPr;
-  void refresh(opts.cwd, opts.branch, {
-    assumeGithub: opts.assumeGithub,
-  })
-    .then((fresh) => {
-      const { lastCtx, lastBranch } = opts.getState();
-      if (
-        decideOpenPrRefreshRerender({
-          lastCtx,
-          lastBranch,
-          refreshKey,
-          shownKey,
-          fresh,
-        }) !== "rerender"
-      ) {
-        return;
-      }
-      if (!lastCtx) return;
-      try {
-        opts.onRerender(lastCtx);
-      } catch (e: any) {
-        console.debug(
-          "[status-line] open-PR refresh update failed:",
-          e?.message || e,
-        );
-      }
+  try {
+    void refresh(opts.cwd, opts.branch, {
+      assumeGithub: opts.assumeGithub,
     })
-    .finally(() => {
-      openPrSchedulePending.delete(refreshKey);
-    });
+      .then((fresh) => {
+        const { lastCtx, lastBranch } = opts.getState();
+        if (
+          decideOpenPrRefreshRerender({
+            lastCtx,
+            lastBranch,
+            refreshKey,
+            shownKey,
+            fresh,
+          }) !== "rerender"
+        ) {
+          return;
+        }
+        if (!lastCtx) return;
+        try {
+          opts.onRerender(lastCtx);
+        } catch (e: any) {
+          console.debug(
+            "[status-line] open-PR refresh update failed:",
+            e?.message || e,
+          );
+        }
+      })
+      .finally(() => {
+        openPrSchedulePending.delete(refreshKey);
+      })
+      .catch(() => {});
+  } catch {
+    openPrSchedulePending.delete(refreshKey);
+  }
 }
 
 // Cache protected branches per repo (fetched once per session)

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -250,6 +250,73 @@ export function shouldApplyOpenPrRefresh(
   return `${lastCtx.cwd || ""}:${lastBranch}` === refreshKey;
 }
 
+export type OpenPrRefreshDecision = "skip" | "rerender";
+
+/** Decide whether a finished refresh should re-run the status-line update. */
+export function decideOpenPrRefreshRerender(args: {
+  lastCtx: { cwd?: string } | null;
+  lastBranch: string | null;
+  refreshKey: string;
+  shownKey: string;
+  fresh: OpenPr | null;
+}): OpenPrRefreshDecision {
+  if (
+    !shouldApplyOpenPrRefresh(args.lastCtx, args.lastBranch, args.refreshKey)
+  ) {
+    return "skip";
+  }
+  const freshKey = args.fresh
+    ? `${args.fresh.number}\0${args.fresh.url}`
+    : "";
+  if (freshKey === args.shownKey) return "skip";
+  return "rerender";
+}
+
+/**
+ * Status-line open-PR refresh callback wiring (no TUI deps).
+ * Schedules refreshOpenPr and optionally re-renders when the result applies.
+ */
+export function scheduleOpenPrStatusRefresh(opts: {
+  cwd?: string;
+  branch: string;
+  shownPr: OpenPr | null;
+  getState: () => {
+    lastCtx: { cwd?: string } | null;
+    lastBranch: string | null;
+  };
+  onRerender: (ctx: { cwd?: string }) => void;
+  refresh?: typeof refreshOpenPr;
+}): void {
+  const refreshKey = `${opts.cwd || ""}:${opts.branch}`;
+  const shownKey = opts.shownPr
+    ? `${opts.shownPr.number}\0${opts.shownPr.url}`
+    : "";
+  const refresh = opts.refresh ?? refreshOpenPr;
+  void refresh(opts.cwd, opts.branch).then((fresh) => {
+    const { lastCtx, lastBranch } = opts.getState();
+    if (
+      decideOpenPrRefreshRerender({
+        lastCtx,
+        lastBranch,
+        refreshKey,
+        shownKey,
+        fresh,
+      }) !== "rerender"
+    ) {
+      return;
+    }
+    if (!lastCtx) return;
+    try {
+      opts.onRerender(lastCtx);
+    } catch (e: any) {
+      console.debug(
+        "[status-line] open-PR refresh update failed:",
+        e?.message || e,
+      );
+    }
+  });
+}
+
 // Cache protected branches per repo (fetched once per session)
 const protectedBranchesCache = new Map<string, Set<string>>();
 

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -185,10 +185,16 @@ function touchOpenPrCache(key: string, entry: OpenPrCacheEntry): void {
  * Cached open PR only — never calls `gh`.
  * Returns stale entries past TTL (stale-while-revalidate); kick
  * {@link refreshOpenPr} to refresh asynchronously.
+ * Pass `assumeGithub: true` when the caller already verified the remote.
  */
-export function getOpenPr(cwd?: string, branch?: string | null): OpenPr | null {
+export function getOpenPr(
+  cwd?: string,
+  branch?: string | null,
+  opts?: { assumeGithub?: boolean },
+): OpenPr | null {
   const b = branch ?? getCurrentBranch(cwd);
-  if (!b || !isGithubRepo(cwd)) return null;
+  if (!b) return null;
+  if (!opts?.assumeGithub && !isGithubRepo(cwd)) return null;
 
   const key = openPrCacheKey(cwd, b);
   const cached = openPrCache.get(key);
@@ -203,13 +209,16 @@ export function getOpenPr(cwd?: string, branch?: string | null): OpenPr | null {
  * Coalesces in-flight lookups per cwd+branch; caches result for 30s.
  * Status-line callers must use {@link getOpenPr} synchronously and only
  * await this to refresh — never block the update path on `gh`.
+ * Pass `assumeGithub: true` when the caller already verified the remote.
  */
 export function refreshOpenPr(
   cwd?: string,
   branch?: string | null,
+  opts?: { assumeGithub?: boolean },
 ): Promise<OpenPr | null> {
   const b = branch ?? getCurrentBranch(cwd);
-  if (!b || !isGithubRepo(cwd)) return Promise.resolve(null);
+  if (!b) return Promise.resolve(null);
+  if (!opts?.assumeGithub && !isGithubRepo(cwd)) return Promise.resolve(null);
 
   const now = Date.now();
   const key = openPrCacheKey(cwd, b);
@@ -285,6 +294,7 @@ export function scheduleOpenPrStatusRefresh(opts: {
     lastBranch: string | null;
   };
   onRerender: (ctx: { cwd?: string }) => void;
+  assumeGithub?: boolean;
   refresh?: typeof refreshOpenPr;
 }): void {
   const refreshKey = `${opts.cwd || ""}:${opts.branch}`;
@@ -292,7 +302,9 @@ export function scheduleOpenPrStatusRefresh(opts: {
     ? `${opts.shownPr.number}\0${opts.shownPr.url}`
     : "";
   const refresh = opts.refresh ?? refreshOpenPr;
-  void refresh(opts.cwd, opts.branch).then((fresh) => {
+  void refresh(opts.cwd, opts.branch, {
+    assumeGithub: opts.assumeGithub,
+  }).then((fresh) => {
     const { lastCtx, lastBranch } = opts.getState();
     if (
       decideOpenPrRefreshRerender({

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -95,6 +95,62 @@ export function getPrMergeStatus(
   }
 }
 
+export type OpenPr = { number: number; url: string };
+
+const OPEN_PR_TTL_MS = 30_000;
+const openPrCache = new Map<string, { at: number; pr: OpenPr | null }>();
+
+/** Parse `gh pr view --json number,url` output. */
+export function parseOpenPrJson(out: string): OpenPr | null {
+  try {
+    const data = JSON.parse(out);
+    if (
+      data &&
+      typeof data.number === "number" &&
+      typeof data.url === "string" &&
+      data.url.length > 0
+    ) {
+      return { number: data.number, url: data.url };
+    }
+  } catch {
+    // invalid JSON
+  }
+  return null;
+}
+
+/** Clear open-PR cache (tests). */
+export function clearOpenPrCache(): void {
+  openPrCache.clear();
+}
+
+/**
+ * Open PR for the current (or given) branch via `gh pr view`.
+ * Cached per cwd+branch for 30s so the status-line poller does not spam gh.
+ */
+export function getOpenPr(cwd?: string, branch?: string | null): OpenPr | null {
+  const b = branch ?? getCurrentBranch(cwd);
+  if (!b || !isGithubRepo(cwd)) return null;
+
+  const key = `${cwd || process.cwd()}:${b}`;
+  const cached = openPrCache.get(key);
+  if (cached && Date.now() - cached.at < OPEN_PR_TTL_MS) return cached.pr;
+
+  let pr: OpenPr | null = null;
+  try {
+    const out = execSync("gh pr view --json number,url", {
+      cwd,
+      timeout: 5000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    pr = parseOpenPrJson(out.trim());
+  } catch {
+    pr = null;
+  }
+  openPrCache.set(key, { at: Date.now(), pr });
+  return pr;
+}
+
 // Cache protected branches per repo (fetched once per session)
 const protectedBranchesCache = new Map<string, Set<string>>();
 

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -240,6 +240,16 @@ export function refreshOpenPr(
   return pending;
 }
 
+/** True when an async open-PR refresh still matches the active cwd/branch. */
+export function shouldApplyOpenPrRefresh(
+  lastCtx: { cwd?: string } | null,
+  lastBranch: string | null,
+  refreshKey: string,
+): boolean {
+  if (!lastCtx || lastBranch == null) return false;
+  return `${lastCtx.cwd || ""}:${lastBranch}` === refreshKey;
+}
+
 // Cache protected branches per repo (fetched once per session)
 const protectedBranchesCache = new Map<string, Set<string>>();
 

--- a/extensions/orchestrator/git-helpers.ts
+++ b/extensions/orchestrator/git-helpers.ts
@@ -343,6 +343,7 @@ export function scheduleOpenPrStatusRefresh(opts: {
       .catch((e: any) => {
         console.debug(
           "[status-line] open-PR refresh failed:",
+          refreshKey,
           e?.message || e,
         );
       });

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -3,7 +3,8 @@
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { getCurrentBranch, runGit } from "./git-helpers.js";
+import { hyperlink } from "@earendil-works/pi-tui";
+import { getCurrentBranch, getOpenPr, runGit } from "./git-helpers.js";
 import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
 import { clockHHMM } from "./utils.js";
 
@@ -67,8 +68,17 @@ export function registerStatusLine(
         changes.length > 0
           ? ctx.ui.theme.fg("error", ICON_GIT_DIRTY)
           : ctx.ui.theme.fg("success", ICON_GIT_CLEAN);
-      const gitPart =
+      let gitPart =
         changes.length > 0 ? `${icon} ${changes.join(" ")}` : icon;
+
+      const pr = getOpenPr(ctx.cwd, b);
+      if (pr) {
+        const prLabel = ctx.ui.theme.fg(
+          "accent",
+          hyperlink(`#${pr.number}`, pr.url),
+        );
+        gitPart = `${gitPart} ${prLabel}`;
+      }
 
       buildStatus(ctx, gitPart);
     } catch (e: any) { console.debug("[status-line] git status update failed:", e?.message || e); }

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -39,12 +39,14 @@ export function registerStatusLine(
   // ── Git branch status line ─────────────────────────────────────────────
 
   let lastCtx: any = null;
+  let lastBranch: string | null = null;
 
   const updateBranch = (_event: any, ctx: any) => {
     lastCtx = ctx;
     try {
       const b = getCurrentBranch(ctx.cwd);
       if (!b) return;
+      lastBranch = b;
 
       const status = runGit(["status", "--porcelain"], ctx.cwd);
       let modified = 0,
@@ -92,9 +94,8 @@ export function registerStatusLine(
       const refreshKey = `${ctx.cwd || ""}:${b}`;
       const shownKey = pr ? `${pr.number}\0${pr.url}` : "";
       void refreshOpenPr(ctx.cwd, b).then((fresh) => {
-        if (!lastCtx) return;
-        const curB = getCurrentBranch(lastCtx.cwd);
-        if (!curB || `${lastCtx.cwd || ""}:${curB}` !== refreshKey) return;
+        if (!lastCtx || lastBranch == null) return;
+        if (`${lastCtx.cwd || ""}:${lastBranch}` !== refreshKey) return;
         const freshKey = fresh ? `${fresh.number}\0${fresh.url}` : "";
         if (freshKey === shownKey) return;
         try {

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -13,6 +13,16 @@ import {
 import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
 import { clockHHMM } from "./utils.js";
 
+/** True when an async open-PR refresh still matches the active cwd/branch. */
+export function shouldApplyOpenPrRefresh(
+  lastCtx: { cwd?: string } | null,
+  lastBranch: string | null,
+  refreshKey: string,
+): boolean {
+  if (!lastCtx || lastBranch == null) return false;
+  return `${lastCtx.cwd || ""}:${lastBranch}` === refreshKey;
+}
+
 export function registerStatusLine(
   pi: ExtensionAPI,
   IN_CONTAINER: boolean,
@@ -45,7 +55,10 @@ export function registerStatusLine(
     lastCtx = ctx;
     try {
       const b = getCurrentBranch(ctx.cwd);
-      if (!b) return;
+      if (!b) {
+        lastBranch = null;
+        return;
+      }
       lastBranch = b;
 
       const status = runGit(["status", "--porcelain"], ctx.cwd);
@@ -94,8 +107,7 @@ export function registerStatusLine(
       const refreshKey = `${ctx.cwd || ""}:${b}`;
       const shownKey = pr ? `${pr.number}\0${pr.url}` : "";
       void refreshOpenPr(ctx.cwd, b).then((fresh) => {
-        if (!lastCtx || lastBranch == null) return;
-        if (`${lastCtx.cwd || ""}:${lastBranch}` !== refreshKey) return;
+        if (!shouldApplyOpenPrRefresh(lastCtx, lastBranch, refreshKey)) return;
         const freshKey = fresh ? `${fresh.number}\0${fresh.url}` : "";
         if (freshKey === shownKey) return;
         try {

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -4,7 +4,12 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { hyperlink } from "@earendil-works/pi-tui";
-import { getCurrentBranch, getOpenPr, runGit } from "./git-helpers.js";
+import {
+  getCurrentBranch,
+  getOpenPr,
+  refreshOpenPr,
+  runGit,
+} from "./git-helpers.js";
 import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
 import { clockHHMM } from "./utils.js";
 
@@ -34,6 +39,7 @@ export function registerStatusLine(
   // ── Git branch status line ─────────────────────────────────────────────
 
   let lastCtx: any = null;
+  let openPrRefreshPending = false;
 
   const updateBranch = (_event: any, ctx: any) => {
     lastCtx = ctx;
@@ -71,6 +77,7 @@ export function registerStatusLine(
       let gitPart =
         changes.length > 0 ? `${icon} ${changes.join(" ")}` : icon;
 
+      // Sync cache only — never block the status path on `gh`.
       const pr = getOpenPr(ctx.cwd, b);
       if (pr) {
         const prLabel = ctx.ui.theme.fg(
@@ -81,6 +88,28 @@ export function registerStatusLine(
       }
 
       buildStatus(ctx, gitPart);
+
+      // One shared waiter — avoid N× updateBranch after coalesced gh resolve.
+      if (openPrRefreshPending) return;
+      openPrRefreshPending = true;
+      const shownKey = pr ? `${pr.number}\0${pr.url}` : "";
+      void refreshOpenPr(ctx.cwd, b)
+        .then((fresh) => {
+          const freshKey = fresh ? `${fresh.number}\0${fresh.url}` : "";
+          if (freshKey === shownKey) return;
+          if (!lastCtx) return;
+          try {
+            updateBranch(null, lastCtx);
+          } catch (e: any) {
+            console.debug(
+              "[status-line] open-PR refresh update failed:",
+              e?.message || e,
+            );
+          }
+        })
+        .finally(() => {
+          openPrRefreshPending = false;
+        });
     } catch (e: any) { console.debug("[status-line] git status update failed:", e?.message || e); }
   };
 

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -7,9 +7,8 @@ import { hyperlink } from "@earendil-works/pi-tui";
 import {
   getCurrentBranch,
   getOpenPr,
-  refreshOpenPr,
   runGit,
-  shouldApplyOpenPrRefresh,
+  scheduleOpenPrStatusRefresh,
 } from "./git-helpers.js";
 import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
 import { clockHHMM } from "./utils.js";
@@ -95,20 +94,12 @@ export function registerStatusLine(
       buildStatus(ctx, gitPart);
 
       // Per-key coalesce lives in refreshOpenPr — no global pending gate.
-      const refreshKey = `${ctx.cwd || ""}:${b}`;
-      const shownKey = pr ? `${pr.number}\0${pr.url}` : "";
-      void refreshOpenPr(ctx.cwd, b).then((fresh) => {
-        if (!shouldApplyOpenPrRefresh(lastCtx, lastBranch, refreshKey)) return;
-        const freshKey = fresh ? `${fresh.number}\0${fresh.url}` : "";
-        if (freshKey === shownKey) return;
-        try {
-          updateBranch(null, lastCtx);
-        } catch (e: any) {
-          console.debug(
-            "[status-line] open-PR refresh update failed:",
-            e?.message || e,
-          );
-        }
+      scheduleOpenPrStatusRefresh({
+        cwd: ctx.cwd,
+        branch: b,
+        shownPr: pr,
+        getState: () => ({ lastCtx, lastBranch }),
+        onRerender: (c) => updateBranch(null, c),
       });
     } catch (e: any) { console.debug("[status-line] git status update failed:", e?.message || e); }
   };

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -39,7 +39,6 @@ export function registerStatusLine(
   // ── Git branch status line ─────────────────────────────────────────────
 
   let lastCtx: any = null;
-  let openPrRefreshPending = false;
 
   const updateBranch = (_event: any, ctx: any) => {
     lastCtx = ctx;
@@ -89,27 +88,24 @@ export function registerStatusLine(
 
       buildStatus(ctx, gitPart);
 
-      // One shared waiter — avoid N× updateBranch after coalesced gh resolve.
-      if (openPrRefreshPending) return;
-      openPrRefreshPending = true;
+      // Per-key coalesce lives in refreshOpenPr — no global pending gate.
+      const refreshKey = `${ctx.cwd || ""}:${b}`;
       const shownKey = pr ? `${pr.number}\0${pr.url}` : "";
-      void refreshOpenPr(ctx.cwd, b)
-        .then((fresh) => {
-          const freshKey = fresh ? `${fresh.number}\0${fresh.url}` : "";
-          if (freshKey === shownKey) return;
-          if (!lastCtx) return;
-          try {
-            updateBranch(null, lastCtx);
-          } catch (e: any) {
-            console.debug(
-              "[status-line] open-PR refresh update failed:",
-              e?.message || e,
-            );
-          }
-        })
-        .finally(() => {
-          openPrRefreshPending = false;
-        });
+      void refreshOpenPr(ctx.cwd, b).then((fresh) => {
+        if (!lastCtx) return;
+        const curB = getCurrentBranch(lastCtx.cwd);
+        if (!curB || `${lastCtx.cwd || ""}:${curB}` !== refreshKey) return;
+        const freshKey = fresh ? `${fresh.number}\0${fresh.url}` : "";
+        if (freshKey === shownKey) return;
+        try {
+          updateBranch(null, lastCtx);
+        } catch (e: any) {
+          console.debug(
+            "[status-line] open-PR refresh update failed:",
+            e?.message || e,
+          );
+        }
+      });
     } catch (e: any) { console.debug("[status-line] git status update failed:", e?.message || e); }
   };
 

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -7,6 +7,7 @@ import { hyperlink } from "@earendil-works/pi-tui";
 import {
   getCurrentBranch,
   getOpenPr,
+  isGithubRepo,
   runGit,
   scheduleOpenPrStatusRefresh,
 } from "./git-helpers.js";
@@ -82,7 +83,9 @@ export function registerStatusLine(
         changes.length > 0 ? `${icon} ${changes.join(" ")}` : icon;
 
       // Sync cache only — never block the status path on `gh`.
-      const pr = getOpenPr(ctx.cwd, b);
+      // One isGithubRepo check for getOpenPr + refresh schedule.
+      const isGh = isGithubRepo(ctx.cwd);
+      const pr = isGh ? getOpenPr(ctx.cwd, b, { assumeGithub: true }) : null;
       if (pr) {
         const prLabel = ctx.ui.theme.fg(
           "accent",
@@ -94,13 +97,16 @@ export function registerStatusLine(
       buildStatus(ctx, gitPart);
 
       // Per-key coalesce lives in refreshOpenPr — no global pending gate.
-      scheduleOpenPrStatusRefresh({
-        cwd: ctx.cwd,
-        branch: b,
-        shownPr: pr,
-        getState: () => ({ lastCtx, lastBranch }),
-        onRerender: (c) => updateBranch(null, c),
-      });
+      if (isGh) {
+        scheduleOpenPrStatusRefresh({
+          cwd: ctx.cwd,
+          branch: b,
+          shownPr: pr,
+          getState: () => ({ lastCtx, lastBranch }),
+          onRerender: (c) => updateBranch(null, c),
+          assumeGithub: true,
+        });
+      }
     } catch (e: any) { console.debug("[status-line] git status update failed:", e?.message || e); }
   };
 

--- a/extensions/orchestrator/status-line.ts
+++ b/extensions/orchestrator/status-line.ts
@@ -9,19 +9,10 @@ import {
   getOpenPr,
   refreshOpenPr,
   runGit,
+  shouldApplyOpenPrRefresh,
 } from "./git-helpers.js";
 import { ICON_SEP, ICON_CONTAINER, ICON_GIT_CLEAN, ICON_GIT_DIRTY } from "./icons.js";
 import { clockHHMM } from "./utils.js";
-
-/** True when an async open-PR refresh still matches the active cwd/branch. */
-export function shouldApplyOpenPrRefresh(
-  lastCtx: { cwd?: string } | null,
-  lastBranch: string | null,
-  refreshKey: string,
-): boolean {
-  if (!lastCtx || lastBranch == null) return false;
-  return `${lastCtx.cwd || ""}:${lastBranch}` === refreshKey;
-}
 
 export function registerStatusLine(
   pi: ExtensionAPI,

--- a/extensions/pidash/pidash.ts
+++ b/extensions/pidash/pidash.ts
@@ -16,6 +16,7 @@ import * as path from "node:path";
 import { setupHeartbeat, setupReconnectPoller } from "../shared/ws-client.js";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { hyperlink } from "@earendil-works/pi-tui";
 // Command handler registry — standalone, populated via pi.events from other extensions
 const commandHandlerRegistry = new Map<string, (args: string, ctx: any) => Promise<void>>();
 import { checkHealth, ensureUiBuilt, spawnDaemon as spawnDaemonGeneric, killDaemon, createLogger } from "../shared/daemon-manager.js";
@@ -520,7 +521,8 @@ export function registerPidash(
         // Show status
         try {
           if (ctx.hasUI) {
-            ctx.ui.setStatus("9-pidash", ctx.ui.theme.fg("accent", `🌐 http://localhost:${pidashPort}`));
+            const link = hyperlink("pi-dash", `http://localhost:${pidashPort}`);
+            ctx.ui.setStatus("9-pidash", ctx.ui.theme.fg("accent", `🌐 ${link}`));
           }
         } catch {
           // ctx may be stale if session was replaced during WebSocket connect

--- a/extensions/pidiff/pidiff.ts
+++ b/extensions/pidiff/pidiff.ts
@@ -12,6 +12,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { createRequire } from "node:module";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { hyperlink } from "@earendil-works/pi-tui";
 import {
   createLogger,
   checkHealth,
@@ -84,7 +85,9 @@ export function registerPidiff(pi: ExtensionAPI): void {
   function setStatus(ctx: any): void {
     try {
       if (ctx?.hasUI && activePort) {
-        ctx.ui.setStatus("8-diff", ctx.ui.theme.fg("accent", `${ICON_DIFF} http://localhost:${activePort}`));
+        const link = hyperlink("pi-diff", `http://localhost:${activePort}`);
+        const label = ICON_DIFF ? `${ICON_DIFF} ${link}` : link;
+        ctx.ui.setStatus("8-diff", ctx.ui.theme.fg("accent", label));
       }
     } catch {
       // ctx may be stale if session was replaced during WebSocket connect

--- a/tests/node/orchestrator/git-helpers-open-pr.test.ts
+++ b/tests/node/orchestrator/git-helpers-open-pr.test.ts
@@ -146,16 +146,24 @@ describe("getOpenPr / refreshOpenPr", () => {
   });
 
   it("refreshOpenPr caches result for getOpenPr", async () => {
-    let nextNumber = 7;
-    setGhPrViewRunner(async () => openPrJson(nextNumber++));
+    setGhPrViewRunner(async () => openPrJson(7));
     const pr = await refreshOpenPr(repo, "main");
     assert.deepEqual(pr, {
       number: 7,
       url: "https://github.com/org/repo/pull/7",
     });
     assert.deepEqual(getOpenPr(repo, "main"), pr);
-    const again = await refreshOpenPr(repo, "main");
-    assert.equal(again?.number, 7, "TTL hit must reuse cached PR");
+  });
+
+  it("refreshOpenPr reuses cached PR within TTL", async () => {
+    let nextNumber = 7;
+    setGhPrViewRunner(async () => openPrJson(nextNumber++));
+    assert.equal((await refreshOpenPr(repo, "main"))?.number, 7);
+    assert.equal(
+      (await refreshOpenPr(repo, "main"))?.number,
+      7,
+      "TTL hit must reuse cached PR",
+    );
   });
 
   it("coalesces concurrent refreshOpenPr calls", async () => {

--- a/tests/node/orchestrator/git-helpers-open-pr.test.ts
+++ b/tests/node/orchestrator/git-helpers-open-pr.test.ts
@@ -17,8 +17,17 @@ import {
   setGhPrViewRunner,
 } from "../../../extensions/orchestrator/git-helpers.js";
 
+const {
+  GIT_DIR: _GIT_DIR,
+  GIT_WORK_TREE: _GIT_WORK_TREE,
+  GIT_INDEX_FILE: _GIT_INDEX_FILE,
+  GIT_COMMON_DIR: _GIT_COMMON_DIR,
+  GIT_CEILING_DIRECTORIES: _GIT_CEILING_DIRECTORIES,
+  ...baseEnv
+} = process.env;
+
 const GIT_ENV = {
-  ...process.env,
+  ...baseEnv,
   GIT_AUTHOR_NAME: "test",
   GIT_AUTHOR_EMAIL: "test@example.com",
   GIT_COMMITTER_NAME: "test",
@@ -116,12 +125,10 @@ describe("clearOpenPrCache", () => {
 
 describe("getOpenPr / refreshOpenPr", () => {
   let repo: string;
-  let ghCalls: number;
 
   beforeEach(() => {
     clearOpenPrCache();
     setGhPrViewRunner(null);
-    ghCalls = 0;
     repo = initGithubRepo();
   });
 
@@ -133,27 +140,22 @@ describe("getOpenPr / refreshOpenPr", () => {
 
   it("returns null from empty cache without calling gh", () => {
     setGhPrViewRunner(async () => {
-      ghCalls++;
-      return openPrJson(1);
+      throw new Error("gh should not run for sync getOpenPr");
     });
     assert.equal(getOpenPr(repo, "main"), null);
-    assert.equal(ghCalls, 0);
   });
 
   it("refreshOpenPr caches result for getOpenPr", async () => {
-    setGhPrViewRunner(async () => {
-      ghCalls++;
-      return openPrJson(7);
-    });
+    let nextNumber = 7;
+    setGhPrViewRunner(async () => openPrJson(nextNumber++));
     const pr = await refreshOpenPr(repo, "main");
     assert.deepEqual(pr, {
       number: 7,
       url: "https://github.com/org/repo/pull/7",
     });
-    assert.equal(ghCalls, 1);
     assert.deepEqual(getOpenPr(repo, "main"), pr);
-    await refreshOpenPr(repo, "main");
-    assert.equal(ghCalls, 1, "TTL hit must not re-call gh");
+    const again = await refreshOpenPr(repo, "main");
+    assert.equal(again?.number, 7, "TTL hit must reuse cached PR");
   });
 
   it("coalesces concurrent refreshOpenPr calls", async () => {
@@ -161,29 +163,29 @@ describe("getOpenPr / refreshOpenPr", () => {
     const gate = new Promise<string>((r) => {
       resolveGh = r;
     });
-    setGhPrViewRunner(async () => {
-      ghCalls++;
-      return gate;
-    });
+    setGhPrViewRunner(async () => gate);
     const a = refreshOpenPr(repo, "main");
     const b = refreshOpenPr(repo, "main");
     resolveGh(openPrJson(9));
     const [pa, pb] = await Promise.all([a, b]);
-    assert.equal(ghCalls, 1);
     assert.deepEqual(pa, pb);
     assert.equal(pa?.number, 9);
   });
 
   it("refreshOpenPr stores null on gh failure", async () => {
+    let shouldFail = true;
     setGhPrViewRunner(async () => {
-      ghCalls++;
-      throw new Error("gh failed");
+      if (shouldFail) throw new Error("gh failed");
+      return openPrJson(1);
     });
     assert.equal(await refreshOpenPr(repo, "main"), null);
     assert.equal(getOpenPr(repo, "main"), null);
-    assert.equal(ghCalls, 1);
-    await refreshOpenPr(repo, "main");
-    assert.equal(ghCalls, 1, "null result still cached for TTL");
+    shouldFail = false;
+    assert.equal(
+      await refreshOpenPr(repo, "main"),
+      null,
+      "null result still cached for TTL",
+    );
   });
 
   it("returns stale cache until refresh completes", async () => {
@@ -193,12 +195,8 @@ describe("getOpenPr / refreshOpenPr", () => {
     });
     assert.equal(getOpenPr(repo, "main")?.number, 3);
 
-    setGhPrViewRunner(async () => {
-      ghCalls++;
-      return openPrJson(4);
-    });
+    setGhPrViewRunner(async () => openPrJson(4));
     const fresh = await refreshOpenPr(repo, "main");
-    assert.equal(ghCalls, 1);
     assert.equal(fresh?.number, 4);
     assert.equal(getOpenPr(repo, "main")?.number, 4);
   });

--- a/tests/node/orchestrator/git-helpers-open-pr.test.ts
+++ b/tests/node/orchestrator/git-helpers-open-pr.test.ts
@@ -2,20 +2,61 @@
  * Tests for open-PR parsing / cache helpers used by the status line.
  * Run with: npx tsx --test tests/node/orchestrator/git-helpers-open-pr.test.ts
  */
-import { describe, it, beforeEach } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 import {
   clearOpenPrCache,
+  getOpenPr,
   parseOpenPrJson,
+  refreshOpenPr,
+  seedOpenPrCacheForTests,
+  setGhPrViewRunner,
 } from "../../../extensions/orchestrator/git-helpers.js";
 
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@example.com",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@example.com",
+};
+
+function initGithubRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "open-pr-"));
+  execFileSync("git", ["init", "-b", "main"], {
+    cwd: dir,
+    stdio: "ignore",
+    env: GIT_ENV,
+  });
+  execFileSync("git", ["commit", "--allow-empty", "-m", "init"], {
+    cwd: dir,
+    stdio: "ignore",
+    env: GIT_ENV,
+  });
+  execFileSync(
+    "git",
+    ["remote", "add", "origin", "https://github.com/org/repo.git"],
+    { cwd: dir, stdio: "ignore", env: GIT_ENV },
+  );
+  return dir;
+}
+
+function openPrJson(
+  number: number,
+  url = `https://github.com/org/repo/pull/${number}`,
+  state = "OPEN",
+): string {
+  return JSON.stringify({ number, url, state });
+}
+
 describe("parseOpenPrJson", () => {
-  it("parses number and url", () => {
+  it("parses valid open PR", () => {
     const pr = parseOpenPrJson(
-      JSON.stringify({
-        number: 42,
-        url: "https://github.com/org/repo/pull/42",
-      }),
+      openPrJson(42, "https://github.com/org/repo/pull/42"),
     );
     assert.deepEqual(pr, {
       number: 42,
@@ -26,7 +67,36 @@ describe("parseOpenPrJson", () => {
   it("returns null for missing fields", () => {
     assert.equal(parseOpenPrJson(JSON.stringify({ number: 1 })), null);
     assert.equal(parseOpenPrJson(JSON.stringify({ url: "https://x" })), null);
-    assert.equal(parseOpenPrJson(JSON.stringify({ number: 1, url: "" })), null);
+    assert.equal(
+      parseOpenPrJson(JSON.stringify({ number: 1, url: "", state: "OPEN" })),
+      null,
+    );
+  });
+
+  it("returns null for closed or merged state", () => {
+    assert.equal(
+      parseOpenPrJson(openPrJson(1, "https://github.com/org/repo/pull/1", "CLOSED")),
+      null,
+    );
+    assert.equal(
+      parseOpenPrJson(openPrJson(1, "https://github.com/org/repo/pull/1", "MERGED")),
+      null,
+    );
+  });
+
+  it("returns null for unsafe url or non-integer number", () => {
+    assert.equal(
+      parseOpenPrJson(
+        JSON.stringify({ number: 1.5, url: "https://github.com/o/r/pull/1", state: "OPEN" }),
+      ),
+      null,
+    );
+    assert.equal(
+      parseOpenPrJson(
+        JSON.stringify({ number: 1, url: "javascript:alert(1)", state: "OPEN" }),
+      ),
+      null,
+    );
   });
 
   it("returns null for invalid JSON", () => {
@@ -41,5 +111,95 @@ describe("clearOpenPrCache", () => {
 
   it("is safe to call when empty", () => {
     clearOpenPrCache();
+  });
+});
+
+describe("getOpenPr / refreshOpenPr", () => {
+  let repo: string;
+  let ghCalls: number;
+
+  beforeEach(() => {
+    clearOpenPrCache();
+    setGhPrViewRunner(null);
+    ghCalls = 0;
+    repo = initGithubRepo();
+  });
+
+  afterEach(() => {
+    setGhPrViewRunner(null);
+    clearOpenPrCache();
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("returns null from empty cache without calling gh", () => {
+    setGhPrViewRunner(async () => {
+      ghCalls++;
+      return openPrJson(1);
+    });
+    assert.equal(getOpenPr(repo, "main"), null);
+    assert.equal(ghCalls, 0);
+  });
+
+  it("refreshOpenPr caches result for getOpenPr", async () => {
+    setGhPrViewRunner(async () => {
+      ghCalls++;
+      return openPrJson(7);
+    });
+    const pr = await refreshOpenPr(repo, "main");
+    assert.deepEqual(pr, {
+      number: 7,
+      url: "https://github.com/org/repo/pull/7",
+    });
+    assert.equal(ghCalls, 1);
+    assert.deepEqual(getOpenPr(repo, "main"), pr);
+    await refreshOpenPr(repo, "main");
+    assert.equal(ghCalls, 1, "TTL hit must not re-call gh");
+  });
+
+  it("coalesces concurrent refreshOpenPr calls", async () => {
+    let resolveGh!: (v: string) => void;
+    const gate = new Promise<string>((r) => {
+      resolveGh = r;
+    });
+    setGhPrViewRunner(async () => {
+      ghCalls++;
+      return gate;
+    });
+    const a = refreshOpenPr(repo, "main");
+    const b = refreshOpenPr(repo, "main");
+    resolveGh(openPrJson(9));
+    const [pa, pb] = await Promise.all([a, b]);
+    assert.equal(ghCalls, 1);
+    assert.deepEqual(pa, pb);
+    assert.equal(pa?.number, 9);
+  });
+
+  it("refreshOpenPr stores null on gh failure", async () => {
+    setGhPrViewRunner(async () => {
+      ghCalls++;
+      throw new Error("gh failed");
+    });
+    assert.equal(await refreshOpenPr(repo, "main"), null);
+    assert.equal(getOpenPr(repo, "main"), null);
+    assert.equal(ghCalls, 1);
+    await refreshOpenPr(repo, "main");
+    assert.equal(ghCalls, 1, "null result still cached for TTL");
+  });
+
+  it("returns stale cache until refresh completes", async () => {
+    seedOpenPrCacheForTests(repo, "main", {
+      at: Date.now() - 60_000,
+      pr: { number: 3, url: "https://github.com/org/repo/pull/3" },
+    });
+    assert.equal(getOpenPr(repo, "main")?.number, 3);
+
+    setGhPrViewRunner(async () => {
+      ghCalls++;
+      return openPrJson(4);
+    });
+    const fresh = await refreshOpenPr(repo, "main");
+    assert.equal(ghCalls, 1);
+    assert.equal(fresh?.number, 4);
+    assert.equal(getOpenPr(repo, "main")?.number, 4);
   });
 });

--- a/tests/node/orchestrator/git-helpers-open-pr.test.ts
+++ b/tests/node/orchestrator/git-helpers-open-pr.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for open-PR parsing / cache helpers used by the status line.
+ * Run with: npx tsx --test tests/node/orchestrator/git-helpers-open-pr.test.ts
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  clearOpenPrCache,
+  parseOpenPrJson,
+} from "../../../extensions/orchestrator/git-helpers.js";
+
+describe("parseOpenPrJson", () => {
+  it("parses number and url", () => {
+    const pr = parseOpenPrJson(
+      JSON.stringify({
+        number: 42,
+        url: "https://github.com/org/repo/pull/42",
+      }),
+    );
+    assert.deepEqual(pr, {
+      number: 42,
+      url: "https://github.com/org/repo/pull/42",
+    });
+  });
+
+  it("returns null for missing fields", () => {
+    assert.equal(parseOpenPrJson(JSON.stringify({ number: 1 })), null);
+    assert.equal(parseOpenPrJson(JSON.stringify({ url: "https://x" })), null);
+    assert.equal(parseOpenPrJson(JSON.stringify({ number: 1, url: "" })), null);
+  });
+
+  it("returns null for invalid JSON", () => {
+    assert.equal(parseOpenPrJson("not-json"), null);
+  });
+});
+
+describe("clearOpenPrCache", () => {
+  beforeEach(() => {
+    clearOpenPrCache();
+  });
+
+  it("is safe to call when empty", () => {
+    clearOpenPrCache();
+  });
+});

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { shouldApplyOpenPrRefresh } from "../../../extensions/orchestrator/status-line.js";
+import { shouldApplyOpenPrRefresh } from "../../../extensions/orchestrator/git-helpers.js";
 
 describe("shouldApplyOpenPrRefresh", () => {
   it("returns false when lastCtx is missing", () => {

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -2,9 +2,10 @@
  * Tests for status-line open-PR refresh callback wiring.
  * Run with: npx tsx --test tests/node/orchestrator/status-line-open-pr-refresh.test.ts
  */
-import { describe, it } from "node:test";
+import { describe, it, beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import {
+  clearOpenPrCache,
   decideOpenPrRefreshRerender,
   scheduleOpenPrStatusRefresh,
   shouldApplyOpenPrRefresh,
@@ -93,6 +94,10 @@ describe("decideOpenPrRefreshRerender", () => {
 });
 
 describe("scheduleOpenPrStatusRefresh", () => {
+  beforeEach(() => {
+    clearOpenPrCache();
+  });
+
   it("rerenders when refresh returns a new PR on same branch", async () => {
     let rerenders = 0;
     const ctx = { cwd: "/repo" };
@@ -192,5 +197,30 @@ describe("scheduleOpenPrStatusRefresh", () => {
     } finally {
       console.debug = orig;
     }
+  });
+
+  it("registers one callback while refresh in flight", async () => {
+    let resolve!: (v: OpenPr | null) => void;
+    const pending = new Promise<OpenPr | null>((r) => {
+      resolve = r;
+    });
+    let rerenders = 0;
+    const ctx = { cwd: "/repo" };
+    const opts = {
+      cwd: "/repo",
+      branch: "main",
+      shownPr: null as OpenPr | null,
+      getState: () => ({ lastCtx: ctx, lastBranch: "main" as string | null }),
+      onRerender: () => {
+        rerenders++;
+      },
+      refresh: async () => pending,
+    };
+    scheduleOpenPrStatusRefresh(opts);
+    scheduleOpenPrStatusRefresh(opts);
+    scheduleOpenPrStatusRefresh(opts);
+    resolve({ number: 8, url: "https://github.com/org/repo/pull/8" });
+    await new Promise((r) => setImmediate(r));
+    assert.equal(rerenders, 1);
   });
 });

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -253,35 +253,47 @@ describe("scheduleOpenPrStatusRefresh", () => {
 
   it("clears pending gate when refresh rejects", async () => {
     let calls = 0;
-    scheduleOpenPrStatusRefresh({
-      cwd: "/repo",
-      branch: "bug",
-      shownPr: null,
-      getState: () => ({
-        lastCtx: { cwd: "/repo" },
-        lastBranch: "bug",
-      }),
-      onRerender: () => {},
-      refresh: async () => {
-        throw new Error("async boom");
-      },
-    });
-    await new Promise((r) => setImmediate(r));
-    scheduleOpenPrStatusRefresh({
-      cwd: "/repo",
-      branch: "bug",
-      shownPr: null,
-      getState: () => ({
-        lastCtx: { cwd: "/repo" },
-        lastBranch: "bug",
-      }),
-      onRerender: () => {},
-      refresh: async () => {
-        calls++;
-        return null;
-      },
-    });
-    await new Promise((r) => setImmediate(r));
-    assert.equal(calls, 1);
+    let sawDebug = false;
+    const orig = console.debug;
+    console.debug = (...args: unknown[]) => {
+      if (String(args[0]).includes("open-PR refresh failed")) {
+        sawDebug = true;
+      }
+    };
+    try {
+      scheduleOpenPrStatusRefresh({
+        cwd: "/repo",
+        branch: "bug",
+        shownPr: null,
+        getState: () => ({
+          lastCtx: { cwd: "/repo" },
+          lastBranch: "bug",
+        }),
+        onRerender: () => {},
+        refresh: async () => {
+          throw new Error("async boom");
+        },
+      });
+      await new Promise((r) => setImmediate(r));
+      assert.equal(sawDebug, true);
+      scheduleOpenPrStatusRefresh({
+        cwd: "/repo",
+        branch: "bug",
+        shownPr: null,
+        getState: () => ({
+          lastCtx: { cwd: "/repo" },
+          lastBranch: "bug",
+        }),
+        onRerender: () => {},
+        refresh: async () => {
+          calls++;
+          return null;
+        },
+      });
+      await new Promise((r) => setImmediate(r));
+      assert.equal(calls, 1);
+    } finally {
+      console.debug = orig;
+    }
   });
 });

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -223,4 +223,65 @@ describe("scheduleOpenPrStatusRefresh", () => {
     await new Promise((r) => setImmediate(r));
     assert.equal(rerenders, 1);
   });
+
+  it("clears pending gate when refresh throws sync", async () => {
+    let calls = 0;
+    const opts = {
+      cwd: "/repo",
+      branch: "feat",
+      shownPr: null as OpenPr | null,
+      getState: () => ({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "feat" as string | null,
+      }),
+      onRerender: () => {},
+      refresh: (() => {
+        throw new Error("sync boom");
+      }) as any,
+    };
+    scheduleOpenPrStatusRefresh(opts);
+    scheduleOpenPrStatusRefresh({
+      ...opts,
+      refresh: async () => {
+        calls++;
+        return { number: 9, url: "https://github.com/org/repo/pull/9" };
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    assert.equal(calls, 1);
+  });
+
+  it("clears pending gate when refresh rejects", async () => {
+    let calls = 0;
+    scheduleOpenPrStatusRefresh({
+      cwd: "/repo",
+      branch: "bug",
+      shownPr: null,
+      getState: () => ({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "bug",
+      }),
+      onRerender: () => {},
+      refresh: async () => {
+        throw new Error("async boom");
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    scheduleOpenPrStatusRefresh({
+      cwd: "/repo",
+      branch: "bug",
+      shownPr: null,
+      getState: () => ({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "bug",
+      }),
+      onRerender: () => {},
+      refresh: async () => {
+        calls++;
+        return null;
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    assert.equal(calls, 1);
+  });
 });

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -161,4 +161,36 @@ describe("scheduleOpenPrStatusRefresh", () => {
     await new Promise((r) => setImmediate(r));
     assert.equal(rerenders, 0);
   });
+
+  it("swallows onRerender errors without rejecting", async () => {
+    let sawDebug = false;
+    const orig = console.debug;
+    console.debug = (...args: unknown[]) => {
+      if (String(args[0] || "").includes("open-PR refresh update failed")) {
+        sawDebug = true;
+      }
+    };
+    try {
+      scheduleOpenPrStatusRefresh({
+        cwd: "/repo",
+        branch: "main",
+        shownPr: null,
+        getState: () => ({
+          lastCtx: { cwd: "/repo" },
+          lastBranch: "main",
+        }),
+        onRerender: () => {
+          throw new Error("boom");
+        },
+        refresh: async () => ({
+          number: 5,
+          url: "https://github.com/org/repo/pull/5",
+        }),
+      });
+      await new Promise((r) => setImmediate(r));
+      assert.equal(sawDebug, true);
+    } finally {
+      console.debug = orig;
+    }
+  });
 });

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for open-PR refresh staleness guard used by the status line.
+ * Run with: npx tsx --test tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { shouldApplyOpenPrRefresh } from "../../../extensions/orchestrator/status-line.js";
+
+describe("shouldApplyOpenPrRefresh", () => {
+  it("returns false when lastCtx is missing", () => {
+    assert.equal(shouldApplyOpenPrRefresh(null, "main", "/repo:main"), false);
+  });
+
+  it("returns false when lastBranch is null", () => {
+    assert.equal(
+      shouldApplyOpenPrRefresh({ cwd: "/repo" }, null, "/repo:main"),
+      false,
+    );
+  });
+
+  it("returns false after branch switch", () => {
+    assert.equal(
+      shouldApplyOpenPrRefresh({ cwd: "/repo" }, "feat", "/repo:main"),
+      false,
+    );
+  });
+
+  it("returns false after cwd switch", () => {
+    assert.equal(
+      shouldApplyOpenPrRefresh({ cwd: "/other" }, "main", "/repo:main"),
+      false,
+    );
+  });
+
+  it("returns true when cwd and branch still match", () => {
+    assert.equal(
+      shouldApplyOpenPrRefresh({ cwd: "/repo" }, "main", "/repo:main"),
+      true,
+    );
+  });
+});

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -253,47 +253,35 @@ describe("scheduleOpenPrStatusRefresh", () => {
 
   it("clears pending gate when refresh rejects", async () => {
     let calls = 0;
-    let sawDebug = false;
-    const orig = console.debug;
-    console.debug = (...args: unknown[]) => {
-      if (String(args[0]).includes("open-PR refresh failed")) {
-        sawDebug = true;
-      }
-    };
-    try {
-      scheduleOpenPrStatusRefresh({
-        cwd: "/repo",
-        branch: "bug",
-        shownPr: null,
-        getState: () => ({
-          lastCtx: { cwd: "/repo" },
-          lastBranch: "bug",
-        }),
-        onRerender: () => {},
-        refresh: async () => {
-          throw new Error("async boom");
-        },
-      });
-      await new Promise((r) => setImmediate(r));
-      assert.equal(sawDebug, true);
-      scheduleOpenPrStatusRefresh({
-        cwd: "/repo",
-        branch: "bug",
-        shownPr: null,
-        getState: () => ({
-          lastCtx: { cwd: "/repo" },
-          lastBranch: "bug",
-        }),
-        onRerender: () => {},
-        refresh: async () => {
-          calls++;
-          return null;
-        },
-      });
-      await new Promise((r) => setImmediate(r));
-      assert.equal(calls, 1);
-    } finally {
-      console.debug = orig;
-    }
+    scheduleOpenPrStatusRefresh({
+      cwd: "/repo",
+      branch: "bug",
+      shownPr: null,
+      getState: () => ({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "bug",
+      }),
+      onRerender: () => {},
+      refresh: async () => {
+        throw new Error("async boom");
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    scheduleOpenPrStatusRefresh({
+      cwd: "/repo",
+      branch: "bug",
+      shownPr: null,
+      getState: () => ({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "bug",
+      }),
+      onRerender: () => {},
+      refresh: async () => {
+        calls++;
+        return null;
+      },
+    });
+    await new Promise((r) => setImmediate(r));
+    assert.equal(calls, 1);
   });
 });

--- a/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
+++ b/tests/node/orchestrator/status-line-open-pr-refresh.test.ts
@@ -1,10 +1,15 @@
 /**
- * Tests for open-PR refresh staleness guard used by the status line.
+ * Tests for status-line open-PR refresh callback wiring.
  * Run with: npx tsx --test tests/node/orchestrator/status-line-open-pr-refresh.test.ts
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { shouldApplyOpenPrRefresh } from "../../../extensions/orchestrator/git-helpers.js";
+import {
+  decideOpenPrRefreshRerender,
+  scheduleOpenPrStatusRefresh,
+  shouldApplyOpenPrRefresh,
+  type OpenPr,
+} from "../../../extensions/orchestrator/git-helpers.js";
 
 describe("shouldApplyOpenPrRefresh", () => {
   it("returns false when lastCtx is missing", () => {
@@ -37,5 +42,123 @@ describe("shouldApplyOpenPrRefresh", () => {
       shouldApplyOpenPrRefresh({ cwd: "/repo" }, "main", "/repo:main"),
       true,
     );
+  });
+});
+
+describe("decideOpenPrRefreshRerender", () => {
+  const pr = (n: number): OpenPr => ({
+    number: n,
+    url: `https://github.com/org/repo/pull/${n}`,
+  });
+
+  it("skips when refresh key no longer matches", () => {
+    assert.equal(
+      decideOpenPrRefreshRerender({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "feat",
+        refreshKey: "/repo:main",
+        shownKey: "",
+        fresh: pr(1),
+      }),
+      "skip",
+    );
+  });
+
+  it("skips when fresh PR matches already shown PR", () => {
+    const shown = pr(7);
+    assert.equal(
+      decideOpenPrRefreshRerender({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "main",
+        refreshKey: "/repo:main",
+        shownKey: `${shown.number}\0${shown.url}`,
+        fresh: shown,
+      }),
+      "skip",
+    );
+  });
+
+  it("rerenders when fresh PR differs from shown", () => {
+    assert.equal(
+      decideOpenPrRefreshRerender({
+        lastCtx: { cwd: "/repo" },
+        lastBranch: "main",
+        refreshKey: "/repo:main",
+        shownKey: "",
+        fresh: pr(9),
+      }),
+      "rerender",
+    );
+  });
+});
+
+describe("scheduleOpenPrStatusRefresh", () => {
+  it("rerenders when refresh returns a new PR on same branch", async () => {
+    let rerenders = 0;
+    const ctx = { cwd: "/repo" };
+    let lastBranch: string | null = "main";
+    scheduleOpenPrStatusRefresh({
+      cwd: "/repo",
+      branch: "main",
+      shownPr: null,
+      getState: () => ({ lastCtx: ctx, lastBranch }),
+      onRerender: () => {
+        rerenders++;
+      },
+      refresh: async () => ({
+        number: 3,
+        url: "https://github.com/org/repo/pull/3",
+      }),
+    });
+    await new Promise((r) => setImmediate(r));
+    assert.equal(rerenders, 1);
+  });
+
+  it("skips rerender after branch switch during refresh", async () => {
+    let resolve!: (v: OpenPr | null) => void;
+    const pending = new Promise<OpenPr | null>((r) => {
+      resolve = r;
+    });
+    let rerenders = 0;
+    const ctx = { cwd: "/repo" };
+    let lastBranch: string | null = "main";
+    scheduleOpenPrStatusRefresh({
+      cwd: "/repo",
+      branch: "main",
+      shownPr: null,
+      getState: () => ({ lastCtx: ctx, lastBranch }),
+      onRerender: () => {
+        rerenders++;
+      },
+      refresh: async () => pending,
+    });
+    lastBranch = "other";
+    resolve({ number: 3, url: "https://github.com/org/repo/pull/3" });
+    await new Promise((r) => setImmediate(r));
+    assert.equal(rerenders, 0);
+  });
+
+  it("skips rerender when lastBranch cleared to null", async () => {
+    let resolve!: (v: OpenPr | null) => void;
+    const pending = new Promise<OpenPr | null>((r) => {
+      resolve = r;
+    });
+    let rerenders = 0;
+    const ctx = { cwd: "/repo" };
+    let lastBranch: string | null = "main";
+    scheduleOpenPrStatusRefresh({
+      cwd: "/repo",
+      branch: "main",
+      shownPr: null,
+      getState: () => ({ lastCtx: ctx, lastBranch }),
+      onRerender: () => {
+        rerenders++;
+      },
+      refresh: async () => pending,
+    });
+    lastBranch = null;
+    resolve({ number: 3, url: "https://github.com/org/repo/pull/3" });
+    await new Promise((r) => setImmediate(r));
+    assert.equal(rerenders, 0);
   });
 });


### PR DESCRIPTION
## Summary
- Replace raw localhost URLs in the status line with OSC 8 clickable `pi-diff` / `pi-dash` labels
- Append a clickable `#N` after git status when the current branch has an open PR (`gh pr view`, 30s cache)
- Document the status-line behavior in the README and add unit tests for open-PR JSON parsing

## Test plan
- [ ] Start a pi TUI session with pidash/pidiff enabled; confirm status shows `pi-dash` / `pi-diff` (not full URLs) and clicking opens the local pages
- [ ] On a branch with an open PR, confirm `#N` appears after git status and opens the PR URL
- [ ] On a branch with no PR, confirm no `#N` segment appears
- [ ] `npx tsx --test tests/node/**/*.test.ts`
- [ ] `prek run --all-files`


Made with [Cursor](https://cursor.com)