### PR TITLE
feat(prompts): add /issue-review command with 3 reviewer agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Single extension that provides:
 | **Task tracking** | Structured task lists for multi-step workflows — live widget, progress tracking, reminder nudges ([@tintinweb/pi-tasks](https://github.com/tintinweb/pi-tasks)) |
 | **Neovim integration** | Send changed files and review findings to nvim's quickfix list — only active when running inside nvim |
 | **Inter-agent communication** | P2P (`/coms`) and networked (`/coms-net`) agent communication — on-demand activation via slash commands |
-| **Slash commands** | `/pr-review`, `/release`, `/review-local`, `/review-status`, `/query-db`, `/btw`, `/async-status`, `/async-kill`, `/status`, `/dream`, `/remember`, `/coms`, `/coms-net` — with autocomplete argument hints |
+| **Slash commands** | `/pr-review`, `/issue-review`, `/release`, `/review-local`, `/review-status`, `/query-db`, `/btw`, `/async-status`, `/async-kill`, `/status`, `/dream`, `/remember`, `/coms`, `/coms-net` — with autocomplete argument hints |
 | **GitHub autocomplete** | Type `#` in the editor to get issue/PR suggestions from the current repo — lazy-loaded, 5min cache |
 | **Command arg completions** | Tab-complete arguments for slash commands — providers and models for `/external-ai`, branches for `/review-local`, PR numbers for `/pr-review`, and more |
 | **Discord bot** | Control pi sessions from your phone via Discord DMs — send prompts, answer ask_user dialogs, switch sessions |
@@ -60,6 +60,7 @@ Single extension that provides:
 | `/scout-and-plan <task>` | scout → planner |
 | `/implement-and-review <task>` | worker → 5 reviewers → worker |
 | `/pr-review [number\|url]` | Fetch PR diff, check past review comments, review with guidelines, post and track comments |
+| `/issue-review` | Review a GitHub issue spec and fix it |
 | `/release [flags]` | Create GitHub release with changelog and version bumping |
 | `/review-local [branch]` | Review local uncommitted or branch changes |
 | `/review-handler [url] [--autorabbit] [--autoqodo]` | Process PR review comments, fix approved items |

--- a/agents/issue-reviewer-feasibility.md
+++ b/agents/issue-reviewer-feasibility.md
@@ -1,0 +1,60 @@
+---
+name: issue-reviewer-feasibility
+description: Issue review focused on codebase feasibility — verifying referenced files/functions exist, approach viability, and identifying blockers.
+tools: read, bash
+---
+
+You are an issue review specialist focused on **codebase feasibility and technical viability**.
+
+## Base Rules
+
+- Execute first, explain after
+- Do NOT modify any files or the issue — only review and report findings
+- If a task falls outside your domain, report it and hand off
+
+## Review Focus
+
+You receive the issue body and the repository path. Your job is to verify that the issue's
+technical claims and proposed approach are grounded in reality.
+
+### File & Function References
+
+- Does the issue reference specific files, functions, classes, or modules?
+- For each reference: verify it exists in the codebase using `read` or `bash` (find, grep, rg)
+- Flag references that don't exist or have moved/renamed
+- Flag references that exist but don't match the described behavior
+
+### Approach Viability
+
+- Is the proposed implementation approach realistic?
+- Are there obvious technical blockers (missing APIs, wrong architecture, circular dependencies)?
+- Would the approach require changes to areas not mentioned in the issue?
+- Are there simpler alternatives the issue author may have missed?
+
+### Dependencies & Side Effects
+
+- Does the proposed change depend on external packages, APIs, or services not mentioned?
+- Could the change break existing functionality?
+- Are there migration/compatibility concerns not addressed?
+
+### Effort Estimation
+
+- Is the scope reasonable for a single issue?
+- Are there hidden complexities the issue doesn't account for?
+
+## Output Format
+
+Return ONLY a JSON object. No text before or after. No markdown fences.
+
+```json
+{"findings": [{"severity": "CRITICAL", "category": "feasibility", "description": "What is wrong", "suggestion": "How to fix", "proposed_text": "Exact text to add/replace in issue body (optional)"}]}
+```
+
+If no issues: `{"findings": []}`
+
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+The `proposed_text` field is optional — include it when you can provide exact markdown text
+to add to or replace in the issue body (e.g., correcting a wrong file reference).
+
+After writing your response, validate it is parseable JSON.

--- a/agents/issue-reviewer-scope.md
+++ b/agents/issue-reviewer-scope.md
@@ -1,0 +1,63 @@
+---
+name: issue-reviewer-scope
+description: Issue review focused on scope hygiene — single concern, no scope creep, duplicate detection against open issues.
+tools: read, bash
+---
+
+You are an issue review specialist focused on **scope hygiene and duplicate detection**.
+
+## Base Rules
+
+- Execute first, explain after
+- Do NOT modify any files or the issue — only review and report findings
+- If a task falls outside your domain, report it and hand off
+
+## Review Focus
+
+### Single Concern
+
+- Does the issue describe exactly one problem or feature?
+- Are there multiple unrelated tasks bundled together?
+- Could any part of the issue be a separate issue?
+- Flag "kitchen-sink" issues that mix bug fixes with feature requests or refactoring
+
+### Scope Creep Indicators
+
+- Does the description start narrow but expand with "also", "while we're at it", "bonus"?
+- Are there deliverables that don't relate to the stated problem?
+- Is the `## Done` checklist (if present) internally consistent with the problem statement?
+
+### Duplicate Detection
+
+- Search open issues for similar titles or descriptions:
+
+  ```bash
+  gh issue list --state open --limit 50 --json number,title,body
+  ```
+
+- Flag if an existing open issue covers the same problem
+- Flag if the issue partially overlaps with another (suggest linking or splitting)
+- Use keyword matching and semantic similarity — don't just check exact title matches
+
+### Issue Sizing
+
+- Is this issue appropriately sized for a single PR?
+- Should it be broken into smaller, independently deliverable issues?
+- Are there natural split points in the deliverables?
+
+## Output Format
+
+Return ONLY a JSON object. No text before or after. No markdown fences.
+
+```json
+{"findings": [{"severity": "CRITICAL", "category": "scope", "description": "What is wrong", "suggestion": "How to fix", "proposed_text": "Exact text to add/replace in issue body (optional)"}]}
+```
+
+If no issues: `{"findings": []}`
+
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+The `proposed_text` field is optional — include it when you can suggest restructuring
+(e.g., splitting the issue into multiple issues).
+
+After writing your response, validate it is parseable JSON.

--- a/agents/issue-reviewer-spec.md
+++ b/agents/issue-reviewer-spec.md
@@ -1,0 +1,77 @@
+---
+name: issue-reviewer-spec
+description: Issue review focused on spec completeness — problem statement, Done checklist, acceptance criteria, reproducibility, labels.
+tools: read, bash
+---
+
+You are an issue review specialist focused on **spec completeness and quality**.
+
+## Base Rules
+
+- Execute first, explain after
+- Do NOT modify any files or the issue — only review and report findings
+- If a task falls outside your domain, report it and hand off
+
+## Project Guidelines (MANDATORY — read before reviewing)
+
+Before reviewing, find and read the project's guidelines files.
+Check these locations in order — use the first `AGENTS.md` found, fall back to `CLAUDE.md`:
+
+**AGENTS.md locations (check in order):**
+
+1. `AGENTS.md` (repository root)
+2. `.agents/AGENTS.md`
+
+**CLAUDE.md fallback (only if no AGENTS.md found):**
+
+1. `CLAUDE.md` (repository root)
+2. `.claude/CLAUDE.md`
+
+Use the guidelines to understand how this project defines "done" and what issue structure is expected.
+
+## Review Focus
+
+Evaluate the issue body for:
+
+### Problem Statement
+
+- Is the problem clearly described?
+- For bugs: are there steps to reproduce, expected vs actual behavior, environment info?
+- For features: is the motivation explained (why this is needed)?
+- Is there enough context for someone unfamiliar with the codebase to understand?
+
+### Done Checklist
+
+- Does a `## Done` section exist with checkboxes?
+- Are deliverables concrete and measurable (not vague like "improve X")?
+- Can each checkbox be independently verified?
+- Are there missing deliverables implied by the description but not listed?
+
+### Acceptance Criteria
+
+- Are edge cases considered?
+- Are error scenarios described?
+- For UI changes: are mockups or behavioral descriptions provided?
+
+### Labels & Metadata
+
+- Are appropriate labels assigned (bug, feature, etc.)?
+- Is an assignee set?
+- Is the priority/severity clear from the description?
+
+## Output Format
+
+Return ONLY a JSON object. No text before or after. No markdown fences.
+
+```json
+{"findings": [{"severity": "CRITICAL", "category": "spec", "description": "What is wrong", "suggestion": "How to fix", "proposed_text": "Exact text to add/replace in issue body (optional)"}]}
+```
+
+If no issues: `{"findings": []}`
+
+Severity values: `CRITICAL`, `WARNING`, `SUGGESTION`
+
+The `proposed_text` field is optional — include it when you can provide exact markdown text
+to add to or replace in the issue body (e.g., a missing `## Done` section).
+
+After writing your response, validate it is parseable JSON.

--- a/extensions/acpx-provider/index.ts
+++ b/extensions/acpx-provider/index.ts
@@ -37,6 +37,7 @@ import os from "node:os";
 import { randomUUID, createHash } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
+import { buildExternalSystemPrompt } from "../shared/build-system-prompt.js";
 import {
 	checkMinPiVersion,
 	isPiMetaInvocation,
@@ -294,22 +295,6 @@ async function discoverModelsInternal(state: AgentState): Promise<string[]> {
 // =============================================================================
 
 /**
- * Build the system prompt to send on first session creation.
- * Since acpx sessions maintain their own conversation history,
- * we set the system prompt once at session creation time.
- */
-function buildSystemPrompt(context: Context): string | undefined {
-	if (!context.systemPrompt) return undefined;
-	return [
-		"You are being used as a backend LLM through pi coding agent.",
-		"You have full permission to read, write, edit, and execute any files or commands.",
-		"Follow these instructions:",
-		"",
-		context.systemPrompt,
-	].join("\n");
-}
-
-/**
  * Extract the latest user message from pi's context.
  * Since the acpx session maintains its own conversation history,
  * we only send the newest user message.
@@ -388,7 +373,7 @@ function streamAcpx(
 			// Build system prompt for first use
 			const handleKey = acpxModelId || "default";
 			const needsSystemPrompt = !state.systemPromptSent.has(handleKey);
-			const systemPrompt = needsSystemPrompt ? buildSystemPrompt(context) : undefined;
+			const systemPrompt = needsSystemPrompt ? buildExternalSystemPrompt(context, projectCwd) : undefined;
 
 			// Ensure session handle exists (creates session with model + system prompt if needed)
 			const handle = await ensureHandle(state, acpxModelId, systemPrompt);

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -37,6 +37,7 @@ import type {
 import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { asStringArray, getSetting } from "../orchestrator/project-settings.js";
+import { buildExternalSystemPrompt } from "../shared/build-system-prompt.js";
 import {
   checkMinPiVersion,
   isPiMetaInvocation,
@@ -287,22 +288,6 @@ function ensureSession(
 // Context Helpers (same contract as acpx-provider)
 // =============================================================================
 
-/**
- * Build the system prompt to send on first session creation.
- * CLI sessions maintain their own conversation history via --resume,
- * so we set the system prompt once at first turn.
- */
-function buildSystemPrompt(context: Context): string | undefined {
-  if (!context.systemPrompt) return undefined;
-  return [
-    "You are being used as a backend LLM through pi coding agent.",
-    "You have full permission to read, write, edit, and execute any files or commands.",
-    "Follow these instructions:",
-    "",
-    context.systemPrompt,
-  ].join("\n");
-}
-
 function messageText(msg: { role: string; content: any }): string {
   if (typeof msg.content === "string") return msg.content;
   if (!Array.isArray(msg.content)) return "";
@@ -426,7 +411,7 @@ function streamCli(
       const handleKey = cliModelId || "default";
       // Always build so resume-failure retry can start a fresh CLI session with
       // the system prompt; initial prompt still only prepends when needed.
-      const systemPromptText = buildSystemPrompt(context);
+      const systemPromptText = buildExternalSystemPrompt(context, projectCwd);
       const needsSystemPromptFlag =
         forceHistorySeed || !state.systemPromptSent.has(handleKey);
 

--- a/extensions/cli-provider/index.ts
+++ b/extensions/cli-provider/index.ts
@@ -409,11 +409,13 @@ function streamCli(
       await state.ready;
 
       const handleKey = cliModelId || "default";
-      // Always build so resume-failure retry can start a fresh CLI session with
-      // the system prompt; initial prompt still only prepends when needed.
-      const systemPromptText = buildExternalSystemPrompt(context, projectCwd);
+      // Only build when needed — avoids filesystem IO for enforced entries on
+      // every turn. forceHistorySeed (resume-failure retry) still builds.
       const needsSystemPromptFlag =
         forceHistorySeed || !state.systemPromptSent.has(handleKey);
+      const systemPromptText = needsSystemPromptFlag
+        ? buildExternalSystemPrompt(context, projectCwd)
+        : undefined;
 
       const { sessionId, needsSystemPrompt, key } = ensureSession(
         state,

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -112,7 +112,7 @@ export function formatDuration(ms: number): string {
 }
 
 /** Auto-complete a task via pi-tasks TaskStore (in-process, no AI involvement). */
-async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
+export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
   if (!taskId || taskId === "-1") return false;
   await taskStoreReady;
 
@@ -138,7 +138,7 @@ async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string)
 }
 
 /** Auto-mark a task in_progress via pi-tasks TaskStore (in-process, no AI involvement). */
-async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
+export async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
   if (!taskId || taskId === "-1") return false;
   await taskStoreReady;
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -752,17 +752,17 @@ export function registerAsyncAgents(
     };
     asyncState.jobs.set(id, job);
 
-    // Auto-mark linked task as in_progress at spawn time
-    if (options?.taskId && options.taskId !== "-1") {
-      autoMarkInProgress(options.taskId, asyncState.lastCtx?.sessionManager?.getCwd?.() || cwd, asyncState.lastCtx?.sessionManager?.getSessionId?.() || undefined)
-        .catch(() => {});  // best-effort, don't block spawn
-    }
-
     // addReviewerPending already called above (before piArgs construction)
 
     updateAsyncWidget();
     ensureAsyncPoller();
     startResultWatcher();
+
+    // Auto-mark linked task as in_progress AFTER successful spawn
+    if (options?.taskId && options.taskId !== "-1") {
+      autoMarkInProgress(options.taskId, asyncState.lastCtx?.sessionManager?.getCwd?.() || cwd, asyncState.lastCtx?.sessionManager?.getSessionId?.() || undefined)
+        .catch(() => {});  // best-effort, don't block spawn
+    }
 
     return { id, model: effectiveModel };
   }

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -6,28 +6,9 @@ import { execFileSync, execSync, spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { pathToFileURL } from "node:url";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
-
-// Import TaskStore for direct task auto-completion (bypasses AI)
-let TaskStoreClass: any = null;
-const taskStoreReady: Promise<void> = (async () => {
-  const candidates = [
-    "@tintinweb/pi-tasks/dist/task-store.js",
-    pathToFileURL(path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js")).href,
-  ];
-  for (const candidate of candidates) {
-    try {
-      const mod = await import(candidate);
-      if (mod.TaskStore) { TaskStoreClass = mod.TaskStore; break; }
-    } catch { continue; }
-  }
-  if (!TaskStoreClass) {
-    throw new Error("[async-agents] FATAL: TaskStore not found — @tintinweb/pi-tasks is required but failed to load");
-  }
-})();
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "./agents.js";
@@ -38,6 +19,8 @@ import { addReviewerPending, recordReviewerResult, countFindings, readReviewStat
 import { getMainBranch } from "./git-helpers.js";
 import { waitForResultFiles } from "./async-wait.js";
 import { openAsyncStatusOverlay } from "./async-status-ui.js";
+export { autoCompleteTask, autoMarkInProgress } from "./task-lifecycle.js";
+import { autoCompleteTask, autoMarkInProgress } from "./task-lifecycle.js";
 
 // ── Constants ────────────────────────────────────────────────────────────
 
@@ -109,58 +92,6 @@ export function formatDuration(ms: number): string {
   const m = Math.floor(ms / 60000);
   const s = Math.floor((ms % 60000) / 1000);
   return `${m}m${s}s`;
-}
-
-/** Auto-complete a task via pi-tasks TaskStore (in-process, no AI involvement). */
-export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
-  if (!taskId || taskId === "-1") return false;
-  await taskStoreReady;
-
-  const tasksDir = path.join(cwd, ".pi", "tasks");
-  const candidates: string[] = [];
-  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
-  candidates.push(path.join(tasksDir, "tasks.json"));
-
-  for (const storePath of candidates) {
-    try {
-      const store = new TaskStoreClass(storePath);
-      const task = store.get(taskId);
-      if (task && task.status !== "completed") {
-        store.update(taskId, { status: "completed" });
-        return true;
-      }
-    } catch (e: any) {
-      console.debug(`[async-agents] autoCompleteTask failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);
-      continue;
-    }
-  }
-  return false;
-}
-
-/** Auto-mark a task in_progress via pi-tasks TaskStore (in-process, no AI involvement). */
-export async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
-  if (!taskId || taskId === "-1") return false;
-  await taskStoreReady;
-
-  const tasksDir = path.join(cwd, ".pi", "tasks");
-  const candidates: string[] = [];
-  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
-  candidates.push(path.join(tasksDir, "tasks.json"));
-
-  for (const storePath of candidates) {
-    try {
-      const store = new TaskStoreClass(storePath);
-      const task = store.get(taskId);
-      if (task && task.status === "pending") {
-        store.update(taskId, { status: "in_progress" });
-        return true;
-      }
-    } catch (e: any) {
-      console.debug(`[async-agents] autoMarkInProgress failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);
-      continue;
-    }
-  }
-  return false;
 }
 
 // ── Registration ─────────────────────────────────────────────────────────

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -129,7 +129,10 @@ async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string)
         store.update(taskId, { status: "completed" });
         return true;
       }
-    } catch { continue; }
+    } catch (e: any) {
+      console.debug(`[async-agents] autoCompleteTask failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);
+      continue;
+    }
   }
   return false;
 }
@@ -152,7 +155,10 @@ async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: strin
         store.update(taskId, { status: "in_progress" });
         return true;
       }
-    } catch { continue; }
+    } catch (e: any) {
+      console.debug(`[async-agents] autoMarkInProgress failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);
+      continue;
+    }
   }
   return false;
 }
@@ -1053,6 +1059,8 @@ export function registerAsyncAgents(
     "subagents:rpc:spawn", ({ type, prompt, options }) => {
       const ctx = asyncState.lastCtx;
       if (!ctx) throw new Error("No active session");
+      if (!type || typeof type !== "string") throw new Error("Missing or invalid 'type' parameter");
+      if (!prompt || typeof prompt !== "string") throw new Error("Missing or invalid 'prompt' parameter");
 
       const cwd = options?.cwd || ctx.cwd;
       const discovery = discoverAgents(cwd, "both");

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -134,6 +134,29 @@ async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string)
   return false;
 }
 
+/** Auto-mark a task in_progress via pi-tasks TaskStore (in-process, no AI involvement). */
+async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
+  if (!taskId || taskId === "-1") return false;
+  await taskStoreReady;
+
+  const tasksDir = path.join(cwd, ".pi", "tasks");
+  const candidates: string[] = [];
+  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+  candidates.push(path.join(tasksDir, "tasks.json"));
+
+  for (const storePath of candidates) {
+    try {
+      const store = new TaskStoreClass(storePath);
+      const task = store.get(taskId);
+      if (task && task.status === "pending") {
+        store.update(taskId, { status: "in_progress" });
+        return true;
+      }
+    } catch { continue; }
+  }
+  return false;
+}
+
 // ── Registration ─────────────────────────────────────────────────────────
 
 export function registerAsyncAgents(
@@ -728,6 +751,12 @@ export function registerAsyncAgents(
       model: effectiveModel,
     };
     asyncState.jobs.set(id, job);
+
+    // Auto-mark linked task as in_progress at spawn time
+    if (options?.taskId && options.taskId !== "-1") {
+      autoMarkInProgress(options.taskId, asyncState.lastCtx?.sessionManager?.getCwd?.() || cwd, asyncState.lastCtx?.sessionManager?.getSessionId?.() || undefined)
+        .catch(() => {});  // best-effort, don't block spawn
+    }
 
     // addReviewerPending already called above (before piArgs construction)
 

--- a/extensions/orchestrator/async-agents.ts
+++ b/extensions/orchestrator/async-agents.ts
@@ -31,6 +31,7 @@ const taskStoreReady: Promise<void> = (async () => {
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import type { AgentConfig } from "./agents.js";
+import { discoverAgents } from "./agents.js";
 import { resolveAgentModelProvider } from "./resolve-agent-model.js";
 import { getPiInvocation, getProjectTmpDir, parseProcStartTime, djb2Hash } from "./utils.js";
 import { addReviewerPending, recordReviewerResult, countFindings, readReviewState, markTestsPassed, markTestsFailed } from "./pi-config-review-state.js";
@@ -346,6 +347,15 @@ export function registerAsyncAgents(
       return;
     }
 
+    // Emit lifecycle events for pi-tasks RPC bridge (one per job)
+    for (const j of groupJobs) {
+      if (j.status === "complete") {
+        pi.events.emit("subagents:completed", { id: j.id, result: j.output || "" });
+      } else if (j.status === "failed") {
+        pi.events.emit("subagents:failed", { id: j.id, error: j.output || "Agent failed", result: j.output || "", status: "failed" });
+      }
+    }
+
     const sections: string[] = [];
     for (const j of groupJobs) {
       if (j.fireAndForget) { j.delivered = true; continue; }
@@ -472,6 +482,13 @@ export function registerAsyncAgents(
         deliverGroupResults(groupJobs);
         updateAsyncWidget();
         return;
+      }
+
+      // Emit lifecycle events for pi-tasks RPC bridge
+      if (data.success) {
+        pi.events.emit("subagents:completed", { id: job.id, result: data.output || "" });
+      } else {
+        pi.events.emit("subagents:failed", { id: job.id, error: data.output || "Agent failed", result: data.output || "", status: "failed" });
       }
 
       // Non-grouped job: deliver immediately (existing behavior)
@@ -969,6 +986,76 @@ export function registerAsyncAgents(
     if (typeof target === "string") {
       killAsyncAgent(target);
     }
+  });
+
+  // ── pi-subagents RPC compatibility bridge ──────────────────────────────
+  // Implements the subagents:rpc:* protocol so pi-tasks' TaskExecute
+  // can spawn our agents. Protocol version 2 matches @tintinweb/pi-subagents.
+
+  const RPC_PROTOCOL_VERSION = 2;
+
+  /** Handle an RPC request: parse params, run fn, reply on scoped channel. */
+  function handleRpc<P extends { requestId: string }>(
+    channel: string,
+    fn: (params: P) => unknown | Promise<unknown>,
+  ): () => void {
+    return pi.events.on(channel, async (raw: unknown) => {
+      const params = raw as P;
+      try {
+        const data = await fn(params);
+        const reply: { success: true; data?: unknown } = { success: true };
+        if (data !== undefined) reply.data = data;
+        pi.events.emit(`${channel}:reply:${params.requestId}`, reply);
+      } catch (err: any) {
+        pi.events.emit(`${channel}:reply:${params.requestId}`, {
+          success: false, error: err?.message ?? String(err),
+        });
+      }
+    });
+  }
+
+  // Ping — returns protocol version
+  handleRpc("subagents:rpc:ping", () => {
+    return { version: RPC_PROTOCOL_VERSION };
+  });
+
+  // Spawn — create an async agent from pi-tasks' TaskExecute
+  handleRpc<{ requestId: string; type: string; prompt: string; options?: any }>(
+    "subagents:rpc:spawn", ({ type, prompt, options }) => {
+      const ctx = asyncState.lastCtx;
+      if (!ctx) throw new Error("No active session");
+
+      const cwd = options?.cwd || ctx.cwd;
+      const discovery = discoverAgents(cwd, "both");
+      const agents = discovery.agents;
+
+      // Find agent by type (case-insensitive, fall back to "worker")
+      const agentName = agents.find(a => a.name.toLowerCase() === type.toLowerCase())?.name
+        || agents.find(a => a.name === "worker")?.name
+        || type;
+
+      const result = spawnAsyncAgent(agentName, prompt, cwd, agents, {
+        name: options?.description || agentName,
+        taskId: "-1",  // pi-tasks manages its own task linkage via agentTaskMap
+        fireAndForget: false,
+      });
+
+      if (result.error) throw new Error(result.error);
+      return { id: result.id };
+    },
+  );
+
+  // Stop — kill a running async agent
+  handleRpc<{ requestId: string; agentId: string }>(
+    "subagents:rpc:stop", ({ agentId }) => {
+      const { killed, errors } = killAsyncAgent(agentId);
+      if (killed.length === 0) throw new Error(errors[0] || "Agent not found");
+    },
+  );
+
+  // Emit subagents:ready so pi-tasks can discover us
+  pi.on("session_start", () => {
+    pi.events.emit("subagents:ready", {});
   });
 
   return {

--- a/extensions/orchestrator/extended-autocomplete.ts
+++ b/extensions/orchestrator/extended-autocomplete.ts
@@ -83,11 +83,13 @@ type CompletionFn = (prefix: string) => AutocompleteItem[] | null;
 interface AutocompleteContext {
   prCache: Cache<AutocompleteItem[]>;
   prUrlMap: Map<string, string>;
+  issueCache: Cache<AutocompleteItem[]>;
   branchCache: Cache<AutocompleteItem[]>;
   tagCache: Cache<AutocompleteItem[]>;
   modelCaches: Map<string, Cache<AutocompleteItem[]>>;
   lastCwd: string;
   fetchOpenPRs(cwd: string): Promise<void>;
+  fetchOpenIssues(cwd: string): Promise<void>;
   fetchBranches(cwd: string): Promise<void>;
   fetchModels(provider: string, cwd: string): Promise<void>;
   fetchTags(cwd: string): Promise<void>;
@@ -168,6 +170,11 @@ function registerCompletions(
       if (!ctx.prCache.data) return null;
       const filtered = filter(ctx.prCache.data, prefix.replace(/^#/, ""));
       return filtered ? filtered.map((item) => ({ ...item, value: ctx.prUrlMap.get(item.value) || item.value })) : null;
+    },
+
+    "issue-review": (prefix: string) => {
+      void ctx.fetchOpenIssues(ctx.lastCwd);
+      return ctx.issueCache.data ? filter(ctx.issueCache.data, prefix.replace(/^#/, "")) : null;
     },
 
     "coderabbit-rate-limit": (prefix: string) => {
@@ -339,7 +346,7 @@ function setupPromptTemplateInterceptor(
 
   // Set of prompt template names that we handle
   const promptTemplateCommands = new Set([
-    "external-ai", "pr-review", "coderabbit-rate-limit",
+    "external-ai", "pr-review", "issue-review", "coderabbit-rate-limit",
     "review-local", "release", "review-handler", "cron", "create-skill", "create-coms-feature-manager",
   ]);
 
@@ -440,6 +447,7 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
   const ctx = {} as AutocompleteContext;
   ctx.prCache = createCache<AutocompleteItem[]>();
   ctx.prUrlMap = new Map<string, string>();
+  ctx.issueCache = createCache<AutocompleteItem[]>();
   ctx.branchCache = createCache<AutocompleteItem[]>();
   ctx.tagCache = createCache<AutocompleteItem[]>();
   ctx.modelCaches = new Map<string, Cache<AutocompleteItem[]>>();
@@ -468,6 +476,27 @@ export function registerExtendedAutocomplete(pi: ExtensionAPI): void {
       }
     } catch (e: any) { console.debug("[autocomplete] PR fetch failed:", e?.message || e); }
     ctx.prCache.loading = false;
+  };
+
+  ctx.fetchOpenIssues = async (cwd: string) => {
+    if (isFresh(ctx.issueCache) || ctx.issueCache.loading) return;
+    ctx.issueCache.loading = true;
+    try {
+      const result = await pi.exec(
+        "gh", ["issue", "list", "--state", "open", "--limit", "50", "--json", "number,title"],
+        { cwd, timeout: 10_000 },
+      );
+      if (result.code === 0) {
+        const issues = JSON.parse(result.stdout) as Array<{ number: number; title: string }>;
+        ctx.issueCache.data = issues.map((issue) => ({
+          value: String(issue.number),
+          label: `#${issue.number}`,
+          description: issue.title,
+        }));
+        ctx.issueCache.timestamp = Date.now();
+      }
+    } catch (e: any) { console.debug("[autocomplete] issue fetch failed:", e?.message || e); }
+    ctx.issueCache.loading = false;
   };
 
   ctx.fetchBranches = async (cwd: string) => {

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -292,21 +292,19 @@ export function registerRules(
         const taskCandidates: string[] = [];
         if (sessionId) taskCandidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
         taskCandidates.push(path.join(tasksDir, "tasks.json"));
-        // Accumulate active tasks across ALL stores (dedupe by id) so fallback
-        // tasks.json is checked even when the session-scoped file exists but
-        // contains no active tasks.
-        const seenIds = new Set<string>();
-        const allActiveTasks: Array<{ id: string; status: string; subject: string }> = [];
+        // Session-first fallback: prefer session-scoped store, only fall back
+        // to tasks.json when the session store doesn't exist or has no active tasks.
+        // This matches the semantics used by readTaskSummary() and task lifecycle functions.
+        let allActiveTasks: Array<{ id: string; status: string; subject: string }> = [];
         for (const taskFile of taskCandidates) {
           try {
             if (!fs.existsSync(taskFile)) continue;
             const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
             const tasks = data.tasks || [];
-            for (const t of tasks) {
-              if ((t.status === "in_progress" || t.status === "pending") && !seenIds.has(String(t.id))) {
-                seenIds.add(String(t.id));
-                allActiveTasks.push(t);
-              }
+            const active = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
+            if (active.length > 0) {
+              allActiveTasks = active;
+              break; // Use the first store that has active tasks
             }
           } catch { continue; }
         }

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -38,6 +38,7 @@ let lastInjectedMemories: { text: string; category: string; similarity: number }
 // Don't re-fire for the same user message (prevents loops from followUp turns).
 let lastTaskFocusUserMsgId: string | null = null;
 let taskFocusPending = false;
+let taskFocusPendingMsgId: string | null = null;
 
 /** Log what memories were auto-injected for retrieval telemetry */
 function logMemoryInjection(
@@ -94,6 +95,8 @@ export function registerRules(
   pi.on("session_start", async (_event, ctx) => {
     rebuildDone = false;
     lastTaskFocusUserMsgId = null;
+    taskFocusPending = false;
+    taskFocusPendingMsgId = null;
     try {
       rebuildAndOrganize(ctx.cwd);
       rebuildDone = true;
@@ -289,25 +292,35 @@ export function registerRules(
         const taskCandidates: string[] = [];
         if (sessionId) taskCandidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
         taskCandidates.push(path.join(tasksDir, "tasks.json"));
+        // Accumulate active tasks across ALL stores (dedupe by id) so fallback
+        // tasks.json is checked even when the session-scoped file exists but
+        // contains no active tasks.
+        const seenIds = new Set<string>();
+        const allActiveTasks: Array<{ id: string; status: string; subject: string }> = [];
         for (const taskFile of taskCandidates) {
           try {
             if (!fs.existsSync(taskFile)) continue;
             const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
             const tasks = data.tasks || [];
-            const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
-            if (activeTasks.length > 0) {
-              const summary = activeTasks
-                .slice(0, 3)
-                .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
-                .join(", ");
-              pi.sendMessage({
-                customType: "task-focus-enforcement",
-                content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
-                display: true,
-              }, { triggerTurn: false, deliverAs: "nextTurn" });
+            for (const t of tasks) {
+              if ((t.status === "in_progress" || t.status === "pending") && !seenIds.has(String(t.id))) {
+                seenIds.add(String(t.id));
+                allActiveTasks.push(t);
+              }
             }
-            break;
           } catch { continue; }
+        }
+        if (allActiveTasks.length > 0) {
+          const summary = allActiveTasks
+            .slice(0, 3)
+            .map((t) => `#${t.id} [${t.status}] ${t.subject}`)
+            .join(", ");
+          pi.sendMessage({
+            customType: "task-focus-enforcement",
+            content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${allActiveTasks.length > 3 ? ` (+${allActiveTasks.length - 3} more)` : ""}`,
+            display: true,
+          }, { triggerTurn: false, deliverAs: "nextTurn" });
+          lastTaskFocusUserMsgId = taskFocusPendingMsgId;
         }
       } catch (e: any) { console.debug("[rules] task-focus reminder failed:", e?.message?.slice(0, 100)); }
     }
@@ -377,7 +390,7 @@ export function registerRules(
 
       if (!hadToolCalls && userTriggered) {
         taskFocusPending = true;
-        lastTaskFocusUserMsgId = triggeringMsgId;
+        taskFocusPendingMsgId = triggeringMsgId;
       }
     } catch (e: any) { console.debug("[rules] task-focus enforcement failed:", e?.message?.slice(0, 100)); }
 

--- a/extensions/orchestrator/rules.ts
+++ b/extensions/orchestrator/rules.ts
@@ -37,6 +37,7 @@ let lastInjectedMemories: { text: string; category: string; similarity: number }
 // Track the user message ID that last triggered task-focus enforcement.
 // Don't re-fire for the same user message (prevents loops from followUp turns).
 let lastTaskFocusUserMsgId: string | null = null;
+let taskFocusPending = false;
 
 /** Log what memories were auto-injected for retrieval telemetry */
 function logMemoryInjection(
@@ -279,6 +280,38 @@ export function registerRules(
       } catch (e: any) { console.debug("[rules] session history auto-inject failed:", e?.message?.slice(0, 100)); }
     }
 
+    // Task-focus reminder — compose with FRESH task data (flag set at turn_end)
+    if (taskFocusPending) {
+      taskFocusPending = false;
+      try {
+        const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
+        const sessionId = ctx.sessionManager?.getSessionId?.();
+        const taskCandidates: string[] = [];
+        if (sessionId) taskCandidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+        taskCandidates.push(path.join(tasksDir, "tasks.json"));
+        for (const taskFile of taskCandidates) {
+          try {
+            if (!fs.existsSync(taskFile)) continue;
+            const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
+            const tasks = data.tasks || [];
+            const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
+            if (activeTasks.length > 0) {
+              const summary = activeTasks
+                .slice(0, 3)
+                .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
+                .join(", ");
+              pi.sendMessage({
+                customType: "task-focus-enforcement",
+                content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
+                display: true,
+              }, { triggerTurn: false, deliverAs: "nextTurn" });
+            }
+            break;
+          } catch { continue; }
+        }
+      } catch (e: any) { console.debug("[rules] task-focus reminder failed:", e?.message?.slice(0, 100)); }
+    }
+
     if (!extra && !memories && !contextMemories && !sessionContext) return;
     // Memories at TAIL position (after system prompt) — research proves tail
     // gets highest LLM attention (U-shaped attention curve). Rules/extra stay
@@ -312,12 +345,8 @@ export function registerRules(
 
     // Task-focus enforcement: if this turn had no tool calls but tasks are active,
     // the LLM likely answered a side question and forgot to resume work.
-    // Inject a follow-up to remind about active tasks when the LLM responds
-    // without using any tools (likely chatting instead of working).
-    // Only fires after REAL user messages — not after system-generated followUps.
-    // Detection: walk the branch backwards from the assistant response. If the
-    // entry immediately before the assistant is a custom_message (system-generated),
-    // skip. Only fire if it's a real user message (type: "message", role: "user").
+    // Set a flag here; the actual reminder is composed at before_agent_start
+    // with fresh task data (avoids stale/deleted tasks in the message).
     try {
       const turnToolResults = (_event as any).toolResults;
       const hadToolCalls = turnToolResults && Array.isArray(turnToolResults) && turnToolResults.length > 0;
@@ -327,16 +356,11 @@ export function registerRules(
         const branch = ctx.sessionManager.getBranch();
         for (let i = branch.length - 1; i >= 0; i--) {
           const entry = branch[i];
-          // Skip assistant messages (current turn's response)
           if (entry.type === "message" && (entry as any).message?.role === "assistant") continue;
-          // custom_message = system-generated turn-triggering message (enforcement, async result, coms)
-          // Only check custom_message (from sendMessage), not custom (from appendEntry)
-          // because appendEntry is state storage that other extensions use between turns.
           if (entry.type === "custom_message") {
             userTriggered = false;
             break;
           }
-          // Real user message — but only if we haven't already fired for this exact message
           if (entry.type === "message" && (entry as any).message?.role === "user") {
             const msgId = (entry as any).id;
             if (msgId && msgId === lastTaskFocusUserMsgId) {
@@ -347,39 +371,13 @@ export function registerRules(
             }
             break;
           }
-          // Any other entry type — skip and keep looking
           continue;
         }
       } catch { /* best-effort */ }
 
       if (!hadToolCalls && userTriggered) {
-        // Check for active tasks — session-scoped task file only
-        const tasksDir = path.join(ctx.cwd, ".pi", "tasks");
-        const sessionId = ctx.sessionManager?.getSessionId?.();
-        const candidates: string[] = [];
-        if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
-        candidates.push(path.join(tasksDir, "tasks.json"));
-        for (const taskFile of candidates) {
-          try {
-            if (!fs.existsSync(taskFile)) continue;
-            const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
-            const tasks = data.tasks || [];
-            const activeTasks = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
-            if (activeTasks.length > 0) {
-              const summary = activeTasks
-                .slice(0, 3)
-                .map((t: any) => `#${t.id} [${t.status}] ${t.subject}`)
-                .join(", ");
-              lastTaskFocusUserMsgId = triggeringMsgId;
-              pi.sendMessage({
-                customType: "task-focus-enforcement",
-                content: `⚠️ You have active tasks — resume your workflow now:\n${summary}${activeTasks.length > 3 ? ` (+${activeTasks.length - 3} more)` : ""}`,
-                display: true,
-              }, { triggerTurn: false, deliverAs: "nextTurn" });
-              break;
-            }
-          } catch { continue; }
-        }
+        taskFocusPending = true;
+        lastTaskFocusUserMsgId = triggeringMsgId;
       }
     } catch (e: any) { console.debug("[rules] task-focus enforcement failed:", e?.message?.slice(0, 100)); }
 

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -769,6 +769,7 @@ export function registerSubagentTool(
     parentModelId: string | undefined,
     parentProvider: string | undefined,
     asyncOk: boolean,
+    sessionId?: string,
   ) {
     const results: SingleResult[] = [];
     let prev = "";
@@ -833,7 +834,7 @@ export function registerSubagentTool(
       // Auto-mark linked task as in_progress (same as async path)
       const chainTaskId = s.taskId as string | undefined;
       if (chainTaskId && chainTaskId !== "-1") {
-        await autoMarkInProgress(chainTaskId, s.cwd).catch(() => {});
+        await autoMarkInProgress(chainTaskId, s.cwd, sessionId).catch(() => {});
       }
       const r = await runSingleAgent(
         agents,
@@ -869,7 +870,7 @@ export function registerSubagentTool(
       }
       // Auto-complete linked task on success (same as async path)
       if (chainTaskId && chainTaskId !== "-1") {
-        await autoCompleteTask(chainTaskId, s.cwd).catch(() => {});
+        await autoCompleteTask(chainTaskId, s.cwd, sessionId).catch(() => {});
       }
       prev = getFinalOutput(r.messages);
     }
@@ -897,6 +898,7 @@ export function registerSubagentTool(
     parentModelId: string | undefined,
     parentProvider: string | undefined,
     asyncOk: boolean,
+    sessionId?: string,
   ) {
     if (params.tasks.length > MAX_PARALLEL_TASKS)
       return {
@@ -985,7 +987,7 @@ export function registerSubagentTool(
     for (const t of params.tasks) {
       const tid = (t as any).taskId as string | undefined;
       if (tid && tid !== "-1") {
-        await autoMarkInProgress(tid, t.cwd).catch(() => {});
+        await autoMarkInProgress(tid, t.cwd, sessionId).catch(() => {});
       }
     }
     const results = await mapWithConcurrency(
@@ -1026,7 +1028,7 @@ export function registerSubagentTool(
           r.stopReason !== "error" &&
           r.stopReason !== "aborted"
         ) {
-          await autoCompleteTask(tid, t.cwd).catch(() => {});
+          await autoCompleteTask(tid, t.cwd, sessionId).catch(() => {});
         }
         return r;
       },
@@ -1059,6 +1061,7 @@ export function registerSubagentTool(
     parentModelId: string | undefined,
     parentProvider: string | undefined,
     asyncOk: boolean,
+    sessionId?: string,
   ) {
     if (!params.cwd) {
       return {
@@ -1099,7 +1102,7 @@ export function registerSubagentTool(
     // Auto-mark linked task as in_progress (same as async path)
     const syncTaskId = params.taskId as string | undefined;
     if (syncTaskId && syncTaskId !== "-1") {
-      await autoMarkInProgress(syncTaskId, params.cwd).catch(() => {});
+      await autoMarkInProgress(syncTaskId, params.cwd, sessionId).catch(() => {});
     }
     const r = await runSingleAgent(
       agents,
@@ -1133,7 +1136,7 @@ export function registerSubagentTool(
       };
     // Auto-complete linked task on success (same as async path)
     if (syncTaskId && syncTaskId !== "-1") {
-      await autoCompleteTask(syncTaskId, params.cwd).catch(() => {});
+      await autoCompleteTask(syncTaskId, params.cwd, sessionId).catch(() => {});
     }
     return {
       content: [
@@ -1592,24 +1595,26 @@ export function registerSubagentTool(
         return result;
       };
 
+      const sessionId = ctx.sessionManager?.getSessionId?.();
+
       // Chain mode
       if (params.chain && params.chain.length > 0) {
         return withCapabilityNote(
-          await executeChain(params, agents, mkd, signal, onUpdate, activeAgents, updateWorking, parentModelId, parentProvider, asyncOk),
+          await executeChain(params, agents, mkd, signal, onUpdate, activeAgents, updateWorking, parentModelId, parentProvider, asyncOk, sessionId),
         );
       }
 
       // Parallel mode
       if (params.tasks && params.tasks.length > 0) {
         return withCapabilityNote(
-          await executeParallel(params, agents, mkd, signal, onUpdate, activeAgents, updateWorking, parentModelId, parentProvider, asyncOk),
+          await executeParallel(params, agents, mkd, signal, onUpdate, activeAgents, updateWorking, parentModelId, parentProvider, asyncOk, sessionId),
         );
       }
 
       // Single mode
       if (params.agent && params.task) {
         return withCapabilityNote(
-          await executeSingle(params, agents, mkd, signal, onUpdate, activeAgents, updateWorking, parentModelId, parentProvider, asyncOk),
+          await executeSingle(params, agents, mkd, signal, onUpdate, activeAgents, updateWorking, parentModelId, parentProvider, asyncOk, sessionId),
         );
       }
 

--- a/extensions/orchestrator/subagent-tool.ts
+++ b/extensions/orchestrator/subagent-tool.ts
@@ -47,6 +47,7 @@ import {
   decideAsyncLlmDispatch,
   supportsAsyncLlm,
 } from "./async-capability.js";
+import { autoMarkInProgress, autoCompleteTask } from "./async-agents.js";
 import { resolveAgentModelProvider } from "./resolve-agent-model.js";
 import { clockHHMM, getPiInvocation, getProjectTmpDir, djb2Hash } from "./utils.js";
 
@@ -829,6 +830,11 @@ export function registerSubagentTool(
       activeAgents.clear();
       activeAgents.add(s.agent);
       updateWorking();
+      // Auto-mark linked task as in_progress (same as async path)
+      const chainTaskId = s.taskId as string | undefined;
+      if (chainTaskId && chainTaskId !== "-1") {
+        await autoMarkInProgress(chainTaskId, s.cwd).catch(() => {});
+      }
       const r = await runSingleAgent(
         agents,
         s.agent,
@@ -860,6 +866,10 @@ export function registerSubagentTool(
           details: mkd("chain")(results),
           isError: true,
         };
+      }
+      // Auto-complete linked task on success (same as async path)
+      if (chainTaskId && chainTaskId !== "-1") {
+        await autoCompleteTask(chainTaskId, s.cwd).catch(() => {});
       }
       prev = getFinalOutput(r.messages);
     }
@@ -971,6 +981,13 @@ export function registerSubagentTool(
         };
       }
     }
+    // Auto-mark linked tasks as in_progress
+    for (const t of params.tasks) {
+      const tid = (t as any).taskId as string | undefined;
+      if (tid && tid !== "-1") {
+        await autoMarkInProgress(tid, t.cwd).catch(() => {});
+      }
+    }
     const results = await mapWithConcurrency(
       params.tasks,
       MAX_CONCURRENCY,
@@ -1000,6 +1017,17 @@ export function registerSubagentTool(
         activeAgents.delete(t.name || t.agent);
         updateWorking();
         emitAll();
+        // Auto-complete linked task on success (same as async path)
+        const tid = t.taskId as string | undefined;
+        if (
+          tid &&
+          tid !== "-1" &&
+          r.exitCode === 0 &&
+          r.stopReason !== "error" &&
+          r.stopReason !== "aborted"
+        ) {
+          await autoCompleteTask(tid, t.cwd).catch(() => {});
+        }
         return r;
       },
     );
@@ -1068,6 +1096,11 @@ export function registerSubagentTool(
     const label = params.name || params.agent;
     activeAgents.add(label);
     updateWorking();
+    // Auto-mark linked task as in_progress (same as async path)
+    const syncTaskId = params.taskId as string | undefined;
+    if (syncTaskId && syncTaskId !== "-1") {
+      await autoMarkInProgress(syncTaskId, params.cwd).catch(() => {});
+    }
     const r = await runSingleAgent(
       agents,
       params.agent,
@@ -1098,6 +1131,10 @@ export function registerSubagentTool(
         details: mkd("single")([r]),
         isError: true,
       };
+    // Auto-complete linked task on success (same as async path)
+    if (syncTaskId && syncTaskId !== "-1") {
+      await autoCompleteTask(syncTaskId, params.cwd).catch(() => {});
+    }
     return {
       content: [
         { type: "text" as const, text: getFinalOutput(r.messages) || "(no output)" },

--- a/extensions/orchestrator/task-lifecycle.ts
+++ b/extensions/orchestrator/task-lifecycle.ts
@@ -26,7 +26,7 @@ const taskStoreReady: Promise<void> = (async () => {
 })();
 
 /** Auto-complete a task via pi-tasks TaskStore (in-process, no AI involvement). */
-export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
+export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string, _storeFactory?: (path: string) => any): Promise<boolean> {
   if (!taskId || taskId === "-1") return false;
   await taskStoreReady;
 
@@ -37,7 +37,8 @@ export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: 
 
   for (const storePath of candidates) {
     try {
-      const store = new TaskStoreClass(storePath);
+      const factory = _storeFactory ?? ((p: string) => new TaskStoreClass(p));
+      const store = factory(storePath);
       const task = store.get(taskId);
       if (task) {
         // Task found in this store — do not fall through to later candidates
@@ -56,7 +57,7 @@ export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: 
 }
 
 /** Auto-mark a task in_progress via pi-tasks TaskStore (in-process, no AI involvement). */
-export async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
+export async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: string, _storeFactory?: (path: string) => any): Promise<boolean> {
   if (!taskId || taskId === "-1") return false;
   await taskStoreReady;
 
@@ -67,7 +68,8 @@ export async function autoMarkInProgress(taskId: string, cwd: string, sessionId?
 
   for (const storePath of candidates) {
     try {
-      const store = new TaskStoreClass(storePath);
+      const factory = _storeFactory ?? ((p: string) => new TaskStoreClass(p));
+      const store = factory(storePath);
       const task = store.get(taskId);
       if (task) {
         // Task found in this store — do not fall through to later candidates

--- a/extensions/orchestrator/task-lifecycle.ts
+++ b/extensions/orchestrator/task-lifecycle.ts
@@ -39,9 +39,13 @@ export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: 
     try {
       const store = new TaskStoreClass(storePath);
       const task = store.get(taskId);
-      if (task && task.status !== "completed") {
-        store.update(taskId, { status: "completed" });
-        return true;
+      if (task) {
+        // Task found in this store — do not fall through to later candidates
+        if (task.status !== "completed") {
+          store.update(taskId, { status: "completed" });
+          return true;
+        }
+        return false;
       }
     } catch (e: any) {
       console.debug(`[task-lifecycle] autoCompleteTask failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);
@@ -65,9 +69,13 @@ export async function autoMarkInProgress(taskId: string, cwd: string, sessionId?
     try {
       const store = new TaskStoreClass(storePath);
       const task = store.get(taskId);
-      if (task && task.status === "pending") {
-        store.update(taskId, { status: "in_progress" });
-        return true;
+      if (task) {
+        // Task found in this store — do not fall through to later candidates
+        if (task.status === "pending") {
+          store.update(taskId, { status: "in_progress" });
+          return true;
+        }
+        return false;
       }
     } catch (e: any) {
       console.debug(`[task-lifecycle] autoMarkInProgress failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);

--- a/extensions/orchestrator/task-lifecycle.ts
+++ b/extensions/orchestrator/task-lifecycle.ts
@@ -1,0 +1,78 @@
+/**
+ * Task lifecycle helpers — auto-complete / mark in_progress via pi-tasks TaskStore.
+ * Kept separate from async-agents.ts so unit tests can import without loading
+ * @earendil-works/pi-coding-agent (unavailable in the tsx test harness).
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+let TaskStoreClass: any = null;
+const taskStoreReady: Promise<void> = (async () => {
+  const candidates = [
+    "@tintinweb/pi-tasks/dist/task-store.js",
+    pathToFileURL(path.join(os.homedir(), ".pi/agent/npm/node_modules/@tintinweb/pi-tasks/dist/task-store.js")).href,
+  ];
+  for (const candidate of candidates) {
+    try {
+      const mod = await import(candidate);
+      if (mod.TaskStore) { TaskStoreClass = mod.TaskStore; break; }
+    } catch { continue; }
+  }
+  if (!TaskStoreClass) {
+    throw new Error("[task-lifecycle] FATAL: TaskStore not found — @tintinweb/pi-tasks is required but failed to load");
+  }
+})();
+
+/** Auto-complete a task via pi-tasks TaskStore (in-process, no AI involvement). */
+export async function autoCompleteTask(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
+  if (!taskId || taskId === "-1") return false;
+  await taskStoreReady;
+
+  const tasksDir = path.join(cwd, ".pi", "tasks");
+  const candidates: string[] = [];
+  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+  candidates.push(path.join(tasksDir, "tasks.json"));
+
+  for (const storePath of candidates) {
+    try {
+      const store = new TaskStoreClass(storePath);
+      const task = store.get(taskId);
+      if (task && task.status !== "completed") {
+        store.update(taskId, { status: "completed" });
+        return true;
+      }
+    } catch (e: any) {
+      console.debug(`[task-lifecycle] autoCompleteTask failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);
+      continue;
+    }
+  }
+  return false;
+}
+
+/** Auto-mark a task in_progress via pi-tasks TaskStore (in-process, no AI involvement). */
+export async function autoMarkInProgress(taskId: string, cwd: string, sessionId?: string): Promise<boolean> {
+  if (!taskId || taskId === "-1") return false;
+  await taskStoreReady;
+
+  const tasksDir = path.join(cwd, ".pi", "tasks");
+  const candidates: string[] = [];
+  if (sessionId) candidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+  candidates.push(path.join(tasksDir, "tasks.json"));
+
+  for (const storePath of candidates) {
+    try {
+      const store = new TaskStoreClass(storePath);
+      const task = store.get(taskId);
+      if (task && task.status === "pending") {
+        store.update(taskId, { status: "in_progress" });
+        return true;
+      }
+    } catch (e: any) {
+      console.debug(`[task-lifecycle] autoMarkInProgress failed for task ${taskId}: ${e?.message?.slice(0, 100)}`);
+      continue;
+    }
+  }
+  return false;
+}

--- a/extensions/shared/build-system-prompt.ts
+++ b/extensions/shared/build-system-prompt.ts
@@ -41,7 +41,9 @@ export function buildExternalSystemPrompt(context: ProviderContext, cwd?: string
             rules.push(`- WARNING when running \`${trigger}\`: ${e.text}`);
           } else if (e.action.startsWith("run_after")) {
             const cmd = e.actionCommand || e.action.slice("run_after ".length);
-            rules.push(`- After running \`${trigger}\`, ALWAYS run: \`${cmd}\``);
+            if (cmd) {
+              rules.push(`- After running \`${trigger}\`, ALWAYS run: \`${cmd}\``);
+            }
           }
         }
         if (rules.length > 0) {

--- a/extensions/shared/build-system-prompt.ts
+++ b/extensions/shared/build-system-prompt.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared system prompt builder for CLI and ACPX providers.
+ * Injects enforced memory entries so external agents follow the same rules.
+ */
+
+import { loadEnforcedEntries } from "../orchestrator/enforcement-rules.js";
+
+interface ProviderContext {
+  systemPrompt?: string;
+}
+
+/**
+ * Build the system prompt for external LLM providers (CLI/ACPX).
+ * Appends enforced memory rules so external agents follow project enforcement.
+ */
+export function buildExternalSystemPrompt(context: ProviderContext, cwd?: string): string | undefined {
+  if (!context.systemPrompt) return undefined;
+  const parts = [
+    "You are being used as a backend LLM through pi coding agent.",
+    "You have full permission to read, write, edit, and execute any files or commands.",
+    "Follow these instructions:",
+    "",
+    context.systemPrompt,
+  ];
+
+  // Inject enforced memory entries so CLI/ACPX agents follow the same rules
+  if (cwd) {
+    try {
+      const entries = loadEnforcedEntries(cwd);
+      if (entries.length > 0) {
+        const rules: string[] = [];
+        for (const e of entries) {
+          const trigger = e.trigger
+            .replace(/^bash_contains\s+/, "")
+            .replace(/^bash_regex\s+/, "")
+            .replace(/^tool_name\s+/, "")
+            .replace(/^file_modified\s+/, "");
+          if (e.action === "block") {
+            rules.push(`- NEVER: ${trigger} — ${e.text}`);
+          } else if (e.action === "warn") {
+            rules.push(`- WARNING when running \`${trigger}\`: ${e.text}`);
+          } else if (e.action.startsWith("run_after")) {
+            const cmd = e.actionCommand || e.action.slice("run_after ".length);
+            rules.push(`- After running \`${trigger}\`, ALWAYS run: \`${cmd}\``);
+          }
+        }
+        if (rules.length > 0) {
+          parts.push("", "## Enforced Rules (MANDATORY)", "", ...rules);
+        }
+      }
+    } catch { /* enforcement should never break the provider */ }
+  }
+
+  return parts.join("\n");
+}

--- a/prompts/issue-review.md
+++ b/prompts/issue-review.md
@@ -52,8 +52,6 @@ Create all 10 tasks, then set dependencies via `TaskUpdate` with `addBlockedBy`.
 
 ### Phase 0: Issue Detection — Task 1
 
-Mark Task 1 as `in_progress`.
-
 If the raw arguments are empty:
 
 1. Detect issue from current branch name (extract issue number from branch like `feat/issue-42-...`
@@ -90,11 +88,7 @@ Store:
 - `ISSUE_AUTHOR` — issue author login
 - `OWNER_REPO` — `owner/repo` for all subsequent `gh issue` commands
 
-Mark Task 1 as `completed`.
-
 ### Phase 1: Context Gathering — Task 2
-
-Mark Task 2 as `in_progress`.
 
 Extract all file/function/class references from the issue body and comments:
 
@@ -123,13 +117,9 @@ Write the issue body to a temp file for reviewer access using the `write` tool:
 Use the write tool to create ${PROJECT_TMP_DIR}/issue-body.md with the ISSUE_BODY content
 ```
 
-Mark Task 2 as `completed`.
-
 ### Phase 2: Duplicate Scan — Task 3
 
 Task 3 can run in parallel with Task 2.
-
-Mark Task 3 as `in_progress`.
 
 Search for potential duplicate or overlapping issues:
 
@@ -145,8 +135,6 @@ Compare the current issue against all open issues:
 
 Store results as `DUPLICATES` — a list of `{number, title, similarity_reason}`.
 Only include issues with meaningful overlap, not just shared labels.
-
-Mark Task 3 as `completed`.
 
 ### Phase 3: Review — Tasks 4, 5, 6
 
@@ -167,8 +155,6 @@ After spawning, end your turn. Results arrive automatically.
 
 ### Phase 4: Merge Findings — Task 7
 
-Mark Task 7 as `in_progress`.
-
 Merge and deduplicate findings from all 3 reviewers:
 
 1. Parse JSON findings from each reviewer
@@ -180,11 +166,7 @@ Merge and deduplicate findings from all 3 reviewers:
    - **Add metadata** — missing labels, assignee
    - **Flag only** — scope concerns, duplicates (can't be auto-fixed in body)
 
-Mark Task 7 as `completed`.
-
 ### Phase 5: User Selection — Task 8
-
-Mark Task 8 as `in_progress`.
 
 Present ALL findings to the user in a table:
 
@@ -210,11 +192,7 @@ Which fixes to apply? (e.g., 'all', 'none', '1,2,4', or specific numbers)
 
 Use `ask_user` for the selection.
 
-Mark Task 8 as `completed`.
-
 ### Phase 6: Apply Fixes — Task 9
-
-Mark Task 9 as `in_progress`.
 
 For each approved fix:
 
@@ -244,11 +222,7 @@ gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> [--add-label "<label>" ...] [--
 Build the flags from the user's approved findings — only add labels/assignees that were
 explicitly selected. Do not hardcode any specific labels or assignees.
 
-Mark Task 9 as `completed`.
-
 ### Phase 7: Summary — Task 10
-
-Mark Task 10 as `in_progress`.
 
 Display:
 
@@ -267,8 +241,6 @@ Changes:
 - ✅ Corrected file reference (src/auth.py → src/auth/validate.ts)
 - ⚠️ Flagged: overlaps with #38 — consider linking
 ```
-
-Mark Task 10 as `completed`.
 
 ### Cleanup
 

--- a/prompts/issue-review.md
+++ b/prompts/issue-review.md
@@ -63,13 +63,21 @@ If the raw arguments are empty:
 
 If the raw arguments contain an issue number or URL:
 
-1. Parse the number (e.g., `42`) or extract from URL (e.g., `https://github.com/owner/repo/issues/42`)
+1. Parse the number (e.g., `42`) or extract from URL (e.g., `https://github.com/owner/repo/issues/42`). For URLs, also extract `OWNER_REPO` as `owner/repo`.
+
+Resolve `OWNER_REPO`:
+
+- URL argument → extract from the URL (`owner/repo`)
+- Auto-detected / bare number → `gh repo view --json owner,name --jq '.owner.login + "/" + .name'`
 
 Fetch issue metadata:
 
 ```bash
-gh issue view <number> --json number,title,body,labels,assignees,state,comments,milestone,author --jq '.'
+gh issue view <number> --repo <OWNER_REPO> --json number,title,body,labels,assignees,state,comments,milestone,author --jq '.'
 ```
+
+Where `<OWNER_REPO>` is from `gh repo view --json owner,name` for auto-detected issues,
+or extracted from the URL for URL-based arguments.
 
 Store:
 
@@ -80,14 +88,7 @@ Store:
 - `ISSUE_ASSIGNEES` — assignees array
 - `ISSUE_COMMENTS` — comments array
 - `ISSUE_AUTHOR` — issue author login
-
-Also get repo info:
-
-```bash
-gh repo view --json owner,name --jq '.owner.login + "/" + .name'
-```
-
-Store as `OWNER_REPO`.
+- `OWNER_REPO` — `owner/repo` for all subsequent `gh issue` commands
 
 Mark Task 1 as `completed`.
 
@@ -133,7 +134,7 @@ Mark Task 3 as `in_progress`.
 Search for potential duplicate or overlapping issues:
 
 ```bash
-gh issue list --state open --limit 50 --json number,title,body,labels
+gh issue list --repo <OWNER_REPO> --state open --limit 50 --json number,title,body,labels
 ```
 
 Compare the current issue against all open issues:
@@ -223,20 +224,20 @@ For each approved fix:
 4. If confirmed, update the issue:
 
 ```bash
-gh issue edit <ISSUE_NUMBER> --body-file <temp_file_with_new_body>
+gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> --body-file <temp_file_with_new_body>
 ```
 
 Write the new body to a temp file first to handle special characters:
 
 ```bash
 write ${PROJECT_TMP_DIR}/updated-issue-body.md with the new body content
-gh issue edit <ISSUE_NUMBER> --body-file ${PROJECT_TMP_DIR}/updated-issue-body.md
+gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> --body-file ${PROJECT_TMP_DIR}/updated-issue-body.md
 ```
 
 If the user also approved label/assignee changes, apply those:
 
 ```bash
-gh issue edit <ISSUE_NUMBER> --add-label "bug" --add-assignee "@me"
+gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> --add-label "bug" --add-assignee "@me"
 ```
 
 Mark Task 9 as `completed`.

--- a/prompts/issue-review.md
+++ b/prompts/issue-review.md
@@ -1,0 +1,270 @@
+---
+description: "Review a GitHub issue spec and fix it — /issue-review [issue number or URL]"
+argument-hint: "[issue number or URL]"
+---
+
+## Raw Arguments
+
+```text
+$ARGUMENTS
+```
+
+# GitHub Issue Review Command
+
+> **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
+> while executing this command — DO NOT work around it silently. Ask the user:
+> "Should I create a GitHub issue for this?" Route to:
+> `myk-org/pi-config` for plugin/command spec or `myk-pi-tools` CLI issues.
+> Do not silently skip steps or apply manual fixes that hide the root cause.
+
+Reviews a GitHub issue for spec quality, feasibility, and scope — then edits the issue body to fix problems.
+
+## Usage
+
+- `/issue-review` — review issue linked to current branch (auto-detect)
+- `/issue-review 42` — review issue #42
+- `/issue-review https://github.com/owner/repo/issues/42` — review from URL
+
+## Task Plan
+
+Before starting any work, create ALL tasks upfront using `TaskCreate`, then set dependencies.
+
+### Task List
+
+| Task | Title | blockedBy |
+|------|-------|-----------|
+| 1 | Issue detection | — |
+| 2 | Context gathering | 1 |
+| 3 | Duplicate scan | 1 |
+| 4 | Review — Spec | 2 |
+| 5 | Review — Feasibility | 2 |
+| 6 | Review — Scope | 2, 3 |
+| 7 | Merge findings | 4, 5, 6 |
+| 8 | User selection | 7 |
+| 9 | Apply fixes to issue body | 8 |
+| 10 | Summary | 9 |
+
+Create all 10 tasks, then set dependencies via `TaskUpdate` with `addBlockedBy`.
+
+## Workflow
+
+**PROJECT_TMP_DIR** is the project-scoped temp directory from `getProjectTmpDir(cwd)`.
+
+### Phase 0: Issue Detection — Task 1
+
+Mark Task 1 as `in_progress`.
+
+If the raw arguments are empty:
+
+1. Detect issue from current branch name (extract issue number from branch like `feat/issue-42-...`
+   or `fix/issue-42-...`).
+2. If no issue number in branch, try: `gh issue list --assignee @me --state open --limit 1 --json number --jq '.[0].number'`
+3. If still nothing, ask the user for an issue number.
+
+If the raw arguments contain an issue number or URL:
+
+1. Parse the number (e.g., `42`) or extract from URL (e.g., `https://github.com/owner/repo/issues/42`)
+
+Fetch issue metadata:
+
+```bash
+gh issue view <number> --json number,title,body,labels,assignees,state,comments,milestone,author --jq '.'
+```
+
+Store:
+
+- `ISSUE_NUMBER` — the issue number
+- `ISSUE_TITLE` — the issue title
+- `ISSUE_BODY` — the full issue body (markdown)
+- `ISSUE_LABELS` — labels array
+- `ISSUE_ASSIGNEES` — assignees array
+- `ISSUE_COMMENTS` — comments array
+- `ISSUE_AUTHOR` — issue author login
+
+Also get repo info:
+
+```bash
+gh repo view --json owner,name --jq '.owner.login + "/" + .name'
+```
+
+Store as `OWNER_REPO`.
+
+Mark Task 1 as `completed`.
+
+### Phase 1: Context Gathering — Task 2
+
+Mark Task 2 as `in_progress`.
+
+Extract all file/function/class references from the issue body and comments:
+
+1. Scan the issue body for patterns like:
+   - File paths: `src/foo.ts`, `extensions/bar/baz.py`, backtick-wrapped paths
+   - Function/method references: `functionName()`, `Class.method()`
+   - Code blocks referencing specific files
+
+2. For each reference, verify it exists in the codebase:
+
+   ```bash
+   test -f <path> && echo "EXISTS" || echo "MISSING"
+   ```
+
+   For function references:
+
+   ```bash
+   rg "function <name>|def <name>|<name>\s*=" <likely_files> --count
+   ```
+
+3. Store results as `CODEBASE_REFS` — a list of `{ref, exists, location}` objects.
+
+Write the issue body to a temp file for reviewer access:
+
+```bash
+write ${PROJECT_TMP_DIR}/issue-body.md with the ISSUE_BODY content
+```
+
+Mark Task 2 as `completed`.
+
+### Phase 2: Duplicate Scan — Task 3
+
+Task 3 can run in parallel with Task 2.
+
+Mark Task 3 as `in_progress`.
+
+Search for potential duplicate or overlapping issues:
+
+```bash
+gh issue list --state open --limit 50 --json number,title,body,labels
+```
+
+Compare the current issue against all open issues:
+
+- Title keyword similarity
+- Body content overlap
+- Same labels + similar description
+
+Store results as `DUPLICATES` — a list of `{number, title, similarity_reason}`.
+Only include issues with meaningful overlap, not just shared labels.
+
+Mark Task 3 as `completed`.
+
+### Phase 3: Review — Tasks 4, 5, 6
+
+Spawn ALL 3 review agents as async subagents. Each reviewer gets the issue body
+and relevant context.
+
+**Important:** Pass `cwd` as the current project directory so reviewers can access the codebase.
+
+```text
+subagent(tasks=[
+  {agent: "issue-reviewer-spec", task: "Review this GitHub issue for spec completeness.\n\nIssue #<ISSUE_NUMBER>: <ISSUE_TITLE>\n\n<issue-body>\n<ISSUE_BODY>\n</issue-body>\n\nLabels: <ISSUE_LABELS>\nAssignees: <ISSUE_ASSIGNEES>\n\nReturn findings as JSON.", cwd: "<project_dir>", name: "Issue Spec", taskId: "<task 4 ID>"},
+  {agent: "issue-reviewer-feasibility", task: "Review this GitHub issue for codebase feasibility.\n\nIssue #<ISSUE_NUMBER>: <ISSUE_TITLE>\n\n<issue-body>\n<ISSUE_BODY>\n</issue-body>\n\n<codebase-refs>\n<CODEBASE_REFS>\n</codebase-refs>\n\nVerify all file/function references and assess approach viability. Return findings as JSON.", cwd: "<project_dir>", name: "Issue Feasibility", taskId: "<task 5 ID>"},
+  {agent: "issue-reviewer-scope", task: "Review this GitHub issue for scope hygiene.\n\nIssue #<ISSUE_NUMBER>: <ISSUE_TITLE>\n\n<issue-body>\n<ISSUE_BODY>\n</issue-body>\n\n<duplicate-candidates>\n<DUPLICATES>\n</duplicate-candidates>\n\nCheck for single concern, scope creep, and duplicates. Return findings as JSON.", cwd: "<project_dir>", name: "Issue Scope", taskId: "<task 6 ID>"},
+])
+```
+
+After spawning, end your turn. Results arrive automatically.
+
+### Phase 4: Merge Findings — Task 7
+
+Mark Task 7 as `in_progress`.
+
+Merge and deduplicate findings from all 3 reviewers:
+
+1. Parse JSON findings from each reviewer
+2. Remove duplicates (same description targeting same issue section)
+3. Sort by severity: CRITICAL → WARNING → SUGGESTION
+4. For each finding, determine the fix action:
+   - **Add section** — missing `## Done`, missing reproduction steps, etc.
+   - **Rewrite section** — vague problem statement, unclear deliverables
+   - **Add metadata** — missing labels, assignee
+   - **Flag only** — scope concerns, duplicates (can't be auto-fixed in body)
+
+Mark Task 7 as `completed`.
+
+### Phase 5: User Selection — Task 8
+
+Mark Task 8 as `in_progress`.
+
+Present ALL findings to the user in a table:
+
+```text
+## Issue Review Findings
+
+| # | Severity | Category | Finding | Fix |
+|---|----------|----------|---------|-----|
+| 1 | CRITICAL | spec | Missing ## Done checklist | Add section |
+| 2 | WARNING | feasibility | references src/auth.py which doesn't exist | Correct reference |
+| 3 | WARNING | scope | Overlaps with #38 (similar auth refactor) | Flag only |
+| 4 | SUGGESTION | spec | Bug report missing environment info | Add section |
+```
+
+For each finding that has a fix (not "flag only"), show the proposed change
+(what will be added/modified in the issue body).
+
+Then ask the user:
+
+```text
+Which fixes to apply? (e.g., 'all', 'none', '1,2,4', or specific numbers)
+```
+
+Use `ask_user` for the selection.
+
+Mark Task 8 as `completed`.
+
+### Phase 6: Apply Fixes — Task 9
+
+Mark Task 9 as `in_progress`.
+
+For each approved fix:
+
+1. Build the updated issue body by applying all selected changes to `ISSUE_BODY`
+2. Show the user the diff (original vs updated body) as a preview
+3. Ask for confirmation: "Apply these changes to issue #N?"
+4. If confirmed, update the issue:
+
+```bash
+gh issue edit <ISSUE_NUMBER> --body-file <temp_file_with_new_body>
+```
+
+Write the new body to a temp file first to handle special characters:
+
+```bash
+write ${PROJECT_TMP_DIR}/updated-issue-body.md with the new body content
+gh issue edit <ISSUE_NUMBER> --body-file ${PROJECT_TMP_DIR}/updated-issue-body.md
+```
+
+If the user also approved label/assignee changes, apply those:
+
+```bash
+gh issue edit <ISSUE_NUMBER> --add-label "bug" --add-assignee "@me"
+```
+
+Mark Task 9 as `completed`.
+
+### Phase 7: Summary — Task 10
+
+Mark Task 10 as `in_progress`.
+
+Display:
+
+```text
+## Issue Review Complete
+
+Issue: #<NUMBER> — <TITLE>
+URL: https://github.com/<OWNER_REPO>/issues/<NUMBER>
+
+Applied: <N> fixes
+Skipped: <N> findings
+Flagged: <N> (manual action needed)
+
+Changes:
+- ✅ Added ## Done checklist (4 items)
+- ✅ Corrected file reference (src/auth.py → src/auth/validate.ts)
+- ⚠️ Flagged: overlaps with #38 — consider linking
+```
+
+Mark Task 10 as `completed`.
+
+### Cleanup
+
+Delete all tasks created in this workflow.

--- a/prompts/issue-review.md
+++ b/prompts/issue-review.md
@@ -3,13 +3,13 @@ description: "Review a GitHub issue spec and fix it — /issue-review [issue num
 argument-hint: "[issue number or URL]"
 ---
 
+# GitHub Issue Review Command
+
 ## Raw Arguments
 
 ```text
 $ARGUMENTS
 ```
-
-# GitHub Issue Review Command
 
 > **Bug Reporting Policy:** If you encounter ANY error, unexpected behavior, or reproducible bug
 > while executing this command — DO NOT work around it silently. Ask the user:
@@ -116,10 +116,10 @@ Extract all file/function/class references from the issue body and comments:
 
 3. Store results as `CODEBASE_REFS` — a list of `{ref, exists, location}` objects.
 
-Write the issue body to a temp file for reviewer access:
+Write the issue body to a temp file for reviewer access using the `write` tool:
 
-```bash
-write ${PROJECT_TMP_DIR}/issue-body.md with the ISSUE_BODY content
+```text
+Use the write tool to create ${PROJECT_TMP_DIR}/issue-body.md with the ISSUE_BODY content
 ```
 
 Mark Task 2 as `completed`.
@@ -267,4 +267,8 @@ Mark Task 10 as `completed`.
 
 ### Cleanup
 
-Delete all tasks created in this workflow.
+Delete all tasks created in this workflow:
+
+```text
+For each task ID created in Phase 0, call TaskUpdate(taskId="<ID>", status="deleted").
+```

--- a/prompts/issue-review.md
+++ b/prompts/issue-review.md
@@ -73,7 +73,7 @@ Resolve `OWNER_REPO`:
 Fetch issue metadata:
 
 ```bash
-gh issue view <number> --repo <OWNER_REPO> --json number,title,body,labels,assignees,state,comments,milestone,author --jq '.'
+gh issue view <ISSUE_NUMBER> --repo <OWNER_REPO> --json number,title,body,labels,assignees,state,comments,milestone,author --jq '.'
 ```
 
 Where `<OWNER_REPO>` is from `gh repo view --json owner,name` for auto-detected issues,
@@ -234,11 +234,15 @@ write ${PROJECT_TMP_DIR}/updated-issue-body.md with the new body content
 gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> --body-file ${PROJECT_TMP_DIR}/updated-issue-body.md
 ```
 
-If the user also approved label/assignee changes, apply those:
+If the user also approved label/assignee changes, construct the `gh issue edit` command
+dynamically from the approved selections:
 
 ```bash
-gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> --add-label "bug" --add-assignee "@me"
+gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> [--add-label "<label>" ...] [--add-assignee "<user>" ...]
 ```
+
+Build the flags from the user's approved findings — only add labels/assignees that were
+explicitly selected. Do not hardcode any specific labels or assignees.
 
 Mark Task 9 as `completed`.
 

--- a/prompts/issue-review.md
+++ b/prompts/issue-review.md
@@ -207,8 +207,13 @@ gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> --body-file <temp_file_with_new
 
 Write the new body to a temp file first to handle special characters:
 
+```text
+Use the write tool to create ${PROJECT_TMP_DIR}/updated-issue-body.md with the new body content
+```
+
+Then apply the update:
+
 ```bash
-write ${PROJECT_TMP_DIR}/updated-issue-body.md with the new body content
 gh issue edit <ISSUE_NUMBER> --repo <OWNER_REPO> --body-file ${PROJECT_TMP_DIR}/updated-issue-body.md
 ```
 

--- a/prompts/pr-review.md
+++ b/prompts/pr-review.md
@@ -143,8 +143,6 @@ All temp files for this workflow go there —
 
 ### Phase 0: PR Detection — Task 1
 
-Mark Task 1 as `in_progress`.
-
 If the raw arguments are empty:
 
 1. Detect from current branch and fetch PR metadata:
@@ -195,14 +193,10 @@ If the raw arguments contain a PR number or URL:
 
    Store this as `LATEST_COMMIT_DATE` (ISO 8601 timestamp).
 
-Mark Task 1 as `completed`.
-
 Tasks 2 and 3 are independent — execute them in parallel.
 Task 4 depends on Task 2 (needs the diff data) and will start after Task 2 completes.
 
 ### Phase 1a: Clone & Checkout PR — Task 2
-
-Mark Task 2 as `in_progress`.
 
 Clone the target repo and checkout the PR branch. This gives reviewers full repo access
 instead of passing a truncated diff in the prompt.
@@ -222,17 +216,12 @@ Store:
 
 If cloning or checkout fails, fall back to `myk-pi-tools pr diff` (original behavior).
 
-Mark Task 2 as `completed`.
-
 ### Phase 1b: (Removed — reviewers read AGENTS.md from clone)
 
 Task 3 is no longer needed — reviewers have full repo access via the clone
 and read AGENTS.md independently per their agent instructions.
-Mark Task 3 as `completed` immediately.
 
 ### Phase 1c: Check Past Review Comments — Task 4
-
-Mark Task 4 as `in_progress`.
 
 Fetch ALL human review threads (resolved + unresolved) from the PR:
 
@@ -388,11 +377,9 @@ The suggested answer should:
 - Be concise — answer the question, don't lecture
 - If the answer requires a code change, note that explicitly
 
-Mark Task 4 as `completed`.
-
 ### Phase 2: Code Analysis — Tasks 5, 6, 7, 8, 9
 
-Mark Tasks 5, 6, 7, 8, 9 as `in_progress`, then spawn ALL 5 review agents as async subagents
+Spawn ALL 5 review agents as async subagents
 with `taskId` linking each to its task:
 
 Use the actual task IDs returned by `TaskCreate` — do NOT hardcode IDs.
@@ -457,8 +444,6 @@ Task 10 (Merge findings) auto-unblocks when all 5 reviewer tasks complete.
 
 ### Phase 3: Merge & Deduplicate Findings — Task 10
 
-Mark Task 10 as `in_progress`.
-
 Merge and deduplicate the findings from all 5 reviewers AND the past review comment analysis from Task 4 into a single combined findings list.
 
 Reviewers were already instructed in Phase 2 to skip findings that duplicate existing
@@ -487,11 +472,7 @@ For each `[NEW]` finding, compare against the skipped list using path + body sim
 `"Auto-skipped (previously dismissed): <skip_reason>"`. The user still sees them in the
 Phase 4 table and can override by selecting them explicitly.
 
-Mark Task 10 as `completed`.
-
 ### Phase 4: User Selection — Task 11
-
-Mark Task 11 as `in_progress`.
 
 Present ALL findings to user in one combined list, grouped by severity (CRITICAL, WARNING, SUGGESTION).
 This includes:
@@ -600,11 +581,7 @@ findings minus user-selected findings). If the skipped set is non-empty:
    This file is read by all 5 reviewer agents before reviewing, so the same class of
    finding won't be raised again on future PRs in this repo.
 
-Mark Task 11 as `completed`.
-
 ### Phase 5: Post Comments — Task 12
-
-Mark Task 12 as `in_progress`.
 
 **Step 1: Post `[NEW]` and `[PREV-*]` findings as new review comments:**
 
@@ -675,11 +652,7 @@ NEVER build JSON by string interpolation — always write the reply body as raw 
 and use `jq -Rs '{body: .}'` to produce valid JSON. This prevents both shell injection
 and JSON encoding errors from quotes, backslashes, or newlines in the answer.
 
-Mark Task 12 as `completed`.
-
 ### Phase 5b: Store Posted Comments — Task 13
-
-Mark Task 13 as `in_progress`.
 
 After posting comments, store ALL findings (posted AND skipped) in the PR review database
 for future cycle tracking and same-PR dedup of skipped findings.
@@ -762,11 +735,7 @@ myk-pi-tools pr store-pr-review ${PROJECT_TMP_DIR}/pr-review-store.json
 runs to track which comments were posted, verify they were addressed, and auto-skip
 previously dismissed findings.
 
-Mark Task 13 as `completed`.
-
 ### Phase 6: Summary — Task 14
-
-Mark Task 14 as `in_progress`.
 
 Display final summary with counts and links. Include:
 
@@ -775,8 +744,6 @@ Display final summary with counts and links. Include:
 - Author questions answered / skipped counts
 - Total comments posted
 - PR link
-
-Mark Task 14 as `completed`.
 
 ### Cleanup
 

--- a/prompts/review-local.md
+++ b/prompts/review-local.md
@@ -95,8 +95,6 @@ TaskUpdate(taskId="8", addBlockedBy=["7"])
 
 ### Phase 1: Get Diff — Task 1
 
-Mark Task 1 as `in_progress`.
-
 **If the raw arguments are not empty:**
 
 Compare current branch against the specified branch:
@@ -113,11 +111,9 @@ Get all uncommitted changes (staged + unstaged):
 git diff HEAD
 ```
 
-Mark Task 1 as `completed`.
-
 ### Phase 2: Code Analysis — Tasks 2, 3, 4, 5, 6
 
-Mark Tasks 2, 3, 4, 5, 6 as `in_progress`, then spawn ALL 5 review agents as async subagents
+Spawn ALL 5 review agents as async subagents
 with `taskId` linking each to its task.
 Use the actual task IDs returned by `TaskCreate` — do NOT hardcode IDs.
 
@@ -152,20 +148,12 @@ Task 7 (Merge findings) auto-unblocks when all 5 reviewer tasks complete.
 
 ### Phase 3: Merge & Deduplicate Findings — Task 7
 
-Mark Task 7 as `in_progress`.
-
 Merge and deduplicate the findings from all 5 reviewers into a single combined findings list.
 
-Mark Task 7 as `completed`.
-
 ### Phase 4: Present Review — Task 8
-
-Mark Task 8 as `in_progress`.
 
 Display findings grouped by severity:
 
 - **Critical issues** (must fix)
 - **Warnings** (should fix)
 - **Suggestions** (nice to have)
-
-Mark Task 8 as `completed`.

--- a/rules/10-agent-routing.md
+++ b/rules/10-agent-routing.md
@@ -50,6 +50,7 @@ The orchestrator MUST NEVER fetch external docs directly — always delegate to 
 Some agents are dispatched internally by rules or prompt templates, not by the routing table:
 
 - `code-reviewer-quality`, `code-reviewer-guidelines`, `code-reviewer-security`, `code-reviewer-docs`, `code-reviewer-spec` — dispatched via `rules/20-code-review-loop.md`
+- `issue-reviewer-spec`, `issue-reviewer-feasibility`, `issue-reviewer-scope` — dispatched via `prompts/issue-review.md`
 - `reviewer` — dispatched via prompt templates
 
 ## Fallback

--- a/rules/50-agent-bug-reporting.md
+++ b/rules/50-agent-bug-reporting.md
@@ -18,6 +18,9 @@ This rule applies ONLY to agents defined in this repository (`agents/` directory
 - code-reviewer-quality
 - code-reviewer-security
 - code-reviewer-spec
+- issue-reviewer-spec
+- issue-reviewer-feasibility
+- issue-reviewer-scope
 - debugger
 - docs-fetcher
 - docker-expert

--- a/rules/60-task-tracking.md
+++ b/rules/60-task-tracking.md
@@ -31,7 +31,8 @@ Tasks MUST be **detailed and specific** — not high-level summaries.
 ## Task Lifecycle (MANDATORY)
 
 Create all tasks BEFORE starting work via `TaskCreate`.
-Mark each `in_progress` before starting and `completed` immediately after finishing via `TaskUpdate`.
+Task status transitions (`in_progress`, `completed`) are **auto-managed by the subagent tool** — do NOT call `TaskUpdate` for status changes.
+The system marks tasks `in_progress` at spawn and `completed` on success, for both sync and async agents.
 Work through tasks in order — do not skip tasks or start new work while unchecked tasks exist (unless user explicitly pivots).
 
 ---
@@ -50,17 +51,18 @@ Never abandon tasks — if scope changes, use `TaskUpdate` with `status: "delete
 
 ---
 
-## Async Agent taskId (MANDATORY — code-enforced)
+## Agent taskId (MANDATORY — code-enforced)
 
-**Every async agent call MUST include `taskId`.** Enforced — calls without it are rejected.
+**Every agent call (sync and async) auto-manages task status when `taskId` is provided.**
+For async agents, `taskId` is enforced — calls without it are rejected.
 Pass the task ID (e.g., `"5"`) when linked to a task, or `"-1"` when not.
-Linked tasks auto-complete on agent success — no manual `TaskUpdate` needed.
+Linked tasks are auto-marked `in_progress` at spawn and `completed` on success — no manual `TaskUpdate` needed.
 
 ```text
 subagent(agent="code-reviewer-quality", task="...", cwd="...", async=true, name="Review", taskId="5")
 subagent(agent="worker", task="...", cwd="...", async=true, name="Qodo Poll", taskId="-1")
 ```
 
-- ✅ **ALWAYS** pass `taskId` — auto-completes on success, stays `in_progress` on failure
-- ❌ **NEVER** manually `TaskUpdate` a task to `completed` if it has an async agent
-- ❌ **NEVER** omit `taskId` — the call will fail
+- ✅ **ALWAYS** pass `taskId` — auto-marks `in_progress` at spawn, `completed` on success
+- ❌ **NEVER** manually `TaskUpdate` status — the subagent tool handles it
+- ❌ **NEVER** omit `taskId` for async agents — the call will fail

--- a/rules/60-task-tracking.md
+++ b/rules/60-task-tracking.md
@@ -31,8 +31,7 @@ Tasks MUST be **detailed and specific** — not high-level summaries.
 ## Task Lifecycle (MANDATORY)
 
 Create all tasks BEFORE starting work via `TaskCreate`.
-Task status transitions (`in_progress`, `completed`) are **auto-managed by the subagent tool** — do NOT call `TaskUpdate` for status changes.
-The system marks tasks `in_progress` at spawn and `completed` on success, for both sync and async agents.
+Mark each `in_progress` before starting and `completed` immediately after finishing via `TaskUpdate`.
 Work through tasks in order — do not skip tasks or start new work while unchecked tasks exist (unless user explicitly pivots).
 
 ---
@@ -51,18 +50,17 @@ Never abandon tasks — if scope changes, use `TaskUpdate` with `status: "delete
 
 ---
 
-## Agent taskId (MANDATORY — code-enforced)
+## Async Agent taskId (MANDATORY — code-enforced)
 
-**Every agent call (sync and async) auto-manages task status when `taskId` is provided.**
-For async agents, `taskId` is enforced — calls without it are rejected.
+**Every async agent call MUST include `taskId`.** Enforced — calls without it are rejected.
 Pass the task ID (e.g., `"5"`) when linked to a task, or `"-1"` when not.
-Linked tasks are auto-marked `in_progress` at spawn and `completed` on success — no manual `TaskUpdate` needed.
+Linked tasks auto-complete on agent success — no manual `TaskUpdate` needed.
 
 ```text
 subagent(agent="code-reviewer-quality", task="...", cwd="...", async=true, name="Review", taskId="5")
 subagent(agent="worker", task="...", cwd="...", async=true, name="Qodo Poll", taskId="-1")
 ```
 
-- ✅ **ALWAYS** pass `taskId` — auto-marks `in_progress` at spawn, `completed` on success
-- ❌ **NEVER** manually `TaskUpdate` status — the subagent tool handles it
-- ❌ **NEVER** omit `taskId` for async agents — the call will fail
+- ✅ **ALWAYS** pass `taskId` — auto-completes on success, stays `in_progress` on failure
+- ❌ **NEVER** manually `TaskUpdate` a task to `completed` if it has an async agent
+- ❌ **NEVER** omit `taskId` — the call will fail

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for autoCompleteTask() and autoMarkInProgress() task lifecycle helpers.
+ * Run with: npx tsx --test tests/node/orchestrator/auto-task-lifecycle.test.ts
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  autoCompleteTask,
+  autoMarkInProgress,
+} from "../../../extensions/orchestrator/task-lifecycle.js";
+
+function writeTaskStore(dir: string, fileName: string, tasks: Array<{ id: string; status: string; subject: string }>): string {
+  const tasksDir = join(dir, ".pi", "tasks");
+  mkdirSync(tasksDir, { recursive: true });
+  const filePath = join(tasksDir, fileName);
+  writeFileSync(filePath, JSON.stringify({ tasks }));
+  return filePath;
+}
+
+function readTaskStore(filePath: string): Array<{ id: string; status: string; subject: string }> {
+  return JSON.parse(readFileSync(filePath, "utf-8")).tasks;
+}
+
+describe("autoCompleteTask", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "auto-complete-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("completes a pending task in tasks.json", async () => {
+    const storePath = writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "pending", subject: "Test task" },
+    ]);
+    const result = await autoCompleteTask("1", tmp);
+    assert.equal(result, true);
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "completed");
+  });
+
+  it("completes an in_progress task", async () => {
+    const storePath = writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "in_progress", subject: "Test task" },
+    ]);
+    const result = await autoCompleteTask("1", tmp);
+    assert.equal(result, true);
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "completed");
+  });
+
+  it("skips already completed task", async () => {
+    writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "completed", subject: "Test task" },
+    ]);
+    const result = await autoCompleteTask("1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("returns false for non-existent task", async () => {
+    writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "pending", subject: "Test task" },
+    ]);
+    const result = await autoCompleteTask("99", tmp);
+    assert.equal(result, false);
+  });
+
+  it("returns false for empty taskId", async () => {
+    const result = await autoCompleteTask("", tmp);
+    assert.equal(result, false);
+  });
+
+  it("returns false for taskId '-1'", async () => {
+    const result = await autoCompleteTask("-1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("finds task in session-scoped store when sessionId provided", async () => {
+    const storePath = writeTaskStore(tmp, "tasks-sess1.json", [
+      { id: "1", status: "pending", subject: "Session task" },
+    ]);
+    const result = await autoCompleteTask("1", tmp, "sess1");
+    assert.equal(result, true);
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "completed");
+  });
+
+  it("falls back to tasks.json when session store does not have the task", async () => {
+    writeTaskStore(tmp, "tasks-sess1.json", [
+      { id: "2", status: "pending", subject: "Other task" },
+    ]);
+    const storePath = writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "pending", subject: "Fallback task" },
+    ]);
+    const result = await autoCompleteTask("1", tmp, "sess1");
+    assert.equal(result, true);
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "completed");
+  });
+
+  it("returns false when no store files exist", async () => {
+    const result = await autoCompleteTask("1", tmp);
+    assert.equal(result, false);
+  });
+});
+
+describe("autoMarkInProgress", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "auto-mark-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("marks a pending task as in_progress", async () => {
+    const storePath = writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "pending", subject: "Test task" },
+    ]);
+    const result = await autoMarkInProgress("1", tmp);
+    assert.equal(result, true);
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "in_progress");
+  });
+
+  it("does not mark already in_progress task", async () => {
+    writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "in_progress", subject: "Test task" },
+    ]);
+    const result = await autoMarkInProgress("1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("does not mark completed task", async () => {
+    writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "completed", subject: "Test task" },
+    ]);
+    const result = await autoMarkInProgress("1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("returns false for empty taskId", async () => {
+    const result = await autoMarkInProgress("", tmp);
+    assert.equal(result, false);
+  });
+
+  it("returns false for taskId '-1'", async () => {
+    const result = await autoMarkInProgress("-1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("finds task in session-scoped store", async () => {
+    const storePath = writeTaskStore(tmp, "tasks-sess2.json", [
+      { id: "1", status: "pending", subject: "Session task" },
+    ]);
+    const result = await autoMarkInProgress("1", tmp, "sess2");
+    assert.equal(result, true);
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "in_progress");
+  });
+
+  it("returns false when no store files exist", async () => {
+    const result = await autoMarkInProgress("1", tmp);
+    assert.equal(result, false);
+  });
+});

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -332,31 +332,23 @@ describe("autoCompleteTask update-failure handling", () => {
   });
 
   afterEach(() => {
-    try {
-      const tasksDir = join(tmp, ".pi", "tasks");
-      chmodSync(tasksDir, 0o755);
-      for (const f of readdirSync(tasksDir)) {
-        try { chmodSync(join(tasksDir, f), 0o644); } catch {}
-      }
-    } catch {}
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("returns false when store directory is read-only", async () => {
-    const tasksDir = join(tmp, ".pi", "tasks");
-    mkdirSync(tasksDir, { recursive: true });
-    const storePath = join(tasksDir, "tasks.json");
-    writeFileSync(storePath, JSON.stringify({
-      tasks: [{ id: "1", status: "pending", subject: "Task" }],
-    }));
-    // TaskStore uses temp+rename; read-only file is bypassed. Block temp create via dir perms.
-    chmodSync(tasksDir, 0o555);
-    const result = await autoCompleteTask("1", tmp);
+  it("returns false when TaskStore.update throws", async () => {
+    const storePath = writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "pending", subject: "Task" },
+    ]);
+    // Inject a factory that returns a store where update() throws
+    const throwingFactory = (_path: string) => ({
+      get: (id: string) => ({ id, status: "pending", subject: "Task" }),
+      update: () => { throw new Error("disk write failed"); },
+    });
+    const result = await autoCompleteTask("1", tmp, undefined, throwingFactory);
     assert.equal(result, false);
-    // Verify file was NOT mutated
-    chmodSync(tasksDir, 0o755);
-    const content = JSON.parse(readFileSync(storePath, "utf-8"));
-    assert.equal(content.tasks[0].status, "pending");
+    // Verify actual file was NOT mutated
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "pending");
   });
 });
 
@@ -368,29 +360,21 @@ describe("autoMarkInProgress update-failure handling", () => {
   });
 
   afterEach(() => {
-    try {
-      const tasksDir = join(tmp, ".pi", "tasks");
-      chmodSync(tasksDir, 0o755);
-      for (const f of readdirSync(tasksDir)) {
-        try { chmodSync(join(tasksDir, f), 0o644); } catch {}
-      }
-    } catch {}
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("returns false when store directory is read-only", async () => {
-    const tasksDir = join(tmp, ".pi", "tasks");
-    mkdirSync(tasksDir, { recursive: true });
-    const storePath = join(tasksDir, "tasks.json");
-    writeFileSync(storePath, JSON.stringify({
-      tasks: [{ id: "1", status: "pending", subject: "Task" }],
-    }));
-    chmodSync(tasksDir, 0o555);
-    const result = await autoMarkInProgress("1", tmp);
+  it("returns false when TaskStore.update throws", async () => {
+    const storePath = writeTaskStore(tmp, "tasks.json", [
+      { id: "1", status: "pending", subject: "Task" },
+    ]);
+    const throwingFactory = (_path: string) => ({
+      get: (id: string) => ({ id, status: "pending", subject: "Task" }),
+      update: () => { throw new Error("disk write failed"); },
+    });
+    const result = await autoMarkInProgress("1", tmp, undefined, throwingFactory);
     assert.equal(result, false);
-    // Verify file was NOT mutated
-    chmodSync(tasksDir, 0o755);
-    const content = JSON.parse(readFileSync(storePath, "utf-8"));
-    assert.equal(content.tasks[0].status, "pending");
+    // Verify actual file was NOT mutated
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "pending");
   });
 });

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -342,16 +342,21 @@ describe("autoCompleteTask update-failure handling", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("handles read-only store directory gracefully", async () => {
+  it("returns false when store directory is read-only", async () => {
     const tasksDir = join(tmp, ".pi", "tasks");
     mkdirSync(tasksDir, { recursive: true });
-    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+    const storePath = join(tasksDir, "tasks.json");
+    writeFileSync(storePath, JSON.stringify({
       tasks: [{ id: "1", status: "pending", subject: "Task" }],
     }));
+    // TaskStore uses temp+rename; read-only file is bypassed. Block temp create via dir perms.
     chmodSync(tasksDir, 0o555);
     const result = await autoCompleteTask("1", tmp);
-    // Should not crash — returns boolean regardless of write failure
-    assert.equal(typeof result, "boolean");
+    assert.equal(result, false);
+    // Verify file was NOT mutated
+    chmodSync(tasksDir, 0o755);
+    const content = JSON.parse(readFileSync(storePath, "utf-8"));
+    assert.equal(content.tasks[0].status, "pending");
   });
 });
 
@@ -373,14 +378,19 @@ describe("autoMarkInProgress update-failure handling", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("handles read-only store directory gracefully", async () => {
+  it("returns false when store directory is read-only", async () => {
     const tasksDir = join(tmp, ".pi", "tasks");
     mkdirSync(tasksDir, { recursive: true });
-    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+    const storePath = join(tasksDir, "tasks.json");
+    writeFileSync(storePath, JSON.stringify({
       tasks: [{ id: "1", status: "pending", subject: "Task" }],
     }));
     chmodSync(tasksDir, 0o555);
     const result = await autoMarkInProgress("1", tmp);
-    assert.equal(typeof result, "boolean");
+    assert.equal(result, false);
+    // Verify file was NOT mutated
+    chmodSync(tasksDir, 0o755);
+    const content = JSON.parse(readFileSync(storePath, "utf-8"));
+    assert.equal(content.tasks[0].status, "pending");
   });
 });

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -335,7 +335,7 @@ describe("autoCompleteTask update-failure handling", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("returns false when TaskStore.update throws", async () => {
+  it("returns false when task completion cannot be persisted", async () => {
     const storePath = writeTaskStore(tmp, "tasks.json", [
       { id: "1", status: "pending", subject: "Task" },
     ]);
@@ -363,7 +363,7 @@ describe("autoMarkInProgress update-failure handling", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("returns false when TaskStore.update throws", async () => {
+  it("returns false when in-progress status cannot be persisted", async () => {
     const storePath = writeTaskStore(tmp, "tasks.json", [
       { id: "1", status: "pending", subject: "Task" },
     ]);

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, chmodSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
@@ -321,5 +321,66 @@ describe("autoMarkInProgress error handling", () => {
     // Global NOT mutated
     const globalTasks = readTaskStore(globalPath);
     assert.equal(globalTasks[0].status, "pending");
+  });
+});
+
+describe("autoCompleteTask update-failure handling", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "update-fail-"));
+  });
+
+  afterEach(() => {
+    try {
+      const tasksDir = join(tmp, ".pi", "tasks");
+      chmodSync(tasksDir, 0o755);
+      for (const f of readdirSync(tasksDir)) {
+        try { chmodSync(join(tasksDir, f), 0o644); } catch {}
+      }
+    } catch {}
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("handles read-only store directory gracefully", async () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [{ id: "1", status: "pending", subject: "Task" }],
+    }));
+    chmodSync(tasksDir, 0o555);
+    const result = await autoCompleteTask("1", tmp);
+    // Should not crash — returns boolean regardless of write failure
+    assert.equal(typeof result, "boolean");
+  });
+});
+
+describe("autoMarkInProgress update-failure handling", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "update-fail-"));
+  });
+
+  afterEach(() => {
+    try {
+      const tasksDir = join(tmp, ".pi", "tasks");
+      chmodSync(tasksDir, 0o755);
+      for (const f of readdirSync(tasksDir)) {
+        try { chmodSync(join(tasksDir, f), 0o644); } catch {}
+      }
+    } catch {}
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("handles read-only store directory gracefully", async () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [{ id: "1", status: "pending", subject: "Task" }],
+    }));
+    chmodSync(tasksDir, 0o555);
+    const result = await autoMarkInProgress("1", tmp);
+    assert.equal(typeof result, "boolean");
   });
 });

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -172,3 +172,57 @@ describe("autoMarkInProgress", () => {
     assert.equal(result, false);
   });
 });
+
+describe("autoCompleteTask call-site guard (subagent-tool pattern)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "call-site-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  async function simulateSubagentCompletion(chainTaskId: string | undefined, cwd: string): Promise<boolean> {
+    // Replicate the guard from subagent-tool.ts[870-873]
+    if (chainTaskId && chainTaskId !== "-1") {
+      return autoCompleteTask(chainTaskId, cwd).catch(() => false);
+    }
+    return false;
+  }
+
+  it("completes task when chainTaskId is valid", async () => {
+    const storePath = writeTaskStore(tmp, "tasks.json", [
+      { id: "5", status: "in_progress", subject: "Linked task" },
+    ]);
+    const result = await simulateSubagentCompletion("5", tmp);
+    assert.equal(result, true);
+    const tasks = readTaskStore(storePath);
+    assert.equal(tasks[0].status, "completed");
+  });
+
+  it("skips when chainTaskId is undefined", async () => {
+    writeTaskStore(tmp, "tasks.json", [
+      { id: "5", status: "in_progress", subject: "Linked task" },
+    ]);
+    const result = await simulateSubagentCompletion(undefined, tmp);
+    assert.equal(result, false);
+  });
+
+  it("skips when chainTaskId is '-1'", async () => {
+    writeTaskStore(tmp, "tasks.json", [
+      { id: "5", status: "in_progress", subject: "Linked task" },
+    ]);
+    const result = await simulateSubagentCompletion("-1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("skips when chainTaskId is empty string", async () => {
+    writeTaskStore(tmp, "tasks.json", [
+      { id: "5", status: "in_progress", subject: "Linked task" },
+    ]);
+    const result = await simulateSubagentCompletion("", tmp);
+    assert.equal(result, false);
+  });
+});

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -226,3 +226,100 @@ describe("autoCompleteTask call-site guard (subagent-tool pattern)", () => {
     assert.equal(result, false);
   });
 });
+
+describe("autoCompleteTask error handling", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "lifecycle-err-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("skips malformed store and returns false", async () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks.json"), "not valid json at all");
+    const result = await autoCompleteTask("1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("does not fall through to global when session store has the task (already completed)", async () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    // Session store: task exists but already completed
+    writeFileSync(join(tasksDir, "tasks-s1.json"), JSON.stringify({
+      tasks: [{ id: "1", status: "completed", subject: "Done" }],
+    }));
+    // Global store: same ID, pending — should NOT be touched
+    const globalPath = join(tasksDir, "tasks.json");
+    writeFileSync(globalPath, JSON.stringify({
+      tasks: [{ id: "1", status: "pending", subject: "Global task" }],
+    }));
+    const result = await autoCompleteTask("1", tmp, "s1");
+    assert.equal(result, false);
+    // Verify global store was NOT mutated
+    const globalTasks = readTaskStore(globalPath);
+    assert.equal(globalTasks[0].status, "pending");
+  });
+});
+
+describe("autoMarkInProgress error handling", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "lifecycle-err-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("skips malformed store and returns false", async () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks.json"), "not valid json at all");
+    const result = await autoMarkInProgress("1", tmp);
+    assert.equal(result, false);
+  });
+
+  it("does not fall through to global when session store has the task (already in_progress)", async () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    // Session store: task exists but already in_progress
+    writeFileSync(join(tasksDir, "tasks-s2.json"), JSON.stringify({
+      tasks: [{ id: "1", status: "in_progress", subject: "Running" }],
+    }));
+    // Global store: same ID, pending — should NOT be touched
+    const globalPath = join(tasksDir, "tasks.json");
+    writeFileSync(globalPath, JSON.stringify({
+      tasks: [{ id: "1", status: "pending", subject: "Global task" }],
+    }));
+    const result = await autoMarkInProgress("1", tmp, "s2");
+    assert.equal(result, false);
+    // Verify global store was NOT mutated
+    const globalTasks = readTaskStore(globalPath);
+    assert.equal(globalTasks[0].status, "pending");
+  });
+
+  it("does not fall through to global when session store has completed task", async () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    // Session store: task completed
+    writeFileSync(join(tasksDir, "tasks-s3.json"), JSON.stringify({
+      tasks: [{ id: "1", status: "completed", subject: "Done" }],
+    }));
+    // Global store: same ID, pending
+    const globalPath = join(tasksDir, "tasks.json");
+    writeFileSync(globalPath, JSON.stringify({
+      tasks: [{ id: "1", status: "pending", subject: "Global pending" }],
+    }));
+    const result = await autoMarkInProgress("1", tmp, "s3");
+    assert.equal(result, false);
+    // Global NOT mutated
+    const globalTasks = readTaskStore(globalPath);
+    assert.equal(globalTasks[0].status, "pending");
+  });
+});

--- a/tests/node/orchestrator/auto-task-lifecycle.test.ts
+++ b/tests/node/orchestrator/auto-task-lifecycle.test.ts
@@ -238,7 +238,7 @@ describe("autoCompleteTask error handling", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("skips malformed store and returns false", async () => {
+  it("returns false for malformed store", async () => {
     const tasksDir = join(tmp, ".pi", "tasks");
     mkdirSync(tasksDir, { recursive: true });
     writeFileSync(join(tasksDir, "tasks.json"), "not valid json at all");
@@ -277,7 +277,7 @@ describe("autoMarkInProgress error handling", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it("skips malformed store and returns false", async () => {
+  it("returns false for malformed store", async () => {
     const tasksDir = join(tmp, ".pi", "tasks");
     mkdirSync(tasksDir, { recursive: true });
     writeFileSync(join(tasksDir, "tasks.json"), "not valid json at all");

--- a/tests/node/orchestrator/extended-autocomplete-issues.test.ts
+++ b/tests/node/orchestrator/extended-autocomplete-issues.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for fetchOpenIssues autocomplete in extended-autocomplete.ts.
+ * Run with: npx tsx --test tests/node/orchestrator/extended-autocomplete-issues.test.ts
+ */
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Since fetchOpenIssues is internal to registerExtendedAutocomplete,
+// we test the same logic pattern standalone.
+
+interface AutocompleteItem {
+  value: string;
+  label: string;
+  description: string;
+}
+
+interface IssueCache {
+  data: AutocompleteItem[] | null;
+  timestamp: number;
+  loading: boolean;
+}
+
+function isFresh(cache: IssueCache, ttlMs = 30_000): boolean {
+  return cache.data !== null && Date.now() - cache.timestamp < ttlMs;
+}
+
+async function fetchOpenIssues(
+  cache: IssueCache,
+  execFn: (cmd: string, args: string[], opts: any) => Promise<{ code: number; stdout: string }>,
+  cwd: string,
+): Promise<void> {
+  if (isFresh(cache) || cache.loading) return;
+  cache.loading = true;
+  try {
+    const result = await execFn(
+      "gh", ["issue", "list", "--state", "open", "--limit", "50", "--json", "number,title"],
+      { cwd, timeout: 10_000 },
+    );
+    if (result.code === 0) {
+      const issues = JSON.parse(result.stdout) as Array<{ number: number; title: string }>;
+      cache.data = issues.map((issue) => ({
+        value: String(issue.number),
+        label: `#${issue.number}`,
+        description: issue.title,
+      }));
+      cache.timestamp = Date.now();
+    }
+  } catch { /* ignore */ }
+  cache.loading = false;
+}
+
+describe("fetchOpenIssues", () => {
+  let cache: IssueCache;
+
+  beforeEach(() => {
+    cache = { data: null, timestamp: 0, loading: false };
+  });
+
+  it("populates cache from gh issue list output", async () => {
+    const mockExec = async () => ({
+      code: 0,
+      stdout: JSON.stringify([
+        { number: 42, title: "Fix the bug" },
+        { number: 99, title: "Add feature" },
+      ]),
+    });
+
+    await fetchOpenIssues(cache, mockExec, "/tmp");
+
+    assert.equal(cache.data?.length, 2);
+    assert.equal(cache.data![0].value, "42");
+    assert.equal(cache.data![0].label, "#42");
+    assert.equal(cache.data![0].description, "Fix the bug");
+    assert.equal(cache.data![1].value, "99");
+    assert.ok(cache.timestamp > 0);
+    assert.equal(cache.loading, false);
+  });
+
+  it("skips fetch when cache is fresh", async () => {
+    let callCount = 0;
+    const mockExec = async () => {
+      callCount++;
+      return { code: 0, stdout: "[]" };
+    };
+
+    await fetchOpenIssues(cache, mockExec, "/tmp");
+    assert.equal(callCount, 1);
+
+    // Second call — cache is fresh
+    await fetchOpenIssues(cache, mockExec, "/tmp");
+    assert.equal(callCount, 1); // not called again
+  });
+
+  it("skips fetch when already loading", async () => {
+    cache.loading = true;
+    let callCount = 0;
+    const mockExec = async () => {
+      callCount++;
+      return { code: 0, stdout: "[]" };
+    };
+
+    await fetchOpenIssues(cache, mockExec, "/tmp");
+    assert.equal(callCount, 0);
+  });
+
+  it("handles non-zero exit code gracefully", async () => {
+    const mockExec = async () => ({ code: 1, stdout: "" });
+
+    await fetchOpenIssues(cache, mockExec, "/tmp");
+
+    assert.equal(cache.data, null);
+    assert.equal(cache.loading, false);
+  });
+
+  it("handles exec exception gracefully", async () => {
+    const mockExec = async () => { throw new Error("network error"); };
+
+    await fetchOpenIssues(cache, mockExec, "/tmp");
+
+    assert.equal(cache.data, null);
+    assert.equal(cache.loading, false);
+  });
+
+  it("handles empty issue list", async () => {
+    const mockExec = async () => ({ code: 0, stdout: "[]" });
+
+    await fetchOpenIssues(cache, mockExec, "/tmp");
+
+    assert.deepEqual(cache.data, []);
+    assert.ok(cache.timestamp > 0);
+  });
+
+  it("passes correct args to gh", async () => {
+    let capturedArgs: string[] = [];
+    let capturedOpts: any = {};
+    const mockExec = async (_cmd: string, args: string[], opts: any) => {
+      capturedArgs = args;
+      capturedOpts = opts;
+      return { code: 0, stdout: "[]" };
+    };
+
+    await fetchOpenIssues(cache, mockExec, "/my/project");
+
+    assert.deepEqual(capturedArgs, ["issue", "list", "--state", "open", "--limit", "50", "--json", "number,title"]);
+    assert.equal(capturedOpts.cwd, "/my/project");
+    assert.equal(capturedOpts.timeout, 10_000);
+  });
+});

--- a/tests/node/orchestrator/rpc-bridge.test.ts
+++ b/tests/node/orchestrator/rpc-bridge.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Tests for the subagents:rpc:* bridge pattern in async-agents.ts.
+ * Tests the handleRpc request/reply contract without importing internal functions.
+ * Run with: npx tsx --test tests/node/orchestrator/rpc-bridge.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+
+// Replicate the handleRpc pattern from async-agents.ts for testing
+function handleRpc<P extends { requestId: string }>(
+  events: EventEmitter,
+  channel: string,
+  fn: (params: P) => unknown | Promise<unknown>,
+): () => void {
+  const handler = async (raw: unknown) => {
+    const params = raw as P;
+    try {
+      const data = await fn(params);
+      const reply: { success: true; data?: unknown } = { success: true };
+      if (data !== undefined) reply.data = data;
+      events.emit(`${channel}:reply:${params.requestId}`, reply);
+    } catch (err: any) {
+      events.emit(`${channel}:reply:${params.requestId}`, {
+        success: false, error: err?.message ?? String(err),
+      });
+    }
+  };
+  events.on(channel, handler);
+  return () => { events.off(channel, handler); };
+}
+
+describe("handleRpc pattern", () => {
+  it("replies with success on the scoped channel", async () => {
+    const events = new EventEmitter();
+    handleRpc<{ requestId: string }>(events, "test:rpc", () => ({ version: 2 }));
+
+    const replyPromise = new Promise<any>((resolve) => {
+      events.once("test:rpc:reply:req-1", resolve);
+    });
+    events.emit("test:rpc", { requestId: "req-1" });
+
+    const reply = await replyPromise;
+    assert.equal(reply.success, true);
+    assert.deepEqual(reply.data, { version: 2 });
+  });
+
+  it("replies with error when handler throws", async () => {
+    const events = new EventEmitter();
+    handleRpc<{ requestId: string }>(events, "test:rpc:fail", () => {
+      throw new Error("something broke");
+    });
+
+    const replyPromise = new Promise<any>((resolve) => {
+      events.once("test:rpc:fail:reply:req-2", resolve);
+    });
+    events.emit("test:rpc:fail", { requestId: "req-2" });
+
+    const reply = await replyPromise;
+    assert.equal(reply.success, false);
+    assert.equal(reply.error, "something broke");
+  });
+
+  it("omits data key when handler returns undefined", async () => {
+    const events = new EventEmitter();
+    handleRpc<{ requestId: string }>(events, "test:rpc:void", () => undefined);
+
+    const replyPromise = new Promise<any>((resolve) => {
+      events.once("test:rpc:void:reply:req-3", resolve);
+    });
+    events.emit("test:rpc:void", { requestId: "req-3" });
+
+    const reply = await replyPromise;
+    assert.equal(reply.success, true);
+    assert.equal("data" in reply, false);
+  });
+
+  it("handles async handler functions", async () => {
+    const events = new EventEmitter();
+    handleRpc<{ requestId: string }>(events, "test:rpc:async", async () => {
+      return new Promise((resolve) => setTimeout(() => resolve({ result: "ok" }), 10));
+    });
+
+    const replyPromise = new Promise<any>((resolve) => {
+      events.once("test:rpc:async:reply:req-4", resolve);
+    });
+    events.emit("test:rpc:async", { requestId: "req-4" });
+
+    const reply = await replyPromise;
+    assert.equal(reply.success, true);
+    assert.deepEqual(reply.data, { result: "ok" });
+  });
+
+  it("routes replies to correct requestId", async () => {
+    const events = new EventEmitter();
+    let callCount = 0;
+    handleRpc<{ requestId: string; value: number }>(events, "test:rpc:multi", (params) => {
+      callCount++;
+      return { doubled: params.value * 2 };
+    });
+
+    const reply1Promise = new Promise<any>((resolve) => {
+      events.once("test:rpc:multi:reply:a", resolve);
+    });
+    const reply2Promise = new Promise<any>((resolve) => {
+      events.once("test:rpc:multi:reply:b", resolve);
+    });
+
+    events.emit("test:rpc:multi", { requestId: "a", value: 5 });
+    events.emit("test:rpc:multi", { requestId: "b", value: 10 });
+
+    const [reply1, reply2] = await Promise.all([reply1Promise, reply2Promise]);
+    assert.deepEqual(reply1.data, { doubled: 10 });
+    assert.deepEqual(reply2.data, { doubled: 20 });
+    assert.equal(callCount, 2);
+  });
+
+  it("cleanup function removes the handler", async () => {
+    const events = new EventEmitter();
+    let callCount = 0;
+    const cleanup = handleRpc<{ requestId: string }>(events, "test:rpc:clean", () => {
+      callCount++;
+      return "ok";
+    });
+
+    // First call works
+    const reply1 = new Promise<any>((resolve) => events.once("test:rpc:clean:reply:r1", resolve));
+    events.emit("test:rpc:clean", { requestId: "r1" });
+    await reply1;
+    assert.equal(callCount, 1);
+
+    // After cleanup, no more handling
+    cleanup();
+    let gotReply = false;
+    events.once("test:rpc:clean:reply:r2", () => { gotReply = true; });
+    events.emit("test:rpc:clean", { requestId: "r2" });
+    // Give it a tick
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.equal(gotReply, false);
+    assert.equal(callCount, 1);
+  });
+});

--- a/tests/node/orchestrator/task-focus-enforcement.test.ts
+++ b/tests/node/orchestrator/task-focus-enforcement.test.ts
@@ -23,7 +23,7 @@ describe("task-focus enforcement: store scanning", () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  /** Replicate the core store-scanning logic from rules.ts */
+  /** Replicate the core store-scanning logic from rules.ts (session-first fallback) */
   function scanTaskStores(cwd: string, sessionId?: string): Array<{ id: string; status: string; subject: string }> {
     const fs = require("node:fs");
     const path = require("node:path");
@@ -32,18 +32,16 @@ describe("task-focus enforcement: store scanning", () => {
     if (sessionId) taskCandidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
     taskCandidates.push(path.join(tasksDir, "tasks.json"));
 
-    const seenIds = new Set<string>();
-    const allActiveTasks: Array<{ id: string; status: string; subject: string }> = [];
+    let allActiveTasks: Array<{ id: string; status: string; subject: string }> = [];
     for (const taskFile of taskCandidates) {
       try {
         if (!fs.existsSync(taskFile)) continue;
         const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
         const tasks = data.tasks || [];
-        for (const t of tasks) {
-          if ((t.status === "in_progress" || t.status === "pending") && !seenIds.has(String(t.id))) {
-            seenIds.add(String(t.id));
-            allActiveTasks.push(t);
-          }
+        const active = tasks.filter((t: any) => t.status === "in_progress" || t.status === "pending");
+        if (active.length > 0) {
+          allActiveTasks = active;
+          break; // Use the first store that has active tasks
         }
       } catch { continue; }
     }
@@ -107,10 +105,10 @@ describe("task-focus enforcement: store scanning", () => {
     assert.equal(result[0].subject, "Pending in fallback");
   });
 
-  it("deduplicates tasks by id across stores", () => {
+  it("session store wins when it has active tasks (ignores fallback)", () => {
     const tasksDir = join(tmp, ".pi", "tasks");
     mkdirSync(tasksDir, { recursive: true });
-    // Same task id in both files
+    // Same task id in both files — session wins, fallback not merged
     writeFileSync(join(tasksDir, "tasks-sess1.json"), JSON.stringify({
       tasks: [
         { id: "1", status: "in_progress", subject: "Task from session" },
@@ -124,12 +122,9 @@ describe("task-focus enforcement: store scanning", () => {
     }));
 
     const result = scanTaskStores(tmp, "sess1");
-    assert.equal(result.length, 2);
-    // id=1 should come from session (first seen)
+    assert.equal(result.length, 1);
     assert.equal(result[0].id, "1");
     assert.equal(result[0].subject, "Task from session");
-    // id=2 from fallback
-    assert.equal(result[1].id, "2");
   });
 
   it("skips malformed JSON files gracefully", () => {
@@ -147,7 +142,7 @@ describe("task-focus enforcement: store scanning", () => {
     assert.equal(result[0].id, "1");
   });
 
-  it("accumulates active tasks from both stores", () => {
+  it("prefers session store over global when session has active tasks", () => {
     const tasksDir = join(tmp, ".pi", "tasks");
     mkdirSync(tasksDir, { recursive: true });
     writeFileSync(join(tasksDir, "tasks-multi.json"), JSON.stringify({
@@ -162,8 +157,9 @@ describe("task-focus enforcement: store scanning", () => {
     }));
 
     const result = scanTaskStores(tmp, "multi");
-    assert.equal(result.length, 2);
+    // Session-first: only session tasks — no global leak
+    assert.equal(result.length, 1);
     assert.equal(result[0].id, "1");
-    assert.equal(result[1].id, "2");
+    assert.equal(result[0].subject, "Session task");
   });
 });

--- a/tests/node/orchestrator/task-focus-enforcement.test.ts
+++ b/tests/node/orchestrator/task-focus-enforcement.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for task-focus enforcement in rules.ts.
+ * Run with: npx tsx --test tests/node/orchestrator/task-focus-enforcement.test.ts
+ */
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// We can't easily test registerRules directly due to its complex pi dependency.
+// Instead, test the core logic: reading task stores and accumulating active tasks.
+// Extract the logic pattern and test it standalone.
+
+describe("task-focus enforcement: store scanning", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "task-focus-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  /** Replicate the core store-scanning logic from rules.ts */
+  function scanTaskStores(cwd: string, sessionId?: string): Array<{ id: string; status: string; subject: string }> {
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const tasksDir = path.join(cwd, ".pi", "tasks");
+    const taskCandidates: string[] = [];
+    if (sessionId) taskCandidates.push(path.join(tasksDir, `tasks-${sessionId}.json`));
+    taskCandidates.push(path.join(tasksDir, "tasks.json"));
+
+    const seenIds = new Set<string>();
+    const allActiveTasks: Array<{ id: string; status: string; subject: string }> = [];
+    for (const taskFile of taskCandidates) {
+      try {
+        if (!fs.existsSync(taskFile)) continue;
+        const data = JSON.parse(fs.readFileSync(taskFile, "utf-8"));
+        const tasks = data.tasks || [];
+        for (const t of tasks) {
+          if ((t.status === "in_progress" || t.status === "pending") && !seenIds.has(String(t.id))) {
+            seenIds.add(String(t.id));
+            allActiveTasks.push(t);
+          }
+        }
+      } catch { continue; }
+    }
+    return allActiveTasks;
+  }
+
+  it("finds active tasks in tasks.json", () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [
+        { id: "1", status: "in_progress", subject: "Fix bug" },
+        { id: "2", status: "completed", subject: "Done task" },
+        { id: "3", status: "pending", subject: "Next task" },
+      ],
+    }));
+
+    const result = scanTaskStores(tmp);
+    assert.equal(result.length, 2);
+    assert.equal(result[0].id, "1");
+    assert.equal(result[1].id, "3");
+  });
+
+  it("returns empty when no active tasks exist", () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [
+        { id: "1", status: "completed", subject: "Done" },
+      ],
+    }));
+
+    const result = scanTaskStores(tmp);
+    assert.equal(result.length, 0);
+  });
+
+  it("returns empty when no task files exist", () => {
+    const result = scanTaskStores(tmp);
+    assert.equal(result.length, 0);
+  });
+
+  it("scans fallback tasks.json when session file has no active tasks", () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    // Session-scoped file: exists but no active tasks
+    writeFileSync(join(tasksDir, "tasks-session123.json"), JSON.stringify({
+      tasks: [
+        { id: "1", status: "completed", subject: "Done in session" },
+      ],
+    }));
+    // Fallback file: has active tasks
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [
+        { id: "2", status: "pending", subject: "Pending in fallback" },
+      ],
+    }));
+
+    const result = scanTaskStores(tmp, "session123");
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "2");
+    assert.equal(result[0].subject, "Pending in fallback");
+  });
+
+  it("deduplicates tasks by id across stores", () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    // Same task id in both files
+    writeFileSync(join(tasksDir, "tasks-sess1.json"), JSON.stringify({
+      tasks: [
+        { id: "1", status: "in_progress", subject: "Task from session" },
+      ],
+    }));
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [
+        { id: "1", status: "pending", subject: "Task from fallback" },
+        { id: "2", status: "pending", subject: "Another task" },
+      ],
+    }));
+
+    const result = scanTaskStores(tmp, "sess1");
+    assert.equal(result.length, 2);
+    // id=1 should come from session (first seen)
+    assert.equal(result[0].id, "1");
+    assert.equal(result[0].subject, "Task from session");
+    // id=2 from fallback
+    assert.equal(result[1].id, "2");
+  });
+
+  it("skips malformed JSON files gracefully", () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks-bad.json"), "not valid json");
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [
+        { id: "1", status: "pending", subject: "Still found" },
+      ],
+    }));
+
+    const result = scanTaskStores(tmp, "bad");
+    assert.equal(result.length, 1);
+    assert.equal(result[0].id, "1");
+  });
+
+  it("accumulates active tasks from both stores", () => {
+    const tasksDir = join(tmp, ".pi", "tasks");
+    mkdirSync(tasksDir, { recursive: true });
+    writeFileSync(join(tasksDir, "tasks-multi.json"), JSON.stringify({
+      tasks: [
+        { id: "1", status: "in_progress", subject: "Session task" },
+      ],
+    }));
+    writeFileSync(join(tasksDir, "tasks.json"), JSON.stringify({
+      tasks: [
+        { id: "2", status: "pending", subject: "Global task" },
+      ],
+    }));
+
+    const result = scanTaskStores(tmp, "multi");
+    assert.equal(result.length, 2);
+    assert.equal(result[0].id, "1");
+    assert.equal(result[1].id, "2");
+  });
+});

--- a/tests/node/shared/build-system-prompt.test.ts
+++ b/tests/node/shared/build-system-prompt.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Tests for buildExternalSystemPrompt.
+ * Run with: npx tsx --test tests/node/shared/build-system-prompt.test.ts
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildExternalSystemPrompt } from "../../../extensions/shared/build-system-prompt.js";
+
+describe("buildExternalSystemPrompt", () => {
+  it("returns undefined when no systemPrompt", () => {
+    assert.equal(buildExternalSystemPrompt({}), undefined);
+    assert.equal(buildExternalSystemPrompt({ systemPrompt: undefined }), undefined);
+  });
+
+  it("wraps systemPrompt with pi header", () => {
+    const result = buildExternalSystemPrompt({ systemPrompt: "Do stuff" });
+    assert.ok(result);
+    assert.ok(result.includes("You are being used as a backend LLM through pi coding agent"));
+    assert.ok(result.includes("Do stuff"));
+  });
+
+  it("includes systemPrompt content verbatim", () => {
+    const prompt = "Rule 1: never delete files\nRule 2: always test";
+    const result = buildExternalSystemPrompt({ systemPrompt: prompt });
+    assert.ok(result);
+    assert.ok(result.includes("Rule 1: never delete files"));
+    assert.ok(result.includes("Rule 2: always test"));
+  });
+
+  it("works without cwd (no enforcement injection)", () => {
+    const result = buildExternalSystemPrompt({ systemPrompt: "Hello" });
+    assert.ok(result);
+    assert.ok(!result.includes("Enforced Rules"));
+  });
+
+  it("works with cwd that has no enforced entries", () => {
+    // Use /tmp which has no .pi/memory directory
+    const result = buildExternalSystemPrompt({ systemPrompt: "Hello" }, "/tmp");
+    assert.ok(result);
+    // Should not crash, should not include enforced rules section
+    assert.ok(!result.includes("Enforced Rules"));
+  });
+});

--- a/tests/node/shared/build-system-prompt.test.ts
+++ b/tests/node/shared/build-system-prompt.test.ts
@@ -4,6 +4,9 @@
  */
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { buildExternalSystemPrompt } from "../../../extensions/shared/build-system-prompt.js";
 
 describe("buildExternalSystemPrompt", () => {
@@ -34,10 +37,15 @@ describe("buildExternalSystemPrompt", () => {
   });
 
   it("works with cwd that has no enforced entries", () => {
-    // Use /tmp which has no .pi/memory directory
-    const result = buildExternalSystemPrompt({ systemPrompt: "Hello" }, "/tmp");
-    assert.ok(result);
-    // Should not crash, should not include enforced rules section
-    assert.ok(!result.includes("Enforced Rules"));
+    // Use a temp dir guaranteed to have no .pi/memory
+    const tmpDir = mkdtempSync(join(tmpdir(), "build-prompt-test-"));
+    try {
+      const result = buildExternalSystemPrompt({ systemPrompt: "Hello" }, tmpDir);
+      assert.ok(result);
+      // Should not crash, should not include enforced rules section
+      assert.ok(!result.includes("Enforced Rules"));
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
Closes #687

## New command: /issue-review

Reviews a GitHub issue's spec quality and edits the issue body to fix problems.

### Components

- **3 new reviewer agents:**
  - `issue-reviewer-spec` — spec completeness, Done checklist, acceptance criteria, labels
  - `issue-reviewer-feasibility` — codebase feasibility, file/function reference verification
  - `issue-reviewer-scope` — scope hygiene, single concern, duplicate detection

- **Prompt template** (`prompts/issue-review.md`) — full workflow with 10 tasks:
  issue detection → context gathering → duplicate scan → 3 async reviewers →
  merge findings → user selection → edit issue body → summary

- **Autocomplete** — completes with open issue numbers via `gh issue list`

- **Routing + bug reporting** — agents added to `rules/10-agent-routing.md` and `rules/50-agent-bug-reporting.md`

### Usage

- `/issue-review` — auto-detect from current branch
- `/issue-review 42` — review issue #42
- `/issue-review https://github.com/owner/repo/issues/42` — from URL

Made with [Cursor](https://cursor.com)