### PR TITLE
fix(release): detect version files in npm workspace packages

### DIFF
--- a/myk_pi_tools/release/detect_versions.py
+++ b/myk_pi_tools/release/detect_versions.py
@@ -8,6 +8,7 @@ their current version strings.
 from __future__ import annotations
 
 import configparser
+import glob
 import json
 import os
 import re
@@ -200,6 +201,33 @@ def detect_version_files(root: Path | None = None) -> list[VersionFile]:
             version = parser(filepath)
             if version:
                 results.append(VersionFile(path=filename, current_version=version, file_type=file_type))
+
+    # Scan npm workspace packages for version files
+    root_pkg_json = root / "package.json"
+    if root_pkg_json.is_file():
+        try:
+            root_pkg_data = json.loads(root_pkg_json.read_text(encoding="utf-8"))
+            workspaces = root_pkg_data.get("workspaces", [])
+            if isinstance(workspaces, list):
+                for workspace_pattern in workspaces:
+                    for workspace_dir in sorted(glob.glob(str(root / workspace_pattern))):
+                        ws_path = Path(workspace_dir)
+                        if not ws_path.is_dir():
+                            continue
+                        for filename, parser, file_type in _ROOT_SCANNERS:
+                            filepath = ws_path / filename
+                            if filepath.is_file():
+                                version = parser(filepath)
+                                if version:
+                                    results.append(
+                                        VersionFile(
+                                            path=filepath.relative_to(root).as_posix(),
+                                            current_version=version,
+                                            file_type=file_type,
+                                        )
+                                    )
+        except (OSError, json.JSONDecodeError):
+            pass
 
     results.extend(_find_python_version_files(root))
 

--- a/packages/pi-sidecar/package.json
+++ b/packages/pi-sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myk-org/pi-sidecar",
-  "version": "1.5.0",
+  "version": "4.1.0",
   "description": "Standalone HTTP sidecar wrapping the Pi coding agent SDK",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pi-sidecar/pyproject.toml
+++ b/packages/pi-sidecar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pi-sidecar-client"
-version = "1.5.0"
+version = "4.1.0"
 description = "Python client for the Pi SDK sidecar service"
 license = "Apache-2.0"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

`myk-pi-tools release detect-versions` now scans npm workspace package directories for version files (package.json, pyproject.toml, etc.), not just the repo root.

## Changes

- `detect_versions.py`: After root-level scanning, reads `workspaces` from root `package.json` and scans each workspace directory
- Bumps `packages/pi-sidecar/` version from 1.5.0 → 4.1.0 (aligns with pi-config single-version policy)

## Before/After

Before: 3 files detected (root only)
After: 5 files detected (root + `packages/pi-sidecar/`)

Made with [Cursor](https://cursor.com)