### PR TITLE
fix(deps): override protobufjs to ^7.6.5 (#669)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "overrides": {
     "undici": ">=6.27.0 <9.0.0",
     "adm-zip": "^0.6.0",
-    "protobufjs": "^7.6.5"
+    "protobufjs": "7.6.5"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "overrides": {
     "undici": ">=6.27.0 <9.0.0",
-    "adm-zip": "^0.6.0"
+    "adm-zip": "^0.6.0",
+    "protobufjs": "^7.6.5"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary
- Fix #669: override transitive `protobufjs` to `^7.6.5` (CVE via onnxruntime-web)
- `npm audit` → 0 vulnerabilities

## Test plan
- [x] `npm ls protobufjs` shows 7.6.5 overridden
- [x] `npm audit` clean


Made with [Cursor](https://cursor.com)