### PR TITLE
fix(acpx): restore acpx dep and harden cli_agents load

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ uv tool upgrade myk-pi-tools      # CLI tool
 ```
 
 After updating, run `/reload` in pi or restart pi to pick up changes.
+Refresh the global agent package after acpx-provider / cli-provider / settings
+changes so `~/.pi` is not a mixed checkout (see issue #651).
 
 ## Usage
 

--- a/dev-docs/async-internals.md
+++ b/dev-docs/async-internals.md
@@ -23,7 +23,8 @@ Settings: `acpx_agents`, `cli_agents`, `async_llm_provider` + `async_llm_model` 
 **acpx runtime resolution:** `extensions/acpx-provider/load-runtime.ts` prefers a
 global `npm install -g acpx`, then falls back to the package-local `acpx`
 dependency (required so plain `pi` / `~/.pi` installs can `import("acpx/runtime")`).
-Package dep range is intentionally `"*"` (latest always; see issue #651).
+Package dep range is `">=0.12.0 <1"` (latest within acpx 0.x; see issue #651).
+Not `^0.8.0` (that stays on 0.8.x under 0.x caret rules).
 
 **Meta invocations:** `isPiMetaInvocation()` (`extensions/orchestrator/utils.ts`)
 skips acpx/cli provider discovery on `pi --help` / `--version` (`-h` / `-v`).

--- a/dev-docs/async-internals.md
+++ b/dev-docs/async-internals.md
@@ -23,6 +23,7 @@ Settings: `acpx_agents`, `cli_agents`, `async_llm_provider` + `async_llm_model` 
 **acpx runtime resolution:** `extensions/acpx-provider/load-runtime.ts` prefers a
 global `npm install -g acpx`, then falls back to the package-local `acpx`
 dependency (required so plain `pi` / `~/.pi` installs can `import("acpx/runtime")`).
+Package dep range is intentionally `"*"` (latest always; see issue #651).
 
 **Meta invocations:** `isPiMetaInvocation()` (`extensions/orchestrator/utils.ts`)
 skips acpx/cli provider discovery on `pi --help` / `--version` (`-h` / `-v`).

--- a/dev-docs/async-internals.md
+++ b/dev-docs/async-internals.md
@@ -24,6 +24,9 @@ Settings: `acpx_agents`, `cli_agents`, `async_llm_provider` + `async_llm_model` 
 global `npm install -g acpx`, then falls back to the package-local `acpx`
 dependency (required so plain `pi` / `~/.pi` installs can `import("acpx/runtime")`).
 
+**Meta invocations:** `isPiMetaInvocation()` (`extensions/orchestrator/utils.ts`)
+skips acpx/cli provider discovery on `pi --help` / `--version` (`-h` / `-v`).
+
 **Code-enforced (not prompt-only):**
 
 - `subagent-tool.ts` — coerce / sidecar / skip via `decideAsyncLlmDispatch`

--- a/dev-docs/async-internals.md
+++ b/dev-docs/async-internals.md
@@ -20,6 +20,10 @@ provider **does not load** in those children (nested `cursor-agent` hangs), so a
 Module: `extensions/orchestrator/async-capability.ts`  
 Settings: `acpx_agents`, `cli_agents`, `async_llm_provider` + `async_llm_model` (see `dev-docs/project-settings.md`, `dev-docs/cli-provider.md`)
 
+**acpx runtime resolution:** `extensions/acpx-provider/load-runtime.ts` prefers a
+global `npm install -g acpx`, then falls back to the package-local `acpx`
+dependency (required so plain `pi` / `~/.pi` installs can `import("acpx/runtime")`).
+
 **Code-enforced (not prompt-only):**
 
 - `subagent-tool.ts` — coerce / sidecar / skip via `decideAsyncLlmDispatch`

--- a/dev-docs/cli-provider.md
+++ b/dev-docs/cli-provider.md
@@ -29,6 +29,10 @@ Empty / unset → extension registers nothing.
 6. Start session reaper (30m idle / 5m sweep) for `~/.pi/cli-sessions/`
 7. On `session_shutdown`: stop reaper, clear in-memory state (disk markers kept for reload resume)
 
+`pi --help` / `pi --version` (and `-h` / `-v`) still load extensions; both
+`cli-provider` and `acpx-provider` early-return via `isPiMetaInvocation()` so
+they do not run model discovery for meta invocations.
+
 ## Model discovery (CLI only)
 
 | Agent | How models are discovered |

--- a/dev-docs/cli-provider.md
+++ b/dev-docs/cli-provider.md
@@ -16,6 +16,9 @@ Registers real CLI tools as pi providers under the `cli-*` namespace, parallel t
 
 Empty / unset → extension registers nothing.
 
+`cli_agents` is coerced with `asStringArray` before `.filter` so a stale/mismatched
+`getSetting` (non-array) cannot crash extension load (issue #651).
+
 ## Load flow (matches acpx-provider)
 
 1. Read `cli_agents` at extension load

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -33,6 +33,7 @@ import os from "node:os";
 import { randomUUID, createHash } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
+import { isPiMetaInvocation } from "../orchestrator/utils.js";
 import { loadAcpxRuntime } from "./load-runtime.js";
 
 // =============================================================================
@@ -544,6 +545,8 @@ export default async function (pi: ExtensionAPI) {
 	// Subagents don't need acpx providers — they use the parent's model via --model flag.
 	// Without this guard, cursor-agent spawns as a child and prevents the subagent from exiting.
 	if (process.env.PI_SUBAGENT_CHILD === "1") return;
+	// pi --help / --version still loads extensions; skip discovery noise/latency.
+	if (isPiMetaInvocation()) return;
 
 	// Suppress noisy ACP SDK errors for unhandled agent extension methods
 	installConsoleErrorSuppression();

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -32,14 +32,14 @@ import path from "node:path";
 import os from "node:os";
 import { randomUUID, createHash } from "node:crypto";
 import { rm } from "node:fs/promises";
-import { getSetting } from "../orchestrator/project-settings.js";
+import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
 import { loadAcpxRuntime } from "./load-runtime.js";
 
 // =============================================================================
 // Types
 // =============================================================================
 
-// Runtime types come from the globally installed acpx package (see load-runtime.ts).
+// Runtime types from acpx (global install or package dependency — see load-runtime.ts).
 type AcpxRuntimeModule = Awaited<ReturnType<typeof loadAcpxRuntime>>;
 type AcpxRuntime = ReturnType<AcpxRuntimeModule["createAcpRuntime"]>;
 type AcpRuntimeHandle = Awaited<ReturnType<AcpxRuntime["ensureSession"]>>;
@@ -553,7 +553,8 @@ export default async function (pi: ExtensionAPI) {
 	projectCwd = process.cwd();
 	projectCwdSlug = createHash("sha256").update(projectCwd).digest("hex").slice(0, 12);
 
-	const agentList = getSetting(projectCwd, "acpx_agents");
+	// Defensive: stale/mismatched getSetting may return non-array (issue #651).
+	const agentList = asStringArray(getSetting(projectCwd, "acpx_agents"));
 
 	registeredAgents = agentList;
 

--- a/extensions/acpx-provider/load-runtime.ts
+++ b/extensions/acpx-provider/load-runtime.ts
@@ -1,6 +1,6 @@
 /**
- * Load acpx/runtime from the global npm install (entrypoint: npm install -g acpx).
- * Package-local node_modules is not the source of truth.
+ * Load acpx/runtime: prefer a global `npm install -g acpx`, then fall back to the
+ * package-local `acpx` dependency (required for plain `pi` / ~/.pi package installs).
  */
 
 import { createRequire } from "node:module";
@@ -10,7 +10,7 @@ import { pathToFileURL } from "node:url";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 
-/** Minimal surface used by acpx-provider (avoids depending on package-local acpx). */
+/** Minimal surface used by acpx-provider. */
 export type AcpxRuntimeModule = {
   createAcpRuntime: (...args: any[]) => any;
   createFileSessionStore: (...args: any[]) => any;
@@ -72,12 +72,13 @@ async function resolveAcpxRuntime(): Promise<AcpxRuntimeModule> {
   }
 
   throw new Error(
-    "acpx is not installed globally. Install with: npm install -g acpx",
+    "acpx/runtime not found. Install with: npm install -g acpx " +
+      "(or ensure the pi-config package dependency `acpx` is installed)",
   );
 }
 
 /**
- * Resolve acpx/runtime: global install first, then bare import (dev only).
+ * Resolve acpx/runtime: global install first, then package dependency import.
  * Memoized — concurrent/repeated calls share one resolution. Rejected loads
  * clear the cache so a later install can succeed.
  */

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -33,6 +33,7 @@ import type {
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
+import { isPiMetaInvocation } from "../orchestrator/utils.js";
 import { isCliAgentName, type CliAgentName } from "./providers.js";
 import {
   clearCliSessionId,
@@ -508,6 +509,8 @@ function streamCli(
 
 export default async function (pi: ExtensionAPI) {
   // Intentionally does NOT skip PI_SUBAGENT_CHILD — cli-* must work in async children.
+  // pi --help / --version still loads extensions; skip discovery noise/latency.
+  if (isPiMetaInvocation()) return;
 
   // Capture cwd at extension load time, before pi potentially changes directory.
   projectCwd = process.cwd();

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -32,7 +32,7 @@ import type {
 } from "@earendil-works/pi-ai";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { getSetting } from "../orchestrator/project-settings.js";
+import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
 import { isCliAgentName, type CliAgentName } from "./providers.js";
 import {
   clearCliSessionId,
@@ -512,7 +512,10 @@ export default async function (pi: ExtensionAPI) {
   // Capture cwd at extension load time, before pi potentially changes directory.
   projectCwd = process.cwd();
 
-  const agentList = getSetting(projectCwd, "cli_agents").filter(isCliAgentName);
+  // Defensive: stale/mismatched getSetting may return non-array (issue #651).
+  const agentList = asStringArray(getSetting(projectCwd, "cli_agents")).filter(
+    isCliAgentName,
+  );
   registeredAgents = agentList;
 
   // Skip sync discovery if no agents configured

--- a/extensions/orchestrator/async-capability.ts
+++ b/extensions/orchestrator/async-capability.ts
@@ -11,7 +11,7 @@
  * See: https://github.com/myk-org/pi-config/issues/647
  */
 
-import { getSetting } from "./project-settings.js";
+import { asStringArray, getSetting } from "./project-settings.js";
 
 export interface AsyncLlmSidecar {
   provider: string;
@@ -23,7 +23,10 @@ export interface AsyncLlmSidecar {
  * Source of truth: `acpx_agents` in project/global settings (same list acpx-provider uses).
  */
 export function getRegisteredAcpxProviders(cwd: string): string[] {
-  return getSetting(cwd, "acpx_agents").map((agent) => `acpx-${agent}`);
+  // Defensive: stale getSetting may return non-array (issue #651).
+  return asStringArray(getSetting(cwd, "acpx_agents")).map(
+    (agent) => `acpx-${agent}`,
+  );
 }
 
 /** True when provider is one we registered via acpx-provider for this project. */

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -148,6 +148,16 @@ export function parseAgentNameList(value: string | string[] | undefined): string
   return [...new Set(filtered)];
 }
 
+/**
+ * Coerce a getSetting result to string[].
+ * Mixed/stale ~/.pi installs may pair a new provider with an older project-settings
+ * that returns `false` for unknown keys — never assume .filter/.map is safe.
+ */
+export function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((x): x is string => typeof x === "string");
+}
+
 /** @deprecated Use parseAgentNameList — kept for existing imports. */
 export function parseAcpxAgentList(value: string | string[] | undefined): string[] {
   return parseAgentNameList(value);

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -197,8 +197,12 @@ export function djb2Hash(input: string): number {
  * True when this process is a pi --help / --version (or -h / -v) invocation.
  * Pi still loads extensions before printing meta output, so providers should
  * skip expensive model discovery and registration in that case.
+ *
+ * Only true when every arg before `--` is a meta flag (no other options/values),
+ * so prompt values like `-p --help` do not false-positive.
  */
 export function isPiMetaInvocation(argv: string[] = process.argv): boolean {
+  let sawMeta = false;
   for (const arg of argv.slice(2)) {
     if (arg === "--") break;
     if (
@@ -207,8 +211,10 @@ export function isPiMetaInvocation(argv: string[] = process.argv): boolean {
       arg === "--version" ||
       arg === "-v"
     ) {
-      return true;
+      sawMeta = true;
+      continue;
     }
+    return false;
   }
-  return false;
+  return sawMeta;
 }

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -192,3 +192,23 @@ export function djb2Hash(input: string): number {
   }
   return Math.abs(hash);
 }
+
+/**
+ * True when this process is a pi --help / --version (or -h / -v) invocation.
+ * Pi still loads extensions before printing meta output, so providers should
+ * skip expensive model discovery and registration in that case.
+ */
+export function isPiMetaInvocation(argv: string[] = process.argv): boolean {
+  for (const arg of argv.slice(2)) {
+    if (arg === "--") break;
+    if (
+      arg === "--help" ||
+      arg === "-h" ||
+      arg === "--version" ||
+      arg === "-v"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "acpx": "^0.8.0",
+    "acpx": "*",
     "chokidar": "^5.0.0",
     "discord.js": "^14.0.0",
     "ws": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
-    "acpx": "*",
+    "acpx": ">=0.12.0 <1",
     "chokidar": "^5.0.0",
     "discord.js": "^14.0.0",
     "ws": "^8.0.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
+    "acpx": "^0.8.0",
     "chokidar": "^5.0.0",
     "discord.js": "^14.0.0",
     "ws": "^8.0.0"

--- a/tests/node/orchestrator/extension-settings.test.ts
+++ b/tests/node/orchestrator/extension-settings.test.ts
@@ -9,7 +9,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { clearSettingsCache, getSetting, parseAcpxAgentList, setGlobalSettingsPath } from "../../../extensions/orchestrator/project-settings.js";
+import { clearSettingsCache, getSetting, parseAcpxAgentList, asStringArray, setGlobalSettingsPath } from "../../../extensions/orchestrator/project-settings.js";
 
 describe("parseAcpxAgentList", () => {
 	it("parses comma-separated string", () => {
@@ -22,6 +22,20 @@ describe("parseAcpxAgentList", () => {
 
 	it("filters invalid agent names", () => {
 		assert.deepEqual(parseAcpxAgentList("cursor, bad name!, claude"), ["cursor", "claude"]);
+	});
+});
+
+describe("asStringArray", () => {
+	it("returns empty for non-arrays", () => {
+		assert.deepEqual(asStringArray(false), []);
+		assert.deepEqual(asStringArray(undefined), []);
+		assert.deepEqual(asStringArray(null), []);
+		assert.deepEqual(asStringArray("cursor"), []);
+		assert.deepEqual(asStringArray(1), []);
+	});
+
+	it("keeps only string entries", () => {
+		assert.deepEqual(asStringArray(["cursor", 1, "claude", null]), ["cursor", "claude"]);
 	});
 });
 

--- a/tests/node/shared/utils.test.ts
+++ b/tests/node/shared/utils.test.ts
@@ -29,19 +29,42 @@ describe("djb2Hash", () => {
 });
 
 describe("isPiMetaInvocation", () => {
-	it("detects help and version flags", () => {
+	it("detects --help", () => {
 		assert.equal(isPiMetaInvocation(["node", "pi", "--help"]), true);
+	});
+
+	it("detects -h", () => {
 		assert.equal(isPiMetaInvocation(["node", "pi", "-h"]), true);
+	});
+
+	it("detects --version", () => {
 		assert.equal(isPiMetaInvocation(["node", "pi", "--version"]), true);
+	});
+
+	it("detects -v", () => {
 		assert.equal(isPiMetaInvocation(["node", "pi", "-v"]), true);
 	});
 
-	it("ignores normal interactive and prompt invocations", () => {
+	it("ignores bare pi with no args", () => {
 		assert.equal(isPiMetaInvocation(["node", "pi"]), false);
+	});
+
+	it("ignores json mode prompt invocations", () => {
 		assert.equal(
 			isPiMetaInvocation(["node", "pi", "--mode", "json", "-p", "hi"]),
 			false,
 		);
+	});
+
+	it("ignores -h when used as prompt value", () => {
+		assert.equal(
+			isPiMetaInvocation(["node", "pi", "--mode", "json", "-p", "-h"]),
+			false,
+		);
+	});
+
+	it("ignores --help when used as prompt value", () => {
+		assert.equal(isPiMetaInvocation(["node", "pi", "-p", "--help"]), false);
 	});
 
 	it("stops at -- so later help-like tokens are ignored", () => {

--- a/tests/node/shared/utils.test.ts
+++ b/tests/node/shared/utils.test.ts
@@ -1,10 +1,6 @@
-/**
- * Tests for shared utility functions.
- * Run with: npx tsx --test tests/node/shared/utils.test.ts
- */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { djb2Hash } from "../../../extensions/orchestrator/utils.js";
+import { djb2Hash, isPiMetaInvocation } from "../../../extensions/orchestrator/utils.js";
 
 describe("djb2Hash", () => {
 	it("returns same value for same input (deterministic)", () => {
@@ -29,5 +25,26 @@ describe("djb2Hash", () => {
 
 	it("returns a number", () => {
 		assert.equal(typeof djb2Hash("test"), "number");
+	});
+});
+
+describe("isPiMetaInvocation", () => {
+	it("detects help and version flags", () => {
+		assert.equal(isPiMetaInvocation(["node", "pi", "--help"]), true);
+		assert.equal(isPiMetaInvocation(["node", "pi", "-h"]), true);
+		assert.equal(isPiMetaInvocation(["node", "pi", "--version"]), true);
+		assert.equal(isPiMetaInvocation(["node", "pi", "-v"]), true);
+	});
+
+	it("ignores normal interactive and prompt invocations", () => {
+		assert.equal(isPiMetaInvocation(["node", "pi"]), false);
+		assert.equal(
+			isPiMetaInvocation(["node", "pi", "--mode", "json", "-p", "hi"]),
+			false,
+		);
+	});
+
+	it("stops at -- so later help-like tokens are ignored", () => {
+		assert.equal(isPiMetaInvocation(["node", "pi", "--", "--help"]), false);
 	});
 });


### PR DESCRIPTION
## Summary
- Re-add `acpx` (`^0.8.0`) so `import("acpx/runtime")` resolves for plain `pi` / `~/.pi` package installs (global install still preferred).
- Add `asStringArray` and use it in cli-provider, acpx-provider, and async-capability so non-array `getSetting` results cannot crash `.filter`/`.map` on load.
- Docs: note refresh of global package after related updates; document runtime resolution.

Closes #651.

## Test plan
- [x] `npx tsx --test tests/node/**/*.test.ts`
- [x] `uv run --group tests pytest`
- [ ] After merge: `pi update` on a machine with `acpx_agents`/`cli_agents` set; confirm `pi --help` has no `acpx/runtime` MODULE_NOT_FOUND or `.filter is not a function`


Made with [Cursor](https://cursor.com)