### PR TITLE
fix(sidecar): update repository URLs to point to pi-config monorepo

### DIFF
--- a/packages/pi-sidecar/README.md
+++ b/packages/pi-sidecar/README.md
@@ -5,7 +5,7 @@ A standalone HTTP service that wraps the
 (requires `@earendil-works/pi-coding-agent` ≥ 0.81.1), exposing AI sessions over a
 simple JSON API. Ships with a Python client for easy integration.
 
-📖 **[Full Documentation](https://myk-org.github.io/pi-sidecar/)**
+📖 **[Full Documentation](https://myk-org.github.io/pi-config/)**
 
 ## Features
 
@@ -51,7 +51,7 @@ npm run build && node dist/server.js  # listens on 127.0.0.1:9100
 scripts/start-sidecar.sh
 ```
 
-See the [full documentation](https://myk-org.github.io/pi-sidecar/) for everything else.
+See the [full documentation](https://myk-org.github.io/pi-config/) for everything else.
 
 ## License
 

--- a/packages/pi-sidecar/package.json
+++ b/packages/pi-sidecar/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/myk-org/pi-sidecar"
+    "url": "https://github.com/myk-org/pi-config"
   },
   "keywords": [
     "pi",

--- a/packages/pi-sidecar/pyproject.toml
+++ b/packages/pi-sidecar/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.10"
 dependencies = ["httpx>=0.27", "python-simple-logger"]
 
 [project.urls]
-Repository = "https://github.com/myk-org/pi-sidecar"
+Repository = "https://github.com/myk-org/pi-config"
 
 [tool.setuptools.packages.find]
 include = ["pi_sidecar_client*"]


### PR DESCRIPTION
## Summary

Update all pi-sidecar package metadata and documentation URLs from the old standalone repo to the pi-config monorepo.

## Changes

- `packages/pi-sidecar/pyproject.toml` — Repository URL → `github.com/myk-org/pi-config`
- `packages/pi-sidecar/package.json` — repository.url → `github.com/myk-org/pi-config`
- `packages/pi-sidecar/README.md` — Documentation links → `myk-org.github.io/pi-config/`

Made with [Cursor](https://cursor.com)