### PR TITLE
fix(pidash): drop globe emoji from status bar label

### DIFF
--- a/extensions/pidash/pidash.ts
+++ b/extensions/pidash/pidash.ts
@@ -522,7 +522,7 @@ export function registerPidash(
         try {
           if (ctx.hasUI) {
             const link = hyperlink("pi-dash", `http://localhost:${pidashPort}`);
-            ctx.ui.setStatus("9-pidash", ctx.ui.theme.fg("accent", `🌐 ${link}`));
+            ctx.ui.setStatus("9-pidash", ctx.ui.theme.fg("accent", link));
           }
         } catch {
           // ctx may be stale if session was replaced during WebSocket connect


### PR DESCRIPTION
## Summary
- Remove the 🌐 prefix from the pidash status-line widget so it shows only the clickable `pi-dash` label

## Test plan
- [ ] Start pi with pidash enabled
- [ ] Confirm status bar shows `pi-dash` without 🌐
- [ ] Confirm the label still opens the dashboard URL


Made with [Cursor](https://cursor.com)