### PR TITLE
fix(cli-provider): call getSessionId with bound this (#664)

### DIFF
--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -140,9 +140,15 @@ function sessionKeyFor(
 function bindActivePiSessionId(ctx: {
   sessionManager?: { getSessionId?: () => string };
 }): void {
-  const { readPiSessionId: sid } = readPiSessionIdFromManager(
+  const { readPiSessionId: sid, readError } = readPiSessionIdFromManager(
     ctx.sessionManager,
   );
+  if (readError) {
+    cliProviderLog(
+      "warn",
+      "getSessionId threw during before_agent_start; treating sid as unknown",
+    );
+  }
   if (sid) {
     activePiSessionId = sid;
     migrateMarkersToRealPiSessionId(sid);
@@ -661,9 +667,14 @@ export default async function (pi: ExtensionAPI) {
       typeof (event as { reason?: string })?.reason === "string"
         ? (event as { reason: string }).reason
         : "";
-    const { hasGetter, readPiSessionId: rawSid } = readPiSessionIdFromManager(
-      ctx.sessionManager,
-    );
+    const { hasGetter, readPiSessionId: rawSid, readError } =
+      readPiSessionIdFromManager(ctx.sessionManager);
+    if (readError) {
+      cliProviderLog(
+        "warn",
+        "getSessionId threw during session_start; treating sid as unknown",
+      );
+    }
     const prevSid = activePiSessionId;
     const { nextActivePiSessionId, resolvedReadSid } =
       resolveActivePiSessionIdOnSessionStart({

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -47,6 +47,7 @@ import {
   shouldAdoptLegacyCliMarker,
   decideCliSessionStartReseed,
   loadCliSessionId,
+  readPiSessionIdFromManager,
   resolveActivePiSessionIdOnSessionStart,
   resolveCliHistorySeed,
   saveCliSessionId,
@@ -139,10 +140,9 @@ function sessionKeyFor(
 function bindActivePiSessionId(ctx: {
   sessionManager?: { getSessionId?: () => string };
 }): void {
-  const sid =
-    typeof ctx.sessionManager?.getSessionId === "function"
-      ? ctx.sessionManager.getSessionId() || null
-      : null;
+  const { readPiSessionId: sid } = readPiSessionIdFromManager(
+    ctx.sessionManager,
+  );
   if (sid) {
     activePiSessionId = sid;
     migrateMarkersToRealPiSessionId(sid);
@@ -661,9 +661,9 @@ export default async function (pi: ExtensionAPI) {
       typeof (event as { reason?: string })?.reason === "string"
         ? (event as { reason: string }).reason
         : "";
-    const getter = ctx.sessionManager?.getSessionId;
-    const hasGetter = typeof getter === "function";
-    const rawSid = hasGetter ? getter() || null : null;
+    const { hasGetter, readPiSessionId: rawSid } = readPiSessionIdFromManager(
+      ctx.sessionManager,
+    );
     const prevSid = activePiSessionId;
     const { nextActivePiSessionId, resolvedReadSid } =
       resolveActivePiSessionIdOnSessionStart({

--- a/extensions/cli-provider/sessions.ts
+++ b/extensions/cli-provider/sessions.ts
@@ -463,21 +463,27 @@ export function resolveActivePiSessionIdOnSessionStart(opts: {
  * Read pi session id from sessionManager.
  * MUST call getSessionId on the manager object (not as an unbound method) —
  * pi's impl reads `this.sessionId` and throws if `this` is lost (#664).
- * Throws → treat as unknown (hasGetter false).
+ * Throws → treat as unknown (hasGetter false) and set readError for logging.
  */
 export function readPiSessionIdFromManager(sessionManager?: {
   getSessionId?: () => string;
-}): { hasGetter: boolean; readPiSessionId: string | null } {
+}): {
+  hasGetter: boolean;
+  readPiSessionId: string | null;
+  /** True when getSessionId existed but threw — callers should log. */
+  readError: boolean;
+} {
   if (typeof sessionManager?.getSessionId !== "function") {
-    return { hasGetter: false, readPiSessionId: null };
+    return { hasGetter: false, readPiSessionId: null, readError: false };
   }
   try {
     return {
       hasGetter: true,
       readPiSessionId: sessionManager.getSessionId() || null,
+      readError: false,
     };
   } catch {
-    return { hasGetter: false, readPiSessionId: null };
+    return { hasGetter: false, readPiSessionId: null, readError: true };
   }
 }
 

--- a/extensions/cli-provider/sessions.ts
+++ b/extensions/cli-provider/sessions.ts
@@ -460,6 +460,28 @@ export function resolveActivePiSessionIdOnSessionStart(opts: {
 }
 
 /**
+ * Read pi session id from sessionManager.
+ * MUST call getSessionId on the manager object (not as an unbound method) —
+ * pi's impl reads `this.sessionId` and throws if `this` is lost (#664).
+ * Throws → treat as unknown (hasGetter false).
+ */
+export function readPiSessionIdFromManager(sessionManager?: {
+  getSessionId?: () => string;
+}): { hasGetter: boolean; readPiSessionId: string | null } {
+  if (typeof sessionManager?.getSessionId !== "function") {
+    return { hasGetter: false, readPiSessionId: null };
+  }
+  try {
+    return {
+      hasGetter: true,
+      readPiSessionId: sessionManager.getSessionId() || null,
+    };
+  } catch {
+    return { hasGetter: false, readPiSessionId: null };
+  }
+}
+
+/**
  * Unlink CLI session markers for a cwd scoped to a pi session id.
  * By default also clears legacy `default` markers for that cwd (migration).
  * Does not touch other concurrent pi sessions sharing the same project.

--- a/tests/node/cli-provider/index-resume.test.ts
+++ b/tests/node/cli-provider/index-resume.test.ts
@@ -267,6 +267,16 @@ describe("/resume reseed path (markers + history seed)", () => {
     const r = readPiSessionIdFromManager(unbound);
     assert.equal(r.hasGetter, false);
     assert.equal(r.readPiSessionId, null);
+    assert.equal(r.readError, true);
+  });
+
+  it("readPiSessionIdFromManager missing getter is not a readError", async () => {
+    const { readPiSessionIdFromManager } = await import(
+      "../../../extensions/cli-provider/sessions.js"
+    );
+    const r = readPiSessionIdFromManager(undefined);
+    assert.equal(r.hasGetter, false);
+    assert.equal(r.readError, false);
   });
 
   it("reload does not clear markers", () => {

--- a/tests/node/cli-provider/index-resume.test.ts
+++ b/tests/node/cli-provider/index-resume.test.ts
@@ -239,6 +239,36 @@ describe("/resume reseed path (markers + history seed)", () => {
     assert.equal(r.sidKnown, true);
   });
 
+  it("readPiSessionIdFromManager calls through object (keeps this)", async () => {
+    const { readPiSessionIdFromManager } = await import(
+      "../../../extensions/cli-provider/sessions.js"
+    );
+    const manager = {
+      sessionId: "sid-bound",
+      getSessionId() {
+        return this.sessionId;
+      },
+    };
+    const r = readPiSessionIdFromManager(manager);
+    assert.equal(r.hasGetter, true);
+    assert.equal(r.readPiSessionId, "sid-bound");
+  });
+
+  it("readPiSessionIdFromManager treats throw as unknown (issue #664)", async () => {
+    const { readPiSessionIdFromManager } = await import(
+      "../../../extensions/cli-provider/sessions.js"
+    );
+    // Mimic extracting unbound method — calling it would throw on this.sessionId
+    const unbound = {
+      getSessionId() {
+        return (undefined as unknown as { sessionId: string }).sessionId;
+      },
+    };
+    const r = readPiSessionIdFromManager(unbound);
+    assert.equal(r.hasGetter, false);
+    assert.equal(r.readPiSessionId, null);
+  });
+
   it("reload does not clear markers", () => {
     const prevHome = process.env.HOME;
     const prevProfile = process.env.USERPROFILE;


### PR DESCRIPTION
## Summary
- Fix #664: `session_start` no longer calls `getSessionId` as an unbound method (loses `this` → crash on `this.sessionId`)
- Centralize safe read in `readPiSessionIdFromManager` (try/catch → unknown sid)
- Regression tests for bound call + throw-as-unknown

## Test plan
- [x] `npx tsx --test tests/node/cli-provider/index-resume.test.ts`
- [ ] Reload pi / start session — no Extension error on `session_start`
- [ ] CLI `--resume` still binds after session id available


Made with [Cursor](https://cursor.com)