### PR TITLE
fix(cli-provider): strip ANSI from agent --list-models (#666)

### DIFF
--- a/extensions/cli-provider/agents/cursor.ts
+++ b/extensions/cli-provider/agents/cursor.ts
@@ -9,11 +9,19 @@ import { cliProviderLog } from "../../shared/file-logger.js";
 import type { CliProviderDef, DiscoveredCliModel } from "../types.js";
 import { resolveBinary } from "../shared/discover-cache.js";
 
+/** Strip CSI / OSC ANSI sequences so colored CLI output still parses (#666). */
+export function stripAnsi(text: string): string {
+  return text
+    .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g, "")
+    .replace(/\u001b[@-Z\\-_]/g, "");
+}
+
 /** Parse `agent --list-models` text output. */
 export function parseAgentListModels(stdout: string): DiscoveredCliModel[] {
   const models: DiscoveredCliModel[] = [];
   const seen = new Set<string>();
-  for (const line of stdout.split(/\r?\n/)) {
+  for (const line of stripAnsi(stdout).split(/\r?\n/)) {
     const m = line.match(
       /^([a-zA-Z0-9][a-zA-Z0-9._\[\]=,:-]*)\s+-\s+(.+?)\s*$/,
     );
@@ -34,7 +42,8 @@ function discoverCursorModels(): DiscoveredCliModel[] {
   const r = spawnSync(binary, ["--list-models"], {
     encoding: "utf-8",
     timeout: 25_000,
-    env: { ...process.env },
+    // Prefer plain text; still strip ANSI in parser if CLI ignores NO_COLOR.
+    env: { ...process.env, NO_COLOR: "1", FORCE_COLOR: "0" },
   });
   const out = `${r.stdout || ""}\n${r.stderr || ""}`;
   const models = parseAgentListModels(out);

--- a/tests/node/cli-provider/providers.test.ts
+++ b/tests/node/cli-provider/providers.test.ts
@@ -118,6 +118,17 @@ Tip: use --model <id>
     assert.equal(models[2].name, "GPT-5.4 1M");
   });
 
+  it("parses agent --list-models with ANSI color (issue #666)", () => {
+    const colored =
+      "\u001b[36mauto\u001b[0m - \u001b[1mAuto\u001b[0m (default)\n" +
+      "\u001b[32mcomposer-2.5\u001b[0m - Composer 2.5\n";
+    const models = parseAgentListModels(colored);
+    assert.equal(models.length, 2);
+    assert.equal(models[0].id, "auto");
+    assert.equal(models[0].name, "Auto");
+    assert.equal(models[1].id, "composer-2.5");
+  });
+
   it("parses claude binary catalog", () => {
     const models = parseClaudeBinaryCatalog(
       `{id:"claude-opus-4-6",family:"opus",display_name:"Opus 4.6"}` +


### PR DESCRIPTION
## Summary
- Fix #666: `parseAgentListModels` no longer drops colored `agent --list-models` lines
- Strip ANSI before regex; spawn discovery with `NO_COLOR=1` / `FORCE_COLOR=0`
- Regression test with CSI-colored sample

## Test plan
- [x] `npx tsx --test tests/node/cli-provider/providers.test.ts`
- [ ] In FORCE_COLOR=1 container, cli-cursor discovery returns models (not empty)


Made with [Cursor](https://cursor.com)