### PR TITLE
chore: bump version to 3.15.2

### DIFF
--- a/myk_pi_tools/__init__.py
+++ b/myk_pi_tools/__init__.py
@@ -1,3 +1,3 @@
 """myk-pi-tools: CLI utilities for pi orchestrator plugins."""
 
-__version__ = "3.15.1"
+__version__ = "3.15.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-orchestrator-config",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Orchestrator pattern for pi: specialist subagents, enforcement, code review loop, workflow commands",
   "keywords": [
     "pi-package"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myk-pi-tools"
-version = "3.15.1"
+version = "3.15.2"
 description = "CLI utilities for pi orchestrator plugins"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "myk-pi-tools"
-version = "3.15.1"
+version = "3.15.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-cli-runner" },


### PR DESCRIPTION
## Summary
- Bump package/CLI version metadata to 3.15.2 for the release.

## Test plan
- [x] Version files updated via `myk-pi-tools release bump-version`
- [ ] Merge then create GitHub release tag v3.15.2


Made with [Cursor](https://cursor.com)