### PR TITLE
fix(deps): override adm-zip to clear npm audit highs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "undici": ">=6.27.0 <9.0.0",
-    "adm-zip": "0.6.0"
+    "adm-zip": "^0.6.0"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "overrides": {
     "undici": ">=6.27.0 <9.0.0",
-    "adm-zip": ">=0.6.0"
+    "adm-zip": "0.6.0"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "esbuild": true
   },
   "overrides": {
-    "undici": ">=6.27.0 <9.0.0"
+    "undici": ">=6.27.0 <9.0.0",
+    "adm-zip": ">=0.6.0"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary
- Add npm `overrides.adm-zip: ">=0.6.0"` to fix GHSA-xcpc-8h2w-3j85 without downgrading `@huggingface/transformers`
- `npm audit` reports 0 vulnerabilities after override
- Closes #658

## Test plan
- [ ] `npm install` resolves `adm-zip@>=0.6.0` (overridden)
- [ ] `npm audit` shows 0 vulnerabilities
- [ ] Container `pi update` no longer reports the 3 high severity findings for this chain


Made with [Cursor](https://cursor.com)