### PR TITLE
feat(providers): migrate cli+acpx to createProvider ModelRuntime (#672)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ Writing effective rules:
   blocks `curl | bash`, `eval $(curl)`, nested `$(bash -c "$(curl)")`,
   prefix assignments (`VAR=$(curl) cmd`), path-prefixed exec (`/bin/bash -c`).
   Allows safe `VAR=$(curl ...)` variable assignments at statement boundaries.
+- Native `cli-*` / `acpx-*` providers: use `extensions/shared/create-runtime-provider.ts`
+  (`createProvider` + `/login` + fetch/filter) — never legacy `registerProvider(name, bag)`
 
 ## When Modifying Docker
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Single extension that provides:
 |---------|-------------|
 | **Subagent tool** | Delegate tasks to specialist agents (single, parallel, chain, async modes) |
 | **Async background agents** | Spawn agents in background with `async: true` — results surface automatically when complete. On **acpx** parents, optional async is coerced to sync; dream/cron need `async_llm_provider` + `async_llm_model`. `cli-*` providers support async natively (see `dev-docs/cli-provider.md`) |
-| **CLI providers** | Optional `cli_agents` setting registers `cli-claude` / `cli-gemini` / `cli-cursor` via real CLIs (parallel to `acpx_*`) |
+| **CLI / ACPX providers** | Optional `cli_agents` / `acpx_agents` register `cli-*` / `acpx-*` via native `createProvider` (pi ≥ 0.81): `/login cli-<agent>` or `/login acpx-<agent>`, model refresh, filter when unavailable |
 | **`/btw` command** | Quick side questions without polluting conversation history — ephemeral overlay |
 | **`/async-status` command** | Show status of background agents — select one for live output streaming |
 | **`ask_user` tool** | Structured user input with options and free-text — used by workflows |
@@ -367,8 +367,10 @@ Run pi inside a disposable container for **filesystem isolation** — the agent 
 **CLI provider binaries (optional `cli_agents`):** The image installs the CLIs used by
 `cli-*` providers — `claude` (Claude Code), `gemini` (`@google/gemini-cli`), and
 `agent` (Cursor Agent CLI). Enable with `cli_agents` in settings (e.g.
-`["claude","cursor","gemini"]`). Without those binaries on PATH, `cli-*` models will
-not register or will fail at turn time. See `dev-docs/cli-provider.md`.
+`["claude","cursor","gemini"]`). Binary missing at load → `cli-*` not registered.
+After register, `filterModels` hides models when unavailable: PATH cleared while
+agent state remains → restore PATH; after `session_shutdown` (AgentState cleared)
+→ `/reload` or restart (PATH alone is not enough). See `dev-docs/cli-provider.md`.
 
 **CLI specialist agents (Cursor / Claude / Gemini):** On container start, `entrypoint.sh`
 symlinks package `agents/*.md` into the mounted project:
@@ -760,7 +762,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md) for tips on testing extensions locally, run
 
 ## Prerequisites
 
-- [pi](https://github.com/badlogic/pi-mono) (minimum version: **0.80.3**)
+- [pi](https://github.com/badlogic/pi-mono) (minimum version: **0.81.0**)
 - `gh` CLI (for GitHub operations)
 - `uv` (for Python execution)
 - `myk-pi-tools` (optional, for `/pr-review` and `/release`)

--- a/dev-docs/async-internals.md
+++ b/dev-docs/async-internals.md
@@ -26,6 +26,17 @@ dependency (required so plain `pi` / `~/.pi` installs can `import("acpx/runtime"
 Package dep range is `">=0.12.0 <1"` (latest within acpx 0.x; see issue #651).
 Not `^0.8.0` (that stays on 0.8.x under 0.x caret rules).
 
+**Native createProvider (pi ≥ 0.81):** `acpx-*` registers via
+`extensions/shared/create-runtime-provider.ts` (same helper as `cli-*`):
+ambient `resolve`/`check` succeed when `isAcpxAgentConfigured` (`agents.has`);
+`/login acpx-<agent>` stores an optional `configured` marker (not required for ambient
+auth); `fetchModels` rediscovers via `discoverModelsInternal` (returns `[]` if no
+state; empty discovery with state → `${agent}:default`);
+`filterModels` also gates on `agents.has` — **not** a live health probe;
+`session_shutdown` clears `agents`, so models hide until reload/restart;
+streams use `{ stream, streamSimple }` → `streamAcpx`.
+No legacy `registerProvider(name, { streamSimple })` bag.
+
 **Meta invocations:** `isPiMetaInvocation()` (`extensions/orchestrator/utils.ts`)
 skips acpx/cli provider discovery on `pi --help` / `--version` (`-h` / `-v`).
 

--- a/dev-docs/cli-provider.md
+++ b/dev-docs/cli-provider.md
@@ -24,7 +24,9 @@ Empty / unset → extension registers nothing.
 1. Read `cli_agents` at extension load
 2. For each agent: probe binary (30s discovery timeout), create agent state
 3. **Discover models from the CLI only** (see below) — no API keys, no cloud list APIs
-4. Register `cli-${agent}` with discovered models, or `${agent}:default` if discovery returns empty
+4. Register `cli-${agent}` via **`createRuntimeProvider()`** (shared helper wrapping
+   `createProvider`) then `pi.registerProvider(provider)` (pi ≥ 0.81), with discovered
+   models or `${agent}:default` if discovery returns empty
 5. Skip registration if binary missing (no agent state)
 6. Start session reaper (5m sweep; no immediate sweep at load) for
    `~/.pi/cli-sessions/` — deletes idle `status=stopped` markers only.
@@ -46,6 +48,29 @@ Empty / unset → extension registers nothing.
 `pi --help` / `pi --version` (and `-h` / `-v`) still load extensions; both
 `cli-provider` and `acpx-provider` early-return via `isPiMetaInvocation()` so
 they do not run model discovery for meta invocations.
+
+## Native createProvider (pi ≥ 0.81)
+
+Shared helper: `extensions/shared/create-runtime-provider.ts`.
+
+| Piece | Behavior |
+|-------|----------|
+| **auth /login** | `/login cli-<agent>` stores marker credential `configured` when `isCliAgentConfigured` (binary on PATH **and** agent state). Ambient `resolve`/`check` succeed when configured. |
+| **fetchModels** | Not configured (`!isCliAgentConfigured`) → `[]`. Configured (PATH + AgentState) + empty discovery → `${agent}:default`. |
+| **filterModels** | Hides models when `isCliAgentConfigured` is false (binary gone or `agents` cleared on shutdown) |
+| **streams** | Native `ProviderStreams`: `{ stream, streamSimple }` both wrap `streamCli` |
+
+Legacy `pi.registerProvider(name, { apiKey, streamSimple })` bags are **not** used.
+
+**Binary missing at load** → provider is not registered; install then `/reload` or
+restart.
+
+**Already registered, PATH cleared (AgentState remains)** → restore PATH; models
+show again via filter/ambient. `/login` only stores the credential; model refresh
+rediscovers.
+
+**After `session_shutdown`** → `agents` cleared; models stay hidden until
+`/reload` or restart recreates AgentState (PATH restore alone is not enough).
 
 ## Model discovery (CLI only)
 

--- a/dev-docs/project-settings.md
+++ b/dev-docs/project-settings.md
@@ -11,8 +11,8 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 | `dco` | boolean | disabled | `PI_DCO` | Add --signoff to all commits (DCO) |
 | `comment_signature` | boolean | disabled | — | Append AI signature to all PR comments |
 | `review_loop_enforcement` | boolean | disabled | `PI_REVIEW_LOOP_ENFORCEMENT` | Block git commit until all 5 reviewers approve (review loop enforcement) |
-| `acpx_agents` | string or string[] | `[]` | `ACPX_AGENTS` | acpx agents to register as pi models (e.g. `"cursor"` or `["cursor","claude"]`) |
-| `cli_agents` | string or string[] | `[]` | `CLI_AGENTS` | CLI agents to register as `cli-*` providers (e.g. `"cursor"` or `["claude","gemini","cursor"]`). See `dev-docs/cli-provider.md` |
+| `acpx_agents` | string or string[] | `[]` | `ACPX_AGENTS` | acpx agents to register as `acpx-*` models via createProvider (pi ≥ 0.81). Ambient auth when configured (`agents.has`); `/login` stores optional marker. See `dev-docs/async-internals.md` |
+| `cli_agents` | string or string[] | `[]` | `CLI_AGENTS` | CLI agents to register as `cli-*` providers via createProvider (pi ≥ 0.81; e.g. `"cursor"` or `["claude","gemini","cursor"]`). Ambient auth when configured (PATH + AgentState); `/login` optional marker. See `dev-docs/cli-provider.md` |
 | `pidash_enable` | boolean | `true` | `PI_PIDASH_ENABLE` | Enable pidash web dashboard (`false`/`0`/`no`/`off` disables) |
 | `pidiff_enable` | boolean | `true` | `PI_PIDIFF_ENABLE` | Enable pidiff diff viewer (`false`/`0`/`no`/`off` disables) |
 | `pidash_port` | number | `19190` | `PI_PIDASH_PORT` | pidash HTTP/WebSocket port |

--- a/dev-docs/repo-structure.md
+++ b/dev-docs/repo-structure.md
@@ -85,16 +85,21 @@ pi-config/
 │   │   ├── pidiff.ts                # Diff viewer logic (spawns/connects to per-project pidiff server via .pi/tmp/ lockfiles)
 │   │   └── pidiff-ui/               # React diff viewer UI (@pierre/diffs + @pierre/trees)
 │   ├── shared/                      # Shared extension utilities
+│   │   ├── create-runtime-provider.ts # createProvider helpers for cli/acpx (auth/fetch/filter)
 │   │   ├── daemon-manager.ts        # Server infrastructure (spawn, health check, WebSocket) — shared by pidash and pidiff
 │   │   ├── ws-client.ts             # WebSocket heartbeat + reconnect helpers (used by pidash, pidiff)
 │   │   └── ui/                      # Shared shadcn/ui components (used by pidash-ui and pidiff-ui via @ui alias)
-│   ├── acpx-provider/              # ACPX provider extension (acpx/runtime library API)
-│   ├── cli-provider/               # CLI-backed providers (cli-claude, cli-gemini, cli-cursor)
+│   ├── acpx-provider/              # ACPX provider extension (createProvider + acpx/runtime)
+│   │   ├── index.ts                # Provider registration + streamAcpx + discoverAcpxModels
+│   │   ├── load-runtime.ts         # Resolve acpx/runtime (global npm, then package-local)
+│   │   └── runtime-models.ts       # mapAcpxDiscoveredModels → createProvider Model[]
+│   ├── cli-provider/               # CLI-backed providers (createProvider; cli-claude/gemini/cursor)
 │   │   ├── agents/                 # Per-CLI drivers (cursor/claude/gemini) — add new CLI here
 │   │   ├── shared/                 # Shared discovery cache helpers
 │   │   ├── sessions.ts             # Resume directory (lastSeen/status)
-│   │   └── session-reaper.ts       # Idle session marker cleanup
-│   │   └── index.ts                # Provider + exported discoverAcpxModels() for external consumers
+│   │   ├── session-reaper.ts       # Idle session marker cleanup
+│   │   ├── runtime-models.ts       # mapCliDiscoveredModels → createProvider Model[]
+│   │   └── index.ts                # Provider registration + streamCli + discoverCliModels
 │   └── image-gen/                   # Image generation extension (standalone)
 │       ├── index.ts                # Entry point — registers generate_image tool
 │       └── image-gen.ts            # Gemini API image generation (settings: image_model; env: GEMINI_API_KEY)
@@ -156,9 +161,11 @@ pi-config/
 ├── pi-config-settings.example.json    # Example project settings file
 ├── tests/                           # Test suite
 │   ├── node/                        # Node.js tests (tsx + node:test)
+│   │   ├── acpx-provider/           # ACPX createProvider / runtime-model tests
+│   │   ├── cli-provider/            # CLI createProvider / runtime-model tests
 │   │   ├── orchestrator/            # Orchestrator extension tests
 │   │   ├── pidiff/                  # Pidiff extension tests
-│   │   └── shared/                  # Shared utility tests (coms-shared, daemon-manager)
+│   │   └── shared/                  # Shared tests (coms-shared, daemon-manager, create-runtime-provider)
 │   └── python/                      # Python tests (pytest)
 ├── package.json                     # Node.js dependencies (extensions)
 ├── tox.toml                         # Test runner config (Python + Node environments)

--- a/extensions/acpx-provider/configured.ts
+++ b/extensions/acpx-provider/configured.ts
@@ -1,0 +1,27 @@
+/**
+ * ACPX agent "configured" gate: AgentState/runtime present.
+ * Kept separate from index.ts so unit tests can exercise it without loading pi-ai.
+ */
+
+/** Bound to the extension's AgentState map (or a test stand-in). */
+let agentStates: { has(agent: string): boolean } = new Map();
+
+/** Bind the live agents Map from the extension entrypoint. */
+export function bindAcpxAgentStates(map: {
+  has(agent: string): boolean;
+}): void {
+  agentStates = map;
+}
+
+/**
+ * True when this acpx agent has an initialized AgentState/runtime.
+ * Used by /login resolve/check and filterModels.
+ */
+export function isAcpxAgentConfigured(agent: string): boolean {
+  return agentStates.has(agent);
+}
+
+/** @internal — unit tests */
+export function bindAcpxAgentStatesForTests(agents: Iterable<string>): void {
+  agentStates = new Set(agents);
+}

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -262,12 +262,12 @@ export async function discoverAcpxModels(
 			provider: `acpx-${agent}`,
 		}));
 	} catch (err) {
-		console.debug(`[acpx] model discovery failed for ${agent}:`, err);
+		fileLog("acpx-provider", "debug", "acpx-provider", `model discovery failed for ${agent}:`, err);
 		return [];
 	} finally {
 		if (handle) {
 			await runtime.close({ handle, reason: "discovery complete" }).catch((err) => {
-				console.debug("[acpx] failed to close discovery session:", err);
+				fileLog("acpx-provider", "debug", "acpx-provider", "failed to close discovery session:", err);
 			});
 		}
 		await rm(stateDir, { recursive: true, force: true }).catch(() => {});
@@ -284,7 +284,7 @@ async function discoverModelsInternal(state: AgentState): Promise<string[]> {
 			return status.models.availableModelIds;
 		}
 	} catch (err) {
-		console.debug(`[acpx] model discovery failed for ${state.agent}:`, err);
+		fileLog("acpx-provider", "debug", "acpx-provider", `model discovery failed for ${state.agent}:`, err);
 	}
 	return [];
 }
@@ -332,7 +332,7 @@ function extractLatestUserMessage(context: Context): string {
 			}
 		}
 	}
-	console.debug("[acpx] no user message found in context, using fallback");
+	fileLog("acpx-provider", "debug", "acpx-provider", "no user message found in context, using fallback");
 	return "hello";
 }
 
@@ -609,7 +609,7 @@ export default async function (pi: ExtensionAPI) {
 					const runtime = await createAgentRuntime();
 					// Check timeout after slow runtime creation — don't store state if we already lost the race.
 					// Runtime without handles is lightweight (no connections/processes); safe to discard.
-					if (timedOut) { console.debug(`[acpx] ${agent}: discarding runtime after timeout`); return { agent, modelIds: [] as string[] }; }
+					if (timedOut) { fileLog("acpx-provider", "debug", "acpx-provider", `${agent}: discarding runtime after timeout`); return { agent, modelIds: [] as string[] }; }
 					let signalReady!: () => void;
 					const ready = new Promise<void>((resolve) => { signalReady = resolve; });
 					const state: AgentState = {
@@ -636,7 +636,7 @@ export default async function (pi: ExtensionAPI) {
 				clearTimeout(timer!);
 				return result;
 			} catch (err) {
-				console.debug(`[acpx] runtime init failed for ${agent}:`, err);
+				fileLog("acpx-provider", "debug", "acpx-provider", `runtime init failed for ${agent}:`, err);
 				const state = agents.get(agent);
 				if (state) state.signalReady();
 				return { agent, modelIds: [] as string[] };
@@ -651,7 +651,7 @@ export default async function (pi: ExtensionAPI) {
 		// Skip registration if runtime failed (no AgentState) — prevents
 		// registering a provider whose streamAcpx would always throw.
 		if (!agents.has(agent)) {
-			console.debug(`[acpx] acpx-${agent}: skipped registration (no runtime)`);
+			fileLog("acpx-provider", "debug", "acpx-provider", `acpx-${agent}: skipped registration (no runtime)`);
 			continue;
 		}
 
@@ -682,9 +682,9 @@ export default async function (pi: ExtensionAPI) {
 				api: { stream: streamAcpx, streamSimple: streamAcpx },
 			});
 			pi.registerProvider(provider);
-			console.debug(`[acpx] acpx-${agent}: ${models.length} model(s) registered (createProvider)`);
+			fileLog("acpx-provider", "debug", "acpx-provider", `acpx-${agent}: ${models.length} model(s) registered (createProvider)`);
 		} catch (err) {
-			console.debug(`[acpx] acpx-${agent}: setup failed:`, err);
+			fileLog("acpx-provider", "debug", "acpx-provider", `acpx-${agent}: setup failed:`, err);
 		}
 	}
 
@@ -695,7 +695,7 @@ export default async function (pi: ExtensionAPI) {
 			for (const [, handle] of state.handles) {
 				closePromises.push(
 					state.runtime.close({ handle, reason: "pi session shutdown" }).catch((err) => {
-						console.debug(`[acpx] session close failed:`, err);
+						fileLog("acpx-provider", "debug", "acpx-provider", "session close failed:", err);
 					}),
 				);
 			}

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -562,15 +562,23 @@ export default async function (pi: ExtensionAPI) {
 	if (isPiMetaInvocation()) return;
 
 	const versionCheck = checkMinPiVersion();
-	if (!versionCheck.ok) {
+	if (!versionCheck.ok && versionCheck.installed !== null) {
 		fileLog(
 			"acpx-provider",
 			"error",
 			"acpx-provider",
-			`pi ${versionCheck.installed || "unknown"} is below minimum ${versionCheck.required}; ` +
+			`pi ${versionCheck.installed} is below minimum ${versionCheck.required}; ` +
 				`acpx-* providers require createProvider — skipping registration`,
 		);
 		return;
+	}
+	if (versionCheck.installed === null) {
+		fileLog(
+			"acpx-provider",
+			"warn",
+			"acpx-provider",
+			`pi version unknown; attempting createProvider registration (requires >= ${versionCheck.required})`,
+		);
 	}
 
 	// Suppress noisy ACP SDK errors for unhandled agent extension methods

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -5,6 +5,9 @@
  * This lets you use models only available through specific agents (e.g., Cursor's
  * Composer 2, GPT-5.4, etc.) as native pi models.
  *
+ * Registers via createProvider() (pi ≥ 0.81): /login, fetchModels, filterModels,
+ * and native ProviderStreams. Shared helper: extensions/shared/create-runtime-provider.ts.
+ *
  * How it works:
  * 1. During extension load, creates an AcpxRuntime per agent and discovers models synchronously
  * 2. On each LLM request, sends only the latest user message via runtime.startTurn()
@@ -25,6 +28,7 @@ import type {
 	Context,
 	Model,
 	SimpleStreamOptions,
+	StreamOptions,
 } from "@earendil-works/pi-ai";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -34,7 +38,15 @@ import { randomUUID, createHash } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
 import { isPiMetaInvocation } from "../orchestrator/utils.js";
+import {
+	buildAmbientLoginAuth,
+	createRuntimeProvider,
+	filterModelsWhenConfigured,
+} from "../shared/create-runtime-provider.js";
 import { loadAcpxRuntime } from "./load-runtime.js";
+import { mapAcpxDiscoveredModels, modelIdToDisplayName } from "./runtime-models.js";
+
+export { mapAcpxDiscoveredModels, modelIdToDisplayName };
 
 // =============================================================================
 // Types
@@ -267,13 +279,12 @@ async function discoverModelsInternal(state: AgentState): Promise<string[]> {
 	return [];
 }
 
-function modelIdToDisplayName(modelId: string): string {
-	// Strip bracket suffixes for display: gpt-5.4[context=272k,...] -> Gpt 5.4
-	const bracketIdx = modelId.indexOf("[");
-	const baseName = bracketIdx >= 0 ? modelId.substring(0, bracketIdx) : modelId;
-	return baseName
-		.replace(/-/g, " ")
-		.replace(/\b\w/g, (c) => c.toUpperCase());
+/**
+ * True when this acpx agent has an initialized AgentState/runtime.
+ * Used by /login resolve/check and filterModels.
+ */
+export function isAcpxAgentConfigured(agent: string): boolean {
+	return agents.has(agent);
 }
 
 // =============================================================================
@@ -330,7 +341,7 @@ function extractLatestUserMessage(context: Context): string {
 function streamAcpx(
 	model: Model<any>,
 	context: Context,
-	options?: SimpleStreamOptions,
+	options?: SimpleStreamOptions | StreamOptions,
 ): AssistantMessageEventStream {
 	const stream = createAssistantMessageEventStream();
 
@@ -566,13 +577,6 @@ export default async function (pi: ExtensionAPI) {
 
 	const DISCOVERY_TIMEOUT_MS = 30_000;
 
-	const makeModel = (id: string, name: string) => ({
-		id, name, reasoning: false,
-		input: ["text" as const, "image" as const],
-		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 200000, maxTokens: 32768,
-	});
-
 	// Discover models synchronously during extension load.
 	// Pi awaits async extension factories, so models are registered before
 	// the model resolver runs — preventing silent fallback to default model.
@@ -638,18 +642,33 @@ export default async function (pi: ExtensionAPI) {
 		}
 
 		try {
-			const models = modelIds.length > 0
-				? modelIds.map((m) => makeModel(`${agent}:${m}`, `${modelIdToDisplayName(m)} (${agent})`))
-				: [makeModel(`${agent}:default`, `${agent} (default)`)];
-
-			pi.registerProvider(`acpx-${agent}`, {
-				baseUrl: "https://localhost",
-				apiKey: "acpx", // pragma: allowlist secret
-				api: "acpx",
+			const providerId = `acpx-${agent}`;
+			const models = mapAcpxDiscoveredModels(agent, modelIds);
+			const provider = await createRuntimeProvider({
+				id: providerId,
+				name: `ACPX ${agent}`,
+				auth: {
+					apiKey: buildAmbientLoginAuth({
+						displayName: `ACPX ${agent}`,
+						isConfigured: () => isAcpxAgentConfigured(agent),
+						sourceLabel: `${agent} acpx runtime`,
+					}),
+				},
 				models,
-				streamSimple: streamAcpx,
+				fetchModels: async () => {
+					const state = agents.get(agent);
+					if (!state) return [];
+					const nextIds = await discoverModelsInternal(state);
+					return mapAcpxDiscoveredModels(agent, nextIds);
+				},
+				filterModels: (catalog, credential) =>
+					filterModelsWhenConfigured(catalog, credential, () =>
+						isAcpxAgentConfigured(agent),
+					),
+				api: { stream: streamAcpx, streamSimple: streamAcpx },
 			});
-			console.debug(`[acpx] acpx-${agent}: ${models.length} model(s) registered`);
+			pi.registerProvider(provider);
+			console.debug(`[acpx] acpx-${agent}: ${models.length} model(s) registered (createProvider)`);
 		} catch (err) {
 			console.debug(`[acpx] acpx-${agent}: setup failed:`, err);
 		}

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -37,16 +37,25 @@ import os from "node:os";
 import { randomUUID, createHash } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
-import { isPiMetaInvocation } from "../orchestrator/utils.js";
+import {
+	checkMinPiVersion,
+	isPiMetaInvocation,
+} from "../orchestrator/utils.js";
 import {
 	buildAmbientLoginAuth,
 	createRuntimeProvider,
 	filterModelsWhenConfigured,
 } from "../shared/create-runtime-provider.js";
+import { fileLog } from "../shared/file-logger.js";
+import {
+	bindAcpxAgentStates,
+	isAcpxAgentConfigured,
+} from "./configured.js";
 import { loadAcpxRuntime } from "./load-runtime.js";
 import { mapAcpxDiscoveredModels, modelIdToDisplayName } from "./runtime-models.js";
 
 export { mapAcpxDiscoveredModels, modelIdToDisplayName };
+export { isAcpxAgentConfigured } from "./configured.js";
 
 // =============================================================================
 // Types
@@ -80,6 +89,7 @@ interface AgentState {
 
 /** Active agent runtimes keyed by agent name */
 const agents = new Map<string, AgentState>();
+bindAcpxAgentStates(agents);
 
 /**
  * The working directory captured at extension initialization time.
@@ -277,14 +287,6 @@ async function discoverModelsInternal(state: AgentState): Promise<string[]> {
 		console.debug(`[acpx] model discovery failed for ${state.agent}:`, err);
 	}
 	return [];
-}
-
-/**
- * True when this acpx agent has an initialized AgentState/runtime.
- * Used by /login resolve/check and filterModels.
- */
-export function isAcpxAgentConfigured(agent: string): boolean {
-	return agents.has(agent);
 }
 
 // =============================================================================
@@ -558,6 +560,18 @@ export default async function (pi: ExtensionAPI) {
 	if (process.env.PI_SUBAGENT_CHILD === "1") return;
 	// pi --help / --version still loads extensions; skip discovery noise/latency.
 	if (isPiMetaInvocation()) return;
+
+	const versionCheck = checkMinPiVersion();
+	if (!versionCheck.ok) {
+		fileLog(
+			"acpx-provider",
+			"error",
+			"acpx-provider",
+			`pi ${versionCheck.installed || "unknown"} is below minimum ${versionCheck.required}; ` +
+				`acpx-* providers require createProvider — skipping registration`,
+		);
+		return;
+	}
 
 	// Suppress noisy ACP SDK errors for unhandled agent extension methods
 	installConsoleErrorSuppression();

--- a/extensions/acpx-provider/runtime-models.ts
+++ b/extensions/acpx-provider/runtime-models.ts
@@ -1,0 +1,40 @@
+/**
+ * Map ACPX discovery results → full createProvider Model[].
+ * Kept separate from index.ts so unit tests do not load runtime/stream code.
+ */
+
+import { buildRuntimeModel } from "../shared/create-runtime-provider.js";
+
+export function modelIdToDisplayName(modelId: string): string {
+	// Strip bracket suffixes for display: gpt-5.4[context=272k,...] -> Gpt 5.4
+	const bracketIdx = modelId.indexOf("[");
+	const baseName = bracketIdx >= 0 ? modelId.substring(0, bracketIdx) : modelId;
+	return baseName
+		.replace(/-/g, " ")
+		.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function mapAcpxDiscoveredModels(
+	agent: string,
+	modelIds: readonly string[],
+): ReturnType<typeof buildRuntimeModel>[] {
+	const provider = `acpx-${agent}`;
+	if (modelIds.length === 0) {
+		return [
+			buildRuntimeModel({
+				id: `${agent}:default`,
+				name: `${agent} (default)`,
+				api: "acpx",
+				provider,
+			}),
+		];
+	}
+	return modelIds.map((m) =>
+		buildRuntimeModel({
+			id: `${agent}:${m}`,
+			name: `${modelIdToDisplayName(m)} (${agent})`,
+			api: "acpx",
+			provider,
+		}),
+	);
+}

--- a/extensions/cli-provider/configured.ts
+++ b/extensions/cli-provider/configured.ts
@@ -1,0 +1,30 @@
+/**
+ * CLI agent "configured" gate: binary on PATH + AgentState present.
+ * Kept separate from index.ts so unit tests can exercise it without loading pi-ai.
+ */
+
+import { isCliBinaryAvailable } from "./discover.js";
+import { isCliAgentName } from "./providers.js";
+
+/** Bound to the extension's AgentState map (or a test stand-in). */
+let agentStates: { has(agent: string): boolean } = new Map();
+
+/** Bind the live agents Map from the extension entrypoint. */
+export function bindCliAgentStates(map: { has(agent: string): boolean }): void {
+  agentStates = map;
+}
+
+/**
+ * True when the CLI binary is on PATH and this agent still has AgentState
+ * (cleared on session_shutdown). Used by /login resolve/check, filterModels,
+ * and fetchModels — matches ACPX `agents.has` gating so models hide after shutdown.
+ */
+export function isCliAgentConfigured(agent: string): boolean {
+  if (!isCliAgentName(agent)) return false;
+  return isCliBinaryAvailable(agent) && agentStates.has(agent);
+}
+
+/** @internal — unit tests */
+export function bindCliAgentStatesForTests(agents: Iterable<string>): void {
+  agentStates = new Set(agents);
+}

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -4,6 +4,9 @@
  * Routes pi LLM requests through real CLI tools (claude, gemini, cursor/agent)
  * under the `cli-*` namespace — parallel to `acpx-*`, without using ACP.
  *
+ * Registers via createProvider() (pi ≥ 0.81): /login, fetchModels, filterModels,
+ * and native ProviderStreams. See dev-docs/cli-provider.md.
+ *
  * How it works (matches acpx-provider flow):
  * 1. During extension load, discover models from each agent driver (CLI only)
  * 2. On each LLM request, resume CLI session when possible; recover if resume dies
@@ -29,11 +32,17 @@ import type {
   Context,
   Model,
   SimpleStreamOptions,
+  StreamOptions,
 } from "@earendil-works/pi-ai";
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
 import { isPiMetaInvocation } from "../orchestrator/utils.js";
+import {
+  buildAmbientLoginAuth,
+  createRuntimeProvider,
+  filterModelsWhenConfigured,
+} from "../shared/create-runtime-provider.js";
 import { cliProviderLog } from "../shared/file-logger.js";
 import { isCliAgentName, type CliAgentName } from "./providers.js";
 import {
@@ -68,6 +77,7 @@ import {
   modelIdToDisplayName,
   type DiscoveredCliModel,
 } from "./discover.js";
+import { mapCliDiscoveredModels } from "./runtime-models.js";
 
 export {
   discoverCliModels,
@@ -75,6 +85,7 @@ export {
   discoverCliModelsDetailed,
   modelIdToDisplayName,
   resolveCliHistorySeed,
+  mapCliDiscoveredModels,
 };
 
 // =============================================================================
@@ -114,6 +125,15 @@ const provisionalPiSessionId = createProvisionalPiSessionId();
  * instead of trusting a stale --resume marker (issue #661).
  */
 let forceHistorySeed = false;
+
+/**
+ * True when the CLI binary is on PATH and this agent still has AgentState
+ * (cleared on session_shutdown). Used by /login resolve/check, filterModels,
+ * and fetchModels — matches ACPX `agents.has` gating so models hide after shutdown.
+ */
+export function isCliAgentConfigured(agent: string): boolean {
+  return isCliBinaryAvailable(agent) && agents.has(agent);
+}
 
 // =============================================================================
 // Session ensure (acpx ensureHandle analogue)
@@ -360,7 +380,7 @@ function buildPromptWithHistory(context: Context, hasCliSession: boolean): strin
 function streamCli(
   model: Model<any>,
   context: Context,
-  options?: SimpleStreamOptions,
+  options?: SimpleStreamOptions | StreamOptions,
 ): AssistantMessageEventStream {
   const stream = createAssistantMessageEventStream();
 
@@ -765,16 +785,6 @@ export default async function (pi: ExtensionAPI) {
 
   const DISCOVERY_TIMEOUT_MS = 30_000;
 
-  const makeModel = (id: string, name: string) => ({
-    id,
-    name,
-    reasoning: false,
-    input: ["text" as const, "image" as const],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 200000,
-    maxTokens: 32768,
-  });
-
   // Discover models synchronously during extension load (same pattern as acpx).
   // Pi awaits async extension factories, so models are registered before
   // the model resolver runs — preventing silent fallback to default model.
@@ -855,23 +865,36 @@ export default async function (pi: ExtensionAPI) {
     }
 
     try {
-      const models =
-        discovered.length > 0
-          ? discovered.map((m) =>
-              makeModel(`${agent}:${m.id}`, `${m.name} (${agent})`),
-            )
-          : [makeModel(`${agent}:default`, `${agent} (default)`)];
-
-      pi.registerProvider(`cli-${agent}`, {
-        baseUrl: "https://localhost",
-        apiKey: "cli", // pragma: allowlist secret
-        api: "cli",
+      const providerId = `cli-${agent}`;
+      const models = mapCliDiscoveredModels(agent, discovered);
+      const provider = await createRuntimeProvider({
+        id: providerId,
+        name: `CLI ${agent}`,
+        auth: {
+          apiKey: buildAmbientLoginAuth({
+            displayName: `CLI ${agent}`,
+            isConfigured: () => isCliAgentConfigured(agent),
+            sourceLabel: `${agent} CLI on PATH`,
+          }),
+        },
         models,
-        streamSimple: streamCli,
+        fetchModels: async () => {
+          if (!isCliAgentConfigured(agent)) return [];
+          const next = await discoverCliModelsDetailed(agent);
+          const state = agents.get(agent);
+          if (state) state.availableModelIds = next.map((m) => m.id);
+          return mapCliDiscoveredModels(agent, next);
+        },
+        filterModels: (catalog, credential) =>
+          filterModelsWhenConfigured(catalog, credential, () =>
+            isCliAgentConfigured(agent),
+          ),
+        api: { stream: streamCli, streamSimple: streamCli },
       });
+      pi.registerProvider(provider);
       cliProviderLog(
         "info",
-        `cli-${agent}: ${models.length} model(s) registered`,
+        `cli-${agent}: ${models.length} model(s) registered (createProvider)`,
       );
     } catch (err) {
       cliProviderLog("error", `cli-${agent}: setup failed`, err);

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -659,13 +659,19 @@ export default async function (pi: ExtensionAPI) {
   if (isPiMetaInvocation()) return;
 
   const versionCheck = checkMinPiVersion();
-  if (!versionCheck.ok) {
+  if (!versionCheck.ok && versionCheck.installed !== null) {
     cliProviderLog(
       "error",
-      `pi ${versionCheck.installed || "unknown"} is below minimum ${versionCheck.required}; ` +
+      `pi ${versionCheck.installed} is below minimum ${versionCheck.required}; ` +
         `cli-* providers require createProvider — skipping registration`,
     );
     return;
+  }
+  if (versionCheck.installed === null) {
+    cliProviderLog(
+      "warn",
+      `pi version unknown; attempting createProvider registration (requires >= ${versionCheck.required})`,
+    );
   }
 
   // Capture cwd at extension load time, before pi potentially changes directory.

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -37,13 +37,20 @@ import type {
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
-import { isPiMetaInvocation } from "../orchestrator/utils.js";
+import {
+  checkMinPiVersion,
+  isPiMetaInvocation,
+} from "../orchestrator/utils.js";
 import {
   buildAmbientLoginAuth,
   createRuntimeProvider,
   filterModelsWhenConfigured,
 } from "../shared/create-runtime-provider.js";
 import { cliProviderLog } from "../shared/file-logger.js";
+import {
+  bindCliAgentStates,
+  isCliAgentConfigured,
+} from "./configured.js";
 import { isCliAgentName, type CliAgentName } from "./providers.js";
 import {
   clearCliSessionId,
@@ -87,6 +94,7 @@ export {
   resolveCliHistorySeed,
   mapCliDiscoveredModels,
 };
+export { isCliAgentConfigured } from "./configured.js";
 
 // =============================================================================
 // Types
@@ -111,6 +119,7 @@ interface AgentState {
 let projectCwd = "";
 let registeredAgents: string[] = [];
 const agents = new Map<string, AgentState>();
+bindCliAgentStates(agents);
 
 /** Real pi session UUID from sessionManager (not env — harness never sets PI_SESSION_ID). */
 let activePiSessionId: string | null = null;
@@ -125,15 +134,6 @@ const provisionalPiSessionId = createProvisionalPiSessionId();
  * instead of trusting a stale --resume marker (issue #661).
  */
 let forceHistorySeed = false;
-
-/**
- * True when the CLI binary is on PATH and this agent still has AgentState
- * (cleared on session_shutdown). Used by /login resolve/check, filterModels,
- * and fetchModels — matches ACPX `agents.has` gating so models hide after shutdown.
- */
-export function isCliAgentConfigured(agent: string): boolean {
-  return isCliBinaryAvailable(agent) && agents.has(agent);
-}
 
 // =============================================================================
 // Session ensure (acpx ensureHandle analogue)
@@ -657,6 +657,16 @@ export default async function (pi: ExtensionAPI) {
   // Intentionally does NOT skip PI_SUBAGENT_CHILD — cli-* must work in async children.
   // pi --help / --version still loads extensions; skip discovery noise/latency.
   if (isPiMetaInvocation()) return;
+
+  const versionCheck = checkMinPiVersion();
+  if (!versionCheck.ok) {
+    cliProviderLog(
+      "error",
+      `pi ${versionCheck.installed || "unknown"} is below minimum ${versionCheck.required}; ` +
+        `cli-* providers require createProvider — skipping registration`,
+    );
+    return;
+  }
 
   // Capture cwd at extension load time, before pi potentially changes directory.
   projectCwd = process.cwd();

--- a/extensions/cli-provider/runtime-models.ts
+++ b/extensions/cli-provider/runtime-models.ts
@@ -1,0 +1,32 @@
+/**
+ * Map CLI discovery results → full createProvider Model[].
+ * Kept separate from index.ts so unit tests do not load stream/session code.
+ */
+
+import { buildRuntimeModel } from "../shared/create-runtime-provider.js";
+import type { DiscoveredCliModel } from "./discover.js";
+
+export function mapCliDiscoveredModels(
+  agent: string,
+  discovered: readonly DiscoveredCliModel[],
+): ReturnType<typeof buildRuntimeModel>[] {
+  const provider = `cli-${agent}`;
+  if (discovered.length === 0) {
+    return [
+      buildRuntimeModel({
+        id: `${agent}:default`,
+        name: `${agent} (default)`,
+        api: "cli",
+        provider,
+      }),
+    ];
+  }
+  return discovered.map((m) =>
+    buildRuntimeModel({
+      id: `${agent}:${m.id}`,
+      name: `${m.name} (${agent})`,
+      api: "cli",
+      provider,
+    }),
+  );
+}

--- a/extensions/cli-provider/shared/discover-cache.ts
+++ b/extensions/cli-provider/shared/discover-cache.ts
@@ -12,7 +12,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { delimiter, extname, isAbsolute, join } from "node:path";
+import { extname, isAbsolute, join, posix, win32 } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import type { DiscoveredCliModel } from "../types.js";
@@ -72,6 +72,14 @@ export function candidateSuffixesFor(
     return [""];
   }
   return parsePathext(pathextEnv);
+}
+
+/**
+ * PATH list separator for the *resolved* platform (not the host OS).
+ * Needed so win32 simulation on Unix splits semicolon-separated PATH correctly.
+ */
+export function pathDelimiterFor(platform: NodeJS.Platform): string {
+  return platform === "win32" ? win32.delimiter : posix.delimiter;
 }
 
 /** Exported for tests — regular file + platform launchability rules. */
@@ -148,7 +156,8 @@ export function resolveBinaryForPlatform(
   }
 
   const suffixes = candidateSuffixesFor(binary, platform, pathextEnv);
-  for (const dir of pathEnv.split(delimiter)) {
+  const envDelimiter = pathDelimiterFor(platform);
+  for (const dir of pathEnv.split(envDelimiter)) {
     if (!dir) continue;
     for (const suffix of suffixes) {
       // PATHEXT is typically uppercase; Windows FS is case-insensitive.

--- a/extensions/cli-provider/shared/discover-cache.ts
+++ b/extensions/cli-provider/shared/discover-cache.ts
@@ -25,8 +25,13 @@ export function modelIdToDisplayName(modelId: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Cache keyed by `${binary}\0${PATH}` — successful resolves only (no negative cache). */
+/** Cache keyed by `${platform}\0${binary}\0${PATH}\0${PATHEXT}` — successful resolves only. */
 const resolveBinaryCache = new Map<string, string>();
+
+export type ResolveBinaryEnv = {
+  PATH?: string;
+  PATHEXT?: string;
+};
 
 /** Parse PATHEXT into uppercase extensions (e.g. ".EXE"). Exported for tests. */
 export function parsePathext(pathextEnv?: string): string[] {
@@ -69,7 +74,12 @@ export function candidateSuffixesFor(
   return parsePathext(pathextEnv);
 }
 
-function isExecutable(filePath: string): boolean {
+/** Exported for tests — regular file + platform launchability rules. */
+export function isExecutableForPlatform(
+  filePath: string,
+  platform: NodeJS.Platform,
+  pathextEnv?: string,
+): boolean {
   let st;
   try {
     st = statSync(filePath);
@@ -78,7 +88,8 @@ function isExecutable(filePath: string): boolean {
   }
   // Directories are often X_OK (searchable); only regular files are binaries.
   if (!st.isFile()) return false;
-  if (process.platform === "win32") return isLaunchableWin32(filePath);
+  // Win32: never treat any regular file as executable — require PATHEXT.
+  if (platform === "win32") return isLaunchableWin32(filePath, pathextEnv);
   try {
     accessSync(filePath, constants.X_OK);
     return true;
@@ -95,44 +106,81 @@ function finalizeResolved(filePath: string): string {
   }
 }
 
+function cacheKeyFor(
+  binary: string,
+  platform: NodeJS.Platform,
+  pathEnv: string,
+  pathextEnv: string,
+): string {
+  return `${platform}\0${binary}\0${pathEnv}\0${pathextEnv}`;
+}
+
+/**
+ * Resolve a binary for an explicit platform (injectable for win32 tests on Unix).
+ * Absolute paths still require a launchable PATHEXT extension on win32.
+ */
+export function resolveBinaryForPlatform(
+  binary: string,
+  platform: NodeJS.Platform,
+  env: ResolveBinaryEnv = {},
+): string | null {
+  if (!binary) return null;
+
+  const pathEnv = env.PATH ?? process.env.PATH ?? "";
+  const pathextEnv =
+    env.PATHEXT ?? process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM";
+  const cacheKey = cacheKeyFor(binary, platform, pathEnv, pathextEnv);
+  const cached = resolveBinaryCache.get(cacheKey);
+  if (cached !== undefined) {
+    if (isExecutableForPlatform(cached, platform, pathextEnv)) return cached;
+    resolveBinaryCache.delete(cacheKey);
+  }
+
+  const isExec = (p: string) =>
+    isExecutableForPlatform(p, platform, pathextEnv);
+
+  // Absolute or explicit relative path — check directly (mirrors `which /path`).
+  if (isAbsolute(binary) || binary.includes("/") || binary.includes("\\")) {
+    if (!isExec(binary)) return null;
+    const resolved = finalizeResolved(binary);
+    resolveBinaryCache.set(cacheKey, resolved);
+    return resolved;
+  }
+
+  const suffixes = candidateSuffixesFor(binary, platform, pathextEnv);
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const suffix of suffixes) {
+      // PATHEXT is typically uppercase; Windows FS is case-insensitive.
+      // On case-sensitive hosts (win32 simulation in tests), also try lowercase.
+      const variants =
+        platform === "win32" && suffix && suffix !== suffix.toLowerCase()
+          ? [binary + suffix, binary + suffix.toLowerCase()]
+          : [binary + suffix];
+      for (const name of variants) {
+        const candidate = join(dir, name);
+        if (!isExec(candidate)) continue;
+        const resolved = finalizeResolved(candidate);
+        resolveBinaryCache.set(cacheKey, resolved);
+        return resolved;
+      }
+    }
+  }
+
+  // Do not cache misses — mid-session install with same PATH must rediscover.
+  return null;
+}
+
 /**
  * Resolve a binary name (or absolute path) via an in-process PATH scan.
  * Avoids spawnSync("which") on auth/filter hot paths.
  * Returns realpath when possible, null if missing.
  */
 export function resolveBinary(binary: string): string | null {
-  if (!binary) return null;
-
-  const pathEnv = process.env.PATH ?? "";
-  const cacheKey = `${binary}\0${pathEnv}`;
-  const cached = resolveBinaryCache.get(cacheKey);
-  if (cached !== undefined) {
-    if (isExecutable(cached)) return cached;
-    resolveBinaryCache.delete(cacheKey);
-  }
-
-  // Absolute or explicit relative path — check directly (mirrors `which /path`).
-  if (isAbsolute(binary) || binary.includes("/") || binary.includes("\\")) {
-    if (!isExecutable(binary)) return null;
-    const resolved = finalizeResolved(binary);
-    resolveBinaryCache.set(cacheKey, resolved);
-    return resolved;
-  }
-
-  const suffixes = candidateSuffixesFor(binary);
-  for (const dir of pathEnv.split(delimiter)) {
-    if (!dir) continue;
-    for (const suffix of suffixes) {
-      const candidate = join(dir, binary + suffix);
-      if (!isExecutable(candidate)) continue;
-      const resolved = finalizeResolved(candidate);
-      resolveBinaryCache.set(cacheKey, resolved);
-      return resolved;
-    }
-  }
-
-  // Do not cache misses — mid-session install with same PATH must rediscover.
-  return null;
+  return resolveBinaryForPlatform(binary, process.platform, {
+    PATH: process.env.PATH,
+    PATHEXT: process.env.PATHEXT,
+  });
 }
 
 /** Clear PATH resolve cache (tests / PATH mutation). */

--- a/extensions/cli-provider/shared/discover-cache.ts
+++ b/extensions/cli-provider/shared/discover-cache.ts
@@ -2,8 +2,9 @@
  * Shared helpers for CLI model discovery (cache + binary resolve).
  */
 
-import { spawnSync } from "node:child_process";
 import {
+  accessSync,
+  constants,
   existsSync,
   mkdirSync,
   readFileSync,
@@ -11,7 +12,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { join } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import type { DiscoveredCliModel } from "../types.js";
@@ -24,15 +25,88 @@ export function modelIdToDisplayName(modelId: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-export function resolveBinary(binary: string): string | null {
-  const r = spawnSync("which", [binary], { encoding: "utf-8" });
-  const path = r.stdout?.trim();
-  if (r.status !== 0 || !path) return null;
+/** Cache keyed by `${binary}\0${PATH}` — invalidated when PATH changes. */
+const resolveBinaryCache = new Map<string, string | null>();
+
+function winPathSuffixes(): string[] {
+  const pathext = process.env.PATHEXT || ".EXE;.CMD;.BAT;.COM";
+  return ["", ...pathext.split(";").filter(Boolean)];
+}
+
+function candidateSuffixes(): string[] {
+  return process.platform === "win32" ? winPathSuffixes() : [""];
+}
+
+function isExecutable(filePath: string): boolean {
   try {
-    return realpathSync(path);
+    accessSync(filePath, constants.F_OK);
   } catch {
-    return path;
+    return false;
   }
+  if (process.platform === "win32") return true;
+  try {
+    accessSync(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function finalizeResolved(filePath: string): string {
+  try {
+    return realpathSync(filePath);
+  } catch {
+    return filePath;
+  }
+}
+
+/**
+ * Resolve a binary name (or absolute path) via an in-process PATH scan.
+ * Avoids spawnSync("which") on auth/filter hot paths.
+ * Returns realpath when possible, null if missing.
+ */
+export function resolveBinary(binary: string): string | null {
+  if (!binary) return null;
+
+  const pathEnv = process.env.PATH ?? "";
+  const cacheKey = `${binary}\0${pathEnv}`;
+  if (resolveBinaryCache.has(cacheKey)) {
+    const cached = resolveBinaryCache.get(cacheKey)!;
+    if (cached === null) return null;
+    if (isExecutable(cached)) return cached;
+    resolveBinaryCache.delete(cacheKey);
+  }
+
+  // Absolute or explicit relative path — check directly (mirrors `which /path`).
+  if (isAbsolute(binary) || binary.includes("/") || binary.includes("\\")) {
+    if (!isExecutable(binary)) {
+      resolveBinaryCache.set(cacheKey, null);
+      return null;
+    }
+    const resolved = finalizeResolved(binary);
+    resolveBinaryCache.set(cacheKey, resolved);
+    return resolved;
+  }
+
+  const suffixes = candidateSuffixes();
+  for (const dir of pathEnv.split(delimiter)) {
+    if (!dir) continue;
+    for (const suffix of suffixes) {
+      const candidate = join(dir, binary + suffix);
+      if (!isExecutable(candidate)) continue;
+      const resolved = finalizeResolved(candidate);
+      resolveBinaryCache.set(cacheKey, resolved);
+      return resolved;
+    }
+  }
+
+  resolveBinaryCache.set(cacheKey, null);
+  return null;
+}
+
+/** Clear PATH resolve cache (tests / PATH mutation). */
+export function clearResolveBinaryCache(): void {
+  resolveBinaryCache.clear();
 }
 
 function cacheDir(): string {

--- a/extensions/cli-provider/shared/discover-cache.ts
+++ b/extensions/cli-provider/shared/discover-cache.ts
@@ -25,8 +25,8 @@ export function modelIdToDisplayName(modelId: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-/** Cache keyed by `${binary}\0${PATH}` — invalidated when PATH changes. */
-const resolveBinaryCache = new Map<string, string | null>();
+/** Cache keyed by `${binary}\0${PATH}` — successful resolves only (no negative cache). */
+const resolveBinaryCache = new Map<string, string>();
 
 function winPathSuffixes(): string[] {
   const pathext = process.env.PATHEXT || ".EXE;.CMD;.BAT;.COM";
@@ -70,19 +70,15 @@ export function resolveBinary(binary: string): string | null {
 
   const pathEnv = process.env.PATH ?? "";
   const cacheKey = `${binary}\0${pathEnv}`;
-  if (resolveBinaryCache.has(cacheKey)) {
-    const cached = resolveBinaryCache.get(cacheKey)!;
-    if (cached === null) return null;
+  const cached = resolveBinaryCache.get(cacheKey);
+  if (cached !== undefined) {
     if (isExecutable(cached)) return cached;
     resolveBinaryCache.delete(cacheKey);
   }
 
   // Absolute or explicit relative path — check directly (mirrors `which /path`).
   if (isAbsolute(binary) || binary.includes("/") || binary.includes("\\")) {
-    if (!isExecutable(binary)) {
-      resolveBinaryCache.set(cacheKey, null);
-      return null;
-    }
+    if (!isExecutable(binary)) return null;
     const resolved = finalizeResolved(binary);
     resolveBinaryCache.set(cacheKey, resolved);
     return resolved;
@@ -100,7 +96,7 @@ export function resolveBinary(binary: string): string | null {
     }
   }
 
-  resolveBinaryCache.set(cacheKey, null);
+  // Do not cache misses — mid-session install with same PATH must rediscover.
   return null;
 }
 

--- a/extensions/cli-provider/shared/discover-cache.ts
+++ b/extensions/cli-provider/shared/discover-cache.ts
@@ -12,7 +12,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
-import { delimiter, isAbsolute, join } from "node:path";
+import { delimiter, extname, isAbsolute, join } from "node:path";
 import { homedir } from "node:os";
 import { createHash } from "node:crypto";
 import type { DiscoveredCliModel } from "../types.js";
@@ -28,13 +28,45 @@ export function modelIdToDisplayName(modelId: string): string {
 /** Cache keyed by `${binary}\0${PATH}` — successful resolves only (no negative cache). */
 const resolveBinaryCache = new Map<string, string>();
 
-function winPathSuffixes(): string[] {
-  const pathext = process.env.PATHEXT || ".EXE;.CMD;.BAT;.COM";
-  return ["", ...pathext.split(";").filter(Boolean)];
+/** Parse PATHEXT into uppercase extensions (e.g. ".EXE"). Exported for tests. */
+export function parsePathext(pathextEnv?: string): string[] {
+  const raw = pathextEnv ?? process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM";
+  return raw
+    .split(";")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => (s.startsWith(".") ? s : `.${s}`).toUpperCase());
 }
 
-function candidateSuffixes(): string[] {
-  return process.platform === "win32" ? winPathSuffixes() : [""];
+/**
+ * True when filePath has an extension listed in PATHEXT (case-insensitive).
+ * Extensionless files are not CreateProcess-launchable on Windows.
+ */
+export function isLaunchableWin32(
+  filePath: string,
+  pathextEnv?: string,
+): boolean {
+  const ext = extname(filePath);
+  if (!ext) return false;
+  return parsePathext(pathextEnv).includes(ext.toUpperCase());
+}
+
+/**
+ * Suffixes to try when scanning PATH for `binary`.
+ * On win32: if `binary` already has a PATHEXT extension, try as-is only;
+ * otherwise try each PATHEXT suffix (no bare/empty suffix).
+ */
+export function candidateSuffixesFor(
+  binary: string,
+  platform: NodeJS.Platform = process.platform,
+  pathextEnv?: string,
+): string[] {
+  if (platform !== "win32") return [""];
+  const ext = extname(binary);
+  if (ext && parsePathext(pathextEnv).includes(ext.toUpperCase())) {
+    return [""];
+  }
+  return parsePathext(pathextEnv);
 }
 
 function isExecutable(filePath: string): boolean {
@@ -46,7 +78,7 @@ function isExecutable(filePath: string): boolean {
   }
   // Directories are often X_OK (searchable); only regular files are binaries.
   if (!st.isFile()) return false;
-  if (process.platform === "win32") return true;
+  if (process.platform === "win32") return isLaunchableWin32(filePath);
   try {
     accessSync(filePath, constants.X_OK);
     return true;
@@ -87,7 +119,7 @@ export function resolveBinary(binary: string): string | null {
     return resolved;
   }
 
-  const suffixes = candidateSuffixes();
+  const suffixes = candidateSuffixesFor(binary);
   for (const dir of pathEnv.split(delimiter)) {
     if (!dir) continue;
     for (const suffix of suffixes) {

--- a/extensions/cli-provider/shared/discover-cache.ts
+++ b/extensions/cli-provider/shared/discover-cache.ts
@@ -38,11 +38,14 @@ function candidateSuffixes(): string[] {
 }
 
 function isExecutable(filePath: string): boolean {
+  let st;
   try {
-    accessSync(filePath, constants.F_OK);
+    st = statSync(filePath);
   } catch {
     return false;
   }
+  // Directories are often X_OK (searchable); only regular files are binaries.
+  if (!st.isFile()) return false;
   if (process.platform === "win32") return true;
   try {
     accessSync(filePath, constants.X_OK);

--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -334,11 +334,18 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
     // Check minimum pi version
     const versionCheck = checkMinPiVersion();
     if (!versionCheck.ok) {
-      if (ctx.hasUI) {
+      if (versionCheck.installed === null) {
         ctx.ui.notify(
-          `⚠️ pi ${versionCheck.installed || "unknown"} is below minimum required version ${versionCheck.required}. ` +
-          `CLI/ACPX providers (createProvider) are disabled, and some features (--session-id for async agents, session_info_changed events) will not work. ` +
-          `Update pi: npm install -g @earendil-works/pi-coding-agent`,
+          `⚠️ pi version could not be determined; CLI/ACPX providers require >= ${versionCheck.required} ` +
+            `and will still be attempted. Some features (--session-id for async agents, session_info_changed events) ` +
+            `may not work. Update pi if registration fails: npm install -g @earendil-works/pi-coding-agent`,
+          "warning",
+        );
+      } else {
+        ctx.ui.notify(
+          `⚠️ pi ${versionCheck.installed} is below minimum required version ${versionCheck.required}. ` +
+            `CLI/ACPX providers (createProvider) are disabled, and some features (--session-id for async agents, session_info_changed events) will not work. ` +
+            `Update pi: npm install -g @earendil-works/pi-coding-agent`,
           "warning",
         );
       }

--- a/extensions/orchestrator/session-validation.ts
+++ b/extensions/orchestrator/session-validation.ts
@@ -337,7 +337,7 @@ export function registerSessionValidation(pi: ExtensionAPI): void {
       if (ctx.hasUI) {
         ctx.ui.notify(
           `⚠️ pi ${versionCheck.installed || "unknown"} is below minimum required version ${versionCheck.required}. ` +
-          `Some features (--session-id for async agents, session_info_changed events) will not work. ` +
+          `CLI/ACPX providers (createProvider) are disabled, and some features (--session-id for async agents, session_info_changed events) will not work. ` +
           `Update pi: npm install -g @earendil-works/pi-coding-agent`,
           "warning",
         );

--- a/extensions/orchestrator/utils.ts
+++ b/extensions/orchestrator/utils.ts
@@ -144,7 +144,7 @@ export function tryGetSystemPromptOptions(ctx: any): { contextFiles?: any[]; ski
 }
 
 /** Minimum pi version required by this pi-config version. */
-export const MIN_PI_VERSION = "0.80.3";
+export const MIN_PI_VERSION = "0.81.0";
 
 /** Get the installed pi version from its package.json. */
 export function getPiVersion(): string | null {

--- a/extensions/shared/create-runtime-provider.ts
+++ b/extensions/shared/create-runtime-provider.ts
@@ -1,0 +1,190 @@
+/**
+ * Shared helpers for registering CLI / ACPX providers via pi-ai createProvider().
+ *
+ * Prefer this over legacy `pi.registerProvider(name, { streamSimple })` bags so
+ * providers get /login auth, fetchModels refresh, filterModels, and native
+ * ProviderStreams (requires pi >= 0.81.0).
+ */
+
+import type {
+  Api,
+  AuthCheck,
+  AuthInteraction,
+  AuthResult,
+  Credential,
+  Model,
+  Provider,
+  ProviderAuth,
+  ProviderStreams,
+  RefreshModelsContext,
+} from "@earendil-works/pi-ai";
+
+/** Marker key written by ambient /login when the runtime is available. */
+export const CONFIGURED_CREDENTIAL_KEY = "configured"; // pragma: allowlist secret
+
+/** apiKey value used when resolve() succeeds via ambient availability only. */
+export const AMBIENT_AUTH_KEY = "ambient"; // pragma: allowlist secret
+
+export const DEFAULT_RUNTIME_BASE_URL = "https://localhost";
+
+export interface BuildRuntimeModelOptions {
+  id: string;
+  name: string;
+  api: Api;
+  provider: string;
+  baseUrl?: string;
+  reasoning?: boolean;
+  input?: ("text" | "image")[];
+  cost?: Model<Api>["cost"];
+  contextWindow?: number;
+  maxTokens?: number;
+}
+
+/** Build a full Model with api/provider/baseUrl required by createProvider. */
+export function buildRuntimeModel(opts: BuildRuntimeModelOptions): Model<Api> {
+  return {
+    id: opts.id,
+    name: opts.name,
+    api: opts.api,
+    provider: opts.provider,
+    baseUrl: opts.baseUrl ?? DEFAULT_RUNTIME_BASE_URL,
+    reasoning: opts.reasoning ?? false,
+    input: opts.input ?? ["text", "image"],
+    cost: opts.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: opts.contextWindow ?? 200_000,
+    maxTokens: opts.maxTokens ?? 32_768,
+  };
+}
+
+export interface AmbientLoginAuthOptions {
+  displayName: string;
+  /**
+   * True when the runtime is configured:
+   * CLI = PATH + AgentState; ACPX = agents.has / AgentState (not binary alone).
+   */
+  isConfigured: () => boolean | Promise<boolean>;
+  /** Human-readable source for status UI (e.g. "cursor CLI on PATH"). */
+  sourceLabel: string;
+}
+
+/**
+ * Api-key auth with /login that stores a marker credential when ambient
+ * configuration is present (CLI: PATH + AgentState; ACPX: agents.has /
+ * AgentState) — not an ambient-only stub.
+ */
+export function buildAmbientLoginAuth(
+  opts: AmbientLoginAuthOptions,
+): NonNullable<ProviderAuth["apiKey"]> {
+  const { displayName, isConfigured, sourceLabel } = opts;
+
+  return {
+    name: displayName,
+    async login(interaction: AuthInteraction) {
+      const choice = await interaction.prompt({
+        type: "select",
+        message: `${displayName}: confirm local availability`,
+        options: [
+          {
+            id: "confirm",
+            label: `Use ${sourceLabel}`,
+            description: "Verify and store a local configured credential",
+          },
+        ],
+      });
+
+      // Cancel rejects from prompt; only proceed on explicit confirm.
+      if (choice !== "confirm") {
+        throw new Error("Login cancelled");
+      }
+
+      const ok = await isConfigured();
+      if (!ok) {
+        throw new Error(
+          `${displayName} is not available (${sourceLabel}). Install/configure it, then retry /login.`,
+        );
+      }
+
+      interaction.notify({
+        type: "info",
+        message: `${displayName} ready via ${sourceLabel}`,
+      });
+
+      return { type: "api_key", key: CONFIGURED_CREDENTIAL_KEY };
+    },
+    async resolve({ credential }): Promise<AuthResult | undefined> {
+      if (!(await isConfigured())) {
+        return undefined;
+      }
+      // Never forward arbitrary credential.key into ModelAuth — only our markers.
+      const hasLoginMarker =
+        credential?.type === "api_key" &&
+        credential.key === CONFIGURED_CREDENTIAL_KEY;
+      return {
+        auth: {
+          apiKey: hasLoginMarker
+            ? CONFIGURED_CREDENTIAL_KEY
+            : AMBIENT_AUTH_KEY,
+        },
+        source: sourceLabel,
+      };
+    },
+    async check(): Promise<AuthCheck | undefined> {
+      // Align with resolve(): stale credential alone must not succeed.
+      if (!(await isConfigured())) {
+        return undefined;
+      }
+      return { type: "api_key", source: sourceLabel };
+    },
+  };
+}
+
+/**
+ * Hide models when the runtime is unavailable.
+ * Configured means: CLI = PATH + AgentState; ACPX = agents.has / AgentState
+ * (not binary-on-PATH alone). When configured, models stay visible
+ * (stored credential optional — ambient resolve works).
+ */
+export function filterModelsWhenConfigured<TApi extends Api>(
+  models: readonly Model<TApi>[],
+  _credential: Credential | undefined,
+  isConfigured: () => boolean,
+): readonly Model<TApi>[] {
+  if (!isConfigured()) return [];
+  return models;
+}
+
+export interface CreateRuntimeProviderOptions<TApi extends Api = Api> {
+  id: string;
+  name?: string;
+  baseUrl?: string;
+  auth: ProviderAuth;
+  models: readonly Model<TApi>[];
+  fetchModels?: (
+    context: RefreshModelsContext,
+  ) => Promise<readonly Model<TApi>[]>;
+  filterModels?: (
+    models: readonly Model<TApi>[],
+    credential: Credential | undefined,
+  ) => readonly Model<TApi>[];
+  api: ProviderStreams;
+}
+
+/**
+ * Build a native pi-ai Provider via createProvider (dynamic import so helper
+ * unit tests do not require @earendil-works/pi-ai at import time).
+ */
+export async function createRuntimeProvider<TApi extends Api = Api>(
+  opts: CreateRuntimeProviderOptions<TApi>,
+): Promise<Provider<TApi>> {
+  const { createProvider } = await import("@earendil-works/pi-ai");
+  return createProvider({
+    id: opts.id,
+    name: opts.name,
+    baseUrl: opts.baseUrl ?? DEFAULT_RUNTIME_BASE_URL,
+    auth: opts.auth,
+    models: opts.models,
+    fetchModels: opts.fetchModels,
+    filterModels: opts.filterModels,
+    api: opts.api,
+  });
+}

--- a/tests/node/acpx-provider/create-provider.test.ts
+++ b/tests/node/acpx-provider/create-provider.test.ts
@@ -5,6 +5,7 @@ import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mapAcpxDiscoveredModels } from "../../../extensions/acpx-provider/runtime-models.js";
 import {
+  bindAcpxAgentStates,
   bindAcpxAgentStatesForTests,
   isAcpxAgentConfigured,
 } from "../../../extensions/acpx-provider/configured.js";
@@ -120,5 +121,15 @@ describe("isAcpxAgentConfigured", () => {
     assert.equal(isAcpxAgentConfigured("cursor"), true);
     assert.equal(isAcpxAgentConfigured("claude"), true);
     assert.equal(isAcpxAgentConfigured("gemini"), false);
+  });
+
+  it("bindAcpxAgentStates wires a live Map used by isAcpxAgentConfigured", () => {
+    const live = new Map<string, unknown>();
+    bindAcpxAgentStates(live);
+    assert.equal(isAcpxAgentConfigured("cursor"), false);
+    live.set("cursor", {});
+    assert.equal(isAcpxAgentConfigured("cursor"), true);
+    live.delete("cursor");
+    assert.equal(isAcpxAgentConfigured("cursor"), false);
   });
 });

--- a/tests/node/acpx-provider/create-provider.test.ts
+++ b/tests/node/acpx-provider/create-provider.test.ts
@@ -1,9 +1,13 @@
 /**
  * Tests for acpx-provider createProvider model mapping / fetchModels shape.
  */
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import { mapAcpxDiscoveredModels } from "../../../extensions/acpx-provider/runtime-models.js";
+import {
+  bindAcpxAgentStatesForTests,
+  isAcpxAgentConfigured,
+} from "../../../extensions/acpx-provider/configured.js";
 import {
   buildAmbientLoginAuth,
   filterModelsWhenConfigured,
@@ -98,5 +102,23 @@ describe("acpx-provider auth/filter wiring shape", () => {
       filterModelsWhenConfigured(models, undefined, () => configured).length,
       1,
     );
+  });
+});
+
+describe("isAcpxAgentConfigured", () => {
+  afterEach(() => {
+    bindAcpxAgentStatesForTests([]);
+  });
+
+  it("false when agent state missing", () => {
+    bindAcpxAgentStatesForTests([]);
+    assert.equal(isAcpxAgentConfigured("cursor"), false);
+  });
+
+  it("true when agent state present", () => {
+    bindAcpxAgentStatesForTests(["cursor", "claude"]);
+    assert.equal(isAcpxAgentConfigured("cursor"), true);
+    assert.equal(isAcpxAgentConfigured("claude"), true);
+    assert.equal(isAcpxAgentConfigured("gemini"), false);
   });
 });

--- a/tests/node/acpx-provider/create-provider.test.ts
+++ b/tests/node/acpx-provider/create-provider.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for acpx-provider createProvider model mapping / fetchModels shape.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mapAcpxDiscoveredModels } from "../../../extensions/acpx-provider/runtime-models.js";
+import {
+  buildAmbientLoginAuth,
+  filterModelsWhenConfigured,
+} from "../../../extensions/shared/create-runtime-provider.js";
+
+/**
+ * Mirrors acpx-provider fetchModels gate + mapping (without loading index/runtime).
+ * available ≡ agents.has(agent) / isAcpxAgentConfigured(agent).
+ */
+async function simulateAcpxFetchModels(
+  available: boolean,
+  discover: () => Promise<readonly string[]>,
+  agent: string,
+): Promise<ReturnType<typeof mapAcpxDiscoveredModels>> {
+  if (!available) return [];
+  const nextIds = await discover();
+  return mapAcpxDiscoveredModels(agent, nextIds);
+}
+
+describe("mapAcpxDiscoveredModels", () => {
+  it("maps model ids to full acpx Model shape", () => {
+    const models = mapAcpxDiscoveredModels("cursor", [
+      "composer-2.5[fast=true]",
+      "gpt-5.4",
+    ]);
+    assert.equal(models.length, 2);
+    assert.equal(models[0].id, "cursor:composer-2.5[fast=true]");
+    assert.equal(models[0].api, "acpx");
+    assert.equal(models[0].provider, "acpx-cursor");
+    assert.match(models[0].name, /Composer 2\.5/);
+    assert.match(models[0].name, /\(cursor\)/);
+    assert.equal(models[1].id, "cursor:gpt-5.4");
+  });
+
+  it("falls back to agent:default when discovery empty", () => {
+    const models = mapAcpxDiscoveredModels("claude", []);
+    assert.equal(models.length, 1);
+    assert.equal(models[0].id, "claude:default");
+    assert.equal(models[0].api, "acpx");
+    assert.equal(models[0].provider, "acpx-claude");
+  });
+});
+
+describe("acpx fetchModels (gate + map)", () => {
+  it("unavailable → []", async () => {
+    const out = await simulateAcpxFetchModels(
+      false,
+      async () => ["composer-2.5"],
+      "cursor",
+    );
+    assert.deepEqual(out, []);
+  });
+
+  it("available + empty discovery → agent:default", async () => {
+    const out = await simulateAcpxFetchModels(true, async () => [], "claude");
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, "claude:default");
+    assert.equal(out[0].api, "acpx");
+  });
+
+  it("available + models → mapped full models", async () => {
+    const out = await simulateAcpxFetchModels(
+      true,
+      async () => ["composer-2.5[fast=true]", "gpt-5.4"],
+      "cursor",
+    );
+    assert.equal(out.length, 2);
+    assert.equal(out[0].id, "cursor:composer-2.5[fast=true]");
+    assert.equal(out[0].api, "acpx");
+    assert.equal(out[0].provider, "acpx-cursor");
+    assert.equal(out[1].id, "cursor:gpt-5.4");
+  });
+});
+
+describe("acpx-provider auth/filter wiring shape", () => {
+  it("hides models when runtime unavailable", () => {
+    let configured = false;
+    const auth = buildAmbientLoginAuth({
+      displayName: "ACPX cursor",
+      isConfigured: () => configured,
+      sourceLabel: "cursor acpx runtime",
+    });
+    assert.equal(auth.name, "ACPX cursor");
+
+    const models = mapAcpxDiscoveredModels("cursor", ["composer-2.5"]);
+    assert.deepEqual(
+      filterModelsWhenConfigured(models, undefined, () => configured),
+      [],
+    );
+    configured = true;
+    assert.equal(
+      filterModelsWhenConfigured(models, undefined, () => configured).length,
+      1,
+    );
+  });
+});

--- a/tests/node/cli-provider/create-provider.test.ts
+++ b/tests/node/cli-provider/create-provider.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for cli-provider createProvider model mapping / fetchModels shape.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mapCliDiscoveredModels } from "../../../extensions/cli-provider/runtime-models.js";
+import {
+  buildAmbientLoginAuth,
+  filterModelsWhenConfigured,
+} from "../../../extensions/shared/create-runtime-provider.js";
+import type { DiscoveredCliModel } from "../../../extensions/cli-provider/discover.js";
+
+/**
+ * Mirrors cli-provider fetchModels gate + mapping (without loading index/stream).
+ * available ≡ isCliBinaryAvailable(agent) && agents.has(agent).
+ */
+async function simulateCliFetchModels(
+  available: boolean,
+  discover: () => Promise<readonly DiscoveredCliModel[]>,
+  agent: string,
+  availableModelIds?: string[],
+): Promise<ReturnType<typeof mapCliDiscoveredModels>> {
+  if (!available) return [];
+  const next = await discover();
+  if (availableModelIds) {
+    availableModelIds.length = 0;
+    availableModelIds.push(...next.map((m) => m.id));
+  }
+  return mapCliDiscoveredModels(agent, next);
+}
+
+describe("mapCliDiscoveredModels", () => {
+  it("maps discovered models to full cli Model shape", () => {
+    const models = mapCliDiscoveredModels("cursor", [
+      { id: "composer-2.5", name: "Composer 2.5" },
+      { id: "gpt-5.4", name: "GPT 5.4" },
+    ]);
+    assert.equal(models.length, 2);
+    assert.equal(models[0].id, "cursor:composer-2.5");
+    assert.equal(models[0].name, "Composer 2.5 (cursor)");
+    assert.equal(models[0].api, "cli");
+    assert.equal(models[0].provider, "cli-cursor");
+    assert.ok(models[0].baseUrl);
+    assert.equal(models[1].id, "cursor:gpt-5.4");
+  });
+
+  it("falls back to agent:default when discovery empty", () => {
+    const models = mapCliDiscoveredModels("claude", []);
+    assert.equal(models.length, 1);
+    assert.equal(models[0].id, "claude:default");
+    assert.equal(models[0].name, "claude (default)");
+    assert.equal(models[0].api, "cli");
+    assert.equal(models[0].provider, "cli-claude");
+  });
+});
+
+describe("cli fetchModels (gate + map)", () => {
+  it("unavailable → []", async () => {
+    const out = await simulateCliFetchModels(
+      false,
+      async () => [{ id: "composer-2.5", name: "Composer 2.5" }],
+      "cursor",
+    );
+    assert.deepEqual(out, []);
+  });
+
+  it("available + empty discovery → agent:default", async () => {
+    const out = await simulateCliFetchModels(true, async () => [], "claude");
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, "claude:default");
+  });
+
+  it("available + models → mapped full models", async () => {
+    const out = await simulateCliFetchModels(
+      true,
+      async () => [
+        { id: "composer-2.5", name: "Composer 2.5" },
+        { id: "gpt-5.4", name: "GPT 5.4" },
+      ],
+      "cursor",
+    );
+    assert.equal(out.length, 2);
+    assert.equal(out[0].id, "cursor:composer-2.5");
+    assert.equal(out[0].api, "cli");
+    assert.equal(out[0].provider, "cli-cursor");
+    assert.equal(out[1].id, "cursor:gpt-5.4");
+  });
+
+  it("available + models updates availableModelIds", async () => {
+    const availableModelIds: string[] = ["stale"];
+    const out = await simulateCliFetchModels(
+      true,
+      async () => [
+        { id: "composer-2.5", name: "Composer 2.5" },
+        { id: "gpt-5.4", name: "GPT 5.4" },
+      ],
+      "cursor",
+      availableModelIds,
+    );
+    assert.equal(out.length, 2);
+    assert.deepEqual(availableModelIds, ["composer-2.5", "gpt-5.4"]);
+  });
+});
+
+describe("cli-provider auth/filter wiring shape", () => {
+  it("auth display name and filter hide when binary unavailable", () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => false,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    assert.equal(auth.name, "CLI cursor");
+
+    const models = mapCliDiscoveredModels("cursor", [
+      { id: "composer-2.5", name: "Composer 2.5" },
+    ]);
+    const filtered = filterModelsWhenConfigured(models, undefined, () => false);
+    assert.deepEqual(filtered, []);
+  });
+});

--- a/tests/node/cli-provider/create-provider.test.ts
+++ b/tests/node/cli-provider/create-provider.test.ts
@@ -9,7 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { mapCliDiscoveredModels } from "../../../extensions/cli-provider/runtime-models.js";
 import {
   bindCliAgentStates,
@@ -152,7 +152,7 @@ describe("isCliAgentConfigured", () => {
     binDir = mkdtempSync(join(tmpdir(), "cli-bin-"));
     const dest = join(binDir, name);
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-    process.env.PATH = `${binDir}${prevPath ? `:${prevPath}` : ""}`;
+    process.env.PATH = [binDir, prevPath].filter(Boolean).join(delimiter);
     clearResolveBinaryCache();
   }
 

--- a/tests/node/cli-provider/create-provider.test.ts
+++ b/tests/node/cli-provider/create-provider.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mapCliDiscoveredModels } from "../../../extensions/cli-provider/runtime-models.js";
 import {
+  bindCliAgentStates,
   bindCliAgentStatesForTests,
   isCliAgentConfigured,
 } from "../../../extensions/cli-provider/configured.js";
@@ -180,5 +181,16 @@ describe("isCliAgentConfigured", () => {
     installFakeBinary("agent");
     bindCliAgentStatesForTests(["not-a-cli-agent"]);
     assert.equal(isCliAgentConfigured("not-a-cli-agent"), false);
+  });
+
+  it("bindCliAgentStates wires a live Map used by isCliAgentConfigured", () => {
+    installFakeBinary("agent");
+    const live = new Map<string, unknown>();
+    bindCliAgentStates(live);
+    assert.equal(isCliAgentConfigured("cursor"), false);
+    live.set("cursor", {});
+    assert.equal(isCliAgentConfigured("cursor"), true);
+    live.delete("cursor");
+    assert.equal(isCliAgentConfigured("cursor"), false);
   });
 });

--- a/tests/node/cli-provider/create-provider.test.ts
+++ b/tests/node/cli-provider/create-provider.test.ts
@@ -1,9 +1,21 @@
 /**
  * Tests for cli-provider createProvider model mapping / fetchModels shape.
  */
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { mapCliDiscoveredModels } from "../../../extensions/cli-provider/runtime-models.js";
+import {
+  bindCliAgentStatesForTests,
+  isCliAgentConfigured,
+} from "../../../extensions/cli-provider/configured.js";
+import { clearResolveBinaryCache } from "../../../extensions/cli-provider/shared/discover-cache.js";
 import {
   buildAmbientLoginAuth,
   filterModelsWhenConfigured,
@@ -103,18 +115,70 @@ describe("cli fetchModels (gate + map)", () => {
 });
 
 describe("cli-provider auth/filter wiring shape", () => {
-  it("auth display name and filter hide when binary unavailable", () => {
+  it("auth display name uses CLI agent label", () => {
     const auth = buildAmbientLoginAuth({
       displayName: "CLI cursor",
       isConfigured: () => false,
       sourceLabel: "cursor CLI on PATH",
     });
     assert.equal(auth.name, "CLI cursor");
+  });
 
+  it("filter hides models when binary unavailable", () => {
     const models = mapCliDiscoveredModels("cursor", [
       { id: "composer-2.5", name: "Composer 2.5" },
     ]);
     const filtered = filterModelsWhenConfigured(models, undefined, () => false);
     assert.deepEqual(filtered, []);
+  });
+});
+
+describe("isCliAgentConfigured", () => {
+  const prevPath = process.env.PATH;
+  let binDir: string | undefined;
+
+  afterEach(() => {
+    process.env.PATH = prevPath;
+    clearResolveBinaryCache();
+    bindCliAgentStatesForTests([]);
+    if (binDir) {
+      rmSync(binDir, { recursive: true, force: true });
+      binDir = undefined;
+    }
+  });
+
+  function installFakeBinary(name: string): void {
+    binDir = mkdtempSync(join(tmpdir(), "cli-bin-"));
+    const dest = join(binDir, name);
+    writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = `${binDir}${prevPath ? `:${prevPath}` : ""}`;
+    clearResolveBinaryCache();
+  }
+
+  it("false when agent state missing", () => {
+    installFakeBinary("agent");
+    bindCliAgentStatesForTests([]);
+    assert.equal(isCliAgentConfigured("cursor"), false);
+  });
+
+  it("false when binary missing despite agent state", () => {
+    binDir = mkdtempSync(join(tmpdir(), "cli-bin-empty-"));
+    // PATH with empty dir — no "agent" binary
+    process.env.PATH = binDir;
+    clearResolveBinaryCache();
+    bindCliAgentStatesForTests(["cursor"]);
+    assert.equal(isCliAgentConfigured("cursor"), false);
+  });
+
+  it("true when binary on PATH with agent state", () => {
+    installFakeBinary("agent");
+    bindCliAgentStatesForTests(["cursor"]);
+    assert.equal(isCliAgentConfigured("cursor"), true);
+  });
+
+  it("false for unknown agent name", () => {
+    installFakeBinary("agent");
+    bindCliAgentStatesForTests(["not-a-cli-agent"]);
+    assert.equal(isCliAgentConfigured("not-a-cli-agent"), false);
   });
 });

--- a/tests/node/cli-provider/discover-cache.test.ts
+++ b/tests/node/cli-provider/discover-cache.test.ts
@@ -18,9 +18,11 @@ import { join } from "node:path";
 import {
   candidateSuffixesFor,
   clearResolveBinaryCache,
+  isExecutableForPlatform,
   isLaunchableWin32,
   parsePathext,
   resolveBinary,
+  resolveBinaryForPlatform,
 } from "../../../extensions/cli-provider/shared/discover-cache.js";
 
 describe("resolveBinary", { concurrency: false }, () => {
@@ -152,5 +154,81 @@ describe("win32 launchability helpers", () => {
 
   it("candidateSuffixesFor non-win32 uses empty suffix only", () => {
     assert.deepEqual(candidateSuffixesFor("agent", "linux"), [""]);
+  });
+});
+
+describe("resolveBinaryForPlatform win32", { concurrency: false }, () => {
+  let tmpRoot: string | undefined;
+
+  beforeEach(() => {
+    clearResolveBinaryCache();
+  });
+
+  afterEach(() => {
+    clearResolveBinaryCache();
+    if (tmpRoot) {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  function makeBinDir(): string {
+    tmpRoot = mkdtempSync(join(tmpdir(), "resolve-win-"));
+    return tmpRoot;
+  }
+
+  it("rejects extensionless agent file on win32 PATH", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "agent");
+    writeFileSync(dest, "fake\n", { mode: 0o755 });
+    assert.equal(
+      resolveBinaryForPlatform("agent", "win32", {
+        PATH: dir,
+        PATHEXT: ".EXE;.CMD;.BAT",
+      }),
+      null,
+    );
+    assert.equal(
+      isExecutableForPlatform(dest, "win32", ".EXE;.CMD;.BAT"),
+      false,
+    );
+  });
+
+  it("rejects extensionless absolute path on win32", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "agent");
+    writeFileSync(dest, "fake\n", { mode: 0o755 });
+    assert.equal(
+      resolveBinaryForPlatform(dest, "win32", {
+        PATH: "",
+        PATHEXT: ".EXE;.CMD",
+      }),
+      null,
+    );
+  });
+
+  it("resolves agent.exe via PATHEXT suffix on win32", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "agent.exe");
+    writeFileSync(dest, "fake\n", { mode: 0o644 });
+    const resolved = resolveBinaryForPlatform("agent", "win32", {
+      PATH: dir,
+      PATHEXT: ".EXE;.CMD",
+    });
+    assert.ok(resolved);
+    assert.equal(resolved, realpathSync(dest));
+  });
+
+  it("prefers PATHEXT candidate over extensionless sibling on win32", () => {
+    const dir = makeBinDir();
+    const bare = join(dir, "agent");
+    const withExt = join(dir, "agent.exe");
+    writeFileSync(bare, "bare\n", { mode: 0o755 });
+    writeFileSync(withExt, "exe\n", { mode: 0o644 });
+    const resolved = resolveBinaryForPlatform("agent", "win32", {
+      PATH: dir,
+      PATHEXT: ".EXE;.CMD",
+    });
+    assert.equal(resolved, realpathSync(withExt));
   });
 });

--- a/tests/node/cli-provider/discover-cache.test.ts
+++ b/tests/node/cli-provider/discover-cache.test.ts
@@ -1,7 +1,10 @@
 /**
  * Tests for in-process PATH resolveBinary (no spawnSync which).
+ *
+ * Mutates process.env.PATH — run serially (concurrency: false) so parallel
+ * cases cannot race the shared env / resolveBinaryCache.
  */
-import { describe, it, afterEach } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import {
   mkdtempSync,
@@ -16,9 +19,13 @@ import {
   resolveBinary,
 } from "../../../extensions/cli-provider/shared/discover-cache.js";
 
-describe("resolveBinary", () => {
+describe("resolveBinary", { concurrency: false }, () => {
   const prevPath = process.env.PATH;
   let tmpRoot: string | undefined;
+
+  beforeEach(() => {
+    clearResolveBinaryCache();
+  });
 
   afterEach(() => {
     process.env.PATH = prevPath;
@@ -37,7 +44,6 @@ describe("resolveBinary", () => {
   it("returns null when binary missing from PATH", () => {
     const dir = makeBinDir();
     process.env.PATH = dir;
-    clearResolveBinaryCache();
     assert.equal(resolveBinary("no-such-cli-binary-xyz"), null);
   });
 
@@ -46,7 +52,6 @@ describe("resolveBinary", () => {
     const dest = join(dir, "fake-cli");
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
     process.env.PATH = dir;
-    clearResolveBinaryCache();
     const resolved = resolveBinary("fake-cli");
     assert.ok(resolved);
     assert.equal(resolved, realpathSync(dest));
@@ -57,7 +62,6 @@ describe("resolveBinary", () => {
     const dest = join(dir, "not-exec");
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o644 });
     process.env.PATH = dir;
-    clearResolveBinaryCache();
     assert.equal(resolveBinary("not-exec"), null);
   });
 
@@ -66,26 +70,22 @@ describe("resolveBinary", () => {
     const dest = join(dir, "abs-cli");
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
     process.env.PATH = "";
-    clearResolveBinaryCache();
     const resolved = resolveBinary(dest);
     assert.ok(resolved);
     assert.equal(resolved, realpathSync(dest));
   });
 
-  it("caches by binary name + PATH string", () => {
+  it("caches successful resolves; misses are not cached", () => {
     const dir = makeBinDir();
     const dest = join(dir, "cached-cli");
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
     process.env.PATH = dir;
-    clearResolveBinaryCache();
     const first = resolveBinary("cached-cli");
     rmSync(dest);
-    // Same PATH → negative re-validate drops stale positive, then miss caches null
+    // Stale positive invalidated when binary disappears
     assert.equal(resolveBinary("cached-cli"), null);
-    // Restore + same PATH still has null cached until PATH changes or clear
+    // Mid-session install with same PATH rediscovers (null was not cached)
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-    assert.equal(resolveBinary("cached-cli"), null);
-    process.env.PATH = `${dir}:/usr/bin`;
     assert.equal(resolveBinary("cached-cli"), realpathSync(dest));
     assert.equal(first, realpathSync(dest));
   });

--- a/tests/node/cli-provider/discover-cache.test.ts
+++ b/tests/node/cli-provider/discover-cache.test.ts
@@ -16,7 +16,10 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  candidateSuffixesFor,
   clearResolveBinaryCache,
+  isLaunchableWin32,
+  parsePathext,
   resolveBinary,
 } from "../../../extensions/cli-provider/shared/discover-cache.js";
 
@@ -85,18 +88,69 @@ describe("resolveBinary", { concurrency: false }, () => {
     assert.equal(resolved, realpathSync(dest));
   });
 
-  it("caches successful resolves; misses are not cached", () => {
+  it("caches successful resolve path", () => {
     const dir = makeBinDir();
     const dest = join(dir, "cached-cli");
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
     process.env.PATH = dir;
     const first = resolveBinary("cached-cli");
+    assert.equal(first, realpathSync(dest));
+    assert.equal(resolveBinary("cached-cli"), first);
+  });
+
+  it("invalidates cached resolve when binary is removed", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "cached-cli");
+    writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    assert.equal(resolveBinary("cached-cli"), realpathSync(dest));
     rmSync(dest);
-    // Stale positive invalidated when binary disappears
     assert.equal(resolveBinary("cached-cli"), null);
-    // Mid-session install with same PATH rediscovers (null was not cached)
+  });
+
+  it("rediscovers binary after miss when reinstalled on same PATH", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "cached-cli");
+    process.env.PATH = dir;
+    assert.equal(resolveBinary("cached-cli"), null);
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
     assert.equal(resolveBinary("cached-cli"), realpathSync(dest));
-    assert.equal(first, realpathSync(dest));
+  });
+});
+
+describe("win32 launchability helpers", () => {
+  it("parsePathext normalizes extensions to uppercase with dots", () => {
+    assert.deepEqual(parsePathext(".exe;.Cmd;.BAT"), [".EXE", ".CMD", ".BAT"]);
+  });
+
+  it("isLaunchableWin32 rejects extensionless paths", () => {
+    assert.equal(isLaunchableWin32("C:\\tools\\agent", ".EXE;.CMD"), false);
+  });
+
+  it("isLaunchableWin32 accepts PATHEXT extension", () => {
+    assert.equal(isLaunchableWin32("C:\\tools\\agent.exe", ".EXE;.CMD"), true);
+    assert.equal(isLaunchableWin32("C:\\tools\\agent.CMD", ".EXE;.CMD"), true);
+  });
+
+  it("isLaunchableWin32 rejects non-PATHEXT extension", () => {
+    assert.equal(isLaunchableWin32("C:\\tools\\agent.txt", ".EXE;.CMD"), false);
+  });
+
+  it("candidateSuffixesFor win32 uses PATHEXT only for bare names", () => {
+    assert.deepEqual(
+      candidateSuffixesFor("agent", "win32", ".EXE;.CMD"),
+      [".EXE", ".CMD"],
+    );
+  });
+
+  it("candidateSuffixesFor win32 keeps as-is when binary has PATHEXT ext", () => {
+    assert.deepEqual(
+      candidateSuffixesFor("agent.exe", "win32", ".EXE;.CMD"),
+      [""],
+    );
+  });
+
+  it("candidateSuffixesFor non-win32 uses empty suffix only", () => {
+    assert.deepEqual(candidateSuffixesFor("agent", "linux"), [""]);
   });
 });

--- a/tests/node/cli-provider/discover-cache.test.ts
+++ b/tests/node/cli-provider/discover-cache.test.ts
@@ -21,6 +21,7 @@ import {
   isExecutableForPlatform,
   isLaunchableWin32,
   parsePathext,
+  pathDelimiterFor,
   resolveBinary,
   resolveBinaryForPlatform,
 } from "../../../extensions/cli-provider/shared/discover-cache.js";
@@ -155,6 +156,11 @@ describe("win32 launchability helpers", () => {
   it("candidateSuffixesFor non-win32 uses empty suffix only", () => {
     assert.deepEqual(candidateSuffixesFor("agent", "linux"), [""]);
   });
+
+  it("pathDelimiterFor uses platform delimiter not host", () => {
+    assert.equal(pathDelimiterFor("win32"), ";");
+    assert.equal(pathDelimiterFor("linux"), ":");
+  });
 });
 
 describe("resolveBinaryForPlatform win32", { concurrency: false }, () => {
@@ -230,5 +236,20 @@ describe("resolveBinaryForPlatform win32", { concurrency: false }, () => {
       PATHEXT: ".EXE;.CMD",
     });
     assert.equal(resolved, realpathSync(withExt));
+  });
+
+  it("splits win32 PATH on semicolon across two directories", () => {
+    const root = makeBinDir();
+    const dir1 = join(root, "empty");
+    const dir2 = join(root, "bins");
+    mkdirSync(dir1);
+    mkdirSync(dir2);
+    const dest = join(dir2, "agent.exe");
+    writeFileSync(dest, "fake\n", { mode: 0o644 });
+    const resolved = resolveBinaryForPlatform("agent", "win32", {
+      PATH: `${dir1};${dir2}`,
+      PATHEXT: ".EXE",
+    });
+    assert.equal(resolved, realpathSync(dest));
   });
 });

--- a/tests/node/cli-provider/discover-cache.test.ts
+++ b/tests/node/cli-provider/discover-cache.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for in-process PATH resolveBinary (no spawnSync which).
+ */
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  clearResolveBinaryCache,
+  resolveBinary,
+} from "../../../extensions/cli-provider/shared/discover-cache.js";
+
+describe("resolveBinary", () => {
+  const prevPath = process.env.PATH;
+  let tmpRoot: string | undefined;
+
+  afterEach(() => {
+    process.env.PATH = prevPath;
+    clearResolveBinaryCache();
+    if (tmpRoot) {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  function makeBinDir(): string {
+    tmpRoot = mkdtempSync(join(tmpdir(), "resolve-bin-"));
+    return tmpRoot;
+  }
+
+  it("returns null when binary missing from PATH", () => {
+    const dir = makeBinDir();
+    process.env.PATH = dir;
+    clearResolveBinaryCache();
+    assert.equal(resolveBinary("no-such-cli-binary-xyz"), null);
+  });
+
+  it("finds executable on PATH with realpath when possible", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "fake-cli");
+    writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    clearResolveBinaryCache();
+    const resolved = resolveBinary("fake-cli");
+    assert.ok(resolved);
+    assert.equal(resolved, realpathSync(dest));
+  });
+
+  it("returns null for non-executable file on PATH", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "not-exec");
+    writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o644 });
+    process.env.PATH = dir;
+    clearResolveBinaryCache();
+    assert.equal(resolveBinary("not-exec"), null);
+  });
+
+  it("resolves absolute path without PATH lookup", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "abs-cli");
+    writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = "";
+    clearResolveBinaryCache();
+    const resolved = resolveBinary(dest);
+    assert.ok(resolved);
+    assert.equal(resolved, realpathSync(dest));
+  });
+
+  it("caches by binary name + PATH string", () => {
+    const dir = makeBinDir();
+    const dest = join(dir, "cached-cli");
+    writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    process.env.PATH = dir;
+    clearResolveBinaryCache();
+    const first = resolveBinary("cached-cli");
+    rmSync(dest);
+    // Same PATH → negative re-validate drops stale positive, then miss caches null
+    assert.equal(resolveBinary("cached-cli"), null);
+    // Restore + same PATH still has null cached until PATH changes or clear
+    writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+    assert.equal(resolveBinary("cached-cli"), null);
+    process.env.PATH = `${dir}:/usr/bin`;
+    assert.equal(resolveBinary("cached-cli"), realpathSync(dest));
+    assert.equal(first, realpathSync(dest));
+  });
+});

--- a/tests/node/cli-provider/discover-cache.test.ts
+++ b/tests/node/cli-provider/discover-cache.test.ts
@@ -8,6 +8,7 @@ import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import {
   mkdtempSync,
+  mkdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
@@ -63,6 +64,15 @@ describe("resolveBinary", { concurrency: false }, () => {
     writeFileSync(dest, "#!/bin/sh\nexit 0\n", { mode: 0o644 });
     process.env.PATH = dir;
     assert.equal(resolveBinary("not-exec"), null);
+  });
+
+  it("returns null when PATH candidate is a directory", () => {
+    const dir = makeBinDir();
+    const nested = join(dir, "agent");
+    // Directory named like the binary — searchable (X_OK) but not a file
+    mkdirSync(nested, { mode: 0o755 });
+    process.env.PATH = dir;
+    assert.equal(resolveBinary("agent"), null);
   });
 
   it("resolves absolute path without PATH lookup", () => {

--- a/tests/node/orchestrator/version-check.test.ts
+++ b/tests/node/orchestrator/version-check.test.ts
@@ -1,10 +1,6 @@
-/**
- * Tests for pi version check logic.
- * Run with: npx tsx --test tests/node/orchestrator/version-check.test.ts
- */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { compareSemver } from "../../../extensions/orchestrator/utils.js";
+import { compareSemver, MIN_PI_VERSION } from "../../../extensions/orchestrator/utils.js";
 
 describe("compareSemver", () => {
   it("equal versions return 0", () => {
@@ -39,5 +35,11 @@ describe("compareSemver", () => {
 
   it("major version difference", () => {
     assert.strictEqual(compareSemver("2.0.0", "1.99.99"), 1);
+  });
+});
+
+describe("MIN_PI_VERSION", () => {
+  it("requires 0.81.0 for createProvider providers", () => {
+    assert.strictEqual(MIN_PI_VERSION, "0.81.0");
   });
 });

--- a/tests/node/shared/create-runtime-provider.test.ts
+++ b/tests/node/shared/create-runtime-provider.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Unit tests for shared createProvider helpers (auth / filter / model builder).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  AMBIENT_AUTH_KEY,
+  CONFIGURED_CREDENTIAL_KEY,
+  DEFAULT_RUNTIME_BASE_URL,
+  buildAmbientLoginAuth,
+  buildRuntimeModel,
+  createRuntimeProvider,
+  filterModelsWhenConfigured,
+} from "../../../extensions/shared/create-runtime-provider.js";
+
+describe("buildRuntimeModel", () => {
+  it("fills api, provider, baseUrl and defaults", () => {
+    const m = buildRuntimeModel({
+      id: "cursor:composer-2.5",
+      name: "Composer 2.5 (cursor)",
+      api: "cli",
+      provider: "cli-cursor",
+    });
+    assert.equal(m.id, "cursor:composer-2.5");
+    assert.equal(m.api, "cli");
+    assert.equal(m.provider, "cli-cursor");
+    assert.equal(m.baseUrl, DEFAULT_RUNTIME_BASE_URL);
+    assert.equal(m.reasoning, false);
+    assert.deepEqual(m.input, ["text", "image"]);
+    assert.equal(m.contextWindow, 200_000);
+    assert.equal(m.maxTokens, 32_768);
+  });
+
+  it("allows baseUrl override", () => {
+    const m = buildRuntimeModel({
+      id: "x:default",
+      name: "x",
+      api: "acpx",
+      provider: "acpx-x",
+      baseUrl: "acpx://local",
+    });
+    assert.equal(m.baseUrl, "acpx://local");
+  });
+});
+
+describe("buildAmbientLoginAuth", () => {
+  it("login stores configured marker when isConfigured", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => true,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    const cred = await auth.login!({
+      prompt: async () => "confirm",
+      notify: () => {},
+    });
+    assert.equal(cred.type, "api_key");
+    assert.equal(cred.key, CONFIGURED_CREDENTIAL_KEY);
+  });
+
+  it("login throws when not configured", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => false,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    await assert.rejects(
+      () =>
+        auth.login!({
+          prompt: async () => "confirm",
+          notify: () => {},
+        }),
+      /not available/,
+    );
+  });
+
+  it("login cancel throws", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => true,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    await assert.rejects(
+      () =>
+        auth.login!({
+          prompt: async () => {
+            throw new Error("Login cancelled");
+          },
+          notify: () => {},
+        }),
+      /Login cancelled/,
+    );
+  });
+
+  it("resolve with credential and isConfigured true → success", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => true,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    const result = await auth.resolve({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+      credential: { type: "api_key", key: CONFIGURED_CREDENTIAL_KEY },
+    });
+    assert.ok(result);
+    assert.equal(result!.auth.apiKey, CONFIGURED_CREDENTIAL_KEY);
+    assert.equal(result!.source, "cursor CLI on PATH");
+  });
+
+  it("resolve with credential but isConfigured false → undefined", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => false,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    const result = await auth.resolve({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+      credential: { type: "api_key", key: CONFIGURED_CREDENTIAL_KEY },
+    });
+    assert.equal(result, undefined);
+  });
+
+  it("resolve falls back to ambient when configured without credential", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => true,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    const result = await auth.resolve({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+    });
+    assert.ok(result);
+    assert.equal(result!.auth.apiKey, AMBIENT_AUTH_KEY);
+  });
+
+  it("resolve ignores arbitrary credential.key (returns ambient marker)", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => true,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    const result = await auth.resolve({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+      credential: { type: "api_key", key: "evil-injected-secret" },
+    });
+    assert.ok(result);
+    assert.equal(result!.auth.apiKey, AMBIENT_AUTH_KEY);
+  });
+
+  it("resolve returns undefined when unconfigured and no credential", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => false,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    const result = await auth.resolve({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+    });
+    assert.equal(result, undefined);
+  });
+
+  it("check returns api_key when configured", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "ACPX cursor",
+      isConfigured: () => true,
+      sourceLabel: "cursor acpx runtime",
+    });
+    const check = await auth.check!({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+    });
+    assert.deepEqual(check, {
+      type: "api_key",
+      source: "cursor acpx runtime",
+    });
+  });
+
+  it("check returns undefined when not configured", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "ACPX cursor",
+      isConfigured: () => false,
+      sourceLabel: "cursor acpx runtime",
+    });
+    const check = await auth.check!({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+    });
+    assert.equal(check, undefined);
+  });
+
+  it("check returns undefined when credential present but isConfigured false", async () => {
+    const auth = buildAmbientLoginAuth({
+      displayName: "CLI cursor",
+      isConfigured: () => false,
+      sourceLabel: "cursor CLI on PATH",
+    });
+    const check = await auth.check!({
+      ctx: { env: async () => undefined, fileExists: async () => false },
+      credential: { type: "api_key", key: CONFIGURED_CREDENTIAL_KEY },
+    });
+    assert.equal(check, undefined);
+  });
+});
+
+describe("filterModelsWhenConfigured", () => {
+  const models = [
+    buildRuntimeModel({
+      id: "a:m1",
+      name: "m1",
+      api: "cli",
+      provider: "cli-a",
+    }),
+  ];
+
+  it("hides models when not configured", () => {
+    const out = filterModelsWhenConfigured(models, undefined, () => false);
+    assert.deepEqual(out, []);
+  });
+
+  it("keeps models when configured without credential", () => {
+    const out = filterModelsWhenConfigured(models, undefined, () => true);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].id, "a:m1");
+  });
+
+  it("keeps models when configured with credential", () => {
+    const out = filterModelsWhenConfigured(
+      models,
+      { type: "api_key", key: CONFIGURED_CREDENTIAL_KEY },
+      () => true,
+    );
+    assert.equal(out.length, 1);
+  });
+});
+
+describe("createRuntimeProvider", () => {
+  it("builds a Provider with id and getModels when pi-ai is resolvable", async (t) => {
+    let provider;
+    try {
+      provider = await createRuntimeProvider({
+        id: "cli-test",
+        name: "CLI test",
+        auth: {
+          apiKey: buildAmbientLoginAuth({
+            displayName: "CLI test",
+            isConfigured: () => true,
+            sourceLabel: "test",
+          }),
+        },
+        models: [
+          buildRuntimeModel({
+            id: "test:default",
+            name: "test (default)",
+            api: "cli",
+            provider: "cli-test",
+          }),
+        ],
+        api: {
+          stream: () => {
+            throw new Error("stream not used in test");
+          },
+          streamSimple: () => {
+            throw new Error("streamSimple not used in test");
+          },
+        },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (
+        msg.includes("Cannot find package") ||
+        msg.includes("Cannot find module") ||
+        msg.includes("ERR_MODULE_NOT_FOUND")
+      ) {
+        t.skip(
+          `@earendil-works/pi-ai not resolvable — cannot exercise createProvider (${msg})`,
+        );
+        return;
+      }
+      throw err;
+    }
+    assert.equal(provider.id, "cli-test");
+    assert.equal(provider.getModels().length, 1);
+    assert.equal(provider.getModels()[0].id, "test:default");
+    assert.ok(provider.auth.apiKey);
+  });
+});

--- a/tests/node/shared/create-runtime-provider.test.ts
+++ b/tests/node/shared/create-runtime-provider.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../../extensions/shared/create-runtime-provider.js";
 
 describe("buildRuntimeModel", () => {
-  it("fills api, provider, baseUrl and defaults", () => {
+  it("fills api, provider, baseUrl with defaults", () => {
     const m = buildRuntimeModel({
       id: "cursor:composer-2.5",
       name: "Composer 2.5 (cursor)",
@@ -92,7 +92,7 @@ describe("buildAmbientLoginAuth", () => {
     );
   });
 
-  it("resolve with credential and isConfigured true → success", async () => {
+  it("resolve succeeds when credential present with isConfigured true", async () => {
     const auth = buildAmbientLoginAuth({
       displayName: "CLI cursor",
       isConfigured: () => true,
@@ -147,7 +147,7 @@ describe("buildAmbientLoginAuth", () => {
     assert.equal(result!.auth.apiKey, AMBIENT_AUTH_KEY);
   });
 
-  it("resolve returns undefined when unconfigured and no credential", async () => {
+  it("resolve returns undefined when unconfigured without credential", async () => {
     const auth = buildAmbientLoginAuth({
       displayName: "CLI cursor",
       isConfigured: () => false,
@@ -232,7 +232,7 @@ describe("filterModelsWhenConfigured", () => {
 });
 
 describe("createRuntimeProvider", () => {
-  it("builds a Provider with id and getModels when pi-ai is resolvable", async (t) => {
+  it("builds a Provider with id plus getModels when pi-ai is resolvable", async (t) => {
     let provider;
     try {
       provider = await createRuntimeProvider({


### PR DESCRIPTION
## Summary
- Migrate `cli-*` and `acpx-*` from legacy `registerProvider(name, { streamSimple })` bags to shared `createRuntimeProvider` / `createProvider` (pi ≥ 0.81)
- Full ModelRuntime surface: `/login` auth, `fetchModels` refresh, `filterModels`, native `ProviderStreams`
- Bump `MIN_PI_VERSION` to 0.81.0; docs + tests updated

Closes #672

## Test plan
- [ ] `/login cli-cursor` and `/login acpx-cursor` (or configured agents)
- [ ] `/model` / refresh rediscovers CLI and ACPX models
- [ ] Missing binary/runtime hides models via filterModels
- [ ] Daily path still works: `cli-cursor` / `cursor:cursor-grok-4.5-high`
- [ ] Node tests for shared/cli/acpx create-provider pass
- [ ] pi ≥ 0.81.0 installed

Made with [Cursor](https://cursor.com)