### PR TITLE
feat(sidecar): add bin commands for pi-sidecar and pi-sidecar-start

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,8 @@ pi-sidecar lives under `packages/pi-sidecar/` as an npm workspace package. It is
 - Shared types or re-exports: check `packages/pi-sidecar/src/sessions.ts` imports
 - Before release: run live sidecar smoke test (see `.pi/skills/sidecar-test/`)
 
+**CLI commands:** `npx pi-sidecar` (start server), `npx pi-sidecar-start` (background start/stop).
+
 **Public API contract:** The HTTP REST API (`/health`, `/models`, `/sessions`) and the Python client (`pi_sidecar_client`) are the external contract — never break these.
 Internal code, imports, and structure can change freely.
 

--- a/README.md
+++ b/README.md
@@ -799,6 +799,8 @@ A standalone HTTP sidecar wrapping the Pi SDK, living under `packages/pi-sidecar
 | `@myk-org/pi-sidecar` | TypeScript | npm |
 | `pi-sidecar-client` | Python | PyPI |
 
+CLI commands: `npx pi-sidecar` (start server), `npx pi-sidecar-start` (background start/stop).
+
 See [`packages/pi-sidecar/README.md`](packages/pi-sidecar/README.md) for full documentation.
 
 ## License

--- a/packages/pi-sidecar/README.md
+++ b/packages/pi-sidecar/README.md
@@ -53,6 +53,20 @@ scripts/start-sidecar.sh
 
 See the [full documentation](https://myk-org.github.io/pi-config/) for everything else.
 
+## CLI Commands
+
+After installing `@myk-org/pi-sidecar`, two CLI commands are available:
+
+```bash
+# Start the sidecar server (Node.js entry point)
+npx pi-sidecar
+
+# Start/stop via shell script (background mode, dev defaults on port 9201)
+npx pi-sidecar-start
+npx pi-sidecar-start --stop
+npx pi-sidecar-start --help
+```
+
 ## License
 
 Apache-2.0

--- a/packages/pi-sidecar/package.json
+++ b/packages/pi-sidecar/package.json
@@ -19,6 +19,10 @@
   },
   "type": "module",
   "main": "dist/index.js",
+  "bin": {
+    "pi-sidecar": "dist/server.js",
+    "pi-sidecar-start": "scripts/start-sidecar.sh"
+  },
   "types": "dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/pi-sidecar/scripts/start-sidecar.sh
+++ b/packages/pi-sidecar/scripts/start-sidecar.sh
@@ -15,7 +15,17 @@
 # ---------------------------------------------------------
 set -euo pipefail
 
-readonly SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+_resolve_symlink() {
+    local target="$1"
+    while [ -L "$target" ]; do
+        local dir
+        dir="$(cd "$(dirname "$target")" && pwd)"
+        target="$(readlink "$target")"
+        [[ "$target" != /* ]] && target="$dir/$target"
+    done
+    echo "$target"
+}
+readonly SCRIPT_DIR="$(cd "$(dirname "$(_resolve_symlink "${BASH_SOURCE[0]}")")" && pwd)"
 readonly PKG_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 readonly PORT="${SIDECAR_PORT:-9201}"
 readonly HOST="${SIDECAR_HOST:-127.0.0.1}"

--- a/packages/pi-sidecar/scripts/start-sidecar.sh
+++ b/packages/pi-sidecar/scripts/start-sidecar.sh
@@ -17,7 +17,8 @@ set -euo pipefail
 
 _resolve_symlink() {
     local target="$1"
-    while [ -L "$target" ]; do
+    local max=20
+    while [ -L "$target" ] && (( max-- > 0 )); do
         local dir
         dir="$(cd "$(dirname "$target")" && pwd)"
         target="$(readlink "$target")"

--- a/packages/pi-sidecar/scripts/start-sidecar.sh
+++ b/packages/pi-sidecar/scripts/start-sidecar.sh
@@ -15,7 +15,7 @@
 # ---------------------------------------------------------
 set -euo pipefail
 
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 readonly PKG_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 readonly PORT="${SIDECAR_PORT:-9201}"
 readonly HOST="${SIDECAR_HOST:-127.0.0.1}"

--- a/packages/pi-sidecar/scripts/start-sidecar.sh
+++ b/packages/pi-sidecar/scripts/start-sidecar.sh
@@ -24,6 +24,10 @@ _resolve_symlink() {
         target="$(readlink "$target")"
         [[ "$target" != /* ]] && target="$dir/$target"
     done
+    if [ -L "$target" ]; then
+        echo "ERROR: symlink resolution exceeded 20 hops (possible cycle): $1" >&2
+        exit 1
+    fi
     echo "$target"
 }
 readonly SCRIPT_DIR="$(cd "$(dirname "$(_resolve_symlink "${BASH_SOURCE[0]}")")" && pwd)"

--- a/packages/pi-sidecar/src/server.ts
+++ b/packages/pi-sidecar/src/server.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // Clear process.argv[1] so the subagent extension's getPiInvocation() falls
 // through to `{ command: "pi", args }` instead of re-running the sidecar.
 // This is intentionally in the CLI entry point (not startSidecar()) to avoid


### PR DESCRIPTION
## Summary

Add `bin` field to `@myk-org/pi-sidecar` package so consumers can easily start and test the sidecar.

## CLI Commands

After `npm install @myk-org/pi-sidecar`:

- `npx pi-sidecar` — start the sidecar server (Node.js entry)
- `npx pi-sidecar-start` — start via shell script (background, port 9201)
- `npx pi-sidecar-start --stop` — stop a running sidecar

## Changes

- `packages/pi-sidecar/package.json` — added `bin` field
- `packages/pi-sidecar/README.md` — added CLI Commands section
- `README.md` — added CLI commands note in Workspace Packages section

Made with [Cursor](https://cursor.com)