### PR TITLE
fix(enforcement): prevent task-focus reminder from interrupting user input

### DIFF
--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -375,7 +375,7 @@ export function registerRules(
                 customType: "task-focus-enforcement",
                 content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
                 display: true,
-              }, { triggerTurn: true, deliverAs: "followUp" });
+              }, { triggerTurn: false, deliverAs: "nextTurn" });
               break;
             }
           } catch { continue; }


### PR DESCRIPTION
## Bug

Task-focus enforcement reminder was sent as `triggerTurn: true, deliverAs: "followUp"`, which triggered a new LLM turn. When the LLM had just asked the user a question (plain text or ask_user), the followUp would arrive before the user answered — the LLM would see the reminder and treat it as the user's response, proceeding without actual user input.

## Fix

Changed to `triggerTurn: false, deliverAs: "nextTurn"`:
- User still **sees** the reminder (`display: true`)
- But it **doesn't trigger a new LLM turn**
- When the user sends their next message, the LLM gets the reminder alongside it
- No more interrupting pending questions

Made with [Cursor](https://cursor.com)