### PR TITLE
feat(extensions): overlay dashboard UI, settings-based agent model routing, orchestrator edit/write enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Single extension that provides:
 | Feature | Description |
 |---------|-------------|
 | **Subagent tool** | Delegate tasks to specialist agents (single, parallel, chain, async modes) |
-| **Async background agents** | Spawn agents in background with `async: true` — results surface automatically when complete. On **acpx** parents, optional async is coerced to sync; dream/cron need `async_llm_provider` + `async_llm_model`. `cli-*` providers support async natively (see `dev-docs/cli-provider.md`) |
+| **Async background agents** | Spawn agents in background with `async: true` — results surface automatically when complete. Fullscreen overlay dashboard with live output, keyboard nav, and kill support (`/async-status`, `/async-kill`). On **acpx** parents, optional async is coerced to sync; dream/cron need `async_llm_provider` + `async_llm_model`. `cli-*` providers support async natively (see `dev-docs/cli-provider.md`) |
 | **CLI / ACPX providers** | Optional `cli_agents` / `acpx_agents` register `cli-*` / `acpx-*` via native `createProvider` (pi ≥ 0.81): `/login cli-<agent>` or `/login acpx-<agent>`, model refresh, filter when unavailable |
 | **`/btw` command** | Quick side questions without polluting conversation history — ephemeral overlay |
 | **`/async-status` command** | Show status of background agents — select one for live output streaming |
+| **`/async-kill` command** | Kill async agents (overlay picker or by name/id) |
 | **`ask_user` tool** | Structured user input with options and free-text — used by workflows |
 | **Python/pip enforcement** | Blocks `python`/`pip` — requires `uv`/`uvx` |
 | **Git protection** | Blocks commits/pushes to main/master, merged branches, `--no-verify`, `git add .` |
@@ -34,7 +35,7 @@ Single extension that provides:
 | **Task tracking** | Structured task lists for multi-step workflows — live widget, progress tracking, reminder nudges ([@tintinweb/pi-tasks](https://github.com/tintinweb/pi-tasks)) |
 | **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |
 | **Inter-agent communication** | P2P (`/coms`) and networked (`/coms-net`) agent communication — on-demand activation via slash commands |
-| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/review-status`, `/query-db`, `/btw`, `/async-status`, `/status`, `/dream`, `/remember`, `/coms`, `/coms-net` — with autocomplete argument hints |
+| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/review-status`, `/query-db`, `/btw`, `/async-status`, `/async-kill`, `/status`, `/dream`, `/remember`, `/coms`, `/coms-net` — with autocomplete argument hints |
 | **GitHub autocomplete** | Type `#` in the editor to get issue/PR suggestions from the current repo — lazy-loaded, 5min cache |
 | **Command arg completions** | Tab-complete arguments for slash commands — providers and models for `/external-ai`, branches for `/review-local`, PR numbers for `/pr-review`, and more |
 | **Discord bot** | Control pi sessions from your phone via Discord DMs — send prompts, answer ask_user dialogs, switch sessions |
@@ -72,7 +73,8 @@ Single extension that provides:
 | `/dream` | Run memory consolidation — extract, deduplicate, maintain topic-based memory |
 | `/remember <what>` | Save a memory for future sessions |
 | `/dream-auto` | Toggle automatic memory dreaming (every 3h + session end) |
-| `/cron add\|list\|remove` | Schedule recurring tasks within the pi session (e.g., `/cron add every 2h check for new issues`, `/cron add at 12:00 /review-handler`). Tasks run while pi is active, survive `/reload`, and stop on exit |
+| `/cron add\|list\|list-all\|remove` | Schedule recurring tasks within the pi session (e.g., `/cron add every 2h check for new issues`, `/cron add at 12:00 /review-handler`). `/cron list` and `/cron list-all` open overlay UI (view / remove; list-all = all sessions). Tasks run while pi is active, survive `/reload`, and stop on exit |
+| `/async-kill [name\|id\|all]` | Kill async agents (overlay picker or by name/id) |
 | `/status` | Unified session snapshot — async agents, cron tasks, git branch, context usage |
 | `/nvim-changed-files` | Send git changed files to nvim's quickfix list (only inside nvim) |
 | `/pidiff start\|stop\|restart\|status` | Manage the pidiff diff viewer server (per-project) |
@@ -258,7 +260,12 @@ Create `.pi/pi-config-settings.json` in your project to override global defaults
   "acpx_agents": ["cursor"],
   "cli_agents": ["claude", "cursor"],
   "async_llm_provider": "anthropic",
-  "async_llm_model": "claude-sonnet-4-20250514"
+  "async_llm_model": "claude-sonnet-4-20250514",
+  "agent_provider": "cli-cursor",
+  "agent_model": "cursor:cursor-grok-4.5-high-fast",
+  "agent_overrides": {
+    "git-expert": { "provider": null, "model": null }
+  }
 }
 ```
 
@@ -337,7 +344,7 @@ tools: read, write, edit, bash
 Agent system prompt here.
 ```
 
-Use `agentScope: "both"` in the subagent tool to include project agents.
+Project agents included by default (`agentScope` defaults to `"both"`).
 
 ### Image Generation
 

--- a/dev-docs/extension-commands.md
+++ b/dev-docs/extension-commands.md
@@ -13,10 +13,11 @@ the extension source files under `extensions/`. Each command uses
 | `/pidiff` | `pidiff/pidiff.ts` | Manage pidiff per-project server (start/stop/restart/status) |
 | `/status` | `status.ts` | Unified session status snapshot |
 | `/review-status [worktree-path]` | `enforcement.ts` | Show review loop state. Pass a worktree path to check a specific worktree |
-| `/async-status` | `async-agents.ts` | Background agent status |
+| `/async-status` | `async-agents.ts` + `async-status-ui.ts` | Fullscreen overlay: list async agents → live output; `x` kills selected |
+| `/async-kill` | `async-agents.ts` + `async-status-ui.ts` | Args kill directly; no args = overlay of running agents (`x` kill) |
 | `/dream` | `dreaming.ts` | Memory consolidation |
 | `/dream-auto` | `dreaming.ts` | Toggle automatic dreaming |
-| `/cron` | `cron.ts` | Schedule recurring tasks |
+| `/cron` | `cron.ts` + `cron-status-ui.ts` | `/cron list` + `/cron list-all` = overlay (view / `x` remove; list-all = all sessions) |
 | `/nvim-changed-files` | `nvim.ts` | Send changed files to nvim quickfix |
 | `/coms` | `coms/coms-wrapper.ts` | P2P agent communication (start/stop/status) |
 | `/coms-net` | `coms/coms-net-wrapper.ts` | Networked agent communication (start/connect/disconnect/stop/status) |

--- a/dev-docs/project-settings.md
+++ b/dev-docs/project-settings.md
@@ -11,6 +11,7 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 | `dco` | boolean | disabled | `PI_DCO` | Add --signoff to all commits (DCO) |
 | `comment_signature` | boolean | disabled | — | Append AI signature to all PR comments |
 | `review_loop_enforcement` | boolean | disabled | `PI_REVIEW_LOOP_ENFORCEMENT` | Block git commit until all 5 reviewers approve (review loop enforcement) |
+| `orchestrator_edit_write_block` | boolean | `false` | — | Block orchestrator from using edit and write tools directly (must delegate to subagents). |
 | `review_loop_max_cycles` | number | `3` | `PI_REVIEW_LOOP_MAX_CYCLES` | Max review-loop cycles when `review_loop_enforcement` is enabled. Accepts JSON integers `1`-`10`, or digit strings `"1"`-`"10"` only (after trim). Rejects out-of-range values and non-digit forms (`"01"`, `"10.0"`, `"1e1"`, hex/binary, `"inf"`, `Infinity`, …) — those fall through to the next resolution layer / default `3`. Injected into orchestrator rules text via `{{REVIEW_LOOP_MAX_CYCLES}}` (prompt/LLM compliance only; see `rule-placeholders.ts`). Disable the review loop via `review_loop_enforcement: false`, not via max_cycles. Reaching the cap blocks re-dispatch (step 2 / all 6 agents, including test-automator) after 5a — no further verification dispatch unless `review_loop_max_cycles` is raised; report **Not fixed** (explained why not → outstanding) vs **Fixed** (verification blocked by the cap — cannot re-dispatch to confirm clean) — it does NOT bypass `review_loop_enforcement`'s commit blocking. |
 | `acpx_agents` | string or string[] | `[]` | `ACPX_AGENTS` | acpx agents to register as `acpx-*` models via createProvider (pi ≥ 0.81). Ambient auth when configured (`agents.has`); `/login` stores optional marker. See `dev-docs/async-internals.md` |
 | `cli_agents` | string or string[] | `[]` | `CLI_AGENTS` | CLI agents to register as `cli-*` providers via createProvider (pi ≥ 0.81; e.g. `"cursor"` or `["claude","gemini","cursor"]`). Ambient auth when configured (PATH + AgentState); `/login` optional marker. See `dev-docs/cli-provider.md` |
@@ -20,6 +21,9 @@ Settings file: `.pi/pi-config-settings.json` — per-project configuration overr
 | `image_model` | string | disabled | `PI_IMAGE_MODEL` | Gemini image model for `generate_image` tool |
 | `async_llm_provider` | string | unset | `PI_ASYNC_LLM_PROVIDER` | Provider for detached LLM async children when parent is acpx (dream/cron/fireAndForget). Both this and `async_llm_model` required. |
 | `async_llm_model` | string | unset | `PI_ASYNC_LLM_MODEL` | Model id for those children. If unset on acpx, must-async LLM work is skipped. |
+| `agent_provider` | string | `""` | — | Default provider for all subagents (e.g. `cli-cursor`). |
+| `agent_model` | string | `""` | — | Default model for all subagents (e.g. `cursor:cursor-grok-4.5-high-fast`). |
+| `agent_overrides` | object | `{}` | — | Per-agent provider/model overrides. `null` values = use parent model (skip global setting). |
 
 Resolution: project file → global `~/.pi/pi-config-settings.json` → env var → default.
 

--- a/dev-docs/repo-structure.md
+++ b/dev-docs/repo-structure.md
@@ -35,6 +35,12 @@ pi-config/
 │   │   ├── agents.ts                # Agent discovery
 │   │   ├── ask-user.ts              # ask_user tool
 │   │   ├── async-agents.ts          # Async background agent infrastructure (fireAndForget, group-aware delivery, onComplete callbacks)
+│   │   ├── overlay-dashboard.ts     # Shared fullscreen list→detail overlay (async/cron)
+│   │   ├── overlay-dashboard-utils.ts # Pure selection reconcile helpers
+│   │   ├── async-status-ui.ts       # /async-status overlay (uses overlay-dashboard)
+│   │   ├── async-status-parse.ts    # Pure output.log JSONL → display line parser
+│   │   ├── cron-status-ui.ts        # /cron list + list-all overlay (uses overlay-dashboard)
+│   │   ├── cron-status-format.ts    # Pure cron schedule / next-run display helpers
 │   │   ├── async-capability.ts      # supportsAsyncLlm / acpx coerce + async_llm sidecar settings
 │   │   ├── async-runner.ts          # Standalone async runner (spawned detached)
 │   │   ├── async-wait.ts            # Shared helper for waiting on async result files

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -30,12 +30,13 @@ const taskStoreReady: Promise<void> = (async () => {
 })();
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { matchesKey, Key, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AgentConfig } from "./agents.js";
+import { resolveAgentModelProvider } from "./subagent-tool.js";
 import { getPiInvocation, getProjectTmpDir, parseProcStartTime, djb2Hash } from "./utils.js";
 import { addReviewerPending, recordReviewerResult, countFindings, readReviewState, markTestsPassed, markTestsFailed } from "./pi-config-review-state.js";
 import { getMainBranch } from "./git-helpers.js";
 import { waitForResultFiles } from "./async-wait.js";
+import { openAsyncStatusOverlay } from "./async-status-ui.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -65,6 +66,7 @@ export interface AsyncJob {
   cwd?: string;
   projectCwd?: string;
   sessionId?: string;
+  model?: string;
 }
 
 /** Get the effective working directory for a job. */
@@ -590,9 +592,8 @@ export function registerAsyncAgents(
       : agentName + ':' + task.slice(0, 100);
     const deterministicSessionId = `async-${agentName}-${djb2Hash(sessionIdSource).toString(36)}`;
     piArgs.push("--session-id", deterministicSessionId);
-    const effectiveModel = agent.model || options?.parentModelId;
+    const { model: effectiveModel, provider: effectiveProvider } = resolveAgentModelProvider(agentName, agent, options?.parentModelId, options?.parentProvider, cwd);
     if (effectiveModel) piArgs.push("--model", effectiveModel);
-    const effectiveProvider = agent.provider || options?.parentProvider;
     if (effectiveProvider) piArgs.push("--provider", effectiveProvider);
     if (agent.tools?.length) piArgs.push("--tools", agent.tools.join(","));
 
@@ -707,6 +708,7 @@ export function registerAsyncAgents(
       cwd,
       projectCwd: asyncState.lastCtx?.sessionManager?.getCwd?.(),
       sessionId: asyncState.lastCtx?.sessionManager?.getSessionId?.(),
+      model: effectiveModel,
     };
     asyncState.jobs.set(id, job);
 
@@ -809,6 +811,7 @@ export function registerAsyncAgents(
             cwd: marker.cwd || undefined,
             projectCwd: marker.projectCwd || undefined,
             sessionId: marker.sessionId || undefined,
+            model: status.model || marker.model || undefined,
           };
           asyncState.jobs.set(id, job);
           asyncLog(`restored job: ${id} state=${job.status}`);
@@ -836,217 +839,22 @@ export function registerAsyncAgents(
     if (asyncState.watcher) { asyncState.watcher.close(); asyncState.watcher = null; }
   });
 
-  // /async-status handler — extracted for readability (closure access preserved)
+  // /async-status — fullscreen overlay list → live output detail
   async function handleAsyncStatus(ctx: any): Promise<void> {
-    const jobs = Array.from(asyncState.jobs.values());
-    if (jobs.length === 0) {
-      ctx.ui.notify("No async agents running or recently completed.", "info");
-      return;
-    }
-
-    // If only completed agents, show static summary
-    const running = jobs.filter(j => j.status === "running" || j.status === "queued");
-    if (running.length === 0) {
-      const lines: string[] = ["All agents completed:\n"];
-      for (const job of jobs) {
-        const dur = job.durationMs ? formatDuration(job.durationMs) : formatDuration(Date.now() - job.startedAt);
-        const icon = job.status === "complete" ? "✅" : "❌";
-        lines.push(`${icon} ${job.name || job.agent} (${dur}) — ${job.task.slice(0, 60)}`);
-      }
-      ctx.ui.notify(lines.join("\n"), "info");
-      return;
-    }
-
-    // Build selection list — append short ID to ensure uniqueness
-    const options = running.map((j) => {
-      const duration = formatDuration(Date.now() - j.startedAt);
-      const taskPreview = j.task.length > 60 ? j.task.slice(0, 60) + "..." : j.task;
-      const shortId = j.id.slice(-6);
-      return `${j.name || j.agent} (${duration}) [${shortId}] — ${taskPreview}`;
-    });
-
-    const selected = await ctx.ui.select("View async agent output:", options);
-    if (!selected) return;
-
-    // Extract short ID from selection to find the exact job (avoids indexOf collision on duplicate labels)
-    const idMatch = selected.match(/\[(\w{6})\] —/);
-    const job = idMatch ? running.find(j => j.id.endsWith(idMatch[1])) : running[options.indexOf(selected)];
-    if (!job) return;
-    const outputPath = path.join(job.workerDir, "output.log");
-
-    // Create a live output viewer as an overlay
-    await ctx.ui.custom<void>((tui, _theme, _kb, done) => {
-      const lines: string[] = [];
-      let scrollOffset = 0;
-      let maxScroll = 0;
-      let following = true; // auto-scroll to bottom
-      let closed = false;
-      let cachedWidth: number | undefined;
-      let cachedLines: string[] | undefined;
-
-      // Parse a JSON line from the output log into a display string
-      function parseLine(raw: string): string | null {
-        try {
-          const ev = JSON.parse(raw);
-          if (ev.type === "message_update" && ev.assistantMessageEvent) {
-            const ae = ev.assistantMessageEvent;
-            if (ae.type === "text_delta" && ae.delta) return ae.delta;
-            if (ae.type === "thinking_delta" && ae.delta) return null;
-            if (ae.type === "toolcall_delta" && ae.content) return null;
-            return null;
-          }
-          if (ev.type === "tool_execution_start") {
-            const name = ev.toolName || "tool";
-            const cmd = ev.args?.command ? ` ${ev.args.command.slice(0, 80)}` : "";
-            return `\n🔧 ${name}${cmd}`;
-          }
-          if (ev.type === "tool_execution_end") {
-            const text = ev.result?.content?.[0]?.text || "";
-            const prefix = ev.isError ? "✗" : "✓";
-            return `\n${prefix} ${text.slice(0, 200)}`;
-          }
-          if (ev.type === "agent_end") return "\n--- Agent finished ---";
-          return null;
-        } catch {
-          return null;
-        }
-      }
-
-      // Read existing output and watch for new content
-      let filePos = 0;
-      let textBuffer = "";
-      let lastLoggedError = "";
-
-      function readNewContent() {
-        if (closed) return;
-        try {
-          const content = fs.readFileSync(outputPath, "utf-8");
-          if (content.length > filePos) {
-            const newContent = content.slice(filePos);
-            filePos = content.length;
-            textBuffer += newContent;
-
-            // Process complete lines
-            const parts = textBuffer.split("\n");
-            textBuffer = parts.pop() || "";
-            for (const part of parts) {
-              if (!part.trim()) continue;
-              const parsed = parseLine(part);
-              if (parsed !== null) {
-                for (const l of parsed.split("\n")) {
-                  if (l) lines.push(l);
-                  else lines.push("");
-                }
-              }
-            }
-            cachedWidth = undefined;
-            cachedLines = undefined;
-            tui.requestRender();
-          }
-        } catch (e: any) {
-          if (e?.code === "ENOENT") return;
-          const msg = e?.message || String(e);
-          if (msg !== lastLoggedError) {
-            lastLoggedError = msg;
-            console.debug("[async-agents] live output read failed:", msg);
-          }
-        }
-      }
-
-      // Poll for new content every 500ms
-      const poller = setInterval(readNewContent, 500);
-      readNewContent();
-
-      return {
-        handleInput(data: string) {
-          if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
-            closed = true;
-            clearInterval(poller);
-            done(undefined);
-            return;
-          }
-          if (matchesKey(data, Key.up)) {
-            if (scrollOffset > 0) { scrollOffset--; following = false; cachedWidth = undefined; tui.requestRender(); }
-            return;
-          }
-          if (matchesKey(data, Key.down)) {
-            if (scrollOffset < maxScroll) { scrollOffset++; cachedWidth = undefined; tui.requestRender(); }
-            if (scrollOffset >= maxScroll) following = true;
-            return;
-          }
-          if (matchesKey(data, Key.pageUp)) {
-            scrollOffset = Math.max(0, scrollOffset - 10); following = false; cachedWidth = undefined; tui.requestRender();
-            return;
-          }
-          if (matchesKey(data, Key.pageDown)) {
-            scrollOffset = Math.min(maxScroll, scrollOffset + 10);
-            if (scrollOffset >= maxScroll) following = true;
-            cachedWidth = undefined; tui.requestRender();
-            return;
-          }
-          if (matchesKey(data, Key.home)) {
-            scrollOffset = 0; following = false; cachedWidth = undefined; tui.requestRender();
-            return;
-          }
-          if (matchesKey(data, Key.end)) {
-            scrollOffset = maxScroll; following = true; cachedWidth = undefined; tui.requestRender();
-            return;
-          }
-        },
-
-        invalidate() { cachedWidth = undefined; cachedLines = undefined; },
-
-        render(width: number): string[] {
-          if (cachedLines && cachedWidth === width) return cachedLines;
-
-          const headerWidth = width - 2;
-          const dur = formatDuration(Date.now() - job.startedAt);
-          const status = readAsyncStatus(job.workerDir);
-          const state = status?.state || job.status;
-          const stateIcon = state === "complete" ? "✅" : state === "failed" ? "❌" : "⏳";
-          const header = truncateToWidth(`${stateIcon} ${job.name || job.agent} — ${dur} — ${job.task.slice(0, 40)}`, headerWidth);
-          const footer = truncateToWidth("↑↓ scroll  PgUp/PgDn  Home/End  Esc close", headerWidth);
-          const sep = "─".repeat(Math.min(width, headerWidth));
-
-          // Wrap all lines to fit width
-          const wrapped: string[] = [];
-          for (const line of lines) {
-            const w = wrapTextWithAnsi(line, width - 2);
-            for (const wl of w) {
-              wrapped.push(truncateToWidth(wl, width - 2));
-            }
-          }
-
-          // Calculate visible area
-          const viewHeight = Math.max(5, Math.min(30, ((tui as any).height ?? 24) - 8));
-          maxScroll = Math.max(0, wrapped.length - viewHeight);
-
-          // Auto-scroll to bottom
-          if (following) {
-            scrollOffset = maxScroll;
-          }
-
-          const visible = wrapped.slice(scrollOffset, scrollOffset + viewHeight);
-
-          // Pad to viewHeight
-          while (visible.length < viewHeight) visible.push("");
-
-          cachedLines = [header, sep, ...visible, sep, footer];
-          cachedWidth = width;
-          return cachedLines;
-        },
-
-        dispose() {
-          closed = true;
-          clearInterval(poller);
-        },
-      };
+    if (!ctx.hasUI) return;
+    await openAsyncStatusOverlay(ctx, {
+      listJobs: () => Array.from(asyncState.jobs.values()),
+      killJob: (id) => {
+        killAsyncAgent(id);
+      },
+      formatDuration,
+      readLiveStatus: (workerDir) => readAsyncStatus(workerDir),
     });
   }
 
   // /async-status command
   pi.registerCommand("async-status", {
-    description: "Show status of background async agents — select one to view live output",
+    description: "Fullscreen overlay: list async agents, view live output, kill with x",
     handler: async (_args, ctx) => handleAsyncStatus(ctx),
   });
 
@@ -1131,68 +939,28 @@ export function registerAsyncAgents(
       return;
     }
 
-    const running = Array.from(asyncState.jobs.values()).filter(
-      (j) => j.status === "running" || j.status === "queued",
-    );
-
-    if (running.length === 0) {
-      ctx.ui.notify("No running async agents.", "info");
-      return;
-    }
-
-    // Build selection list — append short ID to ensure uniqueness
-    const options = running.map((j) => {
-      const duration = formatDuration(Date.now() - j.startedAt);
-      const taskPreview = j.task.length > 60 ? j.task.slice(0, 60) + "..." : j.task;
-      const shortId = j.id.slice(-6);
-      return `${j.name || j.agent} (${duration}) [${shortId}] — ${taskPreview}`;
+    if (!ctx.hasUI) return;
+    // Same overlay as /async-status, scoped to running/queued
+    await openAsyncStatusOverlay(ctx, {
+      title: "Kill async agents",
+      emptyMessage: "No running async agents.",
+      footerHints: "↑↓/jk select · Enter view · x kill · Esc close",
+      listJobs: () =>
+        Array.from(asyncState.jobs.values()).filter(
+          (j) => j.status === "running" || j.status === "queued",
+        ),
+      killJob: (id) => {
+        killAsyncAgent(id);
+      },
+      formatDuration,
+      readLiveStatus: (workerDir) => readAsyncStatus(workerDir),
     });
-
-    const selected = await ctx.ui.select("Kill which async agent?", options);
-    if (!selected) return;
-
-    // Extract short ID from selection to find the exact job (avoids indexOf collision on duplicate labels)
-    const idMatch = selected.match(/\[(\w{6})\] —/);
-    const job = idMatch ? running.find(j => j.id.endsWith(idMatch[1])) : running[options.indexOf(selected)];
-    if (!job) return;
-
-    // Kill entire process tree
-    const status = readAsyncStatus(job.workerDir);
-    if (status?.pid) {
-      const killLog: string[] = [];
-      try {
-        const tree = execFileSync("pstree", ["-p", String(status.pid)], { encoding: "utf-8", timeout: 3000 });
-        killLog.push(`pstree output: ${tree.trim()}`);
-        const matches = tree.match(/\((\d+)\)/g);
-        const allPids = matches ? [...new Set(matches.map((m: string) => parseInt(m.slice(1, -1), 10)))] : [status.pid];
-        killLog.push(`PIDs to kill: ${allPids.join(", ")}`);
-        for (const pid of allPids) {
-          try { process.kill(pid, "SIGKILL"); killLog.push(`killed ${pid}`); } catch (e: any) { killLog.push(`failed ${pid}: ${e.message}`); }
-        }
-      } catch (e: any) {
-        killLog.push(`pstree failed: ${e.message}`);
-        try { process.kill(status.pid, "SIGKILL"); killLog.push(`killed runner ${status.pid}`); } catch {}
-        if (status.childPid) try { process.kill(status.childPid, "SIGKILL"); killLog.push(`killed child ${status.childPid}`); } catch {}
-      }
-      const logPath = path.join(job.workerDir, "kill.log");
-      fs.writeFileSync(logPath, killLog.join("\n"), "utf-8");
-    }
-
-    job.status = "failed";
-    job.updatedAt = Date.now();
-    updateAsyncWidget();
-    ctx.ui.notify(`Killed: ${job.name || job.agent}`, "info");
-
-    // Clean up after 5s
-    setTimeout(() => {
-      asyncState.jobs.delete(job.id);
-      updateAsyncWidget();
-    }, 5000);
   }
 
-  // /async-kill command — accepts name/id/"all" or interactive selection
+  // /async-kill command — accepts name/id/"all" or interactive overlay
   pi.registerCommand("async-kill", {
-    description: "Kill async agent(s) — /async-kill <name|id|all>",
+    description:
+      "Kill async agent(s) — /async-kill <name|id|all> or overlay picker",
     handler: async (_args, ctx) => handleAsyncKill((_args || "").trim(), ctx),
   });
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -31,7 +31,7 @@ const taskStoreReady: Promise<void> = (async () => {
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "./agents.js";
-import { resolveAgentModelProvider } from "./subagent-tool.js";
+import { resolveAgentModelProvider } from "./resolve-agent-model.js";
 import { getPiInvocation, getProjectTmpDir, parseProcStartTime, djb2Hash } from "./utils.js";
 import { addReviewerPending, recordReviewerResult, countFindings, readReviewState, markTestsPassed, markTestsFailed } from "./pi-config-review-state.js";
 import { getMainBranch } from "./git-helpers.js";

--- a/extensions/orchestrator/async-status-parse.ts
+++ b/extensions/orchestrator/async-status-parse.ts
@@ -1,0 +1,31 @@
+/**
+ * Pure parsers for async agent output.log JSONL — no TUI deps (unit-testable).
+ */
+
+/** Parse one JSONL event line from async output.log into display text. */
+export function parseAsyncOutputLine(raw: string): string | null {
+  try {
+    const ev = JSON.parse(raw);
+    if (ev.type === "message_update" && ev.assistantMessageEvent) {
+      const ae = ev.assistantMessageEvent;
+      if (ae.type === "text_delta" && ae.delta) return ae.delta;
+      return null;
+    }
+    if (ev.type === "tool_execution_start") {
+      const name = ev.toolName || "tool";
+      const cmd = ev.args?.command
+        ? ` ${String(ev.args.command).slice(0, 80)}`
+        : "";
+      return `\n→ ${name}${cmd}`;
+    }
+    if (ev.type === "tool_execution_end") {
+      const text = ev.result?.content?.[0]?.text || "";
+      const prefix = ev.isError ? "✗" : "✓";
+      return `\n${prefix} ${String(text).slice(0, 200)}`;
+    }
+    if (ev.type === "agent_end") return "\n--- Agent finished ---";
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/extensions/orchestrator/async-status-ui.ts
+++ b/extensions/orchestrator/async-status-ui.ts
@@ -1,0 +1,201 @@
+/**
+ * /async-status fullscreen overlay — list dashboard → live output detail.
+ */
+
+import type { ExtensionCommandContext, Theme } from "@earendil-works/pi-coding-agent";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { parseAsyncOutputLine } from "./async-status-parse.js";
+import {
+  openListDetailOverlay,
+  OverlayScrollDetail,
+} from "./overlay-dashboard.js";
+
+export { parseAsyncOutputLine } from "./async-status-parse.js";
+
+export interface AsyncStatusJobView {
+  id: string;
+  agent: string;
+  name?: string;
+  task: string;
+  status: string;
+  workerDir: string;
+  startedAt: number;
+  durationMs?: number;
+  model?: string;
+}
+
+export interface AsyncStatusUiDeps {
+  listJobs: () => AsyncStatusJobView[];
+  killJob: (id: string) => void;
+  formatDuration: (ms: number) => string;
+  /** Optional live status.json reader for detail header. */
+  readLiveStatus?: (workerDir: string) => { state?: string } | null;
+  title?: string;
+  emptyMessage?: string;
+  footerHints?: string;
+}
+
+function jobTitle(job: AsyncStatusJobView): string {
+  return job.name || job.agent;
+}
+
+function isActive(status: string): boolean {
+  return status === "running" || status === "queued";
+}
+
+function statusGlyph(status: string, theme: Theme): string {
+  switch (status) {
+    case "running":
+    case "queued":
+      return theme.fg("warning", "■");
+    case "complete":
+      return "\x1b[32m■\x1b[0m";
+    case "failed":
+      return theme.fg("error", "■");
+    default:
+      return theme.fg("muted", "■");
+  }
+}
+
+function statusWord(status: string, theme: Theme): string {
+  switch (status) {
+    case "running":
+      return theme.fg("warning", "running");
+    case "queued":
+      return theme.fg("warning", "queued");
+    case "complete":
+      return "\x1b[32mdone\x1b[0m";
+    case "failed":
+      return theme.fg("error", "failed");
+    default:
+      return theme.fg("muted", status);
+  }
+}
+
+function elapsedMs(job: AsyncStatusJobView): number {
+  if (job.durationMs != null && !isActive(job.status)) return job.durationMs;
+  return Date.now() - job.startedAt;
+}
+
+/**
+ * Open fullscreen async-status picker. Loops list → detail until user closes list.
+ */
+export async function openAsyncStatusOverlay(
+  ctx: ExtensionCommandContext,
+  deps: AsyncStatusUiDeps,
+): Promise<void> {
+  await openListDetailOverlay(ctx, {
+    emptyMessage:
+      deps.emptyMessage ?? "No async agents running or recently completed.",
+    listSpec: {
+      title: deps.title ?? "Async agents",
+      countLabel: (jobs) => `${jobs.length} job${jobs.length === 1 ? "" : "s"}`,
+      borderTitle: (jobs) => {
+        const active = jobs.filter((j) => isActive(j.status)).length;
+        return `jobs · ${active} active / ${jobs.length}`;
+      },
+      footerHints:
+        deps.footerHints ?? "↑↓/jk select · Enter view · x kill · Esc close",
+      listItems: () => deps.listJobs(),
+      rowParts: (job, theme) => {
+        const shortId = job.id.length > 8 ? job.id.slice(-8) : job.id;
+        const taskPreview =
+          job.task.length > 40 ? `${job.task.slice(0, 40)}…` : job.task;
+        return {
+          glyph: statusGlyph(job.status, theme),
+          title: jobTitle(job),
+          idLabel: theme.fg("dim", shortId),
+          rightParts: [
+            theme.fg("muted", job.agent),
+            ...(job.model ? [theme.fg("dim", job.model)] : []),
+            theme.fg("dim", taskPreview),
+            theme.fg("muted", deps.formatDuration(elapsedMs(job))),
+            statusWord(job.status, theme),
+          ],
+        };
+      },
+      onX: (job) => {
+        if (isActive(job.status)) deps.killJob(job.id);
+      },
+    },
+    createDetail: (job, tui, theme, done) => {
+      const lines: string[] = [];
+      let filePos = 0;
+      let textBuffer = "";
+      let lastLoggedError = "";
+
+      const readNewContent = (): boolean => {
+        try {
+          const content = fs.readFileSync(
+            path.join(job.workerDir, "output.log"),
+            "utf-8",
+          );
+          if (content.length <= filePos) return false;
+          const newContent = content.slice(filePos);
+          filePos = content.length;
+          textBuffer += newContent;
+
+          const parts = textBuffer.split("\n");
+          textBuffer = parts.pop() || "";
+          let changed = false;
+          for (const part of parts) {
+            if (!part.trim()) continue;
+            const parsed = parseAsyncOutputLine(part);
+            if (parsed === null) continue;
+            for (const l of parsed.split("\n")) lines.push(l);
+            changed = true;
+          }
+          return changed;
+        } catch (e: any) {
+          if (e?.code === "ENOENT") return false;
+          const msg = e?.message || String(e);
+          if (msg !== lastLoggedError) {
+            lastLoggedError = msg;
+            console.debug("[async-status-ui] live output read failed:", msg);
+          }
+          return false;
+        }
+      };
+
+      const jobId = job.id;
+      return new OverlayScrollDetail(
+        tui,
+        theme,
+        {
+          followTail: true,
+          emptyBody: "(no output yet)",
+          footerHints:
+            "↑↓/jk scroll · PgUp/PgDn · Home/End · x kill · Esc back",
+          pollMs: 500,
+          onPoll: readNewContent,
+          onX: () => {
+            const current = deps.listJobs().find((j) => j.id === jobId);
+            if (current && isActive(current.status)) {
+              deps.killJob(jobId);
+              return true;
+            }
+            return false;
+          },
+          getHeader: (t) => {
+            const live = deps.readLiveStatus?.(job.workerDir);
+            const current = deps.listJobs().find((j) => j.id === jobId) || job;
+            const state = live?.state || current.status;
+            const dur = deps.formatDuration(elapsedMs(current));
+            return (
+              `${statusGlyph(state, t)} ` +
+              t.fg(
+                "accent",
+                t.bold(`${jobTitle(current)} · ${current.id.slice(-8)}`),
+              ) +
+              t.fg("muted", ` · ${state} · ${dur}`) +
+              t.fg("dim", ` · ${current.task.slice(0, 40)}`)
+            );
+          },
+          getBodyLines: () => lines,
+        },
+        done,
+      );
+    },
+  });
+}

--- a/extensions/orchestrator/cron-status-format.ts
+++ b/extensions/orchestrator/cron-status-format.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure cron status display helpers — no TUI deps (unit-testable).
+ */
+
+export interface CronStatusTaskView {
+  /** Unique overlay row id (e.g. "1" or "cron-123-abc.json:1"). */
+  id: string;
+  /** Numeric cron task id within its session file. */
+  taskId: number;
+  description: string;
+  task: string;
+  intervalMs?: number;
+  atHour?: number;
+  atMinute?: number;
+  createdAt: number;
+  lastRun?: number;
+  nextRun?: number;
+  /** Shown in list-all rows (e.g. "this session", "PID 42"). */
+  sessionLabel?: string;
+  isLocal?: boolean;
+  cronFile?: string;
+}
+
+export function formatCronSchedule(task: {
+  intervalMs?: number;
+  atHour?: number;
+  atMinute?: number;
+}): string {
+  if (task.intervalMs) {
+    if (task.intervalMs < 60000) return `every ${Math.round(task.intervalMs / 1000)}s`;
+    if (task.intervalMs < 3600000) {
+      return `every ${Math.round(task.intervalMs / 60000)}m`;
+    }
+    const h = Math.floor(task.intervalMs / 3600000);
+    const m = Math.round((task.intervalMs % 3600000) / 60000);
+    return m > 0 ? `every ${h}h${m}m` : `every ${h}h`;
+  }
+  if (task.atHour !== undefined && task.atMinute !== undefined) {
+    return `daily at ${String(task.atHour).padStart(2, "0")}:${String(task.atMinute).padStart(2, "0")}`;
+  }
+  return "unknown";
+}
+
+/** Best-effort next-fire timestamp for display. */
+export function resolveNextRunAt(
+  task: CronStatusTaskView,
+  now = Date.now(),
+): number | undefined {
+  if (task.nextRun != null) return task.nextRun;
+  if (task.intervalMs != null) {
+    if (task.lastRun != null) return task.lastRun + task.intervalMs;
+    return task.createdAt + task.intervalMs;
+  }
+  if (task.atHour !== undefined && task.atMinute !== undefined) {
+    const target = new Date(now);
+    target.setHours(task.atHour, task.atMinute, 0, 0);
+    if (target.getTime() <= now) target.setDate(target.getDate() + 1);
+    return target.getTime();
+  }
+  return undefined;
+}
+
+export function formatRelativeMs(ms: number): string {
+  const abs = Math.abs(ms);
+  if (abs < 60000) return `${Math.round(abs / 1000)}s`;
+  if (abs < 3600000) return `${Math.round(abs / 60000)}m`;
+  const h = Math.floor(abs / 3600000);
+  const m = Math.round((abs % 3600000) / 60000);
+  return m > 0 ? `${h}h${m}m` : `${h}h`;
+}
+
+export function formatLastRunLabel(
+  task: CronStatusTaskView,
+  now = Date.now(),
+): string {
+  if (task.lastRun == null) return "never";
+  return `${formatRelativeMs(now - task.lastRun)} ago`;
+}
+
+export function formatNextRunLabel(
+  task: CronStatusTaskView,
+  now = Date.now(),
+): string {
+  const at = resolveNextRunAt(task, now);
+  if (at == null) return "—";
+  const delta = at - now;
+  if (delta <= 0) return "soon";
+  return `in ${formatRelativeMs(delta)}`;
+}
+
+/** Map a CronTask-like object into an overlay row view. */
+export function toCronStatusTaskView(
+  task: {
+    id: number;
+    description: string;
+    task: string;
+    intervalMs?: number;
+    atHour?: number;
+    atMinute?: number;
+    createdAt: number;
+    lastRun?: number;
+    nextRun?: number;
+  },
+  opts: {
+    overlayId: string;
+    sessionLabel?: string;
+    isLocal?: boolean;
+    cronFile?: string;
+  },
+): CronStatusTaskView {
+  return {
+    id: opts.overlayId,
+    taskId: task.id,
+    description: task.description,
+    task: task.task,
+    intervalMs: task.intervalMs,
+    atHour: task.atHour,
+    atMinute: task.atMinute,
+    createdAt: task.createdAt,
+    lastRun: task.lastRun,
+    nextRun: task.nextRun,
+    sessionLabel: opts.sessionLabel,
+    isLocal: opts.isLocal,
+    cronFile: opts.cronFile,
+  };
+}

--- a/extensions/orchestrator/cron-status-ui.ts
+++ b/extensions/orchestrator/cron-status-ui.ts
@@ -1,0 +1,132 @@
+/**
+ * /cron list + list-all fullscreen overlay — list dashboard → task detail.
+ */
+
+import type { ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import {
+  formatCronSchedule,
+  formatLastRunLabel,
+  formatNextRunLabel,
+  type CronStatusTaskView,
+} from "./cron-status-format.js";
+import {
+  openListDetailOverlay,
+  OverlayScrollDetail,
+} from "./overlay-dashboard.js";
+
+export type { CronStatusTaskView } from "./cron-status-format.js";
+export {
+  formatCronSchedule,
+  formatLastRunLabel,
+  formatNextRunLabel,
+  resolveNextRunAt,
+  toCronStatusTaskView,
+} from "./cron-status-format.js";
+
+export interface CronStatusUiDeps {
+  listTasks: () => CronStatusTaskView[];
+  /** Remove by overlay row id. Return true if removed. */
+  removeTask: (id: string) => boolean;
+  title?: string;
+  emptyMessage?: string;
+  borderTitle?: (tasks: readonly CronStatusTaskView[]) => string;
+}
+
+/**
+ * Open fullscreen cron list. Loops list → detail until user closes list.
+ */
+export async function openCronStatusOverlay(
+  ctx: ExtensionCommandContext,
+  deps: CronStatusUiDeps,
+): Promise<void> {
+  const showSession = () =>
+    deps.listTasks().some((t) => !!t.sessionLabel);
+
+  await openListDetailOverlay(ctx, {
+    emptyMessage: deps.emptyMessage ?? "No scheduled tasks.",
+    listSpec: {
+      title: deps.title ?? "Cron tasks",
+      countLabel: (tasks) =>
+        `${tasks.length} task${tasks.length === 1 ? "" : "s"}`,
+      borderTitle:
+        deps.borderTitle ??
+        ((tasks) => `scheduled · ${tasks.length}`),
+      footerHints: "↑↓/jk select · Enter view · x remove · Esc close",
+      listItems: () => deps.listTasks(),
+      rowParts: (task, theme) => {
+        const now = Date.now();
+        const rightParts = [
+          theme.fg("muted", formatCronSchedule(task)),
+          theme.fg("dim", formatLastRunLabel(task, now)),
+          theme.fg("muted", formatNextRunLabel(task, now)),
+        ];
+        if (showSession() && task.sessionLabel) {
+          rightParts.unshift(theme.fg("dim", task.sessionLabel));
+        }
+        return {
+          glyph: theme.fg("warning", "■"),
+          title: task.description,
+          idLabel: theme.fg("dim", `#${task.taskId}`),
+          rightParts,
+        };
+      },
+      onX: (task) => {
+        deps.removeTask(task.id);
+      },
+    },
+    createDetail: (task, tui, theme, done) => {
+      const rowId = task.id;
+      return new OverlayScrollDetail(
+        tui,
+        theme,
+        {
+          footerHints: "↑↓/jk scroll · x remove · Esc back",
+          onX: () => deps.removeTask(rowId),
+          getHeader: (t) => {
+            const current = deps.listTasks().find((x) => x.id === rowId);
+            if (!current) return t.fg("error", "Task removed.");
+            const session = current.sessionLabel
+              ? t.fg("dim", ` · ${current.sessionLabel}`)
+              : "";
+            return (
+              `${t.fg("warning", "■")} ` +
+              t.fg(
+                "accent",
+                t.bold(`#${current.taskId} · ${current.description}`),
+              ) +
+              t.fg("muted", ` · ${formatCronSchedule(current)}`) +
+              session
+            );
+          },
+          getBodyLines: (t) => {
+            const current = deps.listTasks().find((x) => x.id === rowId);
+            if (!current) {
+              return [t.fg("error", "Task removed."), t.fg("dim", "Esc back")];
+            }
+            const now = Date.now();
+            const lines = [
+              `${t.fg("muted", "Schedule")}  ${formatCronSchedule(current)}`,
+              `${t.fg("muted", "Last run")}  ${formatLastRunLabel(current, now)}` +
+                (current.lastRun
+                  ? t.fg(
+                      "dim",
+                      ` · ${new Date(current.lastRun).toLocaleString()}`,
+                    )
+                  : ""),
+              `${t.fg("muted", "Next run")}  ${formatNextRunLabel(current, now)}`,
+              `${t.fg("muted", "Created")}   ${new Date(current.createdAt).toLocaleString()}`,
+            ];
+            if (current.sessionLabel) {
+              lines.push(
+                `${t.fg("muted", "Session")}  ${current.sessionLabel}`,
+              );
+            }
+            lines.push("", t.fg("muted", "Task"), current.task);
+            return lines;
+          },
+        },
+        done,
+      );
+    },
+  });
+}

--- a/extensions/orchestrator/cron.ts
+++ b/extensions/orchestrator/cron.ts
@@ -18,6 +18,8 @@ import { Type } from "typebox";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { decideAsyncLlmDispatch } from "./async-capability.js";
 import { discoverAgents } from "./agents.js";
+import { formatCronSchedule, toCronStatusTaskView } from "./cron-status-format.js";
+import { openCronStatusOverlay } from "./cron-status-ui.js";
 import { getProjectTmpDir, parseProcStartTime } from "./utils.js";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -48,6 +50,8 @@ interface CronInternals {
 // ── Persistence ──────────────────────────────────────────────────────
 
 let CRON_FILE = ""; // Set on session_start to project-scoped dir
+/** Ignore fs.watch echoes from our own writes. */
+let CRON_IGNORE_WATCH_UNTIL = 0;
 
 /** Unique session suffix — prevents PID collisions across containers */
 /** Suffix must be unique across containers but stable across reloads (same process).
@@ -77,6 +81,7 @@ export function getCronFilePath(): string { return CRON_FILE; }
 function saveCrons(tasks: CronTask[]): void {
   if (!CRON_FILE) return;
   try {
+    CRON_IGNORE_WATCH_UNTIL = Date.now() + 400;
     fs.writeFileSync(CRON_FILE, JSON.stringify(tasks), { mode: 0o600 });
   } catch (e: any) { console.debug("[cron] save crons failed:", e?.message || e); }
 }
@@ -136,20 +141,8 @@ function cleanupOrphanedCronFiles(): void {
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
-function formatDuration(ms: number): string {
-  if (ms < 60000) return `${Math.round(ms / 1000)}s`;
-  if (ms < 3600000) return `${Math.round(ms / 60000)}m`;
-  const h = Math.floor(ms / 3600000);
-  const m = Math.round((ms % 3600000) / 60000);
-  return m > 0 ? `${h}h${m}m` : `${h}h`;
-}
-
 function formatSchedule(task: CronTask): string {
-  if (task.intervalMs) return `every ${formatDuration(task.intervalMs)}`;
-  if (task.atHour !== undefined && task.atMinute !== undefined) {
-    return `daily at ${String(task.atHour).padStart(2, "0")}:${String(task.atMinute).padStart(2, "0")}`;
-  }
-  return "unknown";
+  return formatCronSchedule(task);
 }
 
 function msUntilNextTime(hour: number, minute: number): number {
@@ -301,6 +294,99 @@ function registerCronTool(pi: ExtensionAPI, state: CronInternals): void {
   });
 }
 
+function listLocalCronViews(state: CronInternals) {
+  const file = CRON_FILE || "";
+  return [...state.tasks.values()].map((t) =>
+    toCronStatusTaskView(t, {
+      overlayId: String(t.id),
+      isLocal: true,
+      cronFile: file,
+    }),
+  );
+}
+
+function listAllCronViews(state: CronInternals) {
+  const views: ReturnType<typeof toCronStatusTaskView>[] = [];
+  if (!CRON_FILE) return views;
+  try {
+    const dir = path.dirname(CRON_FILE);
+    const myBase = path.basename(CRON_FILE);
+    for (const f of fs.readdirSync(dir)) {
+      const m = f.match(CRON_FILE_RE);
+      if (!m) continue;
+      const pid = +m[1];
+      const isMe = f === myBase;
+      let alive = isMe;
+      if (!isMe) {
+        try {
+          process.kill(pid, 0);
+          alive = true;
+        } catch {
+          /* dead */
+        }
+      }
+      if (!alive) continue;
+      const filePath = path.join(dir, f);
+      const cronTasks: CronTask[] = isMe
+        ? [...state.tasks.values()]
+        : (() => {
+            try {
+              const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+              if (!Array.isArray(parsed)) return [];
+              return parsed;
+            } catch {
+              return [];
+            }
+          })();
+      if (cronTasks.length === 0) continue;
+      const label = isMe ? `PID ${pid} (this session)` : `PID ${pid}`;
+      for (const t of cronTasks) {
+        views.push(
+          toCronStatusTaskView(t, {
+            overlayId: `${f}:${t.id}`,
+            sessionLabel: label,
+            isLocal: isMe,
+            cronFile: filePath,
+          }),
+        );
+      }
+    }
+  } catch (e: any) {
+    console.debug("[cron] list-all scan failed:", e?.message || e);
+  }
+  return views;
+}
+
+function removeCronByOverlayId(state: CronInternals, overlayId: string): boolean {
+  const fromAll = listAllCronViews(state).find((v) => v.id === overlayId);
+  const fromLocal = listLocalCronViews(state).find((v) => v.id === overlayId);
+  const view = fromAll || fromLocal;
+  if (!view) return false;
+
+  if (view.isLocal || (view.cronFile && view.cronFile === CRON_FILE)) {
+    if (!state.tasks.has(view.taskId)) return false;
+    state.stopTask(view.taskId);
+    state.tasks.delete(view.taskId);
+    saveCrons([...state.tasks.values()]);
+    state.updateCronStatus();
+    return true;
+  }
+
+  // Other session — edit their JSON; their watcher (if running new code) resyncs timers.
+  if (!view.cronFile) return false;
+  try {
+    const raw = JSON.parse(fs.readFileSync(view.cronFile, "utf-8"));
+    if (!Array.isArray(raw)) return false;
+    const next = raw.filter((t: CronTask) => t.id !== view.taskId);
+    if (next.length === raw.length) return false;
+    fs.writeFileSync(view.cronFile, JSON.stringify(next), { mode: 0o600 });
+    return true;
+  } catch (e: any) {
+    console.debug("[cron] remote remove failed:", e?.message || e);
+    return false;
+  }
+}
+
 function registerCronCommand(pi: ExtensionAPI, state: CronInternals): void {
   pi.registerCommand("cron", {
     description: "Schedule recurring tasks — /cron list|list-all|remove <id>|<natural language>",
@@ -313,47 +399,28 @@ function registerCronCommand(pi: ExtensionAPI, state: CronInternals): void {
 
       // Direct handlers — no AI needed
       if (sub === "list" && parts.length === 1) {
-        if (state.tasks.size === 0) {
-          if (ctx.hasUI) ctx.ui.notify("No scheduled tasks.", "info");
-          return;
-        }
-        const lines = [...state.tasks.values()].map(t => {
-          const last = t.lastRun ? new Date(t.lastRun).toLocaleTimeString() : "never";
-          return `#${t.id} | ${formatSchedule(t)} | ${t.description} | last run: ${last}`;
+        if (!ctx.hasUI) return;
+        await openCronStatusOverlay(ctx, {
+          listTasks: () => listLocalCronViews(state),
+          removeTask: (id) => removeCronByOverlayId(state, id),
         });
-        if (ctx.hasUI) ctx.ui.notify(`Scheduled tasks:\n${lines.join("\n")}`, "info");
         return;
       }
 
       if (sub === "list-all") {
-        const sections: string[] = [];
-        if (!CRON_FILE) {
-          if (ctx.hasUI) ctx.ui.notify("No scheduled tasks in any session.", "info");
-          return;
-        }
-        try {
-          const dir = path.dirname(CRON_FILE);
-          for (const f of fs.readdirSync(dir)) {
-            const m = f.match(CRON_FILE_RE);
-            if (!m) continue;
-            const pid = +m[1];
-            const isMe = f === path.basename(CRON_FILE);
-            let alive = isMe;
-            if (!isMe) { try { process.kill(pid, 0); alive = true; } catch {} }
-            if (!alive) continue;
-            const cronTasks: CronTask[] = isMe
-              ? [...state.tasks.values()]
-              : (() => { try { return JSON.parse(fs.readFileSync(path.join(dir, f), "utf-8")); } catch { return []; } })();
-            if (cronTasks.length === 0) continue;
-            const label = isMe ? `PID ${pid} (this session)` : `PID ${pid}`;
-            const lines = cronTasks.map(t => {
-              const last = t.lastRun ? new Date(t.lastRun).toLocaleTimeString() : "never";
-              return `  #${t.id} | ${formatSchedule(t)} | ${t.description} | last run: ${last}`;
-            });
-            sections.push(`${label}:\n${lines.join("\n")}`);
-          }
-        } catch (e: any) { console.debug("[cron] list-all command scan failed:", e?.message || e); }
-        if (ctx.hasUI) ctx.ui.notify(sections.length > 0 ? sections.join("\n\n") : "No crons in any session.", "info");
+        if (!ctx.hasUI) return;
+        await openCronStatusOverlay(ctx, {
+          title: "Cron tasks (all sessions)",
+          emptyMessage: "No crons in any session.",
+          borderTitle: (tasks) => {
+            const sessions = new Set(
+              tasks.map((t) => t.sessionLabel || "?").filter(Boolean),
+            );
+            return `all sessions · ${tasks.length} tasks · ${sessions.size} session${sessions.size === 1 ? "" : "s"}`;
+          },
+          listTasks: () => listAllCronViews(state),
+          removeTask: (id) => removeCronByOverlayId(state, id),
+        });
         return;
       }
 
@@ -528,6 +595,44 @@ export function registerCron(
     }
   }
 
+  /** Resync in-memory tasks from CRON_FILE (external list-all remove / peer edit). */
+  function syncTasksFromDisk(): void {
+    if (!CRON_FILE) return;
+    const onDisk = loadCrons();
+    const diskIds = new Set(onDisk.map((t) => t.id));
+
+    for (const id of [...tasks.keys()]) {
+      if (!diskIds.has(id)) {
+        stopTask(id);
+        tasks.delete(id);
+      }
+    }
+
+    for (const task of onDisk) {
+      // Validate before starting — same rules as add path
+      if (!task.task || typeof task.task !== "string" || !task.task.trim()) continue;
+      if (task.intervalMs !== undefined && task.intervalMs < 10000) continue;
+
+      const existing = tasks.get(task.id);
+      if (!existing) {
+        if (task.id >= state.nextId) state.nextId = task.id + 1;
+        tasks.set(task.id, task);
+        startTask(task);
+        continue;
+      }
+      // Refresh mutable fields from disk without restarting timer unless schedule changed
+      const scheduleChanged =
+        existing.intervalMs !== task.intervalMs ||
+        existing.atHour !== task.atHour ||
+        existing.atMinute !== task.atMinute;
+      Object.assign(existing, task);
+      if (scheduleChanged) startTask(existing);
+    }
+    updateCronStatus();
+  }
+
+  let cronFileWatcher: fs.FSWatcher | null = null;
+
   // Restore persisted crons on session start
   pi.on("session_start", (_event, ctx) => {
     state.lastCwd = ctx.cwd;
@@ -550,6 +655,33 @@ export function registerCron(
       startTask(task);
     }
     updateCronStatus();
+
+    // Ensure file exists so we can watch peer list-all removes
+    if (!fs.existsSync(CRON_FILE)) saveCrons([...tasks.values()]);
+
+    // Watch own file so /cron list-all remove from another session stops our timers
+    try {
+      cronFileWatcher?.close();
+    } catch { /* ignore */ }
+    cronFileWatcher = null;
+    try {
+      let debounce: ReturnType<typeof setTimeout> | null = null;
+      cronFileWatcher = fs.watch(CRON_FILE, () => {
+        if (Date.now() < CRON_IGNORE_WATCH_UNTIL) return;
+        if (debounce) clearTimeout(debounce);
+        debounce = setTimeout(() => {
+          if (Date.now() < CRON_IGNORE_WATCH_UNTIL) return;
+          try {
+            syncTasksFromDisk();
+          } catch (e: any) {
+            console.debug("[cron] sync from disk failed:", e?.message || e);
+          }
+        }, 150);
+      });
+      cronFileWatcher.unref?.();
+    } catch (e: any) {
+      console.debug("[cron] watch setup failed:", e?.message || e);
+    }
   });
 
   // Handle cron kill from pidash browser
@@ -573,6 +705,10 @@ export function registerCron(
 
   // Stop all timers and persist on shutdown
   pi.on("session_shutdown", () => {
+    try {
+      cronFileWatcher?.close();
+    } catch { /* ignore */ }
+    cronFileWatcher = null;
     for (const id of timers.keys()) {
       stopTask(id);
     }

--- a/extensions/orchestrator/enforcement.ts
+++ b/extensions/orchestrator/enforcement.ts
@@ -389,6 +389,18 @@ export function registerEnforcement(pi: ExtensionAPI, inContainer?: boolean): vo
       }
     } catch { /* enforcement should never break normal flow */ }
 
+    // Block orchestrator from using edit/write directly — must delegate to subagents.
+    // Subagents (PI_SUBAGENT_CHILD=1) are allowed.
+    if (process.env.PI_SUBAGENT_CHILD !== "1" && getSetting(ctx.cwd, "orchestrator_edit_write_block")) {
+      if (isToolCallEventType("edit", event) || isToolCallEventType("write", event)) {
+        const toolUsed = isToolCallEventType("edit", event) ? "edit" : "write";
+        return {
+          block: true,
+          reason: `⛔ Orchestrator cannot use ${toolUsed} directly. Delegate to a subagent (e.g. worker, python-expert, ts-expert) via the subagent tool.`,
+        };
+      }
+    }
+
     // Block direct manipulation of review state file — prevents LLM from bypassing review loop
     if (isToolCallEventType("edit", event) || isToolCallEventType("write", event)) {
       const filePath: string | undefined = (event as any).input?.path;

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -18,6 +18,7 @@
  *   /create-skill <Tab>          → (free-text name)
  *   /cron <Tab>                  → add, list, list-all, remove
  *   /dream-auto <Tab>            → on, off
+ *   /async-kill <Tab>            → all (or type name / id prefix)
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -262,6 +263,12 @@ function registerCompletions(
       return filter([
         { value: "on", label: "on", description: "Enable auto-dreaming (every 3h + session end)" },
         { value: "off", label: "off", description: "Disable auto-dreaming" },
+      ], prefix);
+    },
+
+    "async-kill": (prefix: string) => {
+      return filter([
+        { value: "all", label: "all", description: "Kill all running/queued async agents" },
       ], prefix);
     },
 

--- a/extensions/orchestrator/overlay-dashboard-utils.ts
+++ b/extensions/orchestrator/overlay-dashboard-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure overlay dashboard helpers — no TUI deps (unit-testable).
+ */
+
+export type OverlayId = string | number;
+
+export interface OverlaySelection<TId extends OverlayId = OverlayId> {
+  id?: TId;
+  index: number;
+}
+
+export function reconcileSelection<TId extends OverlayId>(
+  selection: OverlaySelection<TId>,
+  items: ReadonlyArray<{ id: TId }>,
+): void {
+  const stableIndex =
+    selection.id !== undefined && selection.id !== null
+      ? items.findIndex((item) => item.id === selection.id)
+      : -1;
+  selection.index =
+    stableIndex >= 0
+      ? stableIndex
+      : Math.min(Math.max(0, selection.index), Math.max(0, items.length - 1));
+  selection.id = items[selection.index]?.id;
+}

--- a/extensions/orchestrator/overlay-dashboard.ts
+++ b/extensions/orchestrator/overlay-dashboard.ts
@@ -1,0 +1,512 @@
+/**
+ * Shared fullscreen overlay list → detail dashboard (pi-tui ui.custom + overlay).
+ * Used by /async-status and /cron list.
+ */
+
+import type {
+  ExtensionCommandContext,
+  KeybindingsManager,
+  Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import {
+  Key,
+  matchesKey,
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import {
+  reconcileSelection,
+  type OverlayId,
+  type OverlaySelection,
+} from "./overlay-dashboard-utils.js";
+
+export {
+  reconcileSelection,
+  type OverlayId,
+  type OverlaySelection,
+} from "./overlay-dashboard-utils.js";
+
+export const OVERLAY_OPTS = {
+  overlay: true as const,
+  overlayOptions: {
+    anchor: "center" as const,
+    width: "100%" as const,
+    maxHeight: "100%" as const,
+  },
+};
+
+export interface OverlayRowParts {
+  /** Already themed status glyph (e.g. ■). */
+  glyph: string;
+  /** Plain title; dashboard applies accent/text. */
+  title: string;
+  /** Dim id label (already themed or plain). */
+  idLabel: string;
+  /** Already themed right-side segments. */
+  rightParts: string[];
+}
+
+export interface OverlayListSpec<
+  TId extends OverlayId,
+  TItem extends { id: TId },
+> {
+  title: string;
+  countLabel: (items: readonly TItem[]) => string;
+  borderTitle: (items: readonly TItem[]) => string;
+  footerHints: string;
+  listItems: () => TItem[];
+  rowParts: (item: TItem, theme: Theme) => OverlayRowParts;
+  /** Optional destructive/action key (x). */
+  onX?: (item: TItem) => void;
+}
+
+export interface OverlayDetailSpec {
+  footerHints: string;
+  /** Stick scroll to bottom as body grows (live logs). */
+  followTail?: boolean;
+  getHeader: (theme: Theme) => string;
+  getBodyLines: (theme: Theme) => string[];
+  emptyBody?: string;
+  /** Return true to close after action. */
+  onX?: () => boolean | void;
+  tickMs?: number;
+  pollMs?: number;
+  /** Return true when content changed (triggers re-render). */
+  onPoll?: () => boolean | void;
+}
+
+export function padAnsi(text: string, width: number): string {
+  const truncated = truncateToWidth(text, width);
+  return truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
+}
+
+export function borderSegment(theme: Theme, width: number, title: string): string {
+  const label = title
+    ? ` ${truncateToWidth(title, Math.max(0, width - 3))} `
+    : "";
+  const labelWidth = visibleWidth(label);
+  return (
+    theme.fg("border", "─") +
+    (label ? theme.fg("text", label) : "") +
+    theme.fg("border", "─".repeat(Math.max(0, width - 1 - labelWidth)))
+  );
+}
+
+/** Join left + right columns with gap, truncated to width. */
+export function splitRow(left: string, right: string, width: number): string {
+  const rightWidth = visibleWidth(right);
+  const leftMax = Math.max(0, width - rightWidth - 2);
+  const leftTruncated = truncateToWidth(left, leftMax);
+  const gap = Math.max(2, width - visibleWidth(leftTruncated) - rightWidth);
+  return truncateToWidth(leftTruncated + " ".repeat(gap) + right, width);
+}
+
+export class OverlayListDashboard<
+  TId extends OverlayId,
+  TItem extends { id: TId },
+> implements Component {
+  private closed = false;
+  private ticker: ReturnType<typeof setInterval>;
+
+  constructor(
+    private tui: TUI,
+    private theme: Theme,
+    private keybindings: KeybindingsManager,
+    private spec: OverlayListSpec<TId, TItem>,
+    private selection: OverlaySelection<TId>,
+    private done: (value: TId | null) => void,
+  ) {
+    this.ticker = setInterval(() => this.tui.requestRender(), 1000);
+  }
+
+  private items(): TItem[] {
+    return this.spec.listItems();
+  }
+
+  private cleanup(): boolean {
+    if (this.closed) return false;
+    this.closed = true;
+    clearInterval(this.ticker);
+    return true;
+  }
+
+  private close(result: TId | null): void {
+    if (this.cleanup()) this.done(result);
+  }
+
+  dispose(): void {
+    this.cleanup();
+  }
+
+  handleInput(data: string): void {
+    const items = this.items();
+    reconcileSelection(this.selection, items);
+
+    if (
+      this.keybindings.matches(data, "tui.select.cancel") ||
+      matchesKey(data, Key.escape) ||
+      matchesKey(data, Key.ctrl("c"))
+    ) {
+      this.close(null);
+      return;
+    }
+    if (
+      this.keybindings.matches(data, "tui.select.confirm") ||
+      matchesKey(data, Key.enter)
+    ) {
+      const item = items[this.selection.index];
+      if (item) this.close(item.id);
+      return;
+    }
+    if (
+      this.keybindings.matches(data, "tui.select.up") ||
+      matchesKey(data, Key.up) ||
+      data === "k"
+    ) {
+      if (items.length > 0) {
+        this.selection.index =
+          (this.selection.index - 1 + items.length) % items.length;
+        this.selection.id = items[this.selection.index]?.id;
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (
+      this.keybindings.matches(data, "tui.select.down") ||
+      matchesKey(data, Key.down) ||
+      data === "j"
+    ) {
+      if (items.length > 0) {
+        this.selection.index = (this.selection.index + 1) % items.length;
+        this.selection.id = items[this.selection.index]?.id;
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (data === "x") {
+      const item = items[this.selection.index];
+      if (item) {
+        this.spec.onX?.(item);
+        if (this.items().length === 0) {
+          this.close(null);
+          return;
+        }
+        this.tui.requestRender();
+      }
+    }
+  }
+
+  render(width: number): string[] {
+    const theme = this.theme;
+    const items = this.items();
+    reconcileSelection(this.selection, items);
+
+    const rows = this.tui.terminal.rows || 30;
+    const bodyHeight = Math.max(6, rows - 5);
+    const innerWidth = width - 2;
+    const lines: string[] = [];
+
+    const headerLeft = theme.fg("accent", theme.bold(this.spec.title));
+    const headerRight = theme.fg("muted", this.spec.countLabel(items));
+    const headerPad = Math.max(
+      1,
+      width - visibleWidth(headerLeft) - visibleWidth(headerRight) - 4,
+    );
+    lines.push(
+      truncateToWidth(
+        `  ${headerLeft}${" ".repeat(headerPad)}${headerRight}  `,
+        width,
+      ),
+    );
+
+    lines.push(
+      theme.fg("border", "╭") +
+        borderSegment(theme, innerWidth, this.spec.borderTitle(items)) +
+        theme.fg("border", "╮"),
+    );
+
+    const divider = theme.fg("border", "│");
+    const rowLines = this.renderRows(items, innerWidth, bodyHeight);
+    for (let i = 0; i < bodyHeight; i++) {
+      lines.push(divider + padAnsi(rowLines[i] ?? "", innerWidth) + divider);
+    }
+
+    lines.push(
+      theme.fg("border", "╰") +
+        theme.fg("border", "─".repeat(innerWidth)) +
+        theme.fg("border", "╯"),
+    );
+
+    lines.push(
+      truncateToWidth(theme.fg("dim", `  ${this.spec.footerHints}`), width),
+    );
+
+    return lines;
+  }
+
+  private renderRows(
+    items: ReadonlyArray<TItem>,
+    width: number,
+    height: number,
+  ): string[] {
+    const theme = this.theme;
+    const out: string[] = [];
+
+    let start = 0;
+    if (items.length > height) {
+      start = Math.min(
+        Math.max(0, this.selection.index - Math.floor(height / 2)),
+        items.length - height,
+      );
+    }
+    const visible = items.slice(start, start + height);
+    const dot = theme.fg("dim", " · ");
+
+    for (let i = 0; i < visible.length; i++) {
+      const item = visible[i];
+      const index = start + i;
+      const isSelected = index === this.selection.index;
+      const parts = this.spec.rowParts(item, theme);
+      const marker = isSelected ? theme.fg("accent", "❯") : " ";
+      const title = isSelected
+        ? theme.fg("accent", parts.title)
+        : theme.fg("text", parts.title);
+      const left = ` ${marker} ${parts.glyph} ${title} ${parts.idLabel}`;
+      const right = `${parts.rightParts.join(dot)} `;
+      out.push(splitRow(left, right, width));
+    }
+
+    if (start > 0) {
+      out[0] = truncateToWidth(theme.fg("dim", `   ... ${start} more`), width);
+    }
+    if (start + height < items.length) {
+      out[out.length - 1] = truncateToWidth(
+        theme.fg("dim", `   ... ${items.length - start - height} more`),
+        width,
+      );
+    }
+    return out;
+  }
+
+  invalidate(): void {}
+}
+
+export class OverlayScrollDetail implements Component {
+  private scrollOffset = 0;
+  private maxScroll = 0;
+  private following: boolean;
+  private closed = false;
+  private cachedWidth: number | undefined;
+  private cachedLines: string[] | undefined;
+  private ticker: ReturnType<typeof setInterval>;
+  private poller: ReturnType<typeof setInterval> | undefined;
+
+  constructor(
+    private tui: TUI,
+    private theme: Theme,
+    private spec: OverlayDetailSpec,
+    private done: (value: null) => void,
+  ) {
+    this.following = !!spec.followTail;
+    // Tick always invalidates — headers may show live clocks / durations.
+    this.ticker = setInterval(() => {
+      this.invalidate();
+      this.tui.requestRender();
+    }, spec.tickMs ?? 1000);
+    if (spec.onPoll) {
+      this.poller = setInterval(() => {
+        if (spec.onPoll?.()) {
+          this.invalidate();
+          this.tui.requestRender();
+        }
+      }, spec.pollMs ?? 500);
+      if (spec.onPoll()) {
+        this.invalidate();
+        this.tui.requestRender();
+      }
+    }
+  }
+
+  private cleanup(): boolean {
+    if (this.closed) return false;
+    this.closed = true;
+    clearInterval(this.ticker);
+    if (this.poller) clearInterval(this.poller);
+    return true;
+  }
+
+  private close(): void {
+    if (this.cleanup()) this.done(null);
+  }
+
+  dispose(): void {
+    this.cleanup();
+  }
+
+  handleInput(data: string): void {
+    if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) {
+      this.close();
+      return;
+    }
+    if (data === "x" && this.spec.onX) {
+      if (this.spec.onX()) this.close();
+      else {
+        this.invalidate();
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (matchesKey(data, Key.up) || data === "k") {
+      if (this.scrollOffset > 0) {
+        this.scrollOffset--;
+        this.following = false;
+        this.invalidate();
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (matchesKey(data, Key.down) || data === "j") {
+      if (this.scrollOffset < this.maxScroll) {
+        this.scrollOffset++;
+        this.invalidate();
+        this.tui.requestRender();
+      }
+      if (this.scrollOffset >= this.maxScroll) this.following = true;
+      return;
+    }
+    if (matchesKey(data, Key.pageUp)) {
+      this.scrollOffset = Math.max(0, this.scrollOffset - 10);
+      this.following = false;
+      this.invalidate();
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.pageDown)) {
+      this.scrollOffset = Math.min(this.maxScroll, this.scrollOffset + 10);
+      if (this.scrollOffset >= this.maxScroll) this.following = true;
+      this.invalidate();
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.home)) {
+      this.scrollOffset = 0;
+      this.following = false;
+      this.invalidate();
+      this.tui.requestRender();
+      return;
+    }
+    if (matchesKey(data, Key.end)) {
+      this.scrollOffset = this.maxScroll;
+      this.following = true;
+      this.invalidate();
+      this.tui.requestRender();
+    }
+  }
+
+  render(width: number): string[] {
+    if (this.cachedLines && this.cachedWidth === width) return this.cachedLines;
+
+    const theme = this.theme;
+    const header = this.spec.getHeader(theme);
+    const footer = theme.fg("dim", this.spec.footerHints);
+    const sep = theme.fg("border", "─".repeat(Math.max(1, width)));
+
+    const body = this.spec.getBodyLines(theme);
+    const wrapped: string[] = [];
+    for (const line of body) {
+      for (const wl of wrapTextWithAnsi(line, Math.max(10, width - 2))) {
+        wrapped.push(truncateToWidth(wl, width));
+      }
+    }
+    if (wrapped.length === 0) {
+      wrapped.push(theme.fg("dim", this.spec.emptyBody ?? "(empty)"));
+    }
+
+    const rows = this.tui.terminal.rows || 30;
+    const viewHeight = Math.max(6, rows - 8);
+    this.maxScroll = Math.max(0, wrapped.length - viewHeight);
+    if (this.following && this.spec.followTail) {
+      this.scrollOffset = this.maxScroll;
+    }
+    if (this.scrollOffset > this.maxScroll) this.scrollOffset = this.maxScroll;
+
+    const visible = wrapped.slice(
+      this.scrollOffset,
+      this.scrollOffset + viewHeight,
+    );
+    while (visible.length < viewHeight) visible.push("");
+
+    this.cachedLines = [
+      truncateToWidth(header, width),
+      sep,
+      ...visible,
+      sep,
+      truncateToWidth(footer, width),
+    ];
+    this.cachedWidth = width;
+    return this.cachedLines;
+  }
+
+  invalidate(): void {
+    this.cachedWidth = undefined;
+    this.cachedLines = undefined;
+  }
+}
+
+/**
+ * Loop: list overlay → detail overlay until list closed / empty.
+ */
+export async function openListDetailOverlay<
+  TId extends OverlayId,
+  TItem extends { id: TId },
+>(
+  ctx: ExtensionCommandContext,
+  options: {
+    emptyMessage: string;
+    listSpec: OverlayListSpec<TId, TItem>;
+    createDetail: (
+      item: TItem,
+      tui: TUI,
+      theme: Theme,
+      done: (value: null) => void,
+    ) => Component;
+  },
+): Promise<void> {
+  if (!ctx.hasUI) return;
+
+  const selection: OverlaySelection<TId> = { index: 0 };
+
+  while (true) {
+    const items = options.listSpec.listItems();
+    if (items.length === 0) {
+      ctx.ui.notify(options.emptyMessage, "info");
+      return;
+    }
+
+    const picked = await ctx.ui.custom<TId | null>(
+      (tui, theme, keybindings, done) =>
+        new OverlayListDashboard(
+          tui,
+          theme,
+          keybindings,
+          options.listSpec,
+          selection,
+          done,
+        ),
+      OVERLAY_OPTS,
+    );
+
+    if (picked === null || picked === undefined) return;
+
+    const item = options.listSpec.listItems().find((i) => i.id === picked);
+    if (!item) continue;
+
+    await ctx.ui.custom<null>(
+      (tui, theme, _kb, done) =>
+        options.createDetail(item, tui, theme, done),
+      OVERLAY_OPTS,
+    );
+  }
+}

--- a/extensions/orchestrator/overlay-dashboard.ts
+++ b/extensions/orchestrator/overlay-dashboard.ts
@@ -205,7 +205,7 @@ export class OverlayListDashboard<
 
     const rows = this.tui.terminal.rows || 30;
     const bodyHeight = Math.max(6, rows - 5);
-    const innerWidth = width - 2;
+    const innerWidth = Math.max(0, width - 2);
     const lines: string[] = [];
 
     const headerLeft = theme.fg("accent", theme.bold(this.spec.title));

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -30,6 +30,8 @@ interface ProjectSettings {
   dco?: boolean;
   comment_signature?: boolean;
   review_loop_enforcement?: boolean;
+  /** Block orchestrator from using edit and write tools directly (must delegate to subagents). Default: false. */
+  orchestrator_edit_write_block?: boolean;
   acpx_agents?: string | string[];
   /** CLI-backed providers to register as cli-${agent} (claude, gemini, cursor). */
   cli_agents?: string | string[];
@@ -43,6 +45,12 @@ interface ProjectSettings {
   async_llm_model?: string;
   /** Max review-loop cycles injected into the rules prompt. Integer 1-10 only. */
   review_loop_max_cycles?: number;
+  /** Default provider for all subagents. */
+  agent_provider?: string;
+  /** Default model for all subagents. */
+  agent_model?: string;
+  /** Per-agent provider/model overrides. null = use parent model (skip global agent_provider/agent_model). */
+  agent_overrides?: Record<string, { provider?: string | null; model?: string | null }>;
 }
 
 const SETTINGS_FILENAME = "pi-config-settings.json";
@@ -66,6 +74,7 @@ function parseSettingsFile(filePath: string): ProjectSettings {
     if (typeof raw.dco === "boolean") result.dco = raw.dco;
     if (typeof raw.comment_signature === "boolean") result.comment_signature = raw.comment_signature;
     if (typeof raw.review_loop_enforcement === "boolean") result.review_loop_enforcement = raw.review_loop_enforcement;
+    if (typeof raw.orchestrator_edit_write_block === "boolean") result.orchestrator_edit_write_block = raw.orchestrator_edit_write_block;
     if (typeof raw.pidash_enable === "boolean") result.pidash_enable = raw.pidash_enable;
     if (typeof raw.pidiff_enable === "boolean") result.pidiff_enable = raw.pidiff_enable;
     if (typeof raw.pidash_port === "number" && Number.isInteger(raw.pidash_port) && raw.pidash_port > 0 && raw.pidash_port <= 65535) {
@@ -93,6 +102,25 @@ function parseSettingsFile(filePath: string): ProjectSettings {
       result.cli_agents = raw.cli_agents;
     } else if (Array.isArray(raw.cli_agents)) {
       result.cli_agents = raw.cli_agents;
+    }
+    if (typeof raw.agent_provider === "string" && raw.agent_provider.trim()) {
+      result.agent_provider = raw.agent_provider.trim();
+    }
+    if (typeof raw.agent_model === "string" && raw.agent_model.trim()) {
+      result.agent_model = raw.agent_model.trim();
+    }
+    if (typeof raw.agent_overrides === "object" && raw.agent_overrides !== null && !Array.isArray(raw.agent_overrides)) {
+      const overrides: Record<string, { provider?: string | null; model?: string | null }> = {};
+      for (const [name, val] of Object.entries(raw.agent_overrides)) {
+        if (typeof val === "object" && val !== null && !Array.isArray(val)) {
+          const v = val as { provider?: unknown; model?: unknown };
+          const entry: { provider?: string | null; model?: string | null } = {};
+          if (v.provider === null || (typeof v.provider === "string")) entry.provider = v.provider === null ? null : v.provider.trim() || undefined;
+          if (v.model === null || (typeof v.model === "string")) entry.model = v.model === null ? null : v.model.trim() || undefined;
+          if (entry.provider !== undefined || entry.model !== undefined) overrides[name] = entry;
+        }
+      }
+      if (Object.keys(overrides).length > 0) result.agent_overrides = overrides;
     }
     return result;
   } catch (e: any) {
@@ -267,6 +295,7 @@ export function getSetting(cwd: string, key: "dream_interval_hours"): number;
 export function getSetting(cwd: string, key: "dco"): boolean;
 export function getSetting(cwd: string, key: "comment_signature"): boolean;
 export function getSetting(cwd: string, key: "review_loop_enforcement"): boolean;
+export function getSetting(cwd: string, key: "orchestrator_edit_write_block"): boolean;
 export function getSetting(cwd: string, key: "acpx_agents"): string[];
 export function getSetting(cwd: string, key: "cli_agents"): string[];
 export function getSetting(cwd: string, key: "pidash_enable"): boolean;
@@ -276,7 +305,10 @@ export function getSetting(cwd: string, key: "image_model"): string;
 export function getSetting(cwd: string, key: "async_llm_provider"): string;
 export function getSetting(cwd: string, key: "async_llm_model"): string;
 export function getSetting(cwd: string, key: "review_loop_max_cycles"): number;
-export function getSetting(cwd: string, key: string): boolean | string | number | string[] {
+export function getSetting(cwd: string, key: "agent_provider"): string;
+export function getSetting(cwd: string, key: "agent_model"): string;
+export function getSetting(cwd: string, key: "agent_overrides"): Record<string, { provider?: string | null; model?: string | null }>;
+export function getSetting(cwd: string, key: string): boolean | string | number | string[] | Record<string, { provider?: string | null; model?: string | null }> {
   const settings = getSettings(cwd);
 
   switch (key) {
@@ -323,6 +355,10 @@ export function getSetting(cwd: string, key: string): boolean | string | number 
       const env = parseBoolEnv("PI_REVIEW_LOOP_ENFORCEMENT");
       if (env !== undefined) return env;
       return false; // default: disabled (opt-in)
+    }
+    case "orchestrator_edit_write_block": {
+      if (settings.orchestrator_edit_write_block !== undefined) return settings.orchestrator_edit_write_block;
+      return false; // default: disabled
     }
     case "acpx_agents": {
       if (projectSettingsFileHasKey(cwd, "acpx_agents")) {
@@ -405,6 +441,15 @@ export function getSetting(cwd: string, key: string): boolean | string | number 
       const env = parseReviewLoopMaxCyclesEnv("PI_REVIEW_LOOP_MAX_CYCLES");
       if (env !== undefined) return env;
       return 3; // default: 3 cycles
+    }
+    case "agent_provider": {
+      return settings.agent_provider || "";
+    }
+    case "agent_model": {
+      return settings.agent_model || "";
+    }
+    case "agent_overrides": {
+      return settings.agent_overrides || {};
     }
     default:
       return false;

--- a/extensions/orchestrator/project-settings.ts
+++ b/extensions/orchestrator/project-settings.ts
@@ -103,10 +103,10 @@ function parseSettingsFile(filePath: string): ProjectSettings {
     } else if (Array.isArray(raw.cli_agents)) {
       result.cli_agents = raw.cli_agents;
     }
-    if (typeof raw.agent_provider === "string" && raw.agent_provider.trim()) {
+    if (typeof raw.agent_provider === "string") {
       result.agent_provider = raw.agent_provider.trim();
     }
-    if (typeof raw.agent_model === "string" && raw.agent_model.trim()) {
+    if (typeof raw.agent_model === "string") {
       result.agent_model = raw.agent_model.trim();
     }
     if (typeof raw.agent_overrides === "object" && raw.agent_overrides !== null && !Array.isArray(raw.agent_overrides)) {

--- a/extensions/orchestrator/resolve-agent-model.ts
+++ b/extensions/orchestrator/resolve-agent-model.ts
@@ -18,6 +18,8 @@ export function resolveAgentModelProvider(
 
   if (override) {
     // null = explicitly use parent (skip agent frontmatter AND global settings)
+    // Model and provider resolve independently on purpose: a partial override
+    // (e.g. only model) still lets provider fall through frontmatter → settings → parent.
     const model = override.model === null ? parentModelId : (override.model || agent.model || getSetting(cwd, "agent_model") || parentModelId);
     const provider = override.provider === null ? parentProvider : (override.provider || agent.provider || getSetting(cwd, "agent_provider") || parentProvider);
     return { model: model || undefined, provider: provider || undefined };

--- a/extensions/orchestrator/resolve-agent-model.ts
+++ b/extensions/orchestrator/resolve-agent-model.ts
@@ -1,0 +1,30 @@
+/**
+ * Resolve effective model/provider for an agent.
+ * Priority: agent_overrides[name] > agent frontmatter > agent_provider/agent_model setting > parent
+ * null in overrides = skip settings, use parent directly.
+ */
+
+import { getSetting } from "./project-settings.js";
+
+export function resolveAgentModelProvider(
+  agentName: string,
+  agent: { model?: string; provider?: string },
+  parentModelId: string | undefined,
+  parentProvider: string | undefined,
+  cwd: string
+): { model: string | undefined; provider: string | undefined } {
+  const overrides = getSetting(cwd, "agent_overrides");
+  const override = overrides[agentName];
+
+  if (override) {
+    // null = explicitly use parent (skip agent frontmatter AND global settings)
+    const model = override.model === null ? parentModelId : (override.model || agent.model || getSetting(cwd, "agent_model") || parentModelId);
+    const provider = override.provider === null ? parentProvider : (override.provider || agent.provider || getSetting(cwd, "agent_provider") || parentProvider);
+    return { model: model || undefined, provider: provider || undefined };
+  }
+
+  // No override: agent frontmatter > global setting > parent
+  const model = agent.model || getSetting(cwd, "agent_model") || parentModelId;
+  const provider = agent.provider || getSetting(cwd, "agent_provider") || parentProvider;
+  return { model: model || undefined, provider: provider || undefined };
+}

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -47,36 +47,10 @@ import {
   decideAsyncLlmDispatch,
   supportsAsyncLlm,
 } from "./async-capability.js";
-import { getSetting } from "./project-settings.js";
+import { resolveAgentModelProvider } from "./resolve-agent-model.js";
 import { clockHHMM, getPiInvocation, getProjectTmpDir, djb2Hash } from "./utils.js";
 
-/**
- * Resolve effective model/provider for an agent.
- * Priority: agent_overrides[name] > agent frontmatter > agent_provider/agent_model setting > parent
- * null in overrides = skip settings, use parent directly.
- */
-export function resolveAgentModelProvider(
-  agentName: string,
-  agent: { model?: string; provider?: string },
-  parentModelId: string | undefined,
-  parentProvider: string | undefined,
-  cwd: string
-): { model: string | undefined; provider: string | undefined } {
-  const overrides = getSetting(cwd, "agent_overrides");
-  const override = overrides[agentName];
-
-  if (override) {
-    // null = explicitly use parent (skip agent frontmatter AND global settings)
-    const model = override.model === null ? parentModelId : (override.model || agent.model || getSetting(cwd, "agent_model") || parentModelId);
-    const provider = override.provider === null ? parentProvider : (override.provider || agent.provider || getSetting(cwd, "agent_provider") || parentProvider);
-    return { model: model || undefined, provider: provider || undefined };
-  }
-
-  // No override: agent frontmatter > global setting > parent
-  const model = agent.model || getSetting(cwd, "agent_model") || parentModelId;
-  const provider = agent.provider || getSetting(cwd, "agent_provider") || parentProvider;
-  return { model: model || undefined, provider: provider || undefined };
-}
+export { resolveAgentModelProvider };
 
 // ── Constants ────────────────────────────────────────────────────────────
 

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -47,7 +47,36 @@ import {
   decideAsyncLlmDispatch,
   supportsAsyncLlm,
 } from "./async-capability.js";
+import { getSetting } from "./project-settings.js";
 import { clockHHMM, getPiInvocation, getProjectTmpDir, djb2Hash } from "./utils.js";
+
+/**
+ * Resolve effective model/provider for an agent.
+ * Priority: agent_overrides[name] > agent frontmatter > agent_provider/agent_model setting > parent
+ * null in overrides = skip settings, use parent directly.
+ */
+export function resolveAgentModelProvider(
+  agentName: string,
+  agent: { model?: string; provider?: string },
+  parentModelId: string | undefined,
+  parentProvider: string | undefined,
+  cwd: string
+): { model: string | undefined; provider: string | undefined } {
+  const overrides = getSetting(cwd, "agent_overrides");
+  const override = overrides[agentName];
+
+  if (override) {
+    // null = explicitly use parent (skip agent frontmatter AND global settings)
+    const model = override.model === null ? parentModelId : (override.model || agent.model || getSetting(cwd, "agent_model") || parentModelId);
+    const provider = override.provider === null ? parentProvider : (override.provider || agent.provider || getSetting(cwd, "agent_provider") || parentProvider);
+    return { model: model || undefined, provider: provider || undefined };
+  }
+
+  // No override: agent frontmatter > global setting > parent
+  const model = agent.model || getSetting(cwd, "agent_model") || parentModelId;
+  const provider = agent.provider || getSetting(cwd, "agent_provider") || parentProvider;
+  return { model: model || undefined, provider: provider || undefined };
+}
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -88,8 +117,8 @@ const ChainItem = Type.Object({
   estimatedSeconds: Type.Number({ description: "Estimated step duration in seconds" }),
 });
 const AgentScopeSchema = StringEnum(["user", "project", "both"] as const, {
-  description: 'Agent directories to use. Default: "user".',
-  default: "user",
+  description: 'Agent directories to use. Default: "both".',
+  default: "both",
 });
 
 const SubagentParams = Type.Object({
@@ -397,9 +426,8 @@ export async function runSingleAgent(
     // Deterministic session ID based on agent + cwd for session reuse
     args.push("--session-id", `sync-${agentName}-${djb2Hash(agentName + ':' + cwd).toString(36)}`);
   }
-  const effectiveModel = agent.model || parentModelId;
+  const { model: effectiveModel, provider: effectiveProvider } = resolveAgentModelProvider(agentName, agent, parentModelId, parentProvider, cwd);
   if (effectiveModel) args.push("--model", effectiveModel);
-  const effectiveProvider = agent.provider || parentProvider;
   if (effectiveProvider) args.push("--provider", effectiveProvider);
   if (agent.tools && agent.tools.length > 0)
     args.push("--tools", agent.tools.join(","));
@@ -1403,7 +1431,7 @@ export function registerSubagentTool(
         }
       };
 
-      const scope: AgentScope = params.agentScope ?? "user";
+      const scope: AgentScope = params.agentScope ?? "both";
       const discovery = discoverAgents(ctx.cwd, scope);
       const agents = discovery.agents;
       const confirm = params.confirmProjectAgents ?? true;
@@ -1588,7 +1616,7 @@ export function registerSubagentTool(
     renderCall(args, theme, context) {
       if (!context.state.startedAt) context.state.startedAt = clockHHMM();
       const ts = theme.fg("dim", `[${context.state.startedAt}] `);
-      const scope: AgentScope = args.agentScope ?? "user";
+      const scope: AgentScope = args.agentScope ?? "both";
       if (args.chain?.length > 0) {
         const chainEst = args.chain.every((s: any) => s.estimatedSeconds != null)
           ? theme.fg("dim", ` ~${args.chain.reduce((sum: number, s: any) => sum + s.estimatedSeconds, 0)}s (sum)`)

--- a/tests/node/orchestrator/async-status-ui.test.ts
+++ b/tests/node/orchestrator/async-status-ui.test.ts
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseAsyncOutputLine } from "../../../extensions/orchestrator/async-status-parse.ts";
+
+describe("parseAsyncOutputLine", () => {
+  it("extracts text_delta", () => {
+    const line = JSON.stringify({
+      type: "message_update",
+      assistantMessageEvent: { type: "text_delta", delta: "hello" },
+    });
+    assert.equal(parseAsyncOutputLine(line), "hello");
+  });
+
+  it("formats tool_execution_start", () => {
+    const line = JSON.stringify({
+      type: "tool_execution_start",
+      toolName: "bash",
+      args: { command: "ls" },
+    });
+    assert.equal(parseAsyncOutputLine(line), "\n→ bash ls");
+  });
+
+  it("returns null for junk", () => {
+    assert.equal(parseAsyncOutputLine("not-json"), null);
+  });
+});

--- a/tests/node/orchestrator/cron-status-ui.test.ts
+++ b/tests/node/orchestrator/cron-status-ui.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  formatCronSchedule,
+  formatLastRunLabel,
+  formatNextRunLabel,
+  resolveNextRunAt,
+  toCronStatusTaskView,
+} from "../../../extensions/orchestrator/cron-status-format.ts";
+
+function sample(overrides: Record<string, unknown> = {}) {
+  return toCronStatusTaskView(
+    {
+      id: 1,
+      description: "x",
+      task: "y",
+      createdAt: 0,
+      ...overrides,
+    } as any,
+    { overlayId: "1", isLocal: true },
+  );
+}
+
+describe("formatCronSchedule", () => {
+  it("formats interval", () => {
+    assert.equal(formatCronSchedule(sample({ intervalMs: 30000 })), "every 30s");
+  });
+
+  it("formats daily time", () => {
+    assert.equal(
+      formatCronSchedule(sample({ atHour: 9, atMinute: 5 })),
+      "daily at 09:05",
+    );
+  });
+});
+
+describe("resolveNextRunAt / labels", () => {
+  it("uses nextRun when set", () => {
+    const now = 1_000_000;
+    const task = sample({ nextRun: now + 45_000 });
+    assert.equal(resolveNextRunAt(task, now), now + 45_000);
+    assert.equal(formatNextRunLabel(task, now), "in 45s");
+  });
+
+  it("derives interval next from lastRun", () => {
+    const now = 1_000_000;
+    const lastRun = now - 10_000;
+    assert.equal(
+      resolveNextRunAt(sample({ intervalMs: 60_000, lastRun }), now),
+      lastRun + 60_000,
+    );
+  });
+
+  it("formats never for missing lastRun", () => {
+    assert.equal(formatLastRunLabel(sample()), "never");
+  });
+});
+
+describe("toCronStatusTaskView", () => {
+  it("builds unique overlay id for list-all", () => {
+    const v = toCronStatusTaskView(
+      {
+        id: 3,
+        description: "d",
+        task: "t",
+        createdAt: 1,
+      },
+      {
+        overlayId: "cron-1-abc.json:3",
+        sessionLabel: "PID 1",
+        isLocal: false,
+        cronFile: "/tmp/cron-1-abc.json",
+      },
+    );
+    assert.equal(v.id, "cron-1-abc.json:3");
+    assert.equal(v.taskId, 3);
+    assert.equal(v.isLocal, false);
+  });
+});

--- a/tests/node/orchestrator/extension-settings.test.ts
+++ b/tests/node/orchestrator/extension-settings.test.ts
@@ -417,4 +417,60 @@ describe("extension settings", () => {
 		clearSettingsCache();
 		assert.equal(getSetting(tmp, "review_loop_max_cycles"), 6);
 	});
+
+	describe("agent model settings", () => {
+		it("agent_provider and agent_model parse from settings JSON", () => {
+			writeSettings({
+				agent_provider: "cli-cursor",
+				agent_model: "cursor:cursor-grok-4.5-high-fast",
+			});
+			assert.equal(getSetting(tmp, "agent_provider"), "cli-cursor");
+			assert.equal(getSetting(tmp, "agent_model"), "cursor:cursor-grok-4.5-high-fast");
+		});
+
+		it("agent_overrides parses with null values preserved", () => {
+			writeSettings({
+				agent_overrides: {
+					debugger: { provider: null, model: null },
+					reviewer: { provider: "cli-claude", model: "claude-sonnet" },
+				},
+			});
+			assert.deepEqual(getSetting(tmp, "agent_overrides"), {
+				debugger: { provider: null, model: null },
+				reviewer: { provider: "cli-claude", model: "claude-sonnet" },
+			});
+		});
+
+		it("empty/missing agent settings return defaults", () => {
+			assert.equal(getSetting(tmp, "agent_provider"), "");
+			assert.equal(getSetting(tmp, "agent_model"), "");
+			assert.deepEqual(getSetting(tmp, "agent_overrides"), {});
+		});
+
+		it("whitespace-only agent_provider/agent_model return defaults", () => {
+			writeSettings({ agent_provider: "   ", agent_model: "  " });
+			assert.equal(getSetting(tmp, "agent_provider"), "");
+			assert.equal(getSetting(tmp, "agent_model"), "");
+		});
+
+		it("invalid agent_overrides shapes are skipped", () => {
+			writeSettings({
+				agent_overrides: {
+					ok: { provider: "cli-cursor", model: "m1" },
+					badArray: ["not", "an", "object"],
+					badNull: null,
+					badString: "nope",
+					emptyObj: {},
+				},
+			});
+			assert.deepEqual(getSetting(tmp, "agent_overrides"), {
+				ok: { provider: "cli-cursor", model: "m1" },
+			});
+		});
+
+		it("array agent_overrides falls through to default {}", () => {
+			writeSettings({ agent_overrides: ["not", "an", "object"] });
+			assert.deepEqual(getSetting(tmp, "agent_overrides"), {});
+		});
+	});
 });

--- a/tests/node/orchestrator/overlay-dashboard.test.ts
+++ b/tests/node/orchestrator/overlay-dashboard.test.ts
@@ -21,17 +21,25 @@ import {
  * - j/k + arrows move selection; x runs onX when provided
  */
 describe("openListDetailOverlay (manual / integration)", () => {
-  it("documents TUI dependency — no direct unit call", () => {
+  it("OverlaySelection type accepts id constrained by OverlayId", () => {
     // Signature constraint: TItem must have id: TId extends OverlayId
     type Ok = OverlaySelection<"a" | "b">;
     const sel: Ok = { index: 0, id: "a" };
     assert.equal(sel.index, 0);
+    assert.equal(sel.id, "a");
+  });
 
-    // OverlayId accepts string | number only (compile-time contract)
+  it("OverlayId accepts string | number only", () => {
     const stringId: OverlayId = "job-1";
     const numberId: OverlayId = 42;
     assert.equal(typeof stringId, "string");
     assert.equal(typeof numberId, "number");
+  });
+
+  it("documents TUI dependency — no direct unit call", () => {
+    // Overlay loop (openListDetailOverlay) needs ExtensionCommandContext + pi-tui.
+    // Not unit-tested here; see file-level comment for manual coverage.
+    assert.ok(true);
   });
 });
 

--- a/tests/node/orchestrator/overlay-dashboard.test.ts
+++ b/tests/node/orchestrator/overlay-dashboard.test.ts
@@ -2,8 +2,38 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   reconcileSelection,
+  type OverlayId,
   type OverlaySelection,
 } from "../../../extensions/orchestrator/overlay-dashboard-utils.ts";
+
+/**
+ * openListDetailOverlay / OverlayListDashboard / OverlayScrollDetail require
+ * ExtensionCommandContext + pi-tui (TUI, Theme, KeybindingsManager). Those
+ * packages are not available in this test harness, so the overlay loop itself
+ * is not unit-tested here.
+ *
+ * Testable pure logic lives in overlay-dashboard-utils.ts (reconcileSelection).
+ *
+ * Manual coverage (pi session):
+ * - Empty list → early return + emptyMessage notify (/async-status, /cron list)
+ * - List → Enter → detail → Esc → back to list
+ * - Esc / Ctrl-C on list closes without detail
+ * - j/k + arrows move selection; x runs onX when provided
+ */
+describe("openListDetailOverlay (manual / integration)", () => {
+  it("documents TUI dependency — no direct unit call", () => {
+    // Signature constraint: TItem must have id: TId extends OverlayId
+    type Ok = OverlaySelection<"a" | "b">;
+    const sel: Ok = { index: 0, id: "a" };
+    assert.equal(sel.index, 0);
+
+    // OverlayId accepts string | number only (compile-time contract)
+    const stringId: OverlayId = "job-1";
+    const numberId: OverlayId = 42;
+    assert.equal(typeof stringId, "string");
+    assert.equal(typeof numberId, "number");
+  });
+});
 
 describe("reconcileSelection", () => {
   it("keeps selection by stable id", () => {
@@ -18,5 +48,47 @@ describe("reconcileSelection", () => {
     reconcileSelection(sel, [{ id: 1 }, { id: 2 }]);
     assert.equal(sel.index, 1);
     assert.equal(sel.id, 2);
+  });
+
+  it("uses index when id unset", () => {
+    const sel: OverlaySelection<string> = { index: 2 };
+    reconcileSelection(sel, [{ id: "a" }, { id: "b" }, { id: "c" }]);
+    assert.equal(sel.index, 2);
+    assert.equal(sel.id, "c");
+  });
+
+  it("clamps negative index to 0", () => {
+    const sel: OverlaySelection<string> = { index: -3 };
+    reconcileSelection(sel, [{ id: "a" }, { id: "b" }]);
+    assert.equal(sel.index, 0);
+    assert.equal(sel.id, "a");
+  });
+
+  it("empty list clears id and keeps index at 0", () => {
+    const sel: OverlaySelection<string> = { id: "gone", index: 4 };
+    reconcileSelection(sel, []);
+    assert.equal(sel.index, 0);
+    assert.equal(sel.id, undefined);
+  });
+
+  it("single item always selects that item", () => {
+    const sel: OverlaySelection<string> = { id: "missing", index: 9 };
+    reconcileSelection(sel, [{ id: "only" }]);
+    assert.equal(sel.index, 0);
+    assert.equal(sel.id, "only");
+  });
+
+  it("treats null id like missing (clamp by index)", () => {
+    const sel = { id: null as unknown as string, index: 1 } as OverlaySelection<string>;
+    reconcileSelection(sel, [{ id: "a" }, { id: "b" }, { id: "c" }]);
+    assert.equal(sel.index, 1);
+    assert.equal(sel.id, "b");
+  });
+
+  it("numeric ids stay stable across reorder", () => {
+    const sel: OverlaySelection<number> = { id: 30, index: 0 };
+    reconcileSelection(sel, [{ id: 10 }, { id: 30 }, { id: 20 }]);
+    assert.equal(sel.index, 1);
+    assert.equal(sel.id, 30);
   });
 });

--- a/tests/node/orchestrator/overlay-dashboard.test.ts
+++ b/tests/node/orchestrator/overlay-dashboard.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  reconcileSelection,
+  type OverlaySelection,
+} from "../../../extensions/orchestrator/overlay-dashboard-utils.ts";
+
+describe("reconcileSelection", () => {
+  it("keeps selection by stable id", () => {
+    const sel: OverlaySelection<string> = { id: "b", index: 0 };
+    reconcileSelection(sel, [{ id: "a" }, { id: "b" }, { id: "c" }]);
+    assert.equal(sel.index, 1);
+    assert.equal(sel.id, "b");
+  });
+
+  it("clamps when id missing", () => {
+    const sel: OverlaySelection<number> = { id: 99, index: 5 };
+    reconcileSelection(sel, [{ id: 1 }, { id: 2 }]);
+    assert.equal(sel.index, 1);
+    assert.equal(sel.id, 2);
+  });
+});

--- a/tests/node/orchestrator/resolve-agent-model.test.ts
+++ b/tests/node/orchestrator/resolve-agent-model.test.ts
@@ -151,4 +151,18 @@ describe("resolveAgentModelProvider", () => {
 		// model from override; provider falls through override → frontmatter
 		assert.deepEqual(result, { model: "override-model", provider: "fm-provider" });
 	});
+
+	it("resolves model and provider independently from override", () => {
+		// override sets only model — provider falls through normally
+		writeSettings({ agent_overrides: { myagent: { model: "custom-model" } } });
+		const result = resolveAgentModelProvider(
+			"myagent",
+			{ provider: "agent-provider" },
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		assert.strictEqual(result.model, "custom-model");
+		assert.strictEqual(result.provider, "agent-provider"); // from frontmatter, not parent
+	});
 });

--- a/tests/node/orchestrator/resolve-agent-model.test.ts
+++ b/tests/node/orchestrator/resolve-agent-model.test.ts
@@ -152,7 +152,7 @@ describe("resolveAgentModelProvider", () => {
 		assert.deepEqual(result, { model: "override-model", provider: "fm-provider" });
 	});
 
-	it("resolves model and provider independently from override", () => {
+	it("resolves model independently when override sets only model", () => {
 		// override sets only model — provider falls through normally
 		writeSettings({ agent_overrides: { myagent: { model: "custom-model" } } });
 		const result = resolveAgentModelProvider(

--- a/tests/node/orchestrator/resolve-agent-model.test.ts
+++ b/tests/node/orchestrator/resolve-agent-model.test.ts
@@ -1,0 +1,154 @@
+/**
+ * resolveAgentModelProvider — priority chain for agent model/provider.
+ *
+ * Isolates settings via setGlobalSettingsPath so tests ignore real ~/.pi/.
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+	clearSettingsCache,
+	setGlobalSettingsPath,
+} from "../../../extensions/orchestrator/project-settings.js";
+import { resolveAgentModelProvider } from "../../../extensions/orchestrator/resolve-agent-model.js";
+
+describe("resolveAgentModelProvider", () => {
+	let tmp: string;
+	let globalTmp: string;
+
+	beforeEach(() => {
+		clearSettingsCache();
+		tmp = mkdtempSync(join(tmpdir(), "pi-resolve-agent-model-"));
+		globalTmp = mkdtempSync(join(tmpdir(), "pi-resolve-agent-model-global-"));
+		setGlobalSettingsPath(join(globalTmp, "pi-config-settings.json"));
+	});
+
+	afterEach(() => {
+		setGlobalSettingsPath(null);
+		clearSettingsCache();
+		rmSync(tmp, { recursive: true, force: true });
+		rmSync(globalTmp, { recursive: true, force: true });
+	});
+
+	function writeSettings(data: Record<string, unknown>): void {
+		mkdirSync(join(tmp, ".pi"), { recursive: true });
+		writeFileSync(join(tmp, ".pi", "pi-config-settings.json"), JSON.stringify(data));
+		clearSettingsCache();
+	}
+
+	it("no settings, no frontmatter → parent model/provider", () => {
+		const result = resolveAgentModelProvider(
+			"worker",
+			{},
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		assert.deepEqual(result, { model: "parent-model", provider: "parent-provider" });
+	});
+
+	it("global agent_provider + agent_model → those values", () => {
+		writeSettings({
+			agent_provider: "global-provider",
+			agent_model: "global-model",
+		});
+		const result = resolveAgentModelProvider(
+			"worker",
+			{},
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		assert.deepEqual(result, { model: "global-model", provider: "global-provider" });
+	});
+
+	it("agent frontmatter overrides global settings", () => {
+		writeSettings({
+			agent_provider: "global-provider",
+			agent_model: "global-model",
+		});
+		const result = resolveAgentModelProvider(
+			"worker",
+			{ model: "fm-model", provider: "fm-provider" },
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		assert.deepEqual(result, { model: "fm-model", provider: "fm-provider" });
+	});
+
+	it("agent_overrides with specific values → uses override", () => {
+		writeSettings({
+			agent_provider: "global-provider",
+			agent_model: "global-model",
+			agent_overrides: {
+				worker: { model: "override-model", provider: "override-provider" },
+			},
+		});
+		const result = resolveAgentModelProvider(
+			"worker",
+			{ model: "fm-model", provider: "fm-provider" },
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		assert.deepEqual(result, { model: "override-model", provider: "override-provider" });
+	});
+
+	it("agent_overrides with null model → parent model (skips settings + frontmatter)", () => {
+		writeSettings({
+			agent_provider: "global-provider",
+			agent_model: "global-model",
+			agent_overrides: {
+				worker: { model: null, provider: "override-provider" },
+			},
+		});
+		const result = resolveAgentModelProvider(
+			"worker",
+			{ model: "fm-model", provider: "fm-provider" },
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		assert.deepEqual(result, { model: "parent-model", provider: "override-provider" });
+	});
+
+	it("agent_overrides with null provider → parent provider", () => {
+		writeSettings({
+			agent_provider: "global-provider",
+			agent_model: "global-model",
+			agent_overrides: {
+				worker: { model: "override-model", provider: null },
+			},
+		});
+		const result = resolveAgentModelProvider(
+			"worker",
+			{ model: "fm-model", provider: "fm-provider" },
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		assert.deepEqual(result, { model: "override-model", provider: "parent-provider" });
+	});
+
+	it("partial override (only model) → model from override, provider from fallback chain", () => {
+		writeSettings({
+			agent_provider: "global-provider",
+			agent_model: "global-model",
+			agent_overrides: {
+				worker: { model: "override-model" },
+			},
+		});
+		const result = resolveAgentModelProvider(
+			"worker",
+			{ provider: "fm-provider" },
+			"parent-model",
+			"parent-provider",
+			tmp
+		);
+		// model from override; provider falls through override → frontmatter
+		assert.deepEqual(result, { model: "override-model", provider: "fm-provider" });
+	});
+});


### PR DESCRIPTION
## Summary

Fullscreen overlay dashboard UI for async agents and cron tasks, settings-based agent model/provider routing, and orchestrator edit/write enforcement.

## Changes

### Overlay Dashboard UI
- **Shared framework** (`overlay-dashboard.ts`) — reusable list→detail overlay with keyboard navigation (↑↓/jk select, Enter detail, x action, Esc close)
- **`/async-status`** — fullscreen overlay listing all async agents with live output viewer, model/provider display
- **`/async-kill`** — overlay picker for running agents (no args) or direct kill (with args)
- **`/cron list`** — overlay with schedule detail and remove support
- **`/cron list-all`** — cross-session overlay with file watcher sync for remote task removal

### Settings-Based Agent Model Routing
- **`agent_provider`** / **`agent_model`** — global default provider/model for all subagents
- **`agent_overrides`** — per-agent provider/model overrides (`null` = use parent model)
- **`resolveAgentModelProvider`** — resolution helper used by both sync and async spawn paths
- Priority: `agent_overrides[name]` → agent frontmatter → global setting → parent model

### Agent Discovery
- `agentScope` default changed from `"user"` to `"both"` — project agents (`.pi/agents/`) now discoverable by default
- `confirmProjectAgents` safety gate unchanged (default `true`, controllable via settings)

### Orchestrator Edit/Write Enforcement
- Code-level block preventing orchestrator from using `edit`/`write` directly — must delegate to subagents
- Subagents (`PI_SUBAGENT_CHILD=1`) unaffected
- Opt-in via `orchestrator_edit_write_block: true` in project settings (default: `false`)

### Docs
- README updated: overlay features, `/async-kill`, `/cron list-all`, agent routing settings, agentScope default
- `dev-docs/project-settings.md` — new settings documented
- `dev-docs/extension-commands.md` — updated command descriptions
- `dev-docs/repo-structure.md` — new modules documented

## Tests
- All pre-commit hooks pass
- pytest: 173 passed
- node tests: 709 passed (including new settings + overlay tests)

Made with [Cursor](https://cursor.com)