### PR TITLE
chore: bump version to 4.1.2

### DIFF
--- a/myk_pi_tools/__init__.py
+++ b/myk_pi_tools/__init__.py
@@ -1,3 +1,3 @@
 """myk-pi-tools: CLI utilities for pi orchestrator plugins."""
 
-__version__ = "4.1.1"
+__version__ = "4.1.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-orchestrator-config",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Orchestrator pattern for pi: specialist subagents, enforcement, code review loop, workflow commands",
   "keywords": [
     "pi-package"

--- a/packages/pi-sidecar/package.json
+++ b/packages/pi-sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myk-org/pi-sidecar",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Standalone HTTP sidecar wrapping the Pi coding agent SDK",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/pi-sidecar/pyproject.toml
+++ b/packages/pi-sidecar/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pi-sidecar-client"
-version = "4.1.1"
+version = "4.1.2"
 description = "Python client for the Pi SDK sidecar service"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myk-pi-tools"
-version = "4.1.1"
+version = "4.1.2"
 description = "CLI utilities for pi orchestrator plugins"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -137,7 +137,7 @@ wheels = [
 
 [[package]]
 name = "myk-pi-tools"
-version = "4.1.1"
+version = "4.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-cli-runner" },


### PR DESCRIPTION
## Summary
Bump package versions to 4.1.2 across pi-config and pi-sidecar (npm + PyPI).

## Test plan
- [x] Version bump only (package.json, pyproject.toml, uv.lock)

Made with [Cursor](https://cursor.com)