### PR TITLE
fix(deps): override sharp to ^0.35.3 to resolve libvips CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "overrides": {
     "undici": ">=6.27.0 <9.0.0",
     "adm-zip": "^0.6.0",
-    "protobufjs": "7.6.5"
+    "protobufjs": "7.6.5",
+    "sharp": "^0.35.3"
   },
   "pi": {
     "extensions": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "undici": ">=6.27.0 <9.0.0",
     "adm-zip": "^0.6.0",
     "protobufjs": "7.6.5",
-    "sharp": "^0.35.3"
+    "sharp": "0.35.3"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
## Summary

Override `sharp` to `^0.35.3` to fix 4 high-severity CVEs in bundled libvips:
- CVE-2026-33327
- CVE-2026-33328
- CVE-2026-35590
- CVE-2026-35591

`@huggingface/transformers` pins `sharp: ^0.34.5` which doesn't resolve to the fixed version. npm override forces 0.35.3+.

`npm audit` now reports 0 vulnerabilities.

Made with [Cursor](https://cursor.com)