### PR TITLE
fix(logging): route extension ops to ~/.pi/logs, not chat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Writing effective rules:
 - Extension commands: see `dev-docs/extension-commands.md`
 - Async agents, async-only list, acpx `supportsAsyncLlm` + sidecar settings, temp dirs: see `dev-docs/async-internals.md`
 - CLI providers (`cli-*`): see `dev-docs/cli-provider.md`
+- Extension ops logs (cli-provider, dreaming): `~/.pi/logs/` — never `console.*` (leaks into chat). See `dev-docs/cli-provider.md` Logging
 - Memory system: see `dev-docs/memory-architecture.md`
 - Enforcement honesty (code vs injected): see `dev-docs/enforcement-honesty-map.md`
 - Memory inventory CLI: `uv run myk-pi-tools memory status`

--- a/README.md
+++ b/README.md
@@ -370,6 +370,9 @@ Run pi inside a disposable container for **filesystem isolation** — the agent 
 `["claude","cursor","gemini"]`). Without those binaries on PATH, `cli-*` models will
 not register or will fail at turn time. See `dev-docs/cli-provider.md`.
 
+**Extension ops logs:** `cli-provider` and dreaming write to `~/.pi/logs/` (not the chat
+UI). Fallback: `$TMPDIR/pi-logs/`. Details in `dev-docs/cli-provider.md` (Logging).
+
 ### Pre-built image
 
 ```bash

--- a/dev-docs/cli-provider.md
+++ b/dev-docs/cli-provider.md
@@ -127,7 +127,12 @@ Operational logs go to **`~/.pi/logs/`** (never `console.*` — that leaks into 
 | `~/.pi/logs/cli-provider.log` | discovery, registration, resume recover, session reaper |
 | `~/.pi/logs/dreaming.log` | dream skip/sidecar notes, provenance merge, promotion/rebuild errors |
 
-Helper: `extensions/shared/file-logger.ts` (`getPiLogPath` is pure; mkdir only on write; newlines collapsed to `\n`; falls back to `$TMPDIR/pi-logs/` if `~/.pi/logs` unwritable).
+Helper: `extensions/shared/file-logger.ts`
+
+- `getPiLogPath` is pure; mkdir only on write
+- Newlines collapsed to `\n`
+- Falls back to `$TMPDIR/pi-logs/` if `~/.pi/logs` unwritable
+- Sync I/O by design for low-volume ops events
 
 ## Async
 

--- a/dev-docs/cli-provider.md
+++ b/dev-docs/cli-provider.md
@@ -118,6 +118,17 @@ File-backed bindings keyed by cwd + agent + model + `PI_SESSION_ID` (t3-style di
 
 This matches using the CLI as a backend LLM with full tool access (same intent as the system prompt we inject).
 
+## Logging
+
+Operational logs go to **`~/.pi/logs/`** (never `console.*` — that leaks into the chat text box):
+
+| File | Contents |
+|------|----------|
+| `~/.pi/logs/cli-provider.log` | discovery, registration, resume recover, session reaper |
+| `~/.pi/logs/dreaming.log` | dream skip/sidecar notes, provenance merge, promotion/rebuild errors |
+
+Helper: `extensions/shared/file-logger.ts`.
+
 ## Async
 
 Unlike `acpx-provider`, this extension **loads in subagent children** (`PI_SUBAGENT_CHILD`).  

--- a/dev-docs/cli-provider.md
+++ b/dev-docs/cli-provider.md
@@ -127,7 +127,7 @@ Operational logs go to **`~/.pi/logs/`** (never `console.*` — that leaks into 
 | `~/.pi/logs/cli-provider.log` | discovery, registration, resume recover, session reaper |
 | `~/.pi/logs/dreaming.log` | dream skip/sidecar notes, provenance merge, promotion/rebuild errors |
 
-Helper: `extensions/shared/file-logger.ts`.
+Helper: `extensions/shared/file-logger.ts` (`getPiLogPath` is pure; mkdir only on write; newlines collapsed to `\n`; falls back to `$TMPDIR/pi-logs/` if `~/.pi/logs` unwritable).
 
 ## Async
 

--- a/dev-docs/cli-provider.md
+++ b/dev-docs/cli-provider.md
@@ -132,7 +132,7 @@ Helper: `extensions/shared/file-logger.ts`
 - `getPiLogPath` is pure; mkdir only on write
 - Newlines collapsed to `\n`
 - Falls back to `$TMPDIR/pi-logs/` if `~/.pi/logs` unwritable
-- Sync I/O by design for low-volume ops events
+- Sync I/O by design for low-volume ops events (mkdir every write; no dir cache)
 
 ## Async
 

--- a/extensions/cli-provider/agents/claude.ts
+++ b/extensions/cli-provider/agents/claude.ts
@@ -3,6 +3,7 @@
  */
 
 import { closeSync, openSync, readSync, statSync } from "node:fs";
+import { cliProviderLog } from "../../shared/file-logger.js";
 import type { CliProviderDef, DiscoveredCliModel } from "../types.js";
 import {
   cacheKeyForFile,
@@ -96,7 +97,7 @@ function discoverClaudeModels(): DiscoveredCliModel[] {
     if (models.length > 0) writeModelCache(key, models);
     return models;
   } catch (err) {
-    console.debug(`[cli-provider] claude: binary catalog failed:`, err);
+    cliProviderLog("error", "claude: binary catalog failed", err);
     return [];
   }
 }

--- a/extensions/cli-provider/agents/cursor.ts
+++ b/extensions/cli-provider/agents/cursor.ts
@@ -5,6 +5,7 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { cliProviderLog } from "../../shared/file-logger.js";
 import type { CliProviderDef, DiscoveredCliModel } from "../types.js";
 import { resolveBinary } from "../shared/discover-cache.js";
 
@@ -38,8 +39,9 @@ function discoverCursorModels(): DiscoveredCliModel[] {
   const out = `${r.stdout || ""}\n${r.stderr || ""}`;
   const models = parseAgentListModels(out);
   if (models.length === 0) {
-    console.debug(
-      `[cli-provider] cursor: --list-models failed (status=${r.status}): ${out.slice(0, 200)}`,
+    cliProviderLog(
+      "warn",
+      `cursor: --list-models failed (status=${r.status}): ${out.slice(0, 200)}`,
     );
   }
   return models;

--- a/extensions/cli-provider/agents/gemini.ts
+++ b/extensions/cli-provider/agents/gemini.ts
@@ -9,6 +9,7 @@ import {
   statSync,
 } from "node:fs";
 import { dirname, join } from "node:path";
+import { cliProviderLog } from "../../shared/file-logger.js";
 import type { CliProviderDef, DiscoveredCliModel } from "../types.js";
 import {
   cacheKeyForFile,
@@ -70,7 +71,7 @@ function discoverGeminiModels(): DiscoveredCliModel[] {
     if (models.length > 0) writeModelCache(key, models);
     return models;
   } catch (err) {
-    console.debug(`[cli-provider] gemini: CLI bundle parse failed:`, err);
+    cliProviderLog("error", "gemini: CLI bundle parse failed", err);
     return [];
   }
 }

--- a/extensions/cli-provider/discover.ts
+++ b/extensions/cli-provider/discover.ts
@@ -5,6 +5,7 @@
  * IMPORTANT: These IDs are CLI `--model` values, NOT acpx model ids.
  */
 
+import { cliProviderLog } from "../shared/file-logger.js";
 import { CLI_PROVIDERS, isCliAgentName, type CliAgentName } from "./providers.js";
 import type { DiscoveredCliModel } from "./types.js";
 import { modelIdToDisplayName, resolveBinary } from "./shared/discover-cache.js";
@@ -32,8 +33,9 @@ export async function discoverCliModelsDetailed(
 ): Promise<DiscoveredCliModel[]> {
   if (!isCliAgentName(agent)) return [];
   if (!isCliBinaryAvailable(agent)) {
-    console.debug(
-      `[cli-provider] ${agent}: binary not found (${CLI_PROVIDERS[agent].binary})`,
+    cliProviderLog(
+      "warn",
+      `${agent}: binary not found (${CLI_PROVIDERS[agent].binary})`,
     );
     return [];
   }
@@ -42,15 +44,13 @@ export async function discoverCliModelsDetailed(
   try {
     discovered = CLI_PROVIDERS[agent].discoverModels();
   } catch (err) {
-    console.debug(`[cli-provider] ${agent}: discovery error:`, err);
+    cliProviderLog("error", `${agent}: discovery error`, err);
   }
 
   if (discovered.length > 0) {
-    console.debug(
-      `[cli-provider] ${agent}: discovered ${discovered.length} model(s)`,
-    );
+    cliProviderLog("info", `${agent}: discovered ${discovered.length} model(s)`);
   } else {
-    console.debug(`[cli-provider] ${agent}: discovery returned no models`);
+    cliProviderLog("warn", `${agent}: discovery returned no models`);
   }
   return discovered;
 }

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -34,6 +34,7 @@ import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
 import { isPiMetaInvocation } from "../orchestrator/utils.js";
+import { cliProviderLog } from "../shared/file-logger.js";
 import { isCliAgentName, type CliAgentName } from "./providers.js";
 import {
   clearCliSessionId,
@@ -140,8 +141,9 @@ async function runCliTurnWithResumeRecover(opts: {
     if (!opts.sessionId || !shouldRetryWithoutResume(message)) {
       throw err;
     }
-    console.debug(
-      `[cli-provider] resume failed for ${opts.agent}; clearing session and retrying: ${message.slice(0, 200)}`,
+    cliProviderLog(
+      "warn",
+      `resume failed for ${opts.agent}; clearing session and retrying: ${message.slice(0, 200)}`,
     );
     clearCliSessionId(opts.key);
     let prompt = opts.rebuildPromptWithoutSession();
@@ -219,7 +221,7 @@ function extractLatestUserMessage(context: Context): string {
       if (text) return text;
     }
   }
-  console.debug("[cli-provider] no user message found in context, using fallback");
+  cliProviderLog("warn", "no user message found in context, using fallback");
   return "hello";
 }
 
@@ -560,8 +562,9 @@ export default async function (pi: ExtensionAPI) {
 
         const discovery = (async () => {
           if (!isCliBinaryAvailable(agent)) {
-            console.debug(
-              `[cli-provider] ${agent}: binary not found, skip registration`,
+            cliProviderLog(
+              "warn",
+              `${agent}: binary not found, skip registration`,
             );
             return { agent, models: [] as DiscoveredCliModel[] };
           }
@@ -594,7 +597,7 @@ export default async function (pi: ExtensionAPI) {
         clearTimeout(timer!);
         return result;
       } catch (err) {
-        console.debug(`[cli-provider] discovery failed for ${agent}:`, err);
+        cliProviderLog("error", `discovery failed for ${agent}`, err);
         const state = agents.get(agent);
         if (state) state.signalReady();
         return { agent, models: [] as DiscoveredCliModel[] };
@@ -609,8 +612,9 @@ export default async function (pi: ExtensionAPI) {
     // Skip registration if probe failed (no AgentState) — prevents
     // registering a provider whose streamCli would always throw.
     if (!agents.has(agent)) {
-      console.debug(
-        `[cli-provider] cli-${agent}: skipped registration (no binary/state)`,
+      cliProviderLog(
+        "warn",
+        `cli-${agent}: skipped registration (no binary/state)`,
       );
       continue;
     }
@@ -630,11 +634,12 @@ export default async function (pi: ExtensionAPI) {
         models,
         streamSimple: streamCli,
       });
-      console.debug(
-        `[cli-provider] cli-${agent}: ${models.length} model(s) registered`,
+      cliProviderLog(
+        "info",
+        `cli-${agent}: ${models.length} model(s) registered`,
       );
     } catch (err) {
-      console.debug(`[cli-provider] cli-${agent}: setup failed:`, err);
+      cliProviderLog("error", `cli-${agent}: setup failed`, err);
     }
   }
 

--- a/extensions/cli-provider/session-reaper.ts
+++ b/extensions/cli-provider/session-reaper.ts
@@ -4,6 +4,7 @@
  */
 
 import { unlinkSync } from "node:fs";
+import { cliProviderLog } from "../shared/file-logger.js";
 import { listCliSessions } from "./sessions.js";
 
 export const DEFAULT_INACTIVITY_THRESHOLD_MS = 30 * 60 * 1000;
@@ -50,12 +51,17 @@ export function reapStaleCliSessions(options?: ReapOptions): number {
     try {
       unlinkSync(path);
       reaped += 1;
-      console.debug(
-        `[cli-provider] reaped session ${record.agent}/${record.model} ` +
+      cliProviderLog(
+        "info",
+        `reaped session ${record.agent}/${record.model} ` +
           `(status=${record.status}, lastSeen=${record.lastSeenAt})`,
       );
-    } catch {
-      /* ignore */
+    } catch (err) {
+      cliProviderLog(
+        "error",
+        `failed to reap session ${record.agent}/${record.model} at ${path}`,
+        err,
+      );
     }
   }
 
@@ -89,7 +95,7 @@ export function startCliSessionReaper(options?: {
         piSessionId: process.env.PI_SESSION_ID || null,
       });
     } catch (err) {
-      console.debug("[cli-provider] session reaper sweep failed:", err);
+      cliProviderLog("error", "session reaper sweep failed", err);
     }
   }, sweepMs);
   reaperTimer.unref?.();

--- a/extensions/orchestrator/dreaming.ts
+++ b/extensions/orchestrator/dreaming.ts
@@ -23,6 +23,7 @@ import { rebuildAndOrganize } from "./situation-report.js";
 import { runPromotionPass } from "./memory-promotion.js";
 import { mergeProvenancePending } from "./memory-provenance.js";
 import { getProjectTmpDir } from "./utils.js";
+import { dreamingLog } from "../shared/file-logger.js";
 
 // Default: 3 hours. Override with PI_DREAM_INTERVAL_HOURS env var (0.5–24).
 const _rawHours = parseFloat(process.env.PI_DREAM_INTERVAL_HOURS || "3");
@@ -82,7 +83,7 @@ export function registerDreaming(
       mustAsync: true,
     });
     if (dreamDispatch.action === "skip") {
-      console.debug(`[dreaming] ${dreamDispatch.note}`);
+      dreamingLog("warn", dreamDispatch.note || "dream skipped (no async LLM path)");
       try {
         lastCtx?.ui?.notify?.(
           "Dream skipped: set async_llm_provider and async_llm_model for acpx sessions",
@@ -179,12 +180,23 @@ export function registerDreaming(
         onComplete: () => {
           dreamInFlight = false;
           updateDreamStatus();
-          try { rebuildAndOrganize(cwd); } catch (e: any) { console.debug("[dreaming] rebuildAndOrganize failed:", e?.message || e); }
+          // File log only — console.* leaks into the chat text box.
+          try {
+            rebuildAndOrganize(cwd);
+          } catch (err) {
+            dreamingLog("error", "rebuildAndOrganize failed", err);
+          }
           try {
             const n = mergeProvenancePending(cwd);
-            if (n > 0) console.debug(`[dreaming] merged provenance for ${n} entries`);
-          } catch (e: any) { console.debug("[dreaming] provenance merge failed:", e?.message || e); }
-          try { runPromotionPass(cwd); } catch (e: any) { console.debug("[dreaming] promotion pass failed:", e?.message || e); }
+            if (n > 0) dreamingLog("info", `merged provenance for ${n} entries`);
+          } catch (err) {
+            dreamingLog("error", "provenance merge failed", err);
+          }
+          try {
+            runPromotionPass(cwd);
+          } catch (err) {
+            dreamingLog("error", "promotion pass failed", err);
+          }
         },
       },
     );
@@ -203,7 +215,10 @@ export function registerDreaming(
         if (dreamInFlight && currentDreamId === dreamId) {
           dreamInFlight = false;
           updateDreamStatus();
-          console.debug("[dreaming] fallback: reset dreamInFlight after 30 min (onComplete never fired)");
+          dreamingLog(
+            "warn",
+            "fallback: reset dreamInFlight after 30 min (onComplete never fired)",
+          );
         }
       }, 30 * 60 * 1000);
       if (fallbackTimer.unref) fallbackTimer.unref();
@@ -237,7 +252,11 @@ export function registerDreaming(
     if (!rebuildTimer) {
       rebuildTimer = setInterval(() => {
         if (enabled && lastCwd) {
-          try { rebuildAndOrganize(lastCwd); } catch (e: any) { console.debug("[dreaming] rebuildAndOrganize failed:", e?.message || e); }
+          try {
+            rebuildAndOrganize(lastCwd);
+          } catch (err) {
+            dreamingLog("error", "rebuildAndOrganize failed", err);
+          }
         }
       }, REBUILD_INTERVAL_MS);
       if (rebuildTimer.unref) rebuildTimer.unref();
@@ -328,6 +347,8 @@ export function registerDreaming(
     // (can't use spawnAsyncAgent since the session is ending)
     try {
       runDreamAsync(lastCwd);
-    } catch (e: any) { console.debug("[dreaming] shutdown dream failed:", e?.message || e); }
+    } catch (err) {
+      dreamingLog("error", "shutdown dream failed", err);
+    }
   });
 }

--- a/extensions/shared/file-logger.ts
+++ b/extensions/shared/file-logger.ts
@@ -1,0 +1,66 @@
+/**
+ * Append-only file logger for extensions.
+ *
+ * NEVER use console.* for operational/debug messages in extensions — pi
+ * surfaces them into the chat text box. Write here instead:
+ *   ~/.pi/logs/<name>.log
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export type FileLogLevel = "debug" | "info" | "warn" | "error";
+
+export function getPiLogsDir(): string {
+  const dir = path.join(os.homedir(), ".pi", "logs");
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function getPiLogPath(name: string): string {
+  const safe = name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return path.join(getPiLogsDir(), `${safe}.log`);
+}
+
+function formatErr(err: unknown): string {
+  if (err instanceof Error) return err.stack || err.message;
+  return String(err);
+}
+
+/**
+ * Append one line to ~/.pi/logs/<name>.log. Never writes to console.
+ */
+export function fileLog(
+  name: string,
+  level: FileLogLevel,
+  prefix: string,
+  message: string,
+  err?: unknown,
+): void {
+  try {
+    const detail =
+      err !== undefined ? ` ${formatErr(err)}` : "";
+    const line = `${new Date().toISOString()} [${level}] [${prefix}] ${message}${detail}\n`;
+    fs.appendFileSync(getPiLogPath(name), line, "utf-8");
+  } catch {
+    // Last resort: do not console.* — that leaks into the chat UI.
+  }
+}
+
+/** Convenience loggers for known components. */
+export function cliProviderLog(
+  level: FileLogLevel,
+  message: string,
+  err?: unknown,
+): void {
+  fileLog("cli-provider", level, "cli-provider", message, err);
+}
+
+export function dreamingLog(
+  level: FileLogLevel,
+  message: string,
+  err?: unknown,
+): void {
+  fileLog("dreaming", level, "dreaming", message, err);
+}

--- a/extensions/shared/file-logger.ts
+++ b/extensions/shared/file-logger.ts
@@ -12,24 +12,55 @@ import * as path from "node:path";
 
 export type FileLogLevel = "debug" | "info" | "warn" | "error";
 
-export function getPiLogsDir(): string {
-  const dir = path.join(os.homedir(), ".pi", "logs");
-  fs.mkdirSync(dir, { recursive: true });
-  return dir;
+/** Last filesystem failure from fileLog (for diagnostics; never console.*). */
+let lastFileLogError: string | null = null;
+let fileLogErrorCount = 0;
+
+export function getLastFileLogError(): string | null {
+  return lastFileLogError;
 }
 
+export function getFileLogErrorCount(): number {
+  return fileLogErrorCount;
+}
+
+/** Pure path — no mkdir. */
+export function getPiLogsDir(): string {
+  return path.join(os.homedir(), ".pi", "logs");
+}
+
+/** Pure path — no mkdir. Callers that only need the path string stay side-effect free. */
 export function getPiLogPath(name: string): string {
   const safe = name.replace(/[^a-zA-Z0-9._-]/g, "_");
   return path.join(getPiLogsDir(), `${safe}.log`);
 }
 
+/** Collapse CR/LF so one fileLog call = one physical log line. */
+function oneLine(text: string): string {
+  return text.replace(/\r\n|\r|\n/g, "\\n");
+}
+
 function formatErr(err: unknown): string {
-  if (err instanceof Error) return err.stack || err.message;
-  return String(err);
+  if (err instanceof Error) return oneLine(err.stack || err.message);
+  return oneLine(String(err));
+}
+
+function recordWriteError(err: unknown): void {
+  fileLogErrorCount += 1;
+  lastFileLogError =
+    err instanceof Error ? err.message : String(err);
+}
+
+function appendLine(filePath: string, line: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.appendFileSync(filePath, line, "utf-8");
 }
 
 /**
- * Append one line to ~/.pi/logs/<name>.log. Never writes to console.
+ * Append one physical line to ~/.pi/logs/<name>.log.
+ * Never writes to console.* (chat UI leak).
+ * Returns true on success.
+ * On primary-path failure, tries os.tmpdir()/pi-logs/<name>.log once.
  */
 export function fileLog(
   name: string,
@@ -37,14 +68,26 @@ export function fileLog(
   prefix: string,
   message: string,
   err?: unknown,
-): void {
+): boolean {
+  const detail =
+    err !== undefined ? ` ${formatErr(err)}` : "";
+  const line = `${new Date().toISOString()} [${level}] [${prefix}] ${oneLine(message)}${detail}\n`;
+  const primary = getPiLogPath(name);
+
   try {
-    const detail =
-      err !== undefined ? ` ${formatErr(err)}` : "";
-    const line = `${new Date().toISOString()} [${level}] [${prefix}] ${message}${detail}\n`;
-    fs.appendFileSync(getPiLogPath(name), line, "utf-8");
-  } catch {
-    // Last resort: do not console.* — that leaks into the chat UI.
+    appendLine(primary, line);
+    return true;
+  } catch (primaryErr) {
+    recordWriteError(primaryErr);
+    try {
+      const fallbackDir = path.join(os.tmpdir(), "pi-logs");
+      const safe = name.replace(/[^a-zA-Z0-9._-]/g, "_");
+      appendLine(path.join(fallbackDir, `${safe}.log`), line);
+      return true;
+    } catch (fallbackErr) {
+      recordWriteError(fallbackErr);
+      return false;
+    }
   }
 }
 
@@ -53,14 +96,14 @@ export function cliProviderLog(
   level: FileLogLevel,
   message: string,
   err?: unknown,
-): void {
-  fileLog("cli-provider", level, "cli-provider", message, err);
+): boolean {
+  return fileLog("cli-provider", level, "cli-provider", message, err);
 }
 
 export function dreamingLog(
   level: FileLogLevel,
   message: string,
   err?: unknown,
-): void {
-  fileLog("dreaming", level, "dreaming", message, err);
+): boolean {
+  return fileLog("dreaming", level, "dreaming", message, err);
 }

--- a/extensions/shared/file-logger.ts
+++ b/extensions/shared/file-logger.ts
@@ -4,6 +4,10 @@
  * NEVER use console.* for operational/debug messages in extensions — pi
  * surfaces them into the chat text box. Write here instead:
  *   ~/.pi/logs/<name>.log
+ *
+ * I/O is intentionally synchronous (mkdirSync/appendFileSync). Call sites are
+ * low-volume ops events (reaper, discovery, dream complete) — not hot loops.
+ * Async would force every caller to await and risk unordered lines.
  */
 
 import * as fs from "node:fs";
@@ -15,6 +19,7 @@ export type FileLogLevel = "debug" | "info" | "warn" | "error";
 /** Last filesystem failure from fileLog (for diagnostics; never console.*). */
 let lastFileLogError: string | null = null;
 let fileLogErrorCount = 0;
+const ensuredDirs = new Set<string>();
 
 export function getLastFileLogError(): string | null {
   return lastFileLogError;
@@ -52,7 +57,11 @@ function recordWriteError(err: unknown): void {
 }
 
 function appendLine(filePath: string, line: string): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const dir = path.dirname(filePath);
+  if (!ensuredDirs.has(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    ensuredDirs.add(dir);
+  }
   fs.appendFileSync(filePath, line, "utf-8");
 }
 
@@ -72,16 +81,16 @@ export function fileLog(
   const detail =
     err !== undefined ? ` ${formatErr(err)}` : "";
   const line = `${new Date().toISOString()} [${level}] [${prefix}] ${oneLine(message)}${detail}\n`;
-  const primary = getPiLogPath(name);
+  const safe = name.replace(/[^a-zA-Z0-9._-]/g, "_");
 
   try {
-    appendLine(primary, line);
+    // Path resolve stays inside try so homedir/path failures still hit fallback.
+    appendLine(getPiLogPath(name), line);
     return true;
   } catch (primaryErr) {
     recordWriteError(primaryErr);
     try {
       const fallbackDir = path.join(os.tmpdir(), "pi-logs");
-      const safe = name.replace(/[^a-zA-Z0-9._-]/g, "_");
       appendLine(path.join(fallbackDir, `${safe}.log`), line);
       return true;
     } catch (fallbackErr) {

--- a/extensions/shared/file-logger.ts
+++ b/extensions/shared/file-logger.ts
@@ -19,7 +19,6 @@ export type FileLogLevel = "debug" | "info" | "warn" | "error";
 /** Last filesystem failure from fileLog (for diagnostics; never console.*). */
 let lastFileLogError: string | null = null;
 let fileLogErrorCount = 0;
-const ensuredDirs = new Set<string>();
 
 export function getLastFileLogError(): string | null {
   return lastFileLogError;
@@ -57,11 +56,9 @@ function recordWriteError(err: unknown): void {
 }
 
 function appendLine(filePath: string, line: string): void {
-  const dir = path.dirname(filePath);
-  if (!ensuredDirs.has(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-    ensuredDirs.add(dir);
-  }
+  // Always mkdirSync(recursive) — no dir cache. Cached "ensured" dirs go stale
+  // if ~/.pi/logs is deleted mid-process and then skip mkdir → lost logs.
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.appendFileSync(filePath, line, "utf-8");
 }
 

--- a/tests/node/shared/file-logger.test.ts
+++ b/tests/node/shared/file-logger.test.ts
@@ -138,6 +138,23 @@ describe("file-logger", () => {
     assert.match(readFileSync(fallback, "utf-8"), /fallback/);
   });
 
+  it("recreates log dir after external delete (no stale mkdir cache)", async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-recreate-"));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+
+    const { fileLog, getPiLogPath } = await import(
+      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 5}`
+    );
+
+    assert.equal(fileLog("cli-provider", "info", "cli-provider", "first"), true);
+    const logPath = getPiLogPath("cli-provider");
+    rmSync(join(tmpHome, ".pi", "logs"), { recursive: true, force: true });
+    assert.equal(fileLog("cli-provider", "info", "cli-provider", "second"), true);
+    const body = readFileSync(logPath, "utf-8");
+    assert.match(body, /second/);
+  });
+
   it("dreaming and cli-provider sources have no executable console.* ops calls", () => {
     const files = [
       join(REPO, "extensions/orchestrator/dreaming.ts"),

--- a/tests/node/shared/file-logger.test.ts
+++ b/tests/node/shared/file-logger.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+describe("file-logger", () => {
+  const originals = {
+    HOME: process.env.HOME,
+    USERPROFILE: process.env.USERPROFILE,
+  };
+  let tmpHome: string | undefined;
+
+  afterEach(() => {
+    if (originals.HOME === undefined) delete process.env.HOME;
+    else process.env.HOME = originals.HOME;
+    if (originals.USERPROFILE === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = originals.USERPROFILE;
+    if (tmpHome) {
+      try {
+        rmSync(tmpHome, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+      tmpHome = undefined;
+    }
+  });
+
+  it("appends leveled lines under ~/.pi/logs without throwing", async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-"));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+
+    const { cliProviderLog, dreamingLog, getPiLogPath } = await import(
+      "../../../extensions/shared/file-logger.ts"
+    );
+
+    cliProviderLog("info", "reaped session cursor/test");
+    cliProviderLog("error", "session reaper sweep failed", new Error("boom"));
+    dreamingLog("info", "merged provenance for 2 entries");
+
+    const cliPath = getPiLogPath("cli-provider");
+    const dreamPath = getPiLogPath("dreaming");
+    const cliBody = readFileSync(cliPath, "utf-8");
+    const dreamBody = readFileSync(dreamPath, "utf-8");
+
+    assert.match(cliBody, /\[info\] \[cli-provider\] reaped session cursor\/test/);
+    assert.match(cliBody, /\[error\] \[cli-provider\] session reaper sweep failed/);
+    assert.match(cliBody, /Error: boom/);
+    assert.match(dreamBody, /\[info\] \[dreaming\] merged provenance for 2 entries/);
+  });
+});

--- a/tests/node/shared/file-logger.test.ts
+++ b/tests/node/shared/file-logger.test.ts
@@ -4,12 +4,15 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
+
+const REPO = join(import.meta.dirname, "../../..");
 
 describe("file-logger", () => {
   const originals = {
@@ -33,38 +36,50 @@ describe("file-logger", () => {
     }
   });
 
-  it("appends leveled one-line records under ~/.pi/logs", async () => {
+  it("writes cli-provider info lines to ~/.pi/logs", async () => {
     tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-"));
     process.env.HOME = tmpHome;
     process.env.USERPROFILE = tmpHome;
 
-    const { cliProviderLog, dreamingLog, getPiLogPath, fileLog } = await import(
+    const { cliProviderLog, getPiLogPath } = await import(
       `../../../extensions/shared/file-logger.ts?t=${Date.now()}`
     );
 
     assert.equal(cliProviderLog("info", "reaped session cursor/test"), true);
-    assert.equal(
-      cliProviderLog("error", "session reaper sweep failed", new Error("boom")),
-      true,
+    const body = readFileSync(getPiLogPath("cli-provider"), "utf-8");
+    assert.match(body, /\[info\] \[cli-provider\] reaped session cursor\/test/);
+  });
+
+  it("writes dreaming info lines to ~/.pi/logs", async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-dream-"));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+
+    const { dreamingLog, getPiLogPath } = await import(
+      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 1}`
     );
+
     assert.equal(dreamingLog("info", "merged provenance for 2 entries"), true);
+    const body = readFileSync(getPiLogPath("dreaming"), "utf-8");
+    assert.match(body, /\[info\] \[dreaming\] merged provenance for 2 entries/);
+  });
 
-    const cliPath = getPiLogPath("cli-provider");
-    const dreamPath = getPiLogPath("dreaming");
-    const cliBody = readFileSync(cliPath, "utf-8");
-    const dreamBody = readFileSync(dreamPath, "utf-8");
+  it("collapses message and Error.stack newlines into one physical line", async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-nl-"));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
 
-    assert.match(cliBody, /\[info\] \[cli-provider\] reaped session cursor\/test/);
-    assert.match(cliBody, /\[error\] \[cli-provider\] session reaper sweep failed/);
-    assert.match(cliBody, /Error: boom/);
-    assert.match(dreamBody, /\[info\] \[dreaming\] merged provenance for 2 entries/);
+    const { fileLog, getPiLogPath } = await import(
+      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 2}`
+    );
 
-    const before = cliBody.trimEnd().split("\n").length;
     fileLog("cli-provider", "warn", "cli-provider", "a\nb\rc", new Error("x\ny"));
-    const afterLines = readFileSync(cliPath, "utf-8").trimEnd().split("\n");
-    assert.equal(afterLines.length, before + 1);
-    assert.match(afterLines.at(-1)!, /a\\nb\\nc/);
-    assert.match(afterLines.at(-1)!, /x\\ny/);
+    const lines = readFileSync(getPiLogPath("cli-provider"), "utf-8")
+      .trimEnd()
+      .split("\n");
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /a\\nb\\nc/);
+    assert.match(lines[0]!, /x\\ny/);
   });
 
   it("getPiLogPath is pure (no mkdir)", async () => {
@@ -73,7 +88,7 @@ describe("file-logger", () => {
     process.env.USERPROFILE = tmpHome;
 
     const { getPiLogPath, getPiLogsDir } = await import(
-      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 1}`
+      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 3}`
     );
 
     const p = getPiLogPath("cli-provider");
@@ -90,14 +105,34 @@ describe("file-logger", () => {
     writeFileSync(join(tmpHome, ".pi", "logs"), "not-a-dir");
 
     const mod = await import(
-      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 2}`
+      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 4}`
     );
     assert.equal(mod.fileLog("cli-provider", "error", "cli-provider", "fallback"), true);
     assert.ok(mod.getFileLogErrorCount() >= 1);
     assert.ok(mod.getLastFileLogError());
 
     const fallback = join(tmpdir(), "pi-logs", "cli-provider.log");
-    const body = readFileSync(fallback, "utf-8");
-    assert.match(body, /fallback/);
+    assert.match(readFileSync(fallback, "utf-8"), /fallback/);
+  });
+
+  it("dreaming and cli-provider sources do not call console.* for ops logs", () => {
+    const files = [
+      join(REPO, "extensions/orchestrator/dreaming.ts"),
+      join(REPO, "extensions/cli-provider/session-reaper.ts"),
+      join(REPO, "extensions/cli-provider/discover.ts"),
+      join(REPO, "extensions/cli-provider/index.ts"),
+      join(REPO, "extensions/cli-provider/agents/cursor.ts"),
+      join(REPO, "extensions/cli-provider/agents/claude.ts"),
+      join(REPO, "extensions/cli-provider/agents/gemini.ts"),
+    ];
+    const consoleRe = /\bconsole\.(debug|log|info|warn|error)\s*\(/;
+    for (const file of files) {
+      const src = readFileSync(file, "utf-8");
+      assert.equal(
+        consoleRe.test(src),
+        false,
+        `${file} still uses console.* (chat leak)`,
+      );
+    }
   });
 });

--- a/tests/node/shared/file-logger.test.ts
+++ b/tests/node/shared/file-logger.test.ts
@@ -1,5 +1,12 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -26,18 +33,21 @@ describe("file-logger", () => {
     }
   });
 
-  it("appends leveled lines under ~/.pi/logs without throwing", async () => {
+  it("appends leveled one-line records under ~/.pi/logs", async () => {
     tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-"));
     process.env.HOME = tmpHome;
     process.env.USERPROFILE = tmpHome;
 
-    const { cliProviderLog, dreamingLog, getPiLogPath } = await import(
-      "../../../extensions/shared/file-logger.ts"
+    const { cliProviderLog, dreamingLog, getPiLogPath, fileLog } = await import(
+      `../../../extensions/shared/file-logger.ts?t=${Date.now()}`
     );
 
-    cliProviderLog("info", "reaped session cursor/test");
-    cliProviderLog("error", "session reaper sweep failed", new Error("boom"));
-    dreamingLog("info", "merged provenance for 2 entries");
+    assert.equal(cliProviderLog("info", "reaped session cursor/test"), true);
+    assert.equal(
+      cliProviderLog("error", "session reaper sweep failed", new Error("boom")),
+      true,
+    );
+    assert.equal(dreamingLog("info", "merged provenance for 2 entries"), true);
 
     const cliPath = getPiLogPath("cli-provider");
     const dreamPath = getPiLogPath("dreaming");
@@ -48,5 +58,46 @@ describe("file-logger", () => {
     assert.match(cliBody, /\[error\] \[cli-provider\] session reaper sweep failed/);
     assert.match(cliBody, /Error: boom/);
     assert.match(dreamBody, /\[info\] \[dreaming\] merged provenance for 2 entries/);
+
+    const before = cliBody.trimEnd().split("\n").length;
+    fileLog("cli-provider", "warn", "cli-provider", "a\nb\rc", new Error("x\ny"));
+    const afterLines = readFileSync(cliPath, "utf-8").trimEnd().split("\n");
+    assert.equal(afterLines.length, before + 1);
+    assert.match(afterLines.at(-1)!, /a\\nb\\nc/);
+    assert.match(afterLines.at(-1)!, /x\\ny/);
+  });
+
+  it("getPiLogPath is pure (no mkdir)", async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-pure-"));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+
+    const { getPiLogPath, getPiLogsDir } = await import(
+      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 1}`
+    );
+
+    const p = getPiLogPath("cli-provider");
+    assert.equal(p, join(getPiLogsDir(), "cli-provider.log"));
+    assert.equal(existsSync(join(tmpHome, ".pi", "logs")), false);
+  });
+
+  it("falls back to tmpdir when home logs are not writable", async () => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-ro-"));
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+
+    mkdirSync(join(tmpHome, ".pi"), { recursive: true });
+    writeFileSync(join(tmpHome, ".pi", "logs"), "not-a-dir");
+
+    const mod = await import(
+      `../../../extensions/shared/file-logger.ts?t=${Date.now() + 2}`
+    );
+    assert.equal(mod.fileLog("cli-provider", "error", "cli-provider", "fallback"), true);
+    assert.ok(mod.getFileLogErrorCount() >= 1);
+    assert.ok(mod.getLastFileLogError());
+
+    const fallback = join(tmpdir(), "pi-logs", "cli-provider.log");
+    const body = readFileSync(fallback, "utf-8");
+    assert.match(body, /fallback/);
   });
 });

--- a/tests/node/shared/file-logger.test.ts
+++ b/tests/node/shared/file-logger.test.ts
@@ -4,36 +4,55 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
-  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, it } from "node:test";
 
-const REPO = join(import.meta.dirname, "../../..");
+const REPO = join(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+/** Strip comments so console.* in docs/strings does not false-fail. */
+function stripTsComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
 
 describe("file-logger", () => {
   const originals = {
     HOME: process.env.HOME,
     USERPROFILE: process.env.USERPROFILE,
+    TMPDIR: process.env.TMPDIR,
+    TMP: process.env.TMP,
+    TEMP: process.env.TEMP,
   };
   let tmpHome: string | undefined;
+  let tmpFallbackBase: string | undefined;
 
   afterEach(() => {
     if (originals.HOME === undefined) delete process.env.HOME;
     else process.env.HOME = originals.HOME;
     if (originals.USERPROFILE === undefined) delete process.env.USERPROFILE;
     else process.env.USERPROFILE = originals.USERPROFILE;
-    if (tmpHome) {
+    if (originals.TMPDIR === undefined) delete process.env.TMPDIR;
+    else process.env.TMPDIR = originals.TMPDIR;
+    if (originals.TMP === undefined) delete process.env.TMP;
+    else process.env.TMP = originals.TMP;
+    if (originals.TEMP === undefined) delete process.env.TEMP;
+    else process.env.TEMP = originals.TEMP;
+    for (const dir of [tmpHome, tmpFallbackBase]) {
+      if (!dir) continue;
       try {
-        rmSync(tmpHome, { recursive: true, force: true });
+        rmSync(dir, { recursive: true, force: true });
       } catch {
         /* ignore */
       }
-      tmpHome = undefined;
     }
+    tmpHome = undefined;
+    tmpFallbackBase = undefined;
   });
 
   it("writes cli-provider info lines to ~/.pi/logs", async () => {
@@ -96,10 +115,14 @@ describe("file-logger", () => {
     assert.equal(existsSync(join(tmpHome, ".pi", "logs")), false);
   });
 
-  it("falls back to tmpdir when home logs are not writable", async () => {
+  it("falls back to isolated TMPDIR when home logs are not writable", async () => {
     tmpHome = mkdtempSync(join(tmpdir(), "pi-file-log-ro-"));
+    tmpFallbackBase = mkdtempSync(join(tmpdir(), "pi-file-log-tmp-"));
     process.env.HOME = tmpHome;
     process.env.USERPROFILE = tmpHome;
+    process.env.TMPDIR = tmpFallbackBase;
+    process.env.TMP = tmpFallbackBase;
+    process.env.TEMP = tmpFallbackBase;
 
     mkdirSync(join(tmpHome, ".pi"), { recursive: true });
     writeFileSync(join(tmpHome, ".pi", "logs"), "not-a-dir");
@@ -111,11 +134,11 @@ describe("file-logger", () => {
     assert.ok(mod.getFileLogErrorCount() >= 1);
     assert.ok(mod.getLastFileLogError());
 
-    const fallback = join(tmpdir(), "pi-logs", "cli-provider.log");
+    const fallback = join(tmpFallbackBase, "pi-logs", "cli-provider.log");
     assert.match(readFileSync(fallback, "utf-8"), /fallback/);
   });
 
-  it("dreaming and cli-provider sources do not call console.* for ops logs", () => {
+  it("dreaming and cli-provider sources have no executable console.* ops calls", () => {
     const files = [
       join(REPO, "extensions/orchestrator/dreaming.ts"),
       join(REPO, "extensions/cli-provider/session-reaper.ts"),
@@ -127,7 +150,7 @@ describe("file-logger", () => {
     ];
     const consoleRe = /\bconsole\.(debug|log|info|warn|error)\s*\(/;
     for (const file of files) {
-      const src = readFileSync(file, "utf-8");
+      const src = stripTsComments(readFileSync(file, "utf-8"));
       assert.equal(
         consoleRe.test(src),
         false,


### PR DESCRIPTION
## Summary
- Extension `console.*` from cli-provider/dreaming was leaking into the pi chat text box
- Added `extensions/shared/file-logger.ts` writing to `~/.pi/logs/cli-provider.log` and `~/.pi/logs/dreaming.log`
- Reaper, discovery, resume recover, and dreaming provenance/rebuild/promotion now log there (errors included — no silent ignore)

## Test plan
- [ ] Reload pi; confirm reaper/dream messages no longer appear in the chat text box
- [ ] Trigger a CLI session / dream path; confirm lines appear in `~/.pi/logs/cli-provider.log` / `dreaming.log`
- [ ] `npx tsx --test tests/node/shared/file-logger.test.ts tests/node/cli-provider/**/*.test.ts`


Made with [Cursor](https://cursor.com)