### PR TITLE
feat(docker): add ripgrep to container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   procps \
   psmisc \
   acl \
+  ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
 # Install GitHub CLI (signed repo, uses curl+gpg from above)

--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ PI_PIDIFF_ENABLE=false pi
 | `docker` / `podman` | Container CLIs (used via `docker-safe` read-only wrapper) |
 | `docker-safe` | Restricted Docker/Podman wrapper — container only (ps, logs, inspect, top, stats) |
 | `jq` | JSON processing |
+| `rg` (ripgrep) | Fast recursive search |
 | `cr` | CodeRabbit CLI — local AI code reviews |
 | `curl` | HTTP requests |
 


### PR DESCRIPTION
## Summary
- Add `ripgrep` to the Docker image apt packages so `rg` is available in the container
- Document `rg` in the README "What's in the image" tools table
- Closes #656

## Test plan
- [ ] Confirm `Dockerfile` includes `ripgrep` in the base apt install block
- [ ] Confirm README lists `rg` (ripgrep)
- [ ] Build image and verify `rg --version` works inside the container


Made with [Cursor](https://cursor.com)